### PR TITLE
Updated NSInvocation to handle up to 8 method parameters

### DIFF
--- a/Frameworks/Foundation/NSInvocation.mm
+++ b/Frameworks/Foundation/NSInvocation.mm
@@ -433,6 +433,24 @@ static uniformAggregate<UniformType> callUniformAggregateImp(IMP imp, id target,
                     *((unsigned*)returnValue) = retVal;
                 } break;
 
+                case 9: {
+                    unsigned retVal;
+
+                    retVal = imp(
+                        target, (SEL)sel, stackParams[2], stackParams[3], stackParams[4], stackParams[5], stackParams[6], stackParams[7], stackParams[8]);
+                    returnValue = IwMalloc(returnSize + 4);
+                    *((unsigned*)returnValue) = retVal;
+                } break;
+
+                case 10: {
+                    unsigned retVal;
+
+                    retVal = imp(
+                        target, (SEL)sel, stackParams[2], stackParams[3], stackParams[4], stackParams[5], stackParams[6], stackParams[7], stackParams[8], stackParams[9]);
+                    returnValue = IwMalloc(returnSize + 4);
+                    *((unsigned*)returnValue) = retVal;
+                } break;
+
                 default:
                     FAIL_FAST_HR_MSG(E_UNEXPECTED, "Unhandled # of args: %d", stackParamsLen);
                     break;


### PR DESCRIPTION
Previously this was limited to 6 parameters.

While this should probably be rewritten to support an arbitrary number of parameters, this update should cover some more extreme cases and allows us to use NSInvocation for our specific use case. :)