### PR TITLE
Fix ~ipad specific bundle loading

### DIFF
--- a/Frameworks/Foundation/NSBundle.mm
+++ b/Frameworks/Foundation/NSBundle.mm
@@ -245,11 +245,11 @@ bool ScanFilename(BundleFile* dest, char* pDirectory, char* pFilename) {
         }
         dest->pszPlatform = copyWithoutExtension("~iphone", "");
         szTemp[strlen(szTemp) - 7] = 0;
-    } else if (hasExtension(szTemp, "~iPad")) {
+    } else if (hasExtension(szTemp, "~ipad")) {
         if (!isTabletDevice()) {
             return false;
         }
-        dest->pszPlatform = copyWithoutExtension("~iPad", "");
+        dest->pszPlatform = copyWithoutExtension("~ipad", "");
         szTemp[strlen(szTemp) - 5] = 0;
     }
 
@@ -867,9 +867,9 @@ static NSString* makePath(NSBundle* self,
             memmove(pPos, pPos + 7, strlen(pPos + 7) + 1);
         }
     } else {
-        if (strstr(szPath, "~iPad") != NULL) {
-            char* pPos = strstr(szPath, "~iPad");
-            memmove(pPos, pPos + 4, strlen(pPos + 4) + 1);
+        if (strstr(szPath, "~ipad") != NULL) {
+            char* pPos = strstr(szPath, "~ipad");
+            memmove(pPos, pPos + 5, strlen(pPos + 5) + 1);
         }
     }
 
@@ -907,7 +907,7 @@ static NSString* checkPath(
         if (!isTabletDevice()) {
             ret = makePath(self, name, extension, directory, localization, sublocal, @"~iphone");
         } else {
-            ret = makePath(self, name, extension, directory, localization, sublocal, @"~iPad");
+            ret = makePath(self, name, extension, directory, localization, sublocal, @"~ipad");
         }
 
         path = (char*)[ret UTF8String];

--- a/Frameworks/StarboardXaml/ApplicationMain.mm
+++ b/Frameworks/StarboardXaml/ApplicationMain.mm
@@ -48,6 +48,11 @@ int ApplicationMainStart(
     WOCDisplayMode* displayMode = [UIApplication displayMode];
     [displayMode _setWindowSize:CGSizeMake(windowWidth, windowHeight)];
 
+    if ([UIApplication respondsToSelector:@selector(setStartupDisplayMode:)]) {
+        [UIApplication setStartupDisplayMode:displayMode];
+        [displayMode _updateDisplaySettings];
+    }
+
     [NSBundle setMainBundlePath:@"."];
 
     NSDictionary* infoDict = [[NSBundle mainBundle] infoDictionary];
@@ -94,10 +99,6 @@ int ApplicationMainStart(
         displayMode.presentationTransform = defaultOrientation;
     }
 #endif
-
-    if ([UIApplication respondsToSelector:@selector(setStartupDisplayMode:)]) {
-        [UIApplication setStartupDisplayMode:displayMode];
-    }
 
     [displayMode _updateDisplaySettings];
 


### PR DESCRIPTION
~ipad should be lower case. Also fixes setStartupDisplayMode: called too late (tablet mode must be configured to load ~ipad resources).

----------

Note that reloading the main bundle in response to changing tablet mode after startup isn't supported.