### PR TITLE
Implementation for CGBitmapContext APIs.

### DIFF
--- a/Frameworks/CoreGraphics/CGBitmapContext.mm
+++ b/Frameworks/CoreGraphics/CGBitmapContext.mm
@@ -72,9 +72,9 @@ CGImageAlphaInfo CGBitmapContextGetAlphaInfo(CGContextRef context) {
  @Notes
 */
 size_t CGBitmapContextGetBitsPerComponent(CGContextRef context) {
-	 CGImageRef imageRef = context->Backing()->DestImage();
-	 size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
-     return bitsPerComponent;
+    CGImageRef imageRef = context->Backing()->DestImage();
+    size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+    return bitsPerComponent;
 }
 
 /**

--- a/Frameworks/CoreGraphics/CGBitmapContext.mm
+++ b/Frameworks/CoreGraphics/CGBitmapContext.mm
@@ -72,9 +72,9 @@ CGImageAlphaInfo CGBitmapContextGetAlphaInfo(CGContextRef context) {
  @Notes
 */
 size_t CGBitmapContextGetBitsPerComponent(CGContextRef context) {
-	  CGImageRef imageRef = context->Backing()->DestImage();
-	  size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
-      return bitsPerComponent;
+	 CGImageRef imageRef = context->Backing()->DestImage();
+	 size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+     return bitsPerComponent;
 }
 
 /**
@@ -83,10 +83,10 @@ size_t CGBitmapContextGetBitsPerComponent(CGContextRef context) {
  Expect returns of 24 bits on Islandwood where 32 bits is expected on iOS.
 */
 size_t CGBitmapContextGetBitsPerPixel(CGContextRef context) {
-	CGImageRef imageRef = context->Backing()->DestImage();
-	size_t bytesPerPixel = imageRef->Backing()->BytesPerPixel();
-	size_t bitesPerCompoenent = CGBitmapContextGetBitsPerComponent(context);
-	return bytesPerPixel * bitesPerCompoenent;
+    CGImageRef imageRef = context->Backing()->DestImage();
+    size_t bytesPerPixel = imageRef->Backing()->BytesPerPixel();
+    size_t bitsPerByte = 8;
+    return bytesPerPixel * bitsPerByte;
 }
 
 /**

--- a/Frameworks/CoreGraphics/CGBitmapContext.mm
+++ b/Frameworks/CoreGraphics/CGBitmapContext.mm
@@ -16,6 +16,9 @@
 
 #import <StubReturn.h>
 #import <CoreGraphics/CGBitmapContext.h>
+#import <CoreGraphics/CGContext.h>
+#import "CGContextInternal.h"
+#import <CoreGraphics/CGImage.h>
 
 /**
  @Status Stub
@@ -45,12 +48,13 @@ CGImageRef CGBitmapContextCreateImage(CGContextRef context) {
 }*/
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes tied to underlying implementation caveats in CGImageGetBitmapInfo. 
 */
 CGBitmapInfo CGBitmapContextGetBitmapInfo(CGContextRef context) {
-    UNIMPLEMENTED();
-    return StubReturn();
+	CGImageRef imageRef = context->Backing()->DestImage();
+	CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
+	return bitmapInfo;
 }
 
 /**
@@ -64,21 +68,25 @@ CGImageAlphaInfo CGBitmapContextGetAlphaInfo(CGContextRef context) {
 }*/
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 size_t CGBitmapContextGetBitsPerComponent(CGContextRef context) {
-    UNIMPLEMENTED();
-    return StubReturn();
+	  CGImageRef imageRef = context->Backing()->DestImage();
+	  size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+      return bitsPerComponent;
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes UIView in Islandwood ignores alpha by default, which differs from iOS.
+ Expect returns of 24 bits on Islandwood where 32 bits is expected on iOS.
 */
 size_t CGBitmapContextGetBitsPerPixel(CGContextRef context) {
-    UNIMPLEMENTED();
-    return StubReturn();
+	CGImageRef imageRef = context->Backing()->DestImage();
+	size_t bytesPerPixel = imageRef->Backing()->BytesPerPixel();
+	size_t bitesPerCompoenent = CGBitmapContextGetBitsPerComponent(context);
+	return bytesPerPixel * bitesPerCompoenent;
 }
 
 /**
@@ -97,7 +105,7 @@ CGColorSpaceRef CGBitmapContextGetColorSpace(CGContextRef context) {
 */
 /*
 void * CGBitmapContextGetData(CGContextRef context) {
-    UNIMPLEMENTED();
+	UNIMPLEMENTED();
     return StubReturn();
 }*/
 

--- a/include/CoreGraphics/CGBitmapContext.h
+++ b/include/CoreGraphics/CGBitmapContext.h
@@ -43,6 +43,6 @@ COREGRAPHICS_EXPORT CGContextRef CGBitmapContextCreateWithData(void* data,
     CGBitmapContextReleaseDataCallback releaseCallback,
     void* releaseInfo) STUB_METHOD;
 
-COREGRAPHICS_EXPORT CGBitmapInfo CGBitmapContextGetBitmapInfo(CGContextRef self) STUB_METHOD;
-COREGRAPHICS_EXPORT size_t CGBitmapContextGetBitsPerPixel(CGContextRef context) STUB_METHOD;
+COREGRAPHICS_EXPORT CGBitmapInfo CGBitmapContextGetBitmapInfo(CGContextRef self);
+COREGRAPHICS_EXPORT size_t CGBitmapContextGetBitsPerPixel(CGContextRef context);
 COREGRAPHICS_EXPORT CGColorSpaceRef CGBitmapContextGetColorSpace(CGContextRef context) STUB_METHOD;


### PR DESCRIPTION
Implement Interoperable state for CGBitmapContextGetBitsPerComponent and
Caveat changes for CGBitmapContextGetBitsPerPixel
CGBitmapContextGetBitmapInfo. CGBitmapContextGetBitsPerPixel returns
different values in Islandwood due to differences in the alpha channel for
UIView between iOS and Windows. CGBitmapContextGetBitmapInfo returns
differences from iOS due to caveats in the underlying implementation for
the backing implementation.

Issue #523