### PR TITLE
Support for signed and unsigned short for NSNumber getValue/stringValue

### DIFF
--- a/Frameworks/UnifiedFoundation/Foundation/NSNumber.mm
+++ b/Frameworks/UnifiedFoundation/Foundation/NSNumber.mm
@@ -556,7 +556,10 @@ static id cachedNumbers[CACHE_NSNUMBERS_BELOW];
         case 'C':
             ret = [NSString stringWithFormat:@"%i", val.i];
             break;
-
+        case 's':
+        case 'S':
+            ret = [NSString stringWithFormat:@"%hi", val.i];
+            break;
         default:
             assert(0);
             break;
@@ -613,7 +616,10 @@ static id cachedNumbers[CACHE_NSNUMBERS_BELOW];
         case 'c':
             *((char*)dest) = (char)val.i;
             break;
-
+        case 's':
+        case 'S':
+            *((short *) dest) = (short)val.i;
+            break;
         default:
             assert(0);
             break;

--- a/build/Tests/UnitTests/UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UnitTests.vcxproj
@@ -257,6 +257,7 @@
     <ClangCompile Include="..\..\..\tests\unittests\NSMutableURLRequest.m" />
     <ClangCompile Include="..\..\..\tests\unittests\NSDateComponents.m" />
     <ClangCompile Include="..\..\..\tests\unittests\NSSortDescriptor.m" />
+    <ClangCompile Include="..\..\..\tests\unittests\NSNumber.mm" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\..\..\tests\unittests\Foundation\NSFileManagerUT.txt">

--- a/tests/unittests/NSNumber.mm
+++ b/tests/unittests/NSNumber.mm
@@ -1,0 +1,56 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include "gtest-api.h"
+#import <Foundation/Foundation.h>
+
+TEST(Foundation, NSNumber_numberWithShortGetStringValueUnSigned) {
+    NSNumber* number = [NSNumber numberWithShort:25];
+    ASSERT_TRUE_MSG(number != nil, "FAILED: number should not be nil!");
+    ASSERT_OBJCEQ_MSG(@"25",[number stringValue], "FAILED: values do not match as expected.");
+}
+
+TEST(Foundation, NSNumber_numberWithShortGetStringValueSigned) {
+    NSNumber* number = [NSNumber numberWithShort:-12];
+    ASSERT_TRUE_MSG(number != nil, "FAILED: number should not be nil!");
+    ASSERT_OBJCEQ_MSG(@"-12",[number stringValue], "FAILED: values do not match as expected.");
+}
+
+TEST(Foundation, NSNumber_numberWithUnsignedShort) {
+    NSNumber* number = [NSNumber numberWithUnsignedShort:25];
+    ASSERT_TRUE_MSG(number != nil, "FAILED: number should not be nil!");
+    ASSERT_OBJCEQ_MSG(@"25",[number stringValue], "FAILED: values do not match as expected.");
+}
+
+TEST(Foundation, NSNumber_getValueUnSigned) {
+    NSNumber* number = [NSNumber numberWithUnsignedShort:25];
+    ASSERT_TRUE_MSG(number != nil, "FAILED: number should not be nil!");
+
+    unsigned short value;
+    [number getValue:&value];
+
+    ASSERT_EQ_MSG(25,value, "FAILED: values do not match as expected.");
+}
+
+TEST(Foundation, NSNumber_getValueSigned) {
+    NSNumber* number = [NSNumber numberWithShort:-12];
+    ASSERT_TRUE_MSG(number != nil, "FAILED: number should not be nil!");
+
+    short value;
+    [number getValue:&value];
+
+    ASSERT_EQ_MSG(-12,value, "FAILED: values do not match as expected.");
+}


### PR DESCRIPTION
Adding the support for unsigned and signed short values for getValue and stringValue. 
Also added unit tests for the un/signed shorts.

fix #310