### PR TITLE
Fix overrelease of dismiss completion block in UIViewController.mm

### DIFF
--- a/Frameworks/UIKit/UIViewController.mm
+++ b/Frameworks/UIKit/UIViewController.mm
@@ -1116,7 +1116,6 @@ UIInterfaceOrientation supportedOrientationForOrientation(UIViewController* cont
 
     if (priv->_dismissCompletionBlock) {
         priv->_dismissCompletionBlock();
-        [priv->_dismissCompletionBlock release];
         priv->_dismissCompletionBlock = nil;
     }
 


### PR DESCRIPTION
Now get a decent stack for a crash with my app pointing to this (and looking at SmartTypes.h idretainp has the same releasing semantics as idretaintype)