### PR TITLE
Add timeZone property to NSDateComponents with related handling in NSCalendar dateFromComponents:

### DIFF
--- a/Frameworks/Foundation/NSCalendar.mm
+++ b/Frameworks/Foundation/NSCalendar.mm
@@ -159,7 +159,7 @@
  @Status Interoperable
 */
 - (void)setTimeZone:(NSTimeZone*)timeZone {
-    timeZone = [timeZone retain];
+    timeZone = [timeZone copy];
     [_timeZone release];
     _timeZone = timeZone;
     _calendarNeedsRebuilding = TRUE;
@@ -169,7 +169,7 @@
  @Status Interoperable
 */
 - (void)setLocale:(NSLocale*)locale {
-    locale = [locale retain];
+    locale = [locale copy];
     [_locale release];
     _locale = locale;
     _calendarNeedsRebuilding = TRUE;
@@ -264,7 +264,7 @@ static Calendar* calendarCopyWithTZAndDate(NSCalendar* self, NSDate* date) {
     NSInteger check;
 
     UErrorCode status = U_ZERO_ERROR;
-    Calendar* copy = calendarCopyWithTZ(self);
+    Calendar* copy = [self _getICUCalendar]->clone();
     copy->clear();
 
     if ((check = [components year]) != NSUndefinedDateComponent)
@@ -283,6 +283,13 @@ static Calendar* calendarCopyWithTZAndDate(NSCalendar* self, NSDate* date) {
         copy->set(UCAL_WEEK_OF_YEAR, check);
     if ((check = [components weekday]) != NSUndefinedDateComponent)
         copy->set(UCAL_DAY_OF_WEEK, check);
+
+    if ([components timeZone] != nil) {
+        icu::TimeZone* tz = [[components timeZone] _createICUTimeZone];
+        copy->setTimeZone(*tz);
+        delete tz;
+    }
+
     id ret = nil;
 
     if (U_SUCCESS(status)) {

--- a/Frameworks/Foundation/NSDateComponents.mm
+++ b/Frameworks/Foundation/NSDateComponents.mm
@@ -18,7 +18,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 #define NSUndefinedDateComponent 0x7fffffff
 
-@implementation NSDateComponents : NSObject
+@implementation NSDateComponents
 - (instancetype)init {
     _era = NSUndefinedDateComponent;
     _year = NSUndefinedDateComponent;
@@ -32,118 +32,6 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     _minute = NSUndefinedDateComponent;
     _second = NSUndefinedDateComponent;
     return self;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setDay:(NSInteger)day {
-    _day = day;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setMonth:(NSInteger)month {
-    _month = month;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setYear:(NSInteger)year {
-    _year = year;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setSecond:(NSInteger)second {
-    _second = second;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setMinute:(NSInteger)minute {
-    _minute = minute;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setHour:(NSInteger)hour {
-    _hour = hour;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setWeekday:(NSInteger)weekday {
-    _weekday = weekday;
-}
-
-/**
- @Status Interoperable
-*/
-- (void)setWeek:(NSInteger)week {
-    _week = week;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)weekday {
-    return _weekday;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)week {
-    return _week;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)day {
-    return _day;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)month {
-    return _month;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)year {
-    return _year;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)hour {
-    return _hour;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)minute {
-    return _minute;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSInteger)second {
-    return _second;
 }
 
 @end

--- a/build/UnitTests/UnitTests.vcxproj
+++ b/build/UnitTests/UnitTests.vcxproj
@@ -297,6 +297,7 @@
     <ClangCompile Include="..\..\tests\unittests\NSURLSessionConfiguration.m" />
     <ClangCompile Include="..\..\tests\unittests\WOCStdLib\mach\mach_test.mm" />
     <ClangCompile Include="..\..\tests\unittests\NSCachedURLResponse.mm" />
+    <ClangCompile Include="..\..\tests\unittests\NSDateComponents.m" />
   </ItemGroup>
   <ItemGroup>
     <SBResourceCopy Include="..\..\tests\unittests\ContainerCRTDeps\msvcp140d_app.dll">

--- a/include/Foundation/NSDateComponents.h
+++ b/include/Foundation/NSDateComponents.h
@@ -11,54 +11,30 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #import <Foundation/NSObject.h>
 
+@class NSTimeZone;
+
 enum {
    NSUndefinedDateComponent = 0x7fffffff
 };
 
 FOUNDATION_EXPORT_CLASS
-@interface NSDateComponents : NSObject {
-    NSInteger _era;
-    NSInteger _year;
-    NSInteger _quarter;
-    NSInteger _month;
-    NSInteger _week;
-    NSInteger _weekday;
-    NSInteger _weekdayOrdinal;
-    NSInteger _day;
-    NSInteger _hour;
-    NSInteger _minute;
-    NSInteger _second;
-}
+@interface NSDateComponents : NSObject
 
-- (NSInteger)era;
-- (NSInteger)year;
-- (NSInteger)quarter;
-- (NSInteger)month;
-- (NSInteger)week;
-- (NSInteger)weekday;
-- (NSInteger)weekdayOrdinal;
-- (NSInteger)day;
-- (NSInteger)hour;
-- (NSInteger)minute;
-- (NSInteger)second;
-- (NSInteger)weekOfMonth;
-- (NSInteger)weekOfYear;
-- (NSInteger)yearForWeekOfYear;
-
-- (void)setEra:(NSInteger)value;
-- (void)setYear:(NSInteger)value;
-- (void)setQuarter:(NSInteger)value;
-- (void)setMonth:(NSInteger)value;
-- (void)setWeek:(NSInteger)value;
-- (void)setWeekday:(NSInteger)value;
-- (void)setWeekdayOrdinal:(NSInteger)value;
-- (void)setDay:(NSInteger)value;
-- (void)setHour:(NSInteger)value;
-- (void)setMinute:(NSInteger)value;
-- (void)setSecond:(NSInteger)value;
-- (void)setWeekOfMonth:(NSInteger)week;
-- (void)setWeekOfYear:(NSInteger)week;
-- (void)setYearForWeekOfYear:(NSInteger)year;
+@property (copy) NSTimeZone* timeZone;
+@property NSInteger era;
+@property NSInteger year;
+@property NSInteger quarter;
+@property NSInteger month;
+@property NSInteger week;
+@property NSInteger weekday;
+@property NSInteger weekdayOrdinal;
+@property NSInteger day;
+@property NSInteger hour;
+@property NSInteger minute;
+@property NSInteger second;
+@property NSInteger weekOfMonth;
+@property NSInteger weekOfYear;
+@property NSInteger yearForWeekOfYear;
 
 @end
 

--- a/tests/unittests/NSDateComponents.m
+++ b/tests/unittests/NSDateComponents.m
@@ -1,0 +1,71 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include "gtest-api.h"
+#import <Foundation/Foundation.h>
+
+TEST(Foundation, NSDateComponents_ComponentsTimeZoneTest) {
+    LOG_INFO("NSDateComponents components with time zone test: ");
+
+    NSTimeZone* estTimeZone = [NSTimeZone timeZoneWithName:@"EST"];
+    NSTimeZone* cstTimeZone = [NSTimeZone timeZoneWithName:@"CST"];
+
+    NSDateComponents* dateComponents = [[NSDateComponents alloc] init];
+    [dateComponents setHour:1];
+    [dateComponents setDay:1];
+    [dateComponents setMonth:4];
+    [dateComponents setYear:1999];
+
+    [dateComponents setTimeZone:estTimeZone];
+    NSDate* estDate = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
+
+    [dateComponents setTimeZone:cstTimeZone];
+    NSDate* cstDateNonMatching = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
+
+    [dateComponents setHour:0];
+    NSDate* cstDateMatching = [[NSCalendar currentCalendar] dateFromComponents:dateComponents];
+
+    NSTimeInterval secondsBetween = [cstDateNonMatching timeIntervalSinceDate:estDate];
+
+    ASSERT_OBJCEQ_MSG(estDate, cstDateMatching, "FAILED: dates should match");
+    ASSERT_OBJCNE_MSG(cstDateNonMatching, cstDateMatching, "FAILED: dates should differ by one hour");
+    ASSERT_OBJCNE_MSG(estDate, cstDateNonMatching, "FAILED: dates should differ by one hour");
+    ASSERT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+}
+
+TEST(Foundation, NSDateComponents_CalendarTimeZoneTest) {
+    LOG_INFO("NSDateComponents calendar with time zone test: ");
+
+    NSTimeZone* estTimeZone = [NSTimeZone timeZoneWithName:@"EST"];
+    NSTimeZone* cstTimeZone = [NSTimeZone timeZoneWithName:@"CST"];
+
+    NSDateComponents* dateComponents = [[NSDateComponents alloc] init];
+    [dateComponents setHour:0];
+    [dateComponents setDay:1];
+    [dateComponents setMonth:4];
+    [dateComponents setYear:1999];
+
+    NSCalendar* calendar = [NSCalendar currentCalendar];
+
+    [calendar setTimeZone:estTimeZone];
+    NSDate* estDate = [calendar dateFromComponents:dateComponents];
+
+    [dateComponents setTimeZone:cstTimeZone];
+    NSDate* cstDate = [calendar dateFromComponents:dateComponents];
+
+    NSTimeInterval secondsBetween = [cstDate timeIntervalSinceDate:estDate];
+    ASSERT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+}


### PR DESCRIPTION

Commit also adds unit test and fixes incorrect retain (should be copy) semantics with NSCalendar timeZone and locale properties.