### PR TITLE
Implemented CG Transparency APIs.

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -59,7 +59,7 @@ __CGContext::__CGContext(CGImageRef pDest) {
 #ifdef DEBUG_CONTEXT_COUNT
     TraceVerbose(TAG, L"contextCount: %d", contextCount);
 #endif
-    object_setClass((id) this, [CGNSContext class]);
+    object_setClass((id)this, [CGNSContext class]);
     scale = 1.0f;
     _backing = pDest->Backing()->CreateDrawingContext(this);
 }
@@ -753,18 +753,16 @@ void CGContextAddLines(CGContextRef pContext, const CGPoint* pt, unsigned count)
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 void CGContextBeginTransparencyLayer(CGContextRef ctx, CFDictionaryRef auxInfo) {
-    UNIMPLEMENTED();
     ctx->Backing()->CGContextBeginTransparencyLayer((id)auxInfo);
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 void CGContextEndTransparencyLayer(CGContextRef ctx) {
-    UNIMPLEMENTED();
     ctx->Backing()->CGContextEndTransparencyLayer();
 }
 
@@ -1131,11 +1129,11 @@ void CGContextBeginPage(CGContextRef c, const CGRect* mediaBox) {
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
-void CGContextBeginTransparencyLayerWithRect(CGContextRef c, CGRect rect, CFDictionaryRef auxInfo) {
-    UNIMPLEMENTED();
+void CGContextBeginTransparencyLayerWithRect(CGContextRef ctx, CGRect rect, CFDictionaryRef auxInfo) {
+    ctx->Backing()->CGContextBeginTransparencyLayerWithRect(rect, (id)auxInfo);
 }
 
 /**

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -694,6 +694,9 @@ void CGContextImpl::CGContextClipToRect(CGRect rect) {
 void CGContextImpl::CGContextBeginTransparencyLayer(id auxInfo) {
 }
 
+void CGContextImpl::CGContextBeginTransparencyLayerWithRect(CGRect rect, id auxInfo) {
+}
+
 void CGContextImpl::CGContextEndTransparencyLayer() {
 }
 

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -123,6 +123,7 @@ public:
     virtual void CGContextClipToRect(CGRect rect);
 
     virtual void CGContextBeginTransparencyLayer(id auxInfo);
+    virtual void CGContextBeginTransparencyLayerWithRect(CGRect rect, id auxInfo);
     virtual void CGContextEndTransparencyLayer();
 
     virtual void CGContextSetGrayStrokeColor(float gray, float alpha);

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -153,6 +153,7 @@ public:
     virtual void CGContextClipToRect(CGRect rect);
 
     virtual void CGContextBeginTransparencyLayer(id auxInfo);
+    virtual void CGContextBeginTransparencyLayerWithRect(CGRect rect, id auxInfo);
     virtual void CGContextEndTransparencyLayer();
 
     virtual void CGContextSetGrayStrokeColor(float gray, float alpha);

--- a/include/CoreGraphics/CGContext.h
+++ b/include/CoreGraphics/CGContext.h
@@ -188,9 +188,9 @@ COREGRAPHICS_EXPORT void CGContextRotateCTM(CGContextRef c, CGFloat angle);
 COREGRAPHICS_EXPORT void CGContextScaleCTM(CGContextRef c, CGFloat sx, CGFloat sy);
 COREGRAPHICS_EXPORT void CGContextTranslateCTM(CGContextRef c, CGFloat tx, CGFloat ty);
 
-COREGRAPHICS_EXPORT void CGContextBeginTransparencyLayer(CGContextRef c, CFDictionaryRef auxiliaryInfo) STUB_METHOD;
-COREGRAPHICS_EXPORT void CGContextBeginTransparencyLayerWithRect(CGContextRef c, CGRect rect, CFDictionaryRef auxInfo) STUB_METHOD;
-COREGRAPHICS_EXPORT void CGContextEndTransparencyLayer(CGContextRef c) STUB_METHOD;
+COREGRAPHICS_EXPORT void CGContextBeginTransparencyLayer(CGContextRef c, CFDictionaryRef auxiliaryInfo);
+COREGRAPHICS_EXPORT void CGContextBeginTransparencyLayerWithRect(CGContextRef c, CGRect rect, CFDictionaryRef auxInfo);
+COREGRAPHICS_EXPORT void CGContextEndTransparencyLayer(CGContextRef c);
 
 COREGRAPHICS_EXPORT void CGContextDrawTiledImage(CGContextRef c, CGRect rect, CGImageRef image);
 COREGRAPHICS_EXPORT void CGContextDrawImage(CGContextRef c, CGRect rect, CGImageRef image);

--- a/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-Headers-WinStore10/CGCatalog-Headers.vcxitems
+++ b/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-Headers-WinStore10/CGCatalog-Headers.vcxitems
@@ -16,6 +16,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGBitmapContentViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextBeginEndTransparencyLayer.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextBeginTransparencyLayerWithRect.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextSetPatternPhase.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextReplacePathWithStrokedPath.h" />
   </ItemGroup>

--- a/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-Headers-WinStore10/CGCatalog-Headers.vcxitems.filters
+++ b/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-Headers-WinStore10/CGCatalog-Headers.vcxitems.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextBeginEndTransparencyLayer.h">
       <Filter>CGCatalog\Samples</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextBeginTransparencyLayerWithRect.h">
+      <Filter>CGCatalog\Samples</Filter>
+    </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CGCatalog\Samples\CGCCGContextSetPatternPhase.h">
       <Filter>CGCatalog\Samples</Filter>
     </ClInclude>

--- a/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-WinStore10/CGCatalog.vcxproj
+++ b/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-WinStore10/CGCatalog.vcxproj
@@ -188,6 +188,7 @@
     <ClangCompile Include="..\..\CGCatalog\Samples\CGCCGContextViewController.m" />
     <ClangCompile Include="..\..\CGCatalog\AppDelegate.m" />
     <ClangCompile Include="..\..\CGCatalog\CGCBaseViewController.m" />
+    <ClangCompile Include="..\..\CGCatalog\Samples\CGCCGContextBeginTransparencyLayerWithRect.m" />
     <ClangCompile Include="..\..\CGCatalog\Samples\CGCCGBitmapContentViewController.m" />
     <ClangCompile Include="..\..\CGCatalog\Samples\CGCCGPathApplyViewController.m" />
     <ClangCompile Include="..\..\CGCatalog\main.m" />

--- a/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-WinStore10/CGCatalog.vcxproj.filters
+++ b/samples/CGCatalog/CGCatalog.vsimporter/CGCatalog-WinStore10/CGCatalog.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClangCompile Include="..\..\CGCatalog\CGCBaseViewController.m">
       <Filter>CGCatalog</Filter>
     </ClangCompile>
+    <ClangCompile Include="..\..\CGCatalog\Samples\CGCCGContextBeginTransparencyLayerWithRect.m">
+      <Filter>CGCatalog\Samples</Filter>
+    </ClangCompile>
     <ClangCompile Include="..\..\CGCatalog\Samples\CGCCGBitmapContentViewController.m">
       <Filter>CGCatalog\Samples</Filter>
     </ClangCompile>

--- a/samples/CGCatalog/CGCatalog.xcodeproj/project.pbxproj
+++ b/samples/CGCatalog/CGCatalog.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		F0D21CBF1D06078D002C32EE /* CGCBaseViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F0D21CBE1D06078D002C32EE /* CGCBaseViewController.m */; };
 		FB10A19A1D10792E008EA8A1 /* CGCCGContextSetPatternPhase.m in Sources */ = {isa = PBXBuildFile; fileRef = FB10A1991D10792E008EA8A1 /* CGCCGContextSetPatternPhase.m */; };
 		FB1264921D0A0484007C907C /* CGCCGContextBeginEndTransparencyLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = FB1264911D0A0484007C907C /* CGCCGContextBeginEndTransparencyLayer.m */; };
+		FB18A4BA1D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.m in Sources */ = {isa = PBXBuildFile; fileRef = FB18A4B91D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.m */; };
 		FBA3A50C1D132C9A00C3C011 /* CGCCGContextReplacePathWithStrokedPath.m in Sources */ = {isa = PBXBuildFile; fileRef = FBA3A50B1D132C9A00C3C011 /* CGCCGContextReplacePathWithStrokedPath.m */; };
 /* End PBXBuildFile section */
 
@@ -45,6 +46,8 @@
 		FB10A1991D10792E008EA8A1 /* CGCCGContextSetPatternPhase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CGCCGContextSetPatternPhase.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		FB1264901D0A0484007C907C /* CGCCGContextBeginEndTransparencyLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CGCCGContextBeginEndTransparencyLayer.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		FB1264911D0A0484007C907C /* CGCCGContextBeginEndTransparencyLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CGCCGContextBeginEndTransparencyLayer.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		FB18A4B81D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CGCCGContextBeginTransparencyLayerWithRect.h; sourceTree = "<group>"; };
+		FB18A4B91D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CGCCGContextBeginTransparencyLayerWithRect.m; sourceTree = "<group>"; };
 		FBA3A50A1D132C9A00C3C011 /* CGCCGContextReplacePathWithStrokedPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = CGCCGContextReplacePathWithStrokedPath.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		FBA3A50B1D132C9A00C3C011 /* CGCCGContextReplacePathWithStrokedPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = CGCCGContextReplacePathWithStrokedPath.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 /* End PBXFileReference section */
@@ -112,6 +115,8 @@
 				552816071D062F6B0082C178 /* CGCCGContextViewController.m */,
 				FB1264901D0A0484007C907C /* CGCCGContextBeginEndTransparencyLayer.h */,
 				FB1264911D0A0484007C907C /* CGCCGContextBeginEndTransparencyLayer.m */,
+				FB18A4B81D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.h */,
+				FB18A4B91D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.m */,
 				FB10A1981D10792E008EA8A1 /* CGCCGContextSetPatternPhase.h */,
 				FB10A1991D10792E008EA8A1 /* CGCCGContextSetPatternPhase.m */,
 				FBA3A50A1D132C9A00C3C011 /* CGCCGContextReplacePathWithStrokedPath.h */,
@@ -207,6 +212,7 @@
 				552816081D062F6B0082C178 /* CGCCGContextViewController.m in Sources */,
 				F0D21C861D05FEF9002C32EE /* AppDelegate.m in Sources */,
 				F0D21CBF1D06078D002C32EE /* CGCBaseViewController.m in Sources */,
+				FB18A4BA1D1AD10A00A9555A /* CGCCGContextBeginTransparencyLayerWithRect.m in Sources */,
 				552816051D062EC90082C178 /* CGCCGBitmapContentViewController.m in Sources */,
 				F0D21CB71D060466002C32EE /* CGCCGPathApplyViewController.m in Sources */,
 				F0D21C831D05FEF9002C32EE /* main.m in Sources */,

--- a/samples/CGCatalog/CGCatalog/CGCRootViewController.m
+++ b/samples/CGCatalog/CGCatalog/CGCRootViewController.m
@@ -17,6 +17,7 @@
 #import "CGCRootViewController.h"
 #import "CGCCGBitmapContentViewController.h"
 #import "CGCCGContextBeginEndTransparencyLayer.h"
+#import "CGCCGContextBeginTransparencyLayerWithRect.h"
 #import "CGCCGContextReplacePathWithStrokedPath.h"
 #import "CGCCGContextSetPatternPhase.h"
 #import "CGCCGContextViewController.h"
@@ -57,6 +58,7 @@
             [SampleRow row:@"CGContext" class:[CGCCGContextViewController class]],
             [SampleRow row:@"CGBitmapContext" class:[CGCCGBitmapContentViewController class]],
             [SampleRow row:@"CGContextBeginEndTransparencyLayer" class:[CGCCGContextBeginEndTransparencyLayer class]],
+            [SampleRow row:@"CGContextBeginTransparencyLayerWithRect" class:[CGCCGContextBeginTransparencyLayerWithRect class]],
             [SampleRow row:@"CGContextSetPatternPhase" class:[CGCCGContextSetPatternPhase class]],
             [SampleRow row:@"CGContextReplacePathWithStrokedPath" class:[CGCCGContextReplacePathWithStrokedPath class]],
         ];

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginEndTransparencyLayer.m
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginEndTransparencyLayer.m
@@ -39,14 +39,9 @@
     CGContextSetFillColorWithColor(context, [UIColor yellowColor].CGColor);
     CGContextFillRect(context, CGRectMake(rectWidth / 2 - 25, maxHeight / 2 - rectHeight / 2 - 25, rectWidth + 25, rectHeight + 25));
 
-    // Note: Shadow or Alpha would be better test samples for this, but are not fully implemented yet in the bridge.
-    // TODO: Use Shadow or Alpha instead of BlendMode when supported by the bridge
-    // Enable shadow
-    /*CGSize shadowOffset = CGSizeMake(10, 20);
-    CGContextSetShadow(context, shadowOffset, 10);*/
-    // Set composite alpha of the transparency layer
-    // CGContextSetAlpha(context, 0.5);
-
+    // Set the blend mode to use between the background rectangle and the ones in the transparency layer
+    // Note: The rectangles in the transparency layer should NOT be blended with each other.
+    //       Only the background rectangle should be blended with the ones in the layer.
     CGContextSetBlendMode(context, kCGBlendModeHue);
 
     // Begin Transparency

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginTransparencyLayerWithRect.h
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginTransparencyLayerWithRect.h
@@ -1,0 +1,24 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#pragma once
+
+#import "CGCBaseViewController.h"
+#import <Foundation/Foundation.h>
+
+@interface CGCCGContextBeginTransparencyLayerWithRect : CGCBaseViewController
+
+@end

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginTransparencyLayerWithRect.m
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginTransparencyLayerWithRect.m
@@ -26,34 +26,29 @@
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGFloat maxWidth = rect.size.width;
     CGFloat maxHeight = rect.size.height;
-    
+
     // White background
     CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
     CGContextFillRect(context, rect);
-    
+
     // Rect Size
     CGFloat rectWidth = maxWidth / 2.0;
     CGFloat rectHeight = rectWidth;
-    
+
     // Draw background rect
     CGContextSetFillColorWithColor(context, [UIColor yellowColor].CGColor);
     CGRect aRect = CGRectMake(rectWidth / 2 - 25, maxHeight / 2 - rectHeight / 2 - 25, rectWidth + 25, rectHeight + 25);
     CGContextFillRect(context, aRect);
-    
-    // Note: Shadow or Alpha would be better test samples for this, but are not fully implemented yet in the bridge.
-    // TODO: Use Shadow or Alpha instead of BlendMode when supported by the bridge
-    // Enable shadow
-    /*CGSize shadowOffset = CGSizeMake(10, 20);
-     CGContextSetShadow(context, shadowOffset, 10);*/
-    // Set composite alpha of the transparency layer
-    // CGContextSetAlpha(context, 0.5);
-    
+
+    // Set the blend mode to use between the background rectangle and the ones in the transparency layer
+    // Note: The rectangles in the transparency layer should NOT be blended with each other.
+    //       Only the background rectangle should be blended with the ones in the layer.
     CGContextSetBlendMode(context, kCGBlendModeHue);
-    
+
     // Begin Transparency
     CGRect bRect = CGRectInset(aRect, 10, 10);
     CGContextBeginTransparencyLayerWithRect(context, bRect, NULL);
-    
+
     CGContextSetFillColorWithColor(context, [UIColor redColor].CGColor);
     CGRect cRect = CGRectMake(rectWidth / 2 + 25, maxHeight / 2 - rectHeight / 2 - 50, rectWidth, rectHeight);
     CGContextFillRect(context, cRect);
@@ -63,7 +58,7 @@
     CGContextSetFillColorWithColor(context, [UIColor blueColor].CGColor);
     CGRect eRect = CGRectMake(rectWidth / 2 - 50, maxHeight / 2 - rectHeight / 2, rectWidth, rectHeight);
     CGContextFillRect(context, eRect);
-    
+
     // End Transparency
     CGContextEndTransparencyLayer(context);
 }
@@ -80,10 +75,11 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     self.view.backgroundColor = [UIColor whiteColor];
-    
-    self.customView = [[TransparencyViewRect alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height)];
+
+    self.customView =
+        [[TransparencyViewRect alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height)];
     [self.view addSubview:self.customView];
 }
 

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginTransparencyLayerWithRect.m
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGContextBeginTransparencyLayerWithRect.m
@@ -14,71 +14,76 @@
 //
 //******************************************************************************
 
-#import "CGCCGContextBeginEndTransparencyLayer.h"
+#import "CGCCGContextBeginTransparencyLayerWithRect.h"
 
-@interface TransparencyView : UIView
+@interface TransparencyViewRect : UIView
 
 @end
 
-@implementation TransparencyView
+@implementation TransparencyViewRect
 
 - (void)drawRect:(CGRect)rect {
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGFloat maxWidth = rect.size.width;
     CGFloat maxHeight = rect.size.height;
-
+    
     // White background
     CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
-    CGContextFillRect(context, CGRectMake(0, 0, maxWidth, maxHeight));
-
+    CGContextFillRect(context, rect);
+    
     // Rect Size
     CGFloat rectWidth = maxWidth / 2.0;
     CGFloat rectHeight = rectWidth;
-
+    
     // Draw background rect
     CGContextSetFillColorWithColor(context, [UIColor yellowColor].CGColor);
-    CGContextFillRect(context, CGRectMake(rectWidth / 2 - 25, maxHeight / 2 - rectHeight / 2 - 25, rectWidth + 25, rectHeight + 25));
-
+    CGRect aRect = CGRectMake(rectWidth / 2 - 25, maxHeight / 2 - rectHeight / 2 - 25, rectWidth + 25, rectHeight + 25);
+    CGContextFillRect(context, aRect);
+    
     // Note: Shadow or Alpha would be better test samples for this, but are not fully implemented yet in the bridge.
     // TODO: Use Shadow or Alpha instead of BlendMode when supported by the bridge
     // Enable shadow
     /*CGSize shadowOffset = CGSizeMake(10, 20);
-    CGContextSetShadow(context, shadowOffset, 10);*/
+     CGContextSetShadow(context, shadowOffset, 10);*/
     // Set composite alpha of the transparency layer
     // CGContextSetAlpha(context, 0.5);
-
+    
     CGContextSetBlendMode(context, kCGBlendModeHue);
-
+    
     // Begin Transparency
-    CGContextBeginTransparencyLayer(context, NULL);
-
+    CGRect bRect = CGRectInset(aRect, 10, 10);
+    CGContextBeginTransparencyLayerWithRect(context, bRect, NULL);
+    
     CGContextSetFillColorWithColor(context, [UIColor redColor].CGColor);
-    CGContextFillRect(context, CGRectMake(rectWidth / 2 + 25, maxHeight / 2 - rectHeight / 2 - 50, rectWidth, rectHeight));
+    CGRect cRect = CGRectMake(rectWidth / 2 + 25, maxHeight / 2 - rectHeight / 2 - 50, rectWidth, rectHeight);
+    CGContextFillRect(context, cRect);
     CGContextSetFillColorWithColor(context, [UIColor greenColor].CGColor);
-    CGContextFillRect(context, CGRectMake(rectWidth / 2 - 25, maxHeight / 2 - rectHeight / 2 + 25, rectWidth, rectHeight));
+    CGRect dRect = CGRectMake(rectWidth / 2 - 25, maxHeight / 2 - rectHeight / 2 + 25, rectWidth, rectHeight);
+    CGContextFillRect(context, dRect);
     CGContextSetFillColorWithColor(context, [UIColor blueColor].CGColor);
-    CGContextFillRect(context, CGRectMake(rectWidth / 2 - 50, maxHeight / 2 - rectHeight / 2, rectWidth, rectHeight));
-
+    CGRect eRect = CGRectMake(rectWidth / 2 - 50, maxHeight / 2 - rectHeight / 2, rectWidth, rectHeight);
+    CGContextFillRect(context, eRect);
+    
     // End Transparency
     CGContextEndTransparencyLayer(context);
 }
 
 @end
 
-@interface CGCCGContextBeginEndTransparencyLayer ()
+@interface CGCCGContextBeginTransparencyLayerWithRect ()
 
-@property (strong, nonatomic, nullable) TransparencyView* customView;
+@property (strong, nonatomic, nullable) TransparencyViewRect* customView;
 
 @end
 
-@implementation CGCCGContextBeginEndTransparencyLayer
+@implementation CGCCGContextBeginTransparencyLayerWithRect
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
+    
     self.view.backgroundColor = [UIColor whiteColor];
-
-    self.customView = [[TransparencyView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height)];
+    
+    self.customView = [[TransparencyViewRect alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height)];
     [self.view addSubview:self.customView];
 }
 


### PR DESCRIPTION
Implemented CGContextBeginTransparencyLayer,
CGContextBeginTransparencyLayerWithRect, CGContextEndTransparencyLayer from #524 

Testing was performed using the CGCatalog sample app, and comparing results in iOS to results in Windows.  Unit tests not included as APIs are graphical.
