### PR TITLE
Remove code duplication when checking NSNumber equality

### DIFF
--- a/Frameworks/Foundation/NSNumber.mm
+++ b/Frameworks/Foundation/NSNumber.mm
@@ -245,30 +245,11 @@ static id cachedNumbers[CACHE_NSNUMBERS_BELOW];
     }
 
     -(BOOL) isEqual:(NSObject *)objAddr {
-        if ( objAddr == self ) return TRUE;
-        if ( objAddr != nil && [objAddr isKindOfClass:[NSNumber class]] ) {
-            NSNumber *other = (NSNumber *) objAddr;
-            if ( type == other->type ) {
-                return val.i == other->val.i;
-            } else {
-                return [self doubleValue] == [other doubleValue];
-            }
-        }
-
-        return FALSE;
+        return [self compare: objAddr] == 0;
     }
 
     -(BOOL) isEqualToNumber:(NSNumber*)objAddr {
-        if ( objAddr == self ) return TRUE;
-        if ( objAddr != nil && [objAddr isKindOfClass:[NSNumber class]] ) {
-            if ( type == objAddr->type ) {
-                return val.i == objAddr->val.i;
-            } else {
-                return [self doubleValue] == [objAddr doubleValue];
-            }
-        }
-
-        return FALSE;
+        return [self compare: objAddr] == 0;
     }
 
     -(int) compare:(NSNumber*)objAddr {

--- a/Frameworks/Foundation/NSNumber.mm
+++ b/Frameworks/Foundation/NSNumber.mm
@@ -253,7 +253,7 @@ static id cachedNumbers[CACHE_NSNUMBERS_BELOW];
     }
 
     -(int) compare:(NSNumber*)objAddr {
-        if ( objAddr == self ) return TRUE;
+        if ( objAddr == self ) return 0;
         if ( objAddr != nil && [objAddr isKindOfClass:[NSNumber class]] ) {         
             if ( type == objAddr->type ) {
                 if ( val.i < objAddr->val.i ) {

--- a/Frameworks/Foundation/NSNumber.mm
+++ b/Frameworks/Foundation/NSNumber.mm
@@ -274,7 +274,7 @@ static id cachedNumbers[CACHE_NSNUMBERS_BELOW];
             }
         }
 
-        return FALSE;
+        return -1;
     }
 
 


### PR DESCRIPTION
The `isEqual:` and `isEqualToNumber:` implementations seem to contain unnecessary code duplication. It seems that reusing the `compare:` implementation for that would both remove the duplication and guarantee semantical consistency between these methods. 

It also looks like the `compare:` implementation should not return `TRUE` when the method parameter is identical to `self`, but should return 0 instead. For the same reason it seems that returning `FALSE` from `compare:` call is also not right.