### PR TITLE
VSO 8015441: Handle NSOperations and GCD main queue post main runloop wait stage

### DIFF
--- a/Frameworks/Foundation/NSRunLoop.mm
+++ b/Frameworks/Foundation/NSRunLoop.mm
@@ -263,11 +263,6 @@ static void DispatchMainRunLoopWakeup(void* arg) {
         [self acceptInputForMode:mode beforeDate:limitDate];
     }
 
-    if ([NSThread currentThread] == [NSThread mainThread]) {
-        [[NSOperationQueue mainQueue] _doMainWork];
-        dispatch_main_queue_callback();
-    }
-
     [pool release];
 
     return (limitDate != nil);
@@ -525,11 +520,21 @@ static void DispatchMainRunLoopWakeup(void* arg) {
 }
 
 - (void)_processMainRunLoop:(int)value {
+    if ([NSThread currentThread] != [NSThread mainThread]) {
+        FAIL_FAST_MSG(E_UNEXPECTED, "_processMainRunLoop should only be scheduled on the main UI thread!");
+    }
+
     NSRunLoopState* state = [self _stateForMode:NSDefaultRunLoopMode];
+
     // Wrap code in a autorelease pool so all the auto released objects from calling the event
     // handlers can be manually released.
     NSAutoreleasePool* pool = [NSAutoreleasePool new];
+
+    [[NSOperationQueue mainQueue] _doMainWork];
+    dispatch_main_queue_callback();
+
     [state _handleSignaledInput:value];
+
     [pool release];
 }
 


### PR DESCRIPTION
This is a regression that was introduced when we moved off fibers. This does not impact functionality but will cause slight performance regression as the run loop will be woken a bit too frequently to service these queues when they have data to be serviced.