### PR TITLE
Fixed return value of -[NSXMLParser parse]

### DIFF
--- a/Frameworks/Foundation/NSXMLParser.mm
+++ b/Frameworks/Foundation/NSXMLParser.mm
@@ -207,7 +207,7 @@
         sax.cdataBlock = cdataCallback;
         sax.getEntity = entityCallback;
 
-        int ret = xmlSAXUserParseMemory(&sax, (void *) self, (const char*) _bytes, _length) == 0 ? YES : NO;
+        int ret = xmlSAXUserParseMemory(&sax, (void *) self, (const char*) _bytes, _length);
         [_emptyDictionary release];
 
         return ret == 0;


### PR DESCRIPTION
The method was returning false instead of true if parsing succeeded.