### PR TITLE
WOCOperationMode should change UIUserInterfaceIdiom. Support UIModalPresentationFormSheet on tablets (non-fullscreen presentation)

### DIFF
--- a/Frameworks/StarboardXaml/ApplicationMain.mm
+++ b/Frameworks/StarboardXaml/ApplicationMain.mm
@@ -39,26 +39,6 @@ void SetCACompositorClient(CACompositorClientInterface* client) {
     _compositorClient = client;
 }
 
-struct ApplicationProperties {
-    float width;
-    float height;
-    float scale;
-    std::string name;
-    bool isTablet;
-    bool isLandscape;
-};
-
-ApplicationProperties g_applicationProperties;
-
-std::string GetAppNameFromPList() {
-    NSString* appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
-    if (appName != nil) {
-        return [appName UTF8String];
-    }
-
-    return "Starboard";
-}
-
 int ApplicationMainStart(
     int argc, char* argv[], const char* principalName, const char* delegateName, float windowWidth, float windowHeight) {
     // Note: We must use nil rather than an empty string for these class names
@@ -67,11 +47,6 @@ int ApplicationMainStart(
 
     WOCDisplayMode* displayMode = [UIApplication displayMode];
     [displayMode _setWindowSize:CGSizeMake(windowWidth, windowHeight)];
-
-    float defaultWidth = GetCACompositor()->screenWidth();
-    float defaultHeight = GetCACompositor()->screenHeight();
-    float defaultScale = GetCACompositor()->screenScale();
-    bool defaultTablet = false;
 
     [NSBundle setMainBundlePath:@"."];
 
@@ -124,14 +99,7 @@ int ApplicationMainStart(
         [UIApplication setStartupDisplayMode:displayMode];
     }
 
-    g_applicationProperties.width = defaultWidth;
-    g_applicationProperties.height = defaultHeight;
-    g_applicationProperties.scale = defaultScale;
-    g_applicationProperties.name = GetAppNameFromPList();
-    g_applicationProperties.isTablet = defaultTablet;
-
     [displayMode _updateDisplaySettings];
-    GetCACompositor()->setTablet(g_applicationProperties.isTablet);
 
     UIApplicationMainInit(argc, argv, principalClassName, delegateClassName, defaultOrientation);
     return UIApplicationMainLoop();

--- a/Frameworks/UIKit/UIApplication.mm
+++ b/Frameworks/UIKit/UIApplication.mm
@@ -2578,6 +2578,7 @@ void UIShutdown() {
             break;
     }
 
+    GetCACompositor()->setTablet(_operationMode == WOCOperationModeTablet);
     GetCACompositor()->setScreenSize(newWidth, newHeight, newMagnification, newRotation);
     GetCACompositor()->setDeviceSize(newWidth, newHeight);
 

--- a/samples/WOCCatalog/WOCCatalog/DisplayModeViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/DisplayModeViewController.m
@@ -37,6 +37,11 @@
     [UIApplication.displayMode updateDisplaySettings];
 }
 
+- (void)toggleTabletMode:(UISwitch*)sender {
+    UIApplication.displayMode.operationMode = sender.on ? WOCOperationModeTablet : WOCOperationModePhone;
+    [UIApplication.displayMode updateDisplaySettings];
+}
+
 - (void)toggleScreenAwake:(UISwitch*)sender {
     [[UIApplication sharedApplication] setIdleTimerDisabled:sender.on];
 }
@@ -260,6 +265,15 @@
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"MenuCell"];
     cell.accessoryView = enableScreenAwake;
     cell.textLabel.text = @"Disable idle screen timer";
+    [self.rows addObject:cell];
+
+    UISwitch* enableTabletMode = [UISwitch new];
+    enableTabletMode.on = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;
+    [enableTabletMode addTarget:self action:@selector(toggleTabletMode:) forControlEvents:UIControlEventValueChanged];
+
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"MenuCell"];
+    cell.accessoryView = enableTabletMode;
+    cell.textLabel.text = @"Tablet Mode";
     [self.rows addObject:cell];
 
     fixedWidth = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 100, 20)];

--- a/samples/WOCCatalog/WOCCatalog/PopoverViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/PopoverViewController.m
@@ -72,10 +72,12 @@
     scrollView.maximumZoomScale = 1.;
     scrollView.minimumZoomScale = minimumScale;
     scrollView.zoomScale = minimumScale;
+
+    imageView.center = CGPointMake(scrollView.contentSize.width * 0.5, scrollView.contentSize.height * 0.5);
 }
 
 - (void)createLayout {
-    [scrollView setBackgroundColor:[UIColor whiteColor]];
+    [scrollView setBackgroundColor:[UIColor lightGrayColor]];
 }
 
 - (void)scrollViewDidZoom:(UIScrollView*)aScrollView {


### PR DESCRIPTION
Also adds examples to WOCCatalog app including resizing modal via
preferredContentSize and toggling tablet mode at runtime.

-----

First, sorry for going AWOL on the last patch!

A couple of things:
This patch doesn't address blocking touches on the parent's view (doesn't even set userInteractionEnabled = FALSE). I'm thinking that should be handled by a dummy full screen view underneath the modal - the same view could be used for the gray overlay applied to the parent's view when using a popover.

I require iPad style form sheet modals and popovers in my app. Are there any unreleased changes regarding popover support pending? I'm thinking popover support is not that bad e.g. not all that different from form sheet (I believe on iOS form sheet modals and popovers are presented in separate UIWindows which apparently doesn't need to be the case here). So the positioning logic for popovers would be similar (though ideally not embedded into UIViewController.mm also!). Popovers would also require the same "if not iPad use full screen" logic.
