### PR TITLE
Remove unnecessary allocation of NSNumber instances when copying

### DIFF
--- a/Frameworks/Foundation/NSNumber.mm
+++ b/Frameworks/Foundation/NSNumber.mm
@@ -298,13 +298,7 @@ static id cachedNumbers[CACHE_NSNUMBERS_BELOW];
 
 
     -(id) copyWithZone:(NSZone*)zone {
-        NSNumber* ret = [NSNumber alloc];
-        ret->val.i = val.i;
-        ret->type = type;
-        ret->objCType = objCType;
-        ret->isBool = isBool;
-
-        return ret;
+        return [self retain];
     }
 
     -(int) intValue {


### PR DESCRIPTION
It seems not necessary to actually create a new `NSNumber` instance when copying since `NSNumbers` are immutable. Returning retained `self` should be essentially the same.