### PR TITLE
Fixed CGPattern dimensions bug

### DIFF
--- a/Frameworks/CoreGraphics/CGPattern.mm
+++ b/Frameworks/CoreGraphics/CGPattern.mm
@@ -39,8 +39,8 @@
         return simpleImage;
     }
 
-    float width = bounds.size.width;
-    float height = bounds.size.height;
+    float width = xStep;
+    float height = yStep;
 
     if (width <= 0.0f || height <= 0.0f) {
         return nullptr;


### PR DESCRIPTION
Changed CGPattern getPatternImage to set height and width variables based
on the xStep and yStep variables instead of bounds.size.  The bounds.size
variable contains the size of the entire pattern area being filled, where
the xStep and yStep variables contain the size of the pattern itself.

Fixes #578