### PR TITLE
KVC: fixed setting primitive type accessor using non-matching NSValue type

### DIFF
--- a/Frameworks/Foundation/NSValueTransformers.h
+++ b/Frameworks/Foundation/NSValueTransformers.h
@@ -76,6 +76,73 @@ id valueFromDataWithType(void* data, const char* objcType) {
     }
     return [NSValue valueWithBytes:data objCType:objcType];
 }
+
+bool dataWithTypeFromValue(void* data, const char* objcType, id value) {
+	switch (objcType[0]) {
+	case '@':
+		woc::ValueTransformer<id>::store(value, data);
+		break;
+	case '#':
+		woc::ValueTransformer<Class>::store(value, data);
+		break;
+	case 'c':
+		woc::ValueTransformer<char>::store(value, data);
+		break;
+	case 'i':
+		woc::ValueTransformer<int>::store(value, data);
+		break;
+	case 's':
+		woc::ValueTransformer<short>::store(value, data);
+		break;
+	case 'l':
+		woc::ValueTransformer<long>::store(value, data);
+		break;
+	case 'q':
+		woc::ValueTransformer<long long>::store(value, data);
+		break;
+	case 'C':
+		woc::ValueTransformer<unsigned char>::store(value, data);
+		break;
+	case 'I':
+		woc::ValueTransformer<unsigned int>::store(value, data);
+		break;
+	case 'S':
+		woc::ValueTransformer<unsigned short>::store(value, data);
+		break;
+	case 'L':
+		woc::ValueTransformer<unsigned long>::store(value, data);
+		break;
+	case 'Q':
+		woc::ValueTransformer<unsigned long long>::store(value, data);
+		break;
+	case 'f':
+		woc::ValueTransformer<float>::store(value, data);
+		break;
+	case 'd':
+		woc::ValueTransformer<double>::store(value, data);
+		break;
+	case 'B':
+		woc::ValueTransformer<bool>::store(value, data);
+		break;
+	case '*':
+	case '^':
+	case '?':
+		// We cannot box/unbox arbitrary pointers or char*.
+		return false;
+	default:
+		NSValue* nsv = static_cast<NSValue*>(value);
+		if (getArgumentSize(objcType) == getArgumentSize([nsv objCType])) {
+			[nsv getValue:data];
+		}
+		else {
+			// If the argument types don't match in size, we just say
+			// that this key can't be coded.
+			return false;
+		}
+		break;
+	}
+	return true;
+}
 }
 
 template <>

--- a/Frameworks/limbo/NSObject_NSFoundation.mm
+++ b/Frameworks/limbo/NSObject_NSFoundation.mm
@@ -197,13 +197,8 @@ static bool trySetViaAccessor(NSObject* self, const char* key, id value) {
 
         const char* valueType = [sig getArgumentTypeAtIndex:2];
         std::vector<uint8_t> data(getArgumentSize(valueType));
-        if (valueType[0] == '@') { // Method is expecting an object: give it the object directly
-            memcpy(data.data(), &value, sizeof(id));
-        } else if (valueType[0] == '*' || valueType[0] == '^' || valueType[0] == '?') {
-            // We can't box or unbox char* or arbitrary pointers.
+        if (!woc::dataWithTypeFromValue(data.data(), valueType, value)) {
             return false;
-        } else if ([value isKindOfClass:[NSValue class]]) {
-            [static_cast<NSValue*>(value) getValue:data.data()];
         }
 
         [invocation setTarget:self];
@@ -226,68 +221,12 @@ static bool trySetViaIvar(NSObject* self, const char* key, id value) {
     const char* argType = curIvar->type;
 
     void* destination = reinterpret_cast<char*>(self) + offset;
-    switch (argType[0]) {
-        case '@':
-            [*reinterpret_cast<id*>(destination) release];
-            woc::ValueTransformer<id>::store(value, destination);
-            break;
-        case '#':
-            woc::ValueTransformer<Class>::store(value, destination);
-            break;
-        case 'c':
-            woc::ValueTransformer<char>::store(value, destination);
-            break;
-        case 'i':
-            woc::ValueTransformer<int>::store(value, destination);
-            break;
-        case 's':
-            woc::ValueTransformer<short>::store(value, destination);
-            break;
-        case 'l':
-            woc::ValueTransformer<long>::store(value, destination);
-            break;
-        case 'q':
-            woc::ValueTransformer<long long>::store(value, destination);
-            break;
-        case 'C':
-            woc::ValueTransformer<unsigned char>::store(value, destination);
-            break;
-        case 'I':
-            woc::ValueTransformer<unsigned int>::store(value, destination);
-            break;
-        case 'S':
-            woc::ValueTransformer<unsigned short>::store(value, destination);
-            break;
-        case 'L':
-            woc::ValueTransformer<unsigned long>::store(value, destination);
-            break;
-        case 'Q':
-            woc::ValueTransformer<unsigned long long>::store(value, destination);
-            break;
-        case 'f':
-            woc::ValueTransformer<float>::store(value, destination);
-            break;
-        case 'd':
-            woc::ValueTransformer<double>::store(value, destination);
-            break;
-        case 'B':
-            woc::ValueTransformer<bool>::store(value, destination);
-            break;
-        case '*':
-        case '^':
-        case '?':
-            // We cannot box/unbox arbitrary pointers or char*.
-            return false;
-        default:
-            NSValue* nsv = static_cast<NSValue*>(value);
-            if (getArgumentSize(argType) == getArgumentSize([nsv objCType])) {
-                [nsv getValue:destination];
-            } else {
-                // If the argument types don't match in size, we just say
-                // that this key can't be coded.
-                return false;
-            }
-            break;
+    if (!woc::dataWithTypeFromValue(destination, argType, value)) {
+        return false;
+    }
+    if (argType[0] == '@') {
+        // retain object-type ivar, old value is _not_ released (iOS/OS X behavior)
+        [*reinterpret_cast<id*>(destination) retain];
     }
 
     return true;


### PR DESCRIPTION
When setting a primitive type accessor via KVC, the code in `trySetViaAccessor()` didn’t consider that the passed-in NSValue instance might be of a different type than the setter’s argument type.

This caused e.g. the following to not work correctly:
```obj-c
// assume `object` with property:
@property (assign) float floatProperty;

[object setValue:@(1.23) forKey:@"floatProperty"]; // note @(1.23) is of type double

=> object.floatProperty != 1.23
```