### PR TITLE
Fix link error with UINavigationItem.

### DIFF
--- a/build/UIKit/UIKit.Shared/UIKit.def
+++ b/build/UIKit/UIKit.Shared/UIKit.def
@@ -96,6 +96,8 @@ LIBRARY UIKit
      __objc_class_name_UITabBarController CONSTANT
      _OBJC_CLASS_UINavigationController DATA
      __objc_class_name_UINavigationController CONSTANT
+     _OBJC_CLASS_UINavigationItem DATA
+     __objc_class_name_UINavigationItem CONSTANT
      _OBJC_CLASS_UINavigationBar DATA
      __objc_class_name_UINavigationBar CONSTANT
      _OBJC_CLASS_UISearchBar DATA

--- a/include/UIKit/UINavigationItem.h
+++ b/include/UIKit/UINavigationItem.h
@@ -36,6 +36,7 @@
 
 @class UIBarButtonItem, UIView, UINavigationBar;
 
+UIKIT_EXPORT_CLASS
 @interface UINavigationItem : NSObject
 
 - (id)initWithTitle:(NSString*)title;


### PR DESCRIPTION
The relevant symbols needed to be exported.