### PR TITLE
Fixed crash when passing nil to NSStringFromClass() or object_getClass()

### DIFF
--- a/Frameworks/Foundation/Utils.mm
+++ b/Frameworks/Foundation/Utils.mm
@@ -97,6 +97,8 @@ SEL NSSelectorFromString(NSString *str)
 
 NSString *NSStringFromClass(Class cls)
 {
+    if (!cls)
+        return nil;
     return [NSString stringWithUTF8String: object_getClassName(cls)];
 }
 

--- a/Frameworks/objcrt/class.c
+++ b/Frameworks/objcrt/class.c
@@ -771,7 +771,7 @@ object_getClass(id obj_)
      * to get the object of the class. 
      */
 
-    if ( obj->isa ) {
+    if ( obj && obj->isa ) {
         extern struct winrt_isa _NSConcreteGlobalBlock;
 
         if ( ((Class) obj->isa)->isa == &_NSConcreteGlobalBlock ) {


### PR DESCRIPTION
The documented behavior for these methods is to return nil if the provided reference is nil.