### PR TITLE
Submit feature implemetation and test about NSTimeZone timeZoneDataVersion/localizedName:locale:   

### DIFF
--- a/Frameworks/UnifiedFoundation/Foundation/NSTimeZone.mm
+++ b/Frameworks/UnifiedFoundation/Foundation/NSTimeZone.mm
@@ -47,6 +47,34 @@ static NSArray* s_KnownTimeZoneNames;
 
 const static int c_minutesToMilliseconds = -60000;
 
+// Convert NSTimeZoneNameStyle to ICU EDisplayType.
+icu::TimeZone::EDisplayType _convertNSTimeZoneNameStyleToICUEDisplayType(NSTimeZoneNameStyle* style, UBool& isDaylight) {
+    switch (*style) {
+        case NSTimeZoneNameStyleStandard:
+            isDaylight = FALSE;
+            return icu::TimeZone::EDisplayType::LONG;
+        case NSTimeZoneNameStyleShortStandard:
+            isDaylight = FALSE;
+            return icu::TimeZone::EDisplayType::SHORT_GMT;
+        case NSTimeZoneNameStyleDaylightSaving:
+            isDaylight = TRUE;
+            return icu::TimeZone::EDisplayType::LONG;
+        case NSTimeZoneNameStyleShortDaylightSaving:
+            isDaylight = TRUE;
+            return icu::TimeZone::EDisplayType::SHORT_GMT;
+        case NSTimeZoneNameStyleGeneric:
+            isDaylight = FALSE;
+            return icu::TimeZone::EDisplayType::LONG_GENERIC;
+        case NSTimeZoneNameStyleShortGeneric:
+            isDaylight = FALSE;
+            // Use LONG_GENERIC instead of SHORT_GENERIC here to get consistent result with IOS
+            return icu::TimeZone::EDisplayType::LONG_GENERIC;
+        default:
+            isDaylight = FALSE;
+            return icu::TimeZone::EDisplayType::SHORT_COMMONLY_USED;
+    }
+}
+
 @implementation NSTimeZone {
     icu::TimeZone* _icuTZ;
 }
@@ -154,6 +182,17 @@ const static int c_minutesToMilliseconds = -60000;
 
 - (icu::TimeZone*)_createICUTimeZone {
     return _icuTZ->clone();
+}
+
+/**
+ @Status Interoperable
+ @Get the time zone data version from ICU. The return value is NSString and based on ICU version.
+*/
++ (NSString*)timeZoneDataVersion {
+    UErrorCode errorCode = U_ZERO_ERROR;
+    const char* tzDataVersion = icu::TimeZone::getTZDataVersion(errorCode);
+    NSString* ret = [NSString stringWithUTF8String:tzDataVersion];
+    return ret;
 }
 
 /**
@@ -384,9 +423,18 @@ const static int c_minutesToMilliseconds = -60000;
 /**
  @Status Stub
 */
-- (NSString*)localizedName:(NSTimeZoneNameStyle)name locale:(NSLocale*)locale {
-    UNIMPLEMENTED();
-    return [self description];
+- (NSString*)localizedName:(NSTimeZoneNameStyle)style locale:(NSLocale*)locale {
+    UBool daylight = TRUE;
+    icu::TimeZone::EDisplayType type = _convertNSTimeZoneNameStyleToICUEDisplayType(&style, daylight);
+
+    NSString* identifier = [locale localeIdentifier];
+    icu::Locale icuLocale = icu::Locale::createFromName([identifier UTF8String]);
+
+    icu_48::UnicodeString ret;
+
+    _icuTZ->getDisplayName(daylight, type, icuLocale, ret);
+
+    return NSStringFromICU(ret);
 }
 
 /**

--- a/include/Foundation/NSTimeZone.h
+++ b/include/Foundation/NSTimeZone.h
@@ -1,5 +1,7 @@
 /* Copyright (c) 2006-2007 Christopher J. W. Lloyd
 
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish,
 distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
@@ -12,12 +14,35 @@ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVE
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
 #import <Foundation/NSObject.h>
 #import <Foundation/NSDate.h>
 
 @class NSArray, NSDate, NSData, NSDictionary, NSLocale, NSString, NSMutableArray;
 
-typedef NSInteger NSTimeZoneNameStyle;
+typedef NS_ENUM(NSInteger, NSTimeZoneNameStyle) {
+    NSTimeZoneNameStyleStandard,
+    NSTimeZoneNameStyleShortStandard,
+    NSTimeZoneNameStyleDaylightSaving,
+    NSTimeZoneNameStyleShortDaylightSaving,
+    NSTimeZoneNameStyleGeneric,
+    NSTimeZoneNameStyleShortGeneric
+};
 
 FOUNDATION_EXPORT NSString* const NSSystemTimeZoneDidChangeNotification;
 
@@ -27,6 +52,7 @@ FOUNDATION_EXPORT_CLASS
 + (NSTimeZone*)localTimeZone;
 + (NSTimeZone*)systemTimeZone;
 + (NSTimeZone*)defaultTimeZone;
++ (NSString*)timeZoneDataVersion;
 
 + (void)resetSystemTimeZone;
 

--- a/tests/unittests/Foundation/NSTimeZoneTests.m
+++ b/tests/unittests/Foundation/NSTimeZoneTests.m
@@ -97,4 +97,38 @@ TEST(Foundation, NSTimeZone) {
     NSArray* knownTimeZoneNames = [NSTimeZone knownTimeZoneNames];
     ASSERT_TRUE_MSG([knownTimeZoneNames count] == 168,
                     "FAILED - [NSTimeZone knownTimeZoneNames] != 168. There should be exactly 168 time zones in ICU. Was ICU updated?");
+
+    // Test for method timeZoneDataVersion. The value is based on the ICU version.
+    NSString* timeZoneDataVersion = [NSTimeZone timeZoneDataVersion];
+    ASSERT_OBJCEQ_MSG(@"2011k",
+                      timeZoneDataVersion,
+                      "FAILED - [NSTimeZone timeZoneDataVersion] != 2011k. The version should be 2011k. Was ICU updated?");
+
+    // Verify localizedName
+    NSTimeZone* aDSTTz = [NSTimeZone timeZoneWithName:@"Pacific/Auckland"];
+    NSString* tzNameStandard = [aDSTTz localizedName:NSTimeZoneNameStyleStandard locale:[NSLocale localeWithLocaleIdentifier:@"en-GB"]];
+    ASSERT_OBJCEQ_MSG(@"New Zealand Standard Time",
+                      tzNameStandard,
+                      "FAILED - localizedName of NSTimeZoneNameStyleStandard is not correct.");
+
+    NSString* tzNameShortStandard =
+        [aDSTTz localizedName:NSTimeZoneNameStyleShortStandard locale:[NSLocale localeWithLocaleIdentifier:@"en-GB"]];
+    ASSERT_OBJCEQ_MSG(@"+1200", tzNameShortStandard, "FAILED - localizedName of NSTimeZoneNameStyleShortStandard is not correct.");
+
+    NSString* tzNameGeneric = [aDSTTz localizedName:NSTimeZoneNameStyleGeneric locale:[NSLocale localeWithLocaleIdentifier:@"en-GB"]];
+    ASSERT_OBJCEQ_MSG(@"New Zealand Time", tzNameGeneric, "FAILED - localizedName of NSTimeZoneNameStyleGeneric is not correct.");
+
+    NSString* tzNameShortGeneric =
+        [aDSTTz localizedName:NSTimeZoneNameStyleShortGeneric locale:[NSLocale localeWithLocaleIdentifier:@"en-GB"]];
+    ASSERT_OBJCEQ_MSG(@"New Zealand Time", tzNameShortGeneric, "FAILED - localizedName of NSTimeZoneNameStyleShortGeneric is not correct.");
+
+    NSString* tzNameDaylight =
+        [aDSTTz localizedName:NSTimeZoneNameStyleDaylightSaving locale:[NSLocale localeWithLocaleIdentifier:@"en-GB"]];
+    ASSERT_OBJCEQ_MSG(@"New Zealand Daylight Time",
+                      tzNameDaylight,
+                      "FAILED - localizedName of NSTimeZoneNameStyleDaylightSaving is not correct.");
+
+    NSString* tzNameShortDaylight =
+        [aDSTTz localizedName:NSTimeZoneNameStyleShortDaylightSaving locale:[NSLocale localeWithLocaleIdentifier:@"en-GB"]];
+    ASSERT_OBJCEQ_MSG(@"+1300", tzNameShortDaylight, "FAILED - localizedName of NSTimeZoneNameStyleShortDaylightSaving is not correct.");
 }


### PR DESCRIPTION
Change Description:
Get the localizedName and timeZoneDavaversion from ICU library. 
Method localizedName is based on getDisplayName in ICU library. The output result of different style are same with IOS API except NSTimeZoneNameStyleShortStandard and NSTimeZoneNameStyleShortDaylightSaving. For these two, IOS outputs the format "GMT+12" while ICU outputs "+1200".
Method timeZoneDataVersion is based on getTZDataVersion from ICU library.

How verified:
Add unittests about new methods.
Run the new tests successful.