### PR TITLE
Implemented CGPathApply.

### DIFF
--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -455,14 +455,12 @@ void CGPathAddPath(CGMutablePathRef path, const CGAffineTransform* m, CGPathRef 
     }
 }
 
-
 /**
  @Status Interoperable
 */
 void CGPathAddEllipseInRect(CGMutablePathRef path, const CGAffineTransform* m, CGRect rect) {
+    CGFloat offsetMultiplier = _CGPathControlPointOffsetMultiplier(M_PI_2);
 
-	CGFloat offsetMultiplier = _CGPathControlPointOffsetMultiplier(M_PI_2);// (4.0/3.0)*tan(M_PI/8.0);
-    
     CGFloat xControlPointOffset = offsetMultiplier * CGRectGetWidth(rect)/2.0;
     CGFloat yControlPointOffset = offsetMultiplier * CGRectGetHeight(rect)/2.0;
     

--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -14,14 +14,14 @@
 //
 //******************************************************************************
 
-#import <StubReturn.h>
-#import <Starboard.h>
-#import <algorithm>
-#import <vector>
-#import <CoreGraphics/CGContext.h>
-#import <CoreGraphics/CGGeometry.h>
 #import "CGPathInternal.h"
 #include "LoggingNative.h"
+#import <CoreGraphics/CGContext.h>
+#import <CoreGraphics/CGGeometry.h>
+#import <Starboard.h>
+#import <StubReturn.h>
+#import <algorithm>
+#import <vector>
 
 static const wchar_t* TAG = L"CGPath";
 
@@ -72,7 +72,6 @@ __CGPath::~__CGPath() {
 void __CGPath::_applyPath(CGContextRef context) {
     for (unsigned i = 0; i < _count; i++) {
         switch (_components[i].type) {
-
             case kCGPathElementMoveToPoint:
                 TraceVerbose(TAG, L"Move to %d, %d", (int)_components[i].points[0].x, (int)_components[i].points[0].y);
                 CGContextMoveToPoint(context, _components[i].points[0].x, _components[i].points[0].y);
@@ -94,7 +93,7 @@ void __CGPath::_applyPath(CGContextRef context) {
                 break;
 
             case kCGPathElementAddQuadCurveToPoint:
-                 CGContextAddQuadCurveToPoint(context,
+                CGContextAddQuadCurveToPoint(context,
                                              _components[i].points[0].x,
                                              _components[i].points[0].y,
                                              _components[i].points[1].x,
@@ -207,34 +206,25 @@ void CGPathAddLineToPoint(CGMutablePathRef path, const CGAffineTransform* m, flo
     }
 
     pathObj->_components[pathObj->_count].type = kCGPathElementAddLineToPoint;
-    
+
     pathObj->_components[pathObj->_count].points = (CGPoint*)IwCalloc(1, sizeof(CGPoint));
-    pathObj->_components[pathObj->_count].points[0] = {x, y};
+    pathObj->_components[pathObj->_count].points[0] = { x, y };
 
     pathObj->_count++;
 }
 
-CGFloat _CGPathControlPointOffsetMultiplier(CGFloat angle){
-    return ( 4.0 / 3.0 ) * tan( angle / 4.0 );
+CGFloat _CGPathControlPointOffsetMultiplier(CGFloat angle) {
+    return (4.0f / 3.0f) * tan(angle / 4.0f);
 }
-
 
 /**
  @Status Caveat
  @Notes transform property not supported
 */
-void CGPathAddArcToPoint(CGMutablePathRef path, 
-                         const CGAffineTransform* m,
-                         float x1, 
-                         float y1, 
-                         float x2, 
-                         float y2, 
-                         float radius) {
-
-
+void CGPathAddArcToPoint(CGMutablePathRef path, const CGAffineTransform* m, float x1, float y1, float x2, float y2, float radius) {
     bool isEmpty = CGPathIsEmpty(path);
 
-    if( isEmpty ){
+    if (isEmpty) {
         return;
     }
 
@@ -275,45 +265,42 @@ void CGPathAddArcToPoint(CGMutablePathRef path,
         n2y = dx2 / xl2;
     }
     t = (dx2 * n2y - dx2 * n0y - dy2 * n2x + dy2 * n0x) / san;
-    CGPathAddArc(	path,
-                    m,
-                    (float)(x1 + radius * (t * dx0 + n0x)),
-                    (float)(y1 + radius * (t * dy0 + n0y)),
-                    radius,
-                    (float)atan2(-n0y, -n0x),
-                    (float)atan2(-n2y, -n2x),
-                    (san < 0));
-
+    CGPathAddArc(path,
+                 m,
+                 (float)(x1 + radius * (t * dx0 + n0x)),
+                 (float)(y1 + radius * (t * dy0 + n0y)),
+                 radius,
+                 (float)atan2(-n0y, -n0x),
+                 (float)atan2(-n2y, -n2x),
+                 (san < 0));
 }
 
 void _CGPathAddArc(CGMutablePathRef path,
-                  const CGAffineTransform* m,
-                  CGFloat x,
-                  CGFloat y,
-                  CGFloat radius,
-                  CGFloat startAngle,
-                  CGFloat endAngle,
-                  bool clockwise) {
-        
+                   const CGAffineTransform* m,
+                   CGFloat x,
+                   CGFloat y,
+                   CGFloat radius,
+                   CGFloat startAngle,
+                   CGFloat endAngle,
+                   bool clockwise) {
     CGFloat delta = endAngle - startAngle;
-    
-   if ( (fabs(delta) > M_PI_2) && (fabs((M_PI_2 - fabs(delta))) > 0.0001)){
-        
-        CGFloat midAngle = startAngle + (M_PI_2 * (delta < 0 ? -1.0 : 1.0));
+
+    if ((fabs(delta) > M_PI_2) && (fabs((M_PI_2 - fabs(delta))) > 0.00001f)) {
+        CGFloat midAngle = startAngle + (M_PI_2 * (delta < 0 ? -1.0f : 1.0f));
 
         _CGPathAddArc(path, m, x, y, radius, startAngle, midAngle, clockwise);
         _CGPathAddArc(path, m, x, y, radius, midAngle, endAngle, clockwise);
         return;
     }
-    
-    CGPoint arcStartRelative = CGPointMake( (cos(startAngle) * radius), (sin(startAngle) * radius));
-    CGPoint arcEndRelative = CGPointMake( (cos(endAngle) * radius), (sin(endAngle) * radius));
-    
+
+    CGPoint arcStartRelative = CGPointMake((cos(startAngle) * radius), (sin(startAngle) * radius));
+    CGPoint arcEndRelative = CGPointMake((cos(endAngle) * radius), (sin(endAngle) * radius));
+
     CGPoint arcStart = CGPointMake(arcStartRelative.x + x, arcStartRelative.y + y);
     CGPoint arcEnd = CGPointMake(arcEndRelative.x + x, arcEndRelative.y + y);
-    
+
     CGFloat offsetMultiplier = _CGPathControlPointOffsetMultiplier(delta);
-    
+
     CGPathAddCurveToPoint(path,
                           m,
                           arcStart.x - (offsetMultiplier * arcStartRelative.y),
@@ -323,7 +310,6 @@ void _CGPathAddArc(CGMutablePathRef path,
                           arcEnd.x,
                           arcEnd.y);
 }
-
 
 /**
  @Status Interoperable
@@ -336,35 +322,32 @@ void CGPathAddArc(CGMutablePathRef path,
                   CGFloat startAngle,
                   CGFloat endAngle,
                   bool clockwise) {
-                
-                 
-    startAngle = fmod(startAngle, 2.0 * M_PI);
-    if(startAngle < 0){
+    startAngle = fmod(startAngle, 2.0f * M_PI);
+    if (startAngle < 0.0f) {
         startAngle += 2.0f * M_PI;
     }
-    
-    endAngle = fmod(endAngle, 2.0 * M_PI);
-    if(endAngle < 0){
+
+    endAngle = fmod(endAngle, 2.0f * M_PI);
+    if (endAngle < 0.0f) {
         endAngle += 2.0f * M_PI;
     }
-    
+
     CGPoint arcStart = CGPointMake((cos(startAngle) * radius) + x, (sin(startAngle) * radius) + y);
-    
-    if (!CGPathIsEmpty(path)){
+
+    if (!CGPathIsEmpty(path)) {
         CGPathAddLineToPoint(path, m, arcStart.x, arcStart.y);
-    }else{
+    } else {
         CGPathMoveToPoint(path, m, arcStart.x, arcStart.y);
     }
 
-    if(clockwise && endAngle > startAngle){
-        startAngle+= 2 * M_PI;
-    }else if(!clockwise && startAngle > endAngle){
-        endAngle += 2 * M_PI;
+    if (clockwise && endAngle > startAngle) {
+        startAngle += 2.0f * M_PI;
+    } else if (!clockwise && startAngle > endAngle) {
+        endAngle += 2.0f * M_PI;
     }
 
     _CGPathAddArc(path, m, x, y, radius, startAngle, endAngle, clockwise);
 }
-
 
 /**
  @Status Interoperable
@@ -391,7 +374,7 @@ void CGPathMoveToPoint(CGMutablePathRef path, const CGAffineTransform* m, float 
 
     pathObj->_components[pathObj->_count].type = kCGPathElementMoveToPoint;
     pathObj->_components[pathObj->_count].points = (CGPoint*)IwCalloc(1, sizeof(CGPoint));
-    pathObj->_components[pathObj->_count].points[0] = {x, y};
+    pathObj->_components[pathObj->_count].points[0] = { x, y };
 
     pathObj->_count++;
 }
@@ -414,13 +397,12 @@ void CGPathAddLines(CGMutablePathRef path, const CGAffineTransform* m, CGPoint* 
  @Status Interoperable
 */
 void CGPathAddRect(CGMutablePathRef path, const CGAffineTransform* m, CGRect rect) {
-
     CGPathMoveToPoint(path, m, CGRectGetMinX(rect), CGRectGetMinY(rect));
 
     CGPathAddLineToPoint(path, m, CGRectGetMaxX(rect), CGRectGetMinY(rect));
     CGPathAddLineToPoint(path, m, CGRectGetMaxX(rect), CGRectGetMaxY(rect));
     CGPathAddLineToPoint(path, m, CGRectGetMinX(rect), CGRectGetMaxY(rect));
-    CGPathAddLineToPoint(path, m, CGRectGetMinX(rect), CGRectGetMinY(rect));
+    CGPathCloseSubpath(path);
 }
 
 /**
@@ -461,17 +443,17 @@ void CGPathAddPath(CGMutablePathRef path, const CGAffineTransform* m, CGPathRef 
 void CGPathAddEllipseInRect(CGMutablePathRef path, const CGAffineTransform* m, CGRect rect) {
     CGFloat offsetMultiplier = _CGPathControlPointOffsetMultiplier(M_PI_2);
 
-    CGFloat xControlPointOffset = offsetMultiplier * CGRectGetWidth(rect)/2.0;
-    CGFloat yControlPointOffset = offsetMultiplier * CGRectGetHeight(rect)/2.0;
-    
+    CGFloat xControlPointOffset = offsetMultiplier * CGRectGetWidth(rect) / 2.0;
+    CGFloat yControlPointOffset = offsetMultiplier * CGRectGetHeight(rect) / 2.0;
+
     CGFloat minX = CGRectGetMinX(rect);
     CGFloat midX = CGRectGetMidX(rect);
     CGFloat maxX = CGRectGetMaxX(rect);
-    
+
     CGFloat minY = CGRectGetMinY(rect);
     CGFloat midY = CGRectGetMidY(rect);
     CGFloat maxY = CGRectGetMaxY(rect);
-    
+
     CGPathMoveToPoint(path, m, maxX, midY);
 
     CGPathAddCurveToPoint(path, m, maxX, midY + yControlPointOffset, midX + xControlPointOffset, maxY, midX, maxY);
@@ -494,7 +476,7 @@ void CGPathCloseSubpath(CGMutablePathRef path) {
     }
 
     pathObj->_components[pathObj->_count].type = kCGPathElementCloseSubpath;
-    
+
     pathObj->_components[pathObj->_count].points = NULL;
     pathObj->_count++;
 }
@@ -556,7 +538,7 @@ void CGPathAddQuadCurveToPoint(CGMutablePathRef path, const CGAffineTransform* m
     int count = pathObj->_count;
 
     pathObj->_components[count].type = kCGPathElementAddQuadCurveToPoint;
-    
+
     pathObj->_components[count].points = (CGPoint*)IwCalloc(2, sizeof(CGPoint));
     pathObj->_components[pathObj->_count].points[0] = cp;
     pathObj->_components[pathObj->_count].points[1] = p;
@@ -655,13 +637,46 @@ void CGPathAddRoundedRect(
     UNIMPLEMENTED();
 }
 
+int _CGPathPointCountForElementType(CGPathElementType type) {
+    int pointCount = 0;
+
+    switch (type) {
+        case kCGPathElementMoveToPoint:
+        case kCGPathElementAddLineToPoint:
+            pointCount = 1;
+            break;
+        case kCGPathElementAddQuadCurveToPoint:
+            pointCount = 2;
+            break;
+        case kCGPathElementAddCurveToPoint:
+            pointCount = 3;
+            break;
+        case kCGPathElementCloseSubpath:
+            pointCount = 0;
+            break;
+    }
+    return pointCount;
+}
+
 /**
  @Status Interoperable
 */
 void CGPathApply(CGPathRef path, void* info, CGPathApplierFunction function) {
+    if (path == NULL) {
+        return;
+    }
+
     for (unsigned i = 0; i < path->_count; i++) {
-        CGPathElement c = path->_components[i];
-        function(info, &c);
+        CGPathElement element = path->_components[i];
+        CGPathElement returnElement;
+        returnElement.type = element.type;
+        int pointCount = _CGPathPointCountForElementType(element.type);
+        returnElement.points = (CGPoint*)IwCalloc(pointCount, sizeof(CGPoint));
+        memcpy(returnElement.points, element.points, pointCount * sizeof(CGPoint));
+        function(info, &returnElement);
+        if (returnElement.points) {
+            IwFree(returnElement.points);
+        }
     }
 }
 
@@ -734,10 +749,9 @@ bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2) {
  @Status Interoperable
 */
 CGPoint CGPathGetCurrentPoint(CGPathRef path) {
-    
-    if (path->_count > 0){
-         CGPathElement c = path->_components[path->_count-1];
-         switch(c.type){
+    if (path->_count > 0) {
+        CGPathElement c = path->_components[path->_count - 1];
+        switch (c.type) {
             case kCGPathElementMoveToPoint:
             case kCGPathElementAddLineToPoint:
                 return c.points[0];
@@ -747,7 +761,7 @@ CGPoint CGPathGetCurrentPoint(CGPathRef path) {
                 return c.points[2];
             default:
                 return CGPointZero;
-         }
+        }
     }
 
     return CGPointZero;

--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -64,7 +64,7 @@ __CGPath::~__CGPath() {
             if (points) {
                 IwFree(points);
             }
-		}
+        }
         IwFree(_components);
     }
 }
@@ -94,7 +94,7 @@ void __CGPath::_applyPath(CGContextRef context) {
                 break;
 
             case kCGPathElementAddQuadCurveToPoint:
-				 CGContextAddQuadCurveToPoint(context,
+                 CGContextAddQuadCurveToPoint(context,
                                              _components[i].points[0].x,
                                              _components[i].points[0].y,
                                              _components[i].points[1].x,
@@ -207,15 +207,15 @@ void CGPathAddLineToPoint(CGMutablePathRef path, const CGAffineTransform* m, flo
     }
 
     pathObj->_components[pathObj->_count].type = kCGPathElementAddLineToPoint;
-	
-	pathObj->_components[pathObj->_count].points = (CGPoint*)IwCalloc(1, sizeof(CGPoint));
-	pathObj->_components[pathObj->_count].points[0] = {x, y};
+    
+    pathObj->_components[pathObj->_count].points = (CGPoint*)IwCalloc(1, sizeof(CGPoint));
+    pathObj->_components[pathObj->_count].points[0] = {x, y};
 
     pathObj->_count++;
 }
 
 CGFloat _CGPathControlPointOffsetMultiplier(CGFloat angle){
-	return ( 4.0 / 3.0 ) * tan( angle / 4.0 );
+    return ( 4.0 / 3.0 ) * tan( angle / 4.0 );
 }
 
 
@@ -224,19 +224,19 @@ CGFloat _CGPathControlPointOffsetMultiplier(CGFloat angle){
  @Notes transform property not supported
 */
 void CGPathAddArcToPoint(CGMutablePathRef path, 
-						 const CGAffineTransform* m,
-						 float x1, 
-						 float y1, 
-						 float x2, 
-						 float y2, 
-						 float radius) {
+                         const CGAffineTransform* m,
+                         float x1, 
+                         float y1, 
+                         float x2, 
+                         float y2, 
+                         float radius) {
 
 
-	bool isEmpty = CGPathIsEmpty(path);
+    bool isEmpty = CGPathIsEmpty(path);
 
-	if( isEmpty ){
-		return;
-	}
+    if( isEmpty ){
+        return;
+    }
 
     CGPoint curPathPosition = CGPathGetCurrentPoint(path);
 
@@ -276,8 +276,8 @@ void CGPathAddArcToPoint(CGMutablePathRef path,
     }
     t = (dx2 * n2y - dx2 * n0y - dy2 * n2x + dy2 * n0x) / san;
     CGPathAddArc(	path,
-					m,
-					(float)(x1 + radius * (t * dx0 + n0x)),
+                    m,
+                    (float)(x1 + radius * (t * dx0 + n0x)),
                     (float)(y1 + radius * (t * dy0 + n0y)),
                     radius,
                     (float)atan2(-n0y, -n0x),
@@ -294,7 +294,7 @@ void _CGPathAddArc(CGMutablePathRef path,
                   CGFloat startAngle,
                   CGFloat endAngle,
                   bool clockwise) {
-		
+        
     CGFloat delta = endAngle - startAngle;
     
    if ( (fabs(delta) > M_PI_2) && (fabs((M_PI_2 - fabs(delta))) > 0.0001)){
@@ -314,14 +314,14 @@ void _CGPathAddArc(CGMutablePathRef path,
     
     CGFloat offsetMultiplier = _CGPathControlPointOffsetMultiplier(delta);
     
-	CGPathAddCurveToPoint(path,
-						  m,
-						  arcStart.x - (offsetMultiplier * arcStartRelative.y),
-						  arcStart.y + (offsetMultiplier * arcStartRelative.x),
-						  arcEnd.x + (offsetMultiplier * arcEndRelative.y),
-						  arcEnd.y - (offsetMultiplier * arcEndRelative.x),
-						  arcEnd.x,
-						  arcEnd.y);
+    CGPathAddCurveToPoint(path,
+                          m,
+                          arcStart.x - (offsetMultiplier * arcStartRelative.y),
+                          arcStart.y + (offsetMultiplier * arcStartRelative.x),
+                          arcEnd.x + (offsetMultiplier * arcEndRelative.y),
+                          arcEnd.y - (offsetMultiplier * arcEndRelative.x),
+                          arcEnd.x,
+                          arcEnd.y);
 }
 
 
@@ -336,33 +336,33 @@ void CGPathAddArc(CGMutablePathRef path,
                   CGFloat startAngle,
                   CGFloat endAngle,
                   bool clockwise) {
-				
-				 
+                
+                 
     startAngle = fmod(startAngle, 2.0 * M_PI);
     if(startAngle < 0){
         startAngle += 2.0f * M_PI;
-	}
+    }
     
     endAngle = fmod(endAngle, 2.0 * M_PI);
     if(endAngle < 0){
         endAngle += 2.0f * M_PI;
-	}
+    }
     
     CGPoint arcStart = CGPointMake((cos(startAngle) * radius) + x, (sin(startAngle) * radius) + y);
     
-	if (!CGPathIsEmpty(path)){
-		CGPathAddLineToPoint(path, m, arcStart.x, arcStart.y);
-	}else{
-		CGPathMoveToPoint(path, m, arcStart.x, arcStart.y);
-	}
+    if (!CGPathIsEmpty(path)){
+        CGPathAddLineToPoint(path, m, arcStart.x, arcStart.y);
+    }else{
+        CGPathMoveToPoint(path, m, arcStart.x, arcStart.y);
+    }
 
     if(clockwise && endAngle > startAngle){
         startAngle+= 2 * M_PI;
     }else if(!clockwise && startAngle > endAngle){
         endAngle += 2 * M_PI;
-	}
+    }
 
-	_CGPathAddArc(path, m, x, y, radius, startAngle, endAngle, clockwise);
+    _CGPathAddArc(path, m, x, y, radius, startAngle, endAngle, clockwise);
 }
 
 
@@ -390,8 +390,8 @@ void CGPathMoveToPoint(CGMutablePathRef path, const CGAffineTransform* m, float 
     }
 
     pathObj->_components[pathObj->_count].type = kCGPathElementMoveToPoint;
-	pathObj->_components[pathObj->_count].points = (CGPoint*)IwCalloc(1, sizeof(CGPoint));
-	pathObj->_components[pathObj->_count].points[0] = {x, y};
+    pathObj->_components[pathObj->_count].points = (CGPoint*)IwCalloc(1, sizeof(CGPoint));
+    pathObj->_components[pathObj->_count].points[0] = {x, y};
 
     pathObj->_count++;
 }
@@ -474,12 +474,12 @@ void CGPathAddEllipseInRect(CGMutablePathRef path, const CGAffineTransform* m, C
     
     CGPathMoveToPoint(path, m, maxX, midY);
 
-	CGPathAddCurveToPoint(path, m, maxX, midY + yControlPointOffset, midX + xControlPointOffset, maxY, midX, maxY);
-	CGPathAddCurveToPoint(path, m, midX - xControlPointOffset, maxY, minX, midY + yControlPointOffset, minX, midY);
-	CGPathAddCurveToPoint(path, m, minX, midY - yControlPointOffset, midX - xControlPointOffset, minY, midX, minY);
-	CGPathAddCurveToPoint(path, m, midX + xControlPointOffset, minY, maxX, midY - yControlPointOffset, maxX, midY);
+    CGPathAddCurveToPoint(path, m, maxX, midY + yControlPointOffset, midX + xControlPointOffset, maxY, midX, maxY);
+    CGPathAddCurveToPoint(path, m, midX - xControlPointOffset, maxY, minX, midY + yControlPointOffset, minX, midY);
+    CGPathAddCurveToPoint(path, m, minX, midY - yControlPointOffset, midX - xControlPointOffset, minY, midX, minY);
+    CGPathAddCurveToPoint(path, m, midX + xControlPointOffset, minY, maxX, midY - yControlPointOffset, maxX, midY);
 
-	CGPathCloseSubpath(path);
+    CGPathCloseSubpath(path);
 }
 
 /**
@@ -494,7 +494,7 @@ void CGPathCloseSubpath(CGMutablePathRef path) {
     }
 
     pathObj->_components[pathObj->_count].type = kCGPathElementCloseSubpath;
-	
+    
     pathObj->_components[pathObj->_count].points = NULL;
     pathObj->_count++;
 }
@@ -556,8 +556,8 @@ void CGPathAddQuadCurveToPoint(CGMutablePathRef path, const CGAffineTransform* m
     int count = pathObj->_count;
 
     pathObj->_components[count].type = kCGPathElementAddQuadCurveToPoint;
-	
-	pathObj->_components[count].points = (CGPoint*)IwCalloc(2, sizeof(CGPoint));
+    
+    pathObj->_components[count].points = (CGPoint*)IwCalloc(2, sizeof(CGPoint));
     pathObj->_components[pathObj->_count].points[0] = cp;
     pathObj->_components[pathObj->_count].points[1] = p;
 
@@ -589,7 +589,7 @@ void CGPathAddCurveToPoint(
     int count = pathObj->_count;
 
     pathObj->_components[count].type = kCGPathElementAddCurveToPoint;
-	pathObj->_components[count].points = (CGPoint*)IwCalloc(3, sizeof(CGPoint));
+    pathObj->_components[count].points = (CGPoint*)IwCalloc(3, sizeof(CGPoint));
     pathObj->_components[count].points[0] = cp1;
     pathObj->_components[count].points[1] = cp2;
     pathObj->_components[count].points[2] = end;
@@ -661,8 +661,8 @@ void CGPathAddRoundedRect(
 void CGPathApply(CGPathRef path, void* info, CGPathApplierFunction function) {
     for (unsigned i = 0; i < path->_count; i++) {
         CGPathElement c = path->_components[i];
-		function(info, &c);
-	}
+        function(info, &c);
+    }
 }
 
 /**
@@ -734,21 +734,21 @@ bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2) {
  @Status Interoperable
 */
 CGPoint CGPathGetCurrentPoint(CGPathRef path) {
-	
-	if (path->_count > 0){
-		 CGPathElement c = path->_components[path->_count-1];
-		 switch(c.type){
-			case kCGPathElementMoveToPoint:
-			case kCGPathElementAddLineToPoint:
-				return c.points[0];
-			case kCGPathElementAddQuadCurveToPoint:
-				return c.points[1];
-			case kCGPathElementAddCurveToPoint:
-				return c.points[2];
-			default:
-				return CGPointZero;
-		 }
-	}
+    
+    if (path->_count > 0){
+         CGPathElement c = path->_components[path->_count-1];
+         switch(c.type){
+            case kCGPathElementMoveToPoint:
+            case kCGPathElementAddLineToPoint:
+                return c.points[0];
+            case kCGPathElementAddQuadCurveToPoint:
+                return c.points[1];
+            case kCGPathElementAddCurveToPoint:
+                return c.points[2];
+            default:
+                return CGPointZero;
+         }
+    }
 
     return CGPointZero;
 }

--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -59,11 +59,11 @@ public:
 
 __CGPath::~__CGPath() {
     if (_components) {
-		for (unsigned i = 0; i < _count; i++) {
-			CGPoint * points = _components[i].points;
-			if( points ){
-				IwFree(points);
-			}
+        for (unsigned i = 0; i < _count; i++) {
+            CGPoint* points = _components[i].points;
+            if (points) {
+                IwFree(points);
+            }
 		}
         IwFree(_components);
     }

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -28,7 +28,7 @@ struct __CGPath : public CFBridgeBase<__CGPath> {
 
     ~__CGPath();
     void _getBoundingBox(CGRect* rectOut);
-	void _applyPath(CGContextRef context);
+    void _applyPath(CGContextRef context);
 };
 
 COREGRAPHICS_EXPORT CGRect _CGPathFitRect(CGPathRef pathref, CGRect rect, CGSize maxSize, float padding);

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -30,22 +30,22 @@ struct CGPathElementInternal : CGPathElement {
 
     // Constructor. Used to adjust array pointer after creation.
     CGPathElementInternal() : CGPathElement() {
-        updatePointsArrayPointer();
+        this->init();
     }
     // Copy Constructor. Used to adjust array pointer after copy.
     CGPathElementInternal(const CGPathElementInternal& copy) : CGPathElement(copy) {
         memcpy(this->internalPoints, copy.internalPoints, sizeof(internalPoints));
-        updatePointsArrayPointer();
+        this->init();
     }
     // Assignment operator. Used to adjust array pointer after assignment.
     CGPathElementInternal& operator=(const CGPathElementInternal& copy) {
         CGPathElement::operator=(copy);
         memcpy(this->internalPoints, copy.internalPoints, sizeof(internalPoints));
-        updatePointsArrayPointer();
+        this->init();
         return *this;
     }
     // This should be called when elements are created with alloc/memcpy
-    void updatePointsArrayPointer() {
+    void init() {
         this->points = internalPoints;
     }
 };

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -17,9 +17,9 @@
 #ifndef __CGPATHINTERNAL_H
 #define __CGPATHINTERNAL_H
 
+#include "CFBridgeBase.h"
 #include "CoreGraphics/CGContext.h"
 #include "CoreGraphics/CGPath.h"
-#include "CFBridgeBase.h"
 
 struct __CGPath : public CFBridgeBase<__CGPath> {
     CGPathElement* _components;

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -21,9 +21,8 @@
 #include "CoreGraphics/CGPath.h"
 #include "CFBridgeBase.h"
 
-
 struct __CGPath : public CFBridgeBase<__CGPath> {
-	CGPathElement* _components;
+    CGPathElement* _components;
     NSUInteger _count;
     NSUInteger _max;
 

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -29,7 +29,7 @@ struct CGPathElementInternal : CGPathElement {
     CGPoint internalPoints[kCGPathMaxPointCount];
 
     // Constructor. Used to adjust array pointer after creation.
-    CGPathElementInternal() {
+    CGPathElementInternal() : CGPathElement() {
         updatePointsArrayPointer();
     }
     // Copy Constructor. Used to adjust array pointer after copy.

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -23,8 +23,36 @@
 
 const int kCGPathMaxPointCount = 3;
 
+struct CGPathElementInternal : CGPathElement {
+    // Internal representation of points used to simplify size calculations
+    // CGPoint* points in CGPathElement should always point to this array
+    CGPoint internalPoints[kCGPathMaxPointCount];
+
+    // Constructor. Used to adjust array pointer after creation.
+    CGPathElementInternal() {
+        updatePointsArrayPointer();
+    }
+    // Copy Constructor. Used to adjust array pointer after copy.
+    CGPathElementInternal(const CGPathElementInternal& copy) : CGPathElement(copy) {
+        memcpy(this->internalPoints, copy.internalPoints, sizeof(internalPoints));
+        updatePointsArrayPointer();
+    }
+    // Assignment operator. Used to adjust array pointer after assignment.
+    CGPathElementInternal& operator=(const CGPathElementInternal& copy) {
+        CGPathElement::operator=(copy);
+        memcpy(this->internalPoints, copy.internalPoints, sizeof(internalPoints));
+        updatePointsArrayPointer();
+        return *this;
+    }
+    // This should be called when elements are created with alloc/memcpy
+    void updatePointsArrayPointer() {
+        this->points = internalPoints;
+    }
+};
+typedef struct CGPathElementInternal CGPathElementInternal;
+
 struct __CGPath : public CFBridgeBase<__CGPath> {
-    CGPathElement* _elements;
+    CGPathElementInternal* _elements;
     NSUInteger _count;
     NSUInteger _max;
 

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -21,67 +21,15 @@
 #include "CoreGraphics/CGPath.h"
 #include "CFBridgeBase.h"
 
-enum pathComponentType {
-    pathComponentRectangle,
-    pathComponentMove,
-    pathComponentLineTo,
-    pathComponentArcToPoint,
-    pathComponentQuadCurve,
-    pathComponentBezierCurve,
-    pathComponentCurve,
-    pathComponentEllipseInRect,
-    pathComponentClose,
-    pathComponentArcAngle,
-};
-
-typedef struct {
-    float x1, y1, x2, y2;
-    float radius;
-} arcToPoint;
-
-typedef struct {
-    float x, y, startAngle, endAngle;
-    float radius;
-    BOOL clockwise;
-} arcAngle;
-
-struct curveToPoint {
-    float x1, y1; // tangent from start
-    float x2, y2; // tangent to end
-    float x, y; // end pos
-};
-
-struct quadCurveToPoint {
-    float cpx, cpy;
-    float x, y;
-};
-
-struct ellipseInRect {
-    CGRect rect;
-};
-
-typedef struct {
-    pathComponentType type;
-
-    union {
-        CGRect rect;
-        CGPoint point;
-        arcToPoint atp;
-        curveToPoint ctp;
-        ellipseInRect eir;
-        quadCurveToPoint qtp;
-        arcAngle aa;
-    };
-} pathComponent;
 
 struct __CGPath : public CFBridgeBase<__CGPath> {
-    pathComponent* _components;
+	CGPathElement* _components;
     NSUInteger _count;
     NSUInteger _max;
 
     ~__CGPath();
     void _getBoundingBox(CGRect* rectOut);
-    void _applyPath(CGContextRef context);
+	void _applyPath(CGContextRef context);
 };
 
 COREGRAPHICS_EXPORT CGRect _CGPathFitRect(CGPathRef pathref, CGRect rect, CGSize maxSize, float padding);

--- a/Frameworks/include/CGPathInternal.h
+++ b/Frameworks/include/CGPathInternal.h
@@ -21,8 +21,10 @@
 #include "CoreGraphics/CGContext.h"
 #include "CoreGraphics/CGPath.h"
 
+const int kCGPathMaxPointCount = 3;
+
 struct __CGPath : public CFBridgeBase<__CGPath> {
-    CGPathElement* _components;
+    CGPathElement* _elements;
     NSUInteger _count;
     NSUInteger _max;
 

--- a/include/CoreGraphics/CGPath.h
+++ b/include/CoreGraphics/CGPath.h
@@ -115,7 +115,7 @@ COREGRAPHICS_EXPORT void CGPathMoveToPoint(CGMutablePathRef path, const CGAffine
 COREGRAPHICS_EXPORT void CGPathCloseSubpath(CGMutablePathRef path);
 COREGRAPHICS_EXPORT void CGPathAddEllipseInRect(CGMutablePathRef path, const CGAffineTransform* m, CGRect rect);
 
-COREGRAPHICS_EXPORT bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2) STUB_METHOD;
+COREGRAPHICS_EXPORT bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2);
 
 COREGRAPHICS_EXPORT CGRect CGPathGetBoundingBox(CGPathRef path);
 

--- a/include/CoreGraphics/CGPath.h
+++ b/include/CoreGraphics/CGPath.h
@@ -15,9 +15,9 @@
 //******************************************************************************
 #pragma once
 
-#import <CoreGraphics/CoreGraphicsExport.h>
-#import <CoreGraphics/CGGeometry.h>
 #import <CoreGraphics/CGAffineTransform.h>
+#import <CoreGraphics/CGGeometry.h>
+#import <CoreGraphics/CoreGraphicsExport.h>
 
 typedef enum { kCGPathFill, kCGPathEOFill, kCGPathStroke, kCGPathFillStroke, kCGPathEOFillStroke } CGPathDrawingMode;
 

--- a/include/CoreGraphics/CGPath.h
+++ b/include/CoreGraphics/CGPath.h
@@ -109,7 +109,7 @@ COREGRAPHICS_EXPORT void CGPathAddRect(CGMutablePathRef path, const CGAffineTran
 COREGRAPHICS_EXPORT void CGPathAddRects(CGMutablePathRef path, const CGAffineTransform* m, const CGRect* rects, size_t count) STUB_METHOD;
 COREGRAPHICS_EXPORT void CGPathAddRoundedRect(
     CGMutablePathRef path, const CGAffineTransform* transform, CGRect rect, CGFloat cornerWidth, CGFloat cornerHeight) STUB_METHOD;
-COREGRAPHICS_EXPORT void CGPathApply(CGPathRef path, void* info, CGPathApplierFunction function) STUB_METHOD;
+COREGRAPHICS_EXPORT void CGPathApply(CGPathRef path, void* info, CGPathApplierFunction function);
 
 COREGRAPHICS_EXPORT void CGPathMoveToPoint(CGMutablePathRef path, const CGAffineTransform* m, CGFloat x, CGFloat y);
 COREGRAPHICS_EXPORT void CGPathCloseSubpath(CGMutablePathRef path);
@@ -120,7 +120,7 @@ COREGRAPHICS_EXPORT bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2) STU
 COREGRAPHICS_EXPORT CGRect CGPathGetBoundingBox(CGPathRef path);
 
 COREGRAPHICS_EXPORT CGRect CGPathGetPathBoundingBox(CGPathRef path) STUB_METHOD;
-COREGRAPHICS_EXPORT CGPoint CGPathGetCurrentPoint(CGPathRef path) STUB_METHOD;
+COREGRAPHICS_EXPORT CGPoint CGPathGetCurrentPoint(CGPathRef path);
 COREGRAPHICS_EXPORT CFTypeID CGPathGetTypeID() STUB_METHOD;
 
 COREGRAPHICS_EXPORT bool CGPathIsEmpty(CGPathRef path);

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGPathApplyViewController.m
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGPathApplyViewController.m
@@ -106,7 +106,7 @@
     }
     {
         CGMutablePathRef path = CGPathCreateMutable();
-        NSArray* points = @[ [NSValue valueWithCGPoint:CGPointMake(25, 100)], @20, @(1.5 * M_PI), @(0), @YES ];
+        NSArray* points = @[ [NSValue valueWithCGPoint:CGPointMake(25, 100)], @20, @(1.25 * M_PI), @(0), @YES ];
         CGPathAddArc(path,
                      &transform,
                      [points[0] CGPointValue].x,

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -14,7 +14,224 @@
 //
 //******************************************************************************
 
-#import <TestFramework.h>
-#import <Starboard.h>
 #import <CoreGraphics\CGPath.h>
 #import <Foundation\Foundation.h>
+#import <Starboard.h>
+#import <TestFramework.h>
+
+static NSString* const kPointsKey = @"PointsKey";
+static NSString* const kTypeKey = @"TypeKey";
+
+int cgPathPointCountForElementType(CGPathElementType type) {
+    int pointCount = 0;
+
+    switch (type) {
+        case kCGPathElementMoveToPoint:
+        case kCGPathElementAddLineToPoint:
+            pointCount = 1;
+            break;
+        case kCGPathElementAddQuadCurveToPoint:
+            pointCount = 2;
+            break;
+        case kCGPathElementAddCurveToPoint:
+            pointCount = 3;
+            break;
+        case kCGPathElementCloseSubpath:
+            pointCount = 0;
+            break;
+    }
+    return pointCount;
+}
+
+// CGPathApplierFunction that attempts to modify elements inside a CGPath
+void cgPathModifyingApplierFunction(void* info, const CGPathElement* element) {
+    int pointCount = cgPathPointCountForElementType(element->type);
+
+    NSMutableArray* points = [NSMutableArray array];
+
+    for (int i = 0; i < pointCount; i++) {
+        element->points[i] = CGPointMake(44, 44);
+    }
+}
+
+// CGPathApplierFunction that adds elements to an NSMutableArray
+void cgPathApplierFunction(void* info, const CGPathElement* element) {
+    NSMutableArray* result = (__bridge NSMutableArray*)(info);
+
+    int pointCount = cgPathPointCountForElementType(element->type);
+
+    NSMutableArray* points = [NSMutableArray array];
+
+    for (int i = 0; i < pointCount; i++) {
+        CGPoint point = element->points[i];
+        [points addObject:@(point.x)];
+        [points addObject:@(point.y)];
+    }
+
+    [result addObject:@{ kTypeKey : @(element->type), kPointsKey : points }];
+}
+
+// Helper function that compares results from cgPathApplierFunction to expected results
+void cgPathCompare(NSArray* expected, NSArray* result) {
+    ASSERT_EQ(expected.count, result.count) << "Counts do not match for expected and result";
+
+    [expected enumerateObjectsUsingBlock:^(NSDictionary* expectedDict, NSUInteger elementIndex, BOOL* stop) {
+        NSDictionary* resultDict = result[elementIndex];
+        CGPathElementType expectedType = (CGPathElementType)[expectedDict[kTypeKey] integerValue];
+        CGPathElementType resultType = (CGPathElementType)[resultDict[kTypeKey] integerValue];
+        ASSERT_EQ(expectedType, resultType) << "Elements in result and expected do not match";
+        ASSERT_EQ([expectedDict[kPointsKey] count], [resultDict[kPointsKey] count])
+            << "Point count in result and expected element do not match";
+
+        [expectedDict[kPointsKey] enumerateObjectsUsingBlock:^(NSNumber* expectedPointValue, NSUInteger pointIndex, BOOL* stop) {
+            float resultPoint = [resultDict[kPointsKey][pointIndex] floatValue];
+            ASSERT_FLOAT_EQ([expectedPointValue floatValue], resultPoint);
+        }];
+    }];
+}
+
+TEST(CGPath, CGPathApplyTestModification) {
+    CGMutablePathRef path = CGPathCreateMutable();
+
+    CGRect rect = CGRectMake(2, 4, 8, 16);
+
+    CGPathAddRect(path, NULL, rect);
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathModifyingApplierFunction);
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @2, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @20 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @2, @20 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] }
+    ];
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}
+
+TEST(CGPath, CGPathApplyAddRect) {
+    CGMutablePathRef path = CGPathCreateMutable();
+
+    CGRect rect = CGRectMake(2, 4, 8, 16);
+
+    CGPathAddRect(path, NULL, rect);
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @2, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @20 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @2, @20 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] }
+    ];
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}
+
+TEST(CGPath, CGPathApplyAddEllipse) {
+    CGMutablePathRef path = CGPathCreateMutable();
+
+    CGRect rect = CGRectMake(40, 40, 200, 40);
+
+    CGPathAddEllipseInRect(path, NULL, rect);
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @240, @60 ] },
+        @{ kTypeKey : @(kCGPathElementAddCurveToPoint),
+           kPointsKey : @[ @240, @71.045695, @195.228475, @80, @140, @80 ] },
+        @{ kTypeKey : @(kCGPathElementAddCurveToPoint),
+           kPointsKey : @[ @84.771525, @80, @40, @71.045695, @40, @60 ] },
+        @{ kTypeKey : @(kCGPathElementAddCurveToPoint),
+           kPointsKey : @[ @40, @48.954305, @84.771525, @40, @140, @40 ] },
+        @{ kTypeKey : @(kCGPathElementAddCurveToPoint),
+           kPointsKey : @[ @195.228475, @40, @240, @48.954305, @240, @60 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] }
+    ];
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}
+
+TEST(CGPath, CGPathApplyAddArc) {
+    CGMutablePathRef path = CGPathCreateMutable();
+
+    CGPathAddArc(path, NULL, 25, 100, 20, M_PI * 1.25, 0, 1);
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @10.857863, @85.857865 ] },
+        @{
+            kTypeKey : @(kCGPathElementAddCurveToPoint),
+            kPointsKey : @[ @3.047378, @93.668352, @3.047379, @106.331651, @10.857865, @114.142137 ]
+        },
+        @{
+            kTypeKey : @(kCGPathElementAddCurveToPoint),
+            kPointsKey : @[ @18.668352, @121.952622, @31.331651, @121.952621, @39.142137, @114.142135 ]
+        },
+        @{ kTypeKey : @(kCGPathElementAddCurveToPoint),
+           kPointsKey : @[ @42.892864, @110.391407, @45, @105.304329, @45, @100 ] }
+    ];
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}
+
+TEST(CGPath, CGPathApplyAddArcToPoint) {
+    CGMutablePathRef path = CGPathCreateMutable();
+
+    CGPathMoveToPoint(path, NULL, 400, 400);
+    CGPathAddArcToPoint(path, NULL, 140, 250, 110, 180, 50);
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @400, @400 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @154.415379, @258.316565 ] },
+        @{
+            kTypeKey : @(kCGPathElementAddCurveToPoint),
+            kPointsKey : @[ @145.057503, @252.917790, @137.699975, @244.633276, @133.444250, @234.703250 ]
+        }
+    ];
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -47,8 +47,6 @@ int cgPathPointCountForElementType(CGPathElementType type) {
 void cgPathModifyingApplierFunction(void* info, const CGPathElement* element) {
     int pointCount = cgPathPointCountForElementType(element->type);
 
-    NSMutableArray* points = [NSMutableArray array];
-
     for (int i = 0; i < pointCount; i++) {
         element->points[i] = CGPointMake(44, 44);
     }

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -21,7 +21,7 @@
 
 static NSString* const kPointsKey = @"PointsKey";
 static NSString* const kTypeKey = @"TypeKey";
-
+// Helper function to know # of points in an element
 int cgPathPointCountForElementType(CGPathElementType type) {
     int pointCount = 0;
 
@@ -41,15 +41,6 @@ int cgPathPointCountForElementType(CGPathElementType type) {
             break;
     }
     return pointCount;
-}
-
-// CGPathApplierFunction that attempts to modify elements inside a CGPath
-void cgPathModifyingApplierFunction(void* info, const CGPathElement* element) {
-    int pointCount = cgPathPointCountForElementType(element->type);
-
-    for (int i = 0; i < pointCount; i++) {
-        element->points[i] = CGPointMake(44, 44);
-    }
 }
 
 // CGPathApplierFunction that adds elements to an NSMutableArray
@@ -86,37 +77,6 @@ void cgPathCompare(NSArray* expected, NSArray* result) {
             ASSERT_FLOAT_EQ([expectedPointValue floatValue], resultPoint);
         }];
     }];
-}
-
-TEST(CGPath, CGPathApplyTestModification) {
-    CGMutablePathRef path = CGPathCreateMutable();
-
-    CGRect rect = CGRectMake(2, 4, 8, 16);
-
-    CGPathAddRect(path, NULL, rect);
-
-    NSMutableArray* result = [NSMutableArray array];
-
-    CGPathApply(path, result, cgPathModifyingApplierFunction);
-
-    CGPathApply(path, result, cgPathApplierFunction);
-
-    NSArray* expected = @[
-        @{ kTypeKey : @(kCGPathElementMoveToPoint),
-           kPointsKey : @[ @2, @4 ] },
-        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
-           kPointsKey : @[ @10, @4 ] },
-        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
-           kPointsKey : @[ @10, @20 ] },
-        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
-           kPointsKey : @[ @2, @20 ] },
-        @{ kTypeKey : @(kCGPathElementCloseSubpath),
-           kPointsKey : [NSArray array] }
-    ];
-
-    cgPathCompare(expected, result);
-
-    CGPathRelease(path);
 }
 
 TEST(CGPath, CGPathApplyAddRect) {
@@ -232,4 +192,157 @@ TEST(CGPath, CGPathApplyAddArcToPoint) {
     cgPathCompare(expected, result);
 
     CGPathRelease(path);
+}
+
+TEST(CGPath, CGPathAddQuadCurveToPoint) {
+    CGMutablePathRef path = CGPathCreateMutable();
+
+    CGPathMoveToPoint(path, NULL, 400, 400);
+    CGPathAddQuadCurveToPoint(path, NULL, 140, 250, 110, 180);
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @400, @400 ] },
+        @{ kTypeKey : @(kCGPathElementAddQuadCurveToPoint),
+           kPointsKey : @[ @140, @250, @110, @180 ] }
+    ];
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}
+
+TEST(CGPath, CGPathCreateMutableCopy) {
+    CGMutablePathRef path1 = CGPathCreateMutable();
+
+    CGRect rect = CGRectMake(2, 4, 8, 16);
+
+    CGPathAddEllipseInRect(path1, NULL, rect);
+
+    CGMutablePathRef path2 = CGPathCreateMutableCopy(path1);
+
+    ASSERT_NE(path1, path2);
+
+    ASSERT_TRUE(CGPathEqualToPath(path1, path2));
+
+    CGPathRelease(path1);
+
+    CGPathRelease(path2);
+}
+
+TEST(CGPath, CGPathEqualToPath) {
+    CGMutablePathRef path1 = CGPathCreateMutable();
+
+    CGRect rect = CGRectMake(2, 4, 8, 16);
+
+    CGPathAddRect(path1, NULL, rect);
+
+    // Create a copy of the path
+    CGMutablePathRef path2 = CGPathCreateMutableCopy(path1);
+
+    // Change the copy
+    CGPathAddEllipseInRect(path2, NULL, rect);
+
+    // Make sure the paths are not the same object
+    ASSERT_NE(path1, path2);
+
+    // Make sure paths are not equal
+    ASSERT_FALSE(CGPathEqualToPath(path1, path2));
+
+    // Release the copy
+    CGPathRelease(path2);
+
+    // Now test the original path to make sure it's still what we expect
+    NSArray* expected = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @2, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @20 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @2, @20 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] }
+    ];
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path1, result, cgPathApplierFunction);
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path1);
+}
+
+TEST(CGPath, CGPathAddPath) {
+    CGMutablePathRef path1 = CGPathCreateMutable();
+
+    CGRect rect1 = CGRectMake(2, 4, 8, 16);
+
+    CGPathAddRect(path1, NULL, rect1);
+
+    CGMutablePathRef path2 = CGPathCreateMutable();
+
+    CGRect rect2 = CGRectMake(4, 4, 8, 16);
+
+    CGPathAddRect(path2, NULL, rect2);
+
+    CGPathAddPath(path1, NULL, path2);
+
+    NSArray* expected1 = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @2, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @10, @20 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @2, @20 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] },
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @4, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @12, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @12, @20 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @4, @20 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] }
+    ];
+
+    NSArray* expected2 = @[
+        @{ kTypeKey : @(kCGPathElementMoveToPoint),
+           kPointsKey : @[ @4, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @12, @4 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @12, @20 ] },
+        @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+           kPointsKey : @[ @4, @20 ] },
+        @{ kTypeKey : @(kCGPathElementCloseSubpath),
+           kPointsKey : [NSArray array] }
+    ];
+
+    NSMutableArray* result2 = [NSMutableArray array];
+
+    CGPathApply(path1, result2, cgPathApplierFunction);
+
+    cgPathCompare(expected1, result2);
+
+    CGPathRelease(path2);
+
+    NSMutableArray* result1 = [NSMutableArray array];
+
+    CGPathApply(path1, result1, cgPathApplierFunction);
+
+    cgPathCompare(expected1, result1);
+
+    CGPathRelease(path1);
 }


### PR DESCRIPTION
Replaced pathComponent with CGPathElement. Rewrote CGPathAddEllipseInRect,
CGPathAddArc, CGPathAddArcToPoint to support CGPathElement.
Implemented CGPathGetCurrentPoint for use in CGPathAddArcToPoint.
Removed caveats for CGPathAddArc, CGPathAddEllipseInRect.
Caveat for CGPathAddArcToPoint remains.

Fix #525 : CGPathApply.