### PR TITLE
Added implementation for -setValuesForKeysWithDictionary:

### DIFF
--- a/Frameworks/Foundation/NSKeyValueCoding.mm
+++ b/Frameworks/Foundation/NSKeyValueCoding.mm
@@ -429,6 +429,19 @@ bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value) {
 }
 
 /**
+ @Status Interoperable
+*/
+- (void)setValuesForKeysWithDictionary:(NSDictionary*)keyedValues {
+    for (NSString *key in keyedValues) {
+        id value = [keyedValues objectForKey:key];
+        if (value == [NSNull null]) {
+            value = nil;
+        }
+        [self setValue:value forKey:key];
+    }
+}
+
+/**
  @Status Stub
  @Notes
 */
@@ -471,14 +484,6 @@ bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value) {
 - (NSMutableOrderedSet*)mutableOrderedSetValueForKeyPath:(NSString*)keyPath {
     UNIMPLEMENTED();
     return StubReturn();
-}
-
-/**
- @Status Stub
- @Notes
-*/
-- (void)setValuesForKeysWithDictionary:(NSDictionary*)keyedValues {
-    UNIMPLEMENTED();
 }
 
 /**

--- a/include/Foundation/NSKeyValueCoding.h
+++ b/include/Foundation/NSKeyValueCoding.h
@@ -53,7 +53,7 @@ FOUNDATION_EXPORT NSString* const NSUnionOfSetsKeyValueOperator;
 - (NSMutableOrderedSet*)mutableOrderedSetValueForKey:(NSString*)key STUB_METHOD;
 - (NSMutableOrderedSet*)mutableOrderedSetValueForKeyPath:(NSString*)keyPath STUB_METHOD;
 - (void)setValue:(id)value forKeyPath:(NSString*)keyPath;
-- (void)setValuesForKeysWithDictionary:(NSDictionary*)keyedValues STUB_METHOD;
+- (void)setValuesForKeysWithDictionary:(NSDictionary*)keyedValues;
 - (void)setNilValueForKey:(NSString*)key STUB_METHOD;
 - (void)setValue:(id)value forKey:(NSString*)key;
 - (void)setValue:(id)value forUndefinedKey:(NSString*)key;

--- a/tests/unittests/Foundation/NSObject_NSKeyValueArrayAdaptersTests.mm
+++ b/tests/unittests/Foundation/NSObject_NSKeyValueArrayAdaptersTests.mm
@@ -144,3 +144,21 @@ TEST(Foundation, NSObject_KVCArrayAutovivification) {
     EXPECT_EQ(1, [[dictionary objectForKey:@"new"] count]);
     EXPECT_OBJCEQ(@"Hello", [[dictionary objectForKey:@"new"] firstObject]);
 }
+
+@interface TestKVCObject : NSObject
+@property (nonatomic, retain) id key1;
+@property (nonatomic, retain) id key2;
+@end
+
+@implementation TestKVCObject
+@end
+
+TEST(Foundation, NSObject_KVCSetValuesForKeysWithDictionary) {
+    TestKVCObject* testObject = [[[TestKVCObject alloc] init] autorelease];
+    testObject.key2 = @"key2Value";
+    NSDictionary* dictionary = @{ @"key1" : @"key1Value", @"key2": [NSNull null] };
+
+    EXPECT_NO_THROW([testObject setValuesForKeysWithDictionary:dictionary]);
+    EXPECT_OBJCEQ(@"key1Value", testObject.key1);
+    EXPECT_EQ(nil, testObject.key2);
+}


### PR DESCRIPTION
Should match reference platform documentation:

> The default implementation invokes setValue:forKey: for each key-value pair, substituting nil for NSNull values in keyedValues.
