### PR TITLE
Implement the new OS version APIs from OS X 10.10 and iOS 8.0.

### DIFF
--- a/include/Foundation/NSProcessInfo.h
+++ b/include/Foundation/NSProcessInfo.h
@@ -17,6 +17,12 @@ enum {
    NSMACHOperatingSystem,
 };
 
+typedef struct {
+    NSInteger majorVersion;
+    NSInteger minorVersion;
+    NSInteger patchVersion;
+} NSOperatingSystemVersion;
+
 @interface NSProcessInfo : NSObject {
    NSMutableDictionary *_environment;
    NSArray      *_arguments;
@@ -35,6 +41,9 @@ enum {
 -(NSUInteger)operatingSystem;
 -(NSString *)operatingSystemName;
 -(NSString *)operatingSystemVersionString;
+
+- (NSOperatingSystemVersion)operatingSystemVersion;
+- (BOOL)isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion)version;
 
 -(NSString *)hostName;
 


### PR DESCRIPTION
I don't feel like setting up a Windows 10 instance to test this right now, but the winOsVersion() function was tested separately and works properly on Windows Desktop and WinRT (returns 6.3.9600 on my Windows 8.1 box).