### PR TITLE
Fixed compile issue in CommonHMAC.h

### DIFF
--- a/include/CommonCrypto/CommonHMAC.h
+++ b/include/CommonCrypto/CommonHMAC.h
@@ -28,7 +28,7 @@ enum {
 };
 
 struct CC_Hmac_State;
-typedef CC_Hmac_State* CCHmacContext;
+typedef struct CC_Hmac_State* CCHmacContext;
 typedef int32_t CCHmacAlgorithm;
 
 SB_EXTERNC_BEGIN


### PR DESCRIPTION
Fixes the following compile error when importing `CommonCrypto/CommonHMAC.h`:

> error: must use 'struct' tag to refer to type 'CC_Hmac_State'