### PR TITLE
Fix sysctlbyname to respect the passed-in buffer size.

### DIFF
--- a/Frameworks/CoreFoundation/CFMisc.mm
+++ b/Frameworks/CoreFoundation/CFMisc.mm
@@ -37,9 +37,16 @@ COREFOUNDATION_EXPORT extern "C" int usleep(long secs)
 COREFOUNDATION_EXPORT extern "C" int sysctlbyname(const char *name, void *out, size_t *outSize, const void *, size_t)
 {
     if ( strcmp(name, "hw.machine") == 0 ) {
-        if ( outSize ) *outSize = 8;
-        if ( out ) strcpy((char *) out, "winobjc");
-        return 0;
+        const int required = 8;
+        if ( outSize ) {
+            // If there's no buffer, we have to return the nr. of bytes required for this response.
+            *outSize = !out ? required : min(*outSize, required);
+        } else {
+            return -1;
+        }
+
+        if ( out ) strncpy((char *) out, "winobjc", *outSize); // outsize is <= required here
+        return *outSize < required ? ENOMEM : 0;
     }
     return -1;
 }


### PR DESCRIPTION
This brings sysctlbyname into compliance with the BSD manual page,
sysctl(3).

Fixes Microsoft/WinObjC#5.
This is designed to bear future changes if we ever decide that we
want to support more than just hw.machine.

---
Invariant at the end of the function: outSize is non-null.