### PR TITLE
Fix 'regression' in popovers implementation where no content view controller is visible in popover

### DIFF
--- a/build/UIKit/lib/UIKitLib.vcxproj
+++ b/build/UIKit/lib/UIKitLib.vcxproj
@@ -232,8 +232,6 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPopoverController.mm" />
     <ClangCompile Include="..\..\..\Frameworks\UIKit\WYPopoverController.m">
       <ObjectiveCARC>true</ObjectiveCARC>
-      <OptimizationLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Disabled</OptimizationLevel>
-      <OptimizationLevel Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Disabled</OptimizationLevel>
     </ClangCompile>
     <ClangCompile Include="..\..\..\Frameworks\UIKit\WYStoryboardPopoverSegue.m">
       <ObjectiveCARC>true</ObjectiveCARC>

--- a/samples/WOCCatalog/WOCCatalog/ControlsViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/ControlsViewController.m
@@ -45,21 +45,30 @@ static const int MODALFORMSHEET_ROW = 4;
 
     const CGFloat buttonHeight = 50;
     const CGFloat buttonWidth = 175;
-    const CGFloat buttonOriginOffset = 25;
+    const CGFloat originOffset = 25;
 
     self.leftPopoverButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     self.leftPopoverButton.titleLabel.font = [UIFont systemFontOfSize:11];
     [self.leftPopoverButton setTitle:@"Popover (left arrow direction)" forState:UIControlStateNormal];
-    [self.leftPopoverButton setFrame:CGRectMake(buttonOriginOffset, buttonOriginOffset, buttonWidth, buttonHeight)];
+    [self.leftPopoverButton setFrame:CGRectMake(originOffset, originOffset, buttonWidth, buttonHeight)];
     [self.leftPopoverButton addTarget:self action:@selector(pressedPopoverButton:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.leftPopoverButton];
 
     self.rightPopoverButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     self.rightPopoverButton.titleLabel.font = [UIFont systemFontOfSize:11];
     [self.rightPopoverButton setTitle:@"Popover (up arrow direction)" forState:UIControlStateNormal];
-    [self.rightPopoverButton setFrame:CGRectMake(self.view.bounds.size.width - buttonOriginOffset - buttonWidth, buttonOriginOffset, buttonWidth, buttonHeight)];
+    [self.rightPopoverButton setFrame:CGRectMake(self.view.bounds.size.width - originOffset - buttonWidth, originOffset, buttonWidth, buttonHeight)];
     [self.rightPopoverButton addTarget:self action:@selector(pressedPopoverButton:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.rightPopoverButton];
+
+    UILabel* popoverDisclaimerLabel = [[UILabel alloc] initWithFrame:
+        CGRectMake(self.leftPopoverButton.frame.origin.x + self.leftPopoverButton.frame.size.width + originOffset,
+                   self.leftPopoverButton.frame.origin.y,
+                   self.rightPopoverButton.frame.origin.x - self.leftPopoverButton.frame.origin.x - self.leftPopoverButton.frame.size.width - originOffset * 2,
+                   self.leftPopoverButton.frame.size.height)];
+    popoverDisclaimerLabel.text = @"Tablet-style popovers require WOCOperationModeTablet to be enabled (see DisplayModeViewController).";
+    popoverDisclaimerLabel.textAlignment = NSTextAlignmentCenter;
+    [self.view addSubview:popoverDisclaimerLabel];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -191,8 +200,6 @@ static const int MODALFORMSHEET_ROW = 4;
 
 - (void)pressedPopoverButton:(UIButton*)sender {
     PopoverViewController* viewController = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
-    viewController.modalPresentationStyle = UIModalPresentationPopover;
-
     assert(viewController.popoverPresentationController == nil);
 
     viewController.modalPresentationStyle = UIModalPresentationPopover;
@@ -218,8 +225,6 @@ static const int MODALFORMSHEET_ROW = 4;
 
 - (void)pressedPopoverBarButton:(UIBarButtonItem*)sender {
     PopoverViewController* viewController = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
-    viewController.modalPresentationStyle = UIModalPresentationPopover;
-
     assert(viewController.popoverPresentationController == nil);
 
     viewController.modalPresentationStyle = UIModalPresentationPopover;

--- a/samples/WOCCatalog/WOCCatalog/PopoverViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/PopoverViewController.m
@@ -28,7 +28,7 @@
 
     self->imageView = [[UIImageView alloc] initWithImage:image];
     UIButton* backButton = [[UIButton alloc] initWithFrame:CGRectMake(10, 10, 100, 25)];
-    [backButton setTitle:@"Back" forState:UIControlStateNormal];
+    [backButton setTitle:@"Done" forState:UIControlStateNormal];
     [backButton addTarget:self action:@selector(dismissViewController) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:backButton];
 


### PR DESCRIPTION
Fix 'regression' in popovers implementation where no content view controller is visible in popover:
- fix prevents |WYPopoverBackgroundView|'s |viewContentInsets| property being used in layout calculation (garbage value results in content view controller drawn offscreen in DEBUG builds)
- fix cleans up WYPopoverController WINOBJC specific changes, removing some cargo-cultish code (that attempted to address an issue better fixed by |viewContentInsets| change)
- fix also removes some unnecessary WINOBJC specific code that was necessary at time of original pull (accessing |barButtonItem|'s |view| via |valueForKey:| now works)
- WYPopoverController files now in sync with fork at https://github.com/ehren/WYPopoverController
- commit also contains some UI tweaks to WOCCatalog app.

-----

Hi, I've rebased my pull so that the WYPopoverController files match the current state of my fork - which also has been updated. It may be easier to review the single commit modifying the current nicolaschengdev/WYPopoverController to add my changes for WINOBJC:
https://github.com/ehren/WYPopoverController/commit/721be41ad48cb4b337b5fa2dca98adbf8723e5b6

Nothing has really changed since I've opened this pull (the #ifndef preventing access to `viewContentInsets` is still necessary).