### PR TITLE
Fixed NSObject valueForKey: pointer return values

### DIFF
--- a/Frameworks/limbo/NSObject_NSFoundation.mm
+++ b/Frameworks/limbo/NSObject_NSFoundation.mm
@@ -41,7 +41,7 @@
         const char* returnType = [sig methodReturnType];
 
         if (strcmp(returnType, "@") == 0) {
-            [invocation getReturnValue:&ret];
+            [invocation getReturnValue:ret];
             return true;
         } else if (strcmp(returnType, "f") == 0) {
             float retVal;


### PR DESCRIPTION
Calling `-[NSObject valueForKey:]` with a key referencing a method returning a pointer was always returning NULL due to an incorrect pointer reference in `tryGetAccessor()`.