### PR TITLE
UITextField setText: should move caret position of underlying TextBox to end.

### DIFF
--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -100,6 +100,10 @@ NSString* const UITextFieldTextDidEndEditingNotification = @"UITextFieldTextDidE
             _passwordBox.password = _text;
         } else {
             _textBox.text = _text;
+            // Ensure caret at end of field in case we programmatically
+            // gain focus (becomeFirstResponder) after the text is set:
+            _textBox.selectionStart = [_text length];
+            _textBox.selectionLength = 0;
         }
         [_secureModeLock unlock];
     }


### PR DESCRIPTION
Ensures caret position is correct if we programmatically gain focus (becomeFirstResponder).

-------------

I'm in a situation where I have certain elements e.g. tableviewcells which, when tapped, programmatically set focus on a text field in the element (so that it's easier to bring the keyboard up without having to touch on exactly the bounds of the text field). There could also be situations where e.g. actual touches on a UITextField are blocked by another transparent UIView covering the field - with actual beginning editing of the covered UITextField handled by |becomeFirstResponder|. 

This change ensures that in the above scenarios the caret is not at the beginning of the textfield's text.  