### PR TITLE
Export NSPropertyListSerialization in Foundation.DLL

### DIFF
--- a/build/Foundation/Foundation.Shared/Foundation.def
+++ b/build/Foundation/Foundation.Shared/Foundation.def
@@ -130,5 +130,7 @@ LIBRARY Foundation
 	 __objc_class_name_NSKeyedArchiver	CONSTANT
      _OBJC_CLASS_NSKeyedUnarchiver DATA
 	 __objc_class_name_NSKeyedUnarchiver	CONSTANT
+     _OBJC_CLASS_NSPropertyListSerialization DATA
+	 __objc_class_name_NSPropertyListSerialization	CONSTANT
      _OBJC_CLASS_NSLocale DATA
 	 __objc_class_name_NSLocale	CONSTANT

--- a/include/Foundation/NSPropertyList.h
+++ b/include/Foundation/NSPropertyList.h
@@ -28,6 +28,7 @@ typedef enum {
    NSPropertyListBinaryFormat_v1_0,
 } NSPropertyListFormat;
 
+FOUNDATION_EXPORT_CLASS
 @interface NSPropertyListSerialization : NSObject
 
 +(BOOL)propertyList:propertyList isValidForFormat:(NSPropertyListFormat)format;


### PR DESCRIPTION
The class was previously not exported, resulting in a linker error upon use.