### PR TITLE
Fix mistake in quaternion multiplication

### DIFF
--- a/include/GLKit/GLKMath.h
+++ b/include/GLKit/GLKMath.h
@@ -987,8 +987,8 @@ inline float GLKQuaternionDot(GLKQuaternion q1, GLKQuaternion q2) {
 inline GLKQuaternion GLKQuaternionMultiply(GLKQuaternion q1, GLKQuaternion q2) {
     GLKQuaternion res;
 
-    res.x = q1.w * q2.x + q1.x + q2.w + q1.y * q2.z - q1.z * q2.y;
-    res.y = q1.w * q2.y - q1.x * q2.z + q1.y * q2.w + q1.z + q2.x;
+    res.x = q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y;
+    res.y = q1.w * q2.y - q1.x * q2.z + q1.y * q2.w + q1.z * q2.x;
     res.z = q1.w * q2.z + q1.x * q2.y - q1.y * q2.x + q1.z * q2.w;
     res.w = q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z;
 


### PR DESCRIPTION
I was referencing GLKMath (along with a couple of web sites) for some quaternion functions I was writing, and I noticed that `GLKQuaternionMultiply` was wrong. See https://en.wikipedia.org/wiki/Quaternion#Hamilton_product for the formula. There are two additions that should be multiplications.