### PR TITLE
[UIWebView alloc] init] needs to call initWebKit()

### DIFF
--- a/Frameworks/UIKit/UIWebView.mm
+++ b/Frameworks/UIKit/UIWebView.mm
@@ -118,6 +118,14 @@ static void initWebKit(UIWebView* self) {
     [self setNeedsLayout];
 }
 
+- (instancetype)init {
+    [super init];
+
+    initWebKit(self);
+
+    return self;
+}
+
 - (instancetype)initWithCoder:(NSCoder*)coder {
     [super initWithCoder:coder];
 


### PR DESCRIPTION
Without this patch [[UIWebView alloc] init] will fail because of missing call to initWebkit(self)