### PR TITLE
add + (UIFont *)italicSystemFontOfSize:(CGFloat)fontSize;  method

### DIFF
--- a/include/UIKit/UIFont.h
+++ b/include/UIKit/UIFont.h
@@ -42,6 +42,7 @@ UIKIT_EXPORT_CLASS
 
 + (UIFont *)systemFontOfSize:(CGFloat)fontSize;
 + (UIFont *)boldSystemFontOfSize:(CGFloat)fontSize;
++ (UIFont *)italicSystemFontOfSize:(CGFloat)fontSize;
 
 - (UIFont *)fontWithSize:(CGFloat)fontSize;
 


### PR DESCRIPTION
italicSystemFontOfSize method is in the UIFont.mm.   
So add it in the UIFont.h