### PR TITLE
Unit test to ensure NSDateFormatter timeStyle and dateStyle properties are writable

### DIFF
--- a/tests/unittests/Foundation/NSDateFormatterTests.m
+++ b/tests/unittests/Foundation/NSDateFormatterTests.m
@@ -92,8 +92,20 @@ TEST(Foundation, NSDateFormatter) {
         testSpecificFormat(i, formattedDateString, testCase);
     }
 
-    // Try some simple formatting
     NSDateFormatter* dateFormatter = [[[NSDateFormatter alloc] init] autorelease];
+
+    // Test setting properties individually.
+    for (int i = 0; i < 5; i++) {
+        [dateFormatter setLocale:localeToTest];
+        [dateFormatter setDateStyle:(NSDateFormatterStyle)i];
+        [dateFormatter setTimeStyle:(NSDateFormatterStyle)i];
+        [dateFormatter setTimeZone:timeZoneToTest];
+        formattedDateString = [dateFormatter stringFromDate:someConstantDate];
+        testSpecificFormat(i, formattedDateString, testCase);
+    }
+
+    // Try some simple formatting
+    // (ensure setDateFormat: overrides individual properties set above).
 
     // Create an NSDate from string with dateFormatter
     [dateFormatter setDateFormat:@"yyyy-MM-dd"];


### PR DESCRIPTION
Recent commit 6c24e62f385dd721aabdf79636ea8990d8caaa9d handled the underlying bug (where these properties were accidentally marked readonly). I've rebased my pull request to only include the unit test change (it passes so might as well merge). No problem with closing though.