### PR TITLE
Add cortana voice command foreground activation

### DIFF
--- a/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
@@ -53,42 +53,36 @@ void InitializeApp() {
     SetupMainRunLoopTimedMultipleWaiter();
 }
 
-extern "C" void RunApplicationMainWithString(Platform::String^ principalClassName,
-                                   Platform::String^ delegateClassName,
-                                   float windowWidth,
-                                   float windowHeight,
-                                   ActivationType activationType,
-                                   Platform::String^ activationString) {
-    // Perform initialization
-    InitializeApp();
-
-    // Kick off iOS application main startup
-    ApplicationMainStartHSTRING(
-        Strings::WideToNarrow(principalClassName->Data()).c_str(),
-        Strings::WideToNarrow(delegateClassName->Data()).c_str(),
-        windowWidth,
-        windowHeight,
-        activationType,
-        reinterpret_cast<HSTRING>(activationString));
-}
-
 extern "C" void RunApplicationMain(Platform::String^ principalClassName,
                                    Platform::String^ delegateClassName,
                                    float windowWidth,
                                    float windowHeight,
                                    ActivationType activationType,
                                    Platform::Object^ activationArg) {
+
     // Perform initialization
     InitializeApp();
 
     // Kick off iOS application main startup
-    ApplicationMainStart(
-        Strings::WideToNarrow(principalClassName->Data()).c_str(),
-        Strings::WideToNarrow(delegateClassName->Data()).c_str(),
-        windowWidth,
-        windowHeight,
-        activationType,
-        reinterpret_cast<IInspectable*>(activationArg));
+    if (activationType == ActivationTypeVoiceCommand){
+        // The activationArg is a Platform::String^, which is not an IInspectable* so it must be converted to an HSTRING before NSString*
+        ApplicationMainStart(
+                Strings::WideToNarrow(principalClassName->Data()).c_str(),
+                Strings::WideToNarrow(delegateClassName->Data()).c_str(),
+                windowWidth,
+                windowHeight,
+                activationType,
+                reinterpret_cast<HSTRING>(activationArg));
+    } else {
+        // Convert Object^ to IInspectable* so it can be passed into Objective C and there converted to its projection
+        ApplicationMainStart(
+                Strings::WideToNarrow(principalClassName->Data()).c_str(),
+                Strings::WideToNarrow(delegateClassName->Data()).c_str(),
+                windowWidth,
+                windowHeight,
+                activationType,
+                reinterpret_cast<IInspectable*>(activationArg));
+    }
 }
 
 // clang-format off

--- a/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
@@ -53,12 +53,31 @@ void InitializeApp() {
     SetupMainRunLoopTimedMultipleWaiter();
 }
 
+extern "C" void RunApplicationMainWithString(Platform::String^ principalClassName,
+                                   Platform::String^ delegateClassName,
+                                   float windowWidth,
+                                   float windowHeight,
+                                   ActivationType activationType,
+                                   Platform::String^ activationString) {
+    // Perform initialization
+    InitializeApp();
+
+    // Kick off iOS application main startup
+    ApplicationMainStartHSTRING(
+        Strings::WideToNarrow(principalClassName->Data()).c_str(),
+        Strings::WideToNarrow(delegateClassName->Data()).c_str(),
+        windowWidth,
+        windowHeight,
+        activationType,
+        reinterpret_cast<HSTRING>(activationString));
+}
+
 extern "C" void RunApplicationMain(Platform::String^ principalClassName,
                                    Platform::String^ delegateClassName,
                                    float windowWidth,
                                    float windowHeight,
                                    ActivationType activationType,
-                                   Platform::String^ activationArg) {
+                                   Platform::Object^ activationArg) {
     // Perform initialization
     InitializeApp();
 
@@ -69,7 +88,7 @@ extern "C" void RunApplicationMain(Platform::String^ principalClassName,
         windowWidth,
         windowHeight,
         activationType,
-        Strings::WideToNarrow(activationArg->Data()).c_str());
+        reinterpret_cast<IInspectable*>(activationArg));
 }
 
 // clang-format off

--- a/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.h
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.h
@@ -27,13 +27,6 @@ extern "C" void RunApplicationMain(Platform::String^ principalClassName,
                                    ActivationType type,
                                    Platform::Object^ activationArg);
 
-// Because String^ does not inherit from IInspectable
-extern "C" void RunApplicationMainWithString(Platform::String^ principalClassName,
-                                   Platform::String^ delegateClassName,
-                                   float windowWidth,
-                                   float windowHeight,
-                                   ActivationType type,
-                                   Platform::String^ activationString);
 #endif
 
 // clang-format on

--- a/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.h
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.h
@@ -25,7 +25,15 @@ extern "C" void RunApplicationMain(Platform::String^ principalClassName,
                                    float windowWidth,
                                    float windowHeight,
                                    ActivationType type,
-                                   Platform::String^ activationArg);
+                                   Platform::Object^ activationArg);
+
+// Because String^ does not inherit from IInspectable
+extern "C" void RunApplicationMainWithString(Platform::String^ principalClassName,
+                                   Platform::String^ delegateClassName,
+                                   float windowWidth,
+                                   float windowHeight,
+                                   ActivationType type,
+                                   Platform::String^ activationString);
 #endif
 
 // clang-format on

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.h
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.h
@@ -25,13 +25,6 @@ extern "C" int ApplicationMainStart(const char* principalName,
                                     float windowWidth,
                                     float windowHeight,
                                     ActivationType activationType,
-                                    IInspectable* activationArg);
-
-extern "C" int ApplicationMainStartHSTRING(const char* principalName,
-                                           const char* delegateName,
-                                           float windowWidth,
-                                           float windowHeight,
-                                           ActivationType activationType,
-                                           HSTRING activationArg);
+                                    void* activationArg);
 
 void SetTemporaryFolder(const char* folder);

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.h
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.h
@@ -16,8 +16,6 @@
 #pragma once
 
 #include "StarboardXaml.h"
-#include <inspectable.h>
-#include <hstring.h>
 
 // IOS application main startup path
 extern "C" int ApplicationMainStart(const char* principalName,

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.h
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include "StarboardXaml.h"
+#include <inspectable.h>
+#include <hstring.h>
 
 // IOS application main startup path
 extern "C" int ApplicationMainStart(const char* principalName,
@@ -23,5 +25,13 @@ extern "C" int ApplicationMainStart(const char* principalName,
                                     float windowWidth,
                                     float windowHeight,
                                     ActivationType activationType,
-                                    const char* activationArg);
+                                    IInspectable* activationArg);
+
+extern "C" int ApplicationMainStartHSTRING(const char* principalName,
+                                           const char* delegateName,
+                                           float windowWidth,
+                                           float windowHeight,
+                                           ActivationType activationType,
+                                           HSTRING activationArg);
+
 void SetTemporaryFolder(const char* folder);

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
@@ -45,20 +45,19 @@ void SetCACompositorClient(CACompositorClientInterface* client) {
 }
 
 int ApplicationMainStart(const char* principalName,
-                          const char* delegateName,
-                          float windowWidth,
-                          float windowHeight,
-                          ActivationType activationType,
-                          void* activationArg) {
-
+                         const char* delegateName,
+                         float windowWidth,
+                         float windowHeight,
+                         ActivationType activationType,
+                         void* activationArg) {
     // Note: We must use nil rather than an empty string for these class names
     NSString* principalClassName = Strings::IsEmpty<const char*>(principalName) ? nil : [[NSString alloc] initWithCString:principalName];
     NSString* delegateClassName = Strings::IsEmpty<const char*>(delegateName) ? nil : [[NSString alloc] initWithCString:delegateName];
 
     id activationArgument = nil;
 
-	// Populate Objective C equivalent of activation argument
-    if (activationType == ActivationTypeToast){
+    // Populate Objective C equivalent of activation argument
+    if (activationType == ActivationTypeToast) {
         NSString* toastArgument = Strings::WideToNSString(static_cast<HSTRING>(activationArg));
         activationArgument = toastArgument;
     } else if (activationType == ActivationTypeVoiceCommand) {
@@ -89,7 +88,7 @@ int ApplicationMainStart(const char* principalName,
         } else if ([orientation isKindOfClass:[NSArray class]]) {
             bool found = false;
 
-            for (NSString* curstr in(NSArray*)orientation) {
+            for (NSString* curstr in (NSArray*)orientation) {
                 UIInterfaceOrientation newOrientation = UIOrientationFromString(defaultOrientation, curstr);
                 if (newOrientation == defaultOrientation) {
                     found = true;

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
@@ -14,9 +14,7 @@
 //
 //******************************************************************************
 
-#include <COMIncludes.h>
 #import "ApplicationMain.h"
-#include <COMIncludes_End.h>
 
 #import <assert.h>
 #import <math.h>

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -91,25 +91,33 @@ void App::OnActivated(IActivatedEventArgs^ args) {
     if (args->Kind == ActivationKind::ToastNotification) {
         Platform::String^ argsString = safe_cast<ToastNotificationActivatedEventArgs^>(args)->Argument;
         TraceVerbose(TAG, L"Received toast notification with argument - %s", argsString->Data());
+
         if (initiateAppLaunch) {
             _ApplicationMainLaunch(ActivationTypeToast, argsString);
         }
+
         UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
     } else if (args->Kind == ActivationKind::VoiceCommand) {
         Windows::Media::SpeechRecognition::SpeechRecognitionResult^ argResult = safe_cast<VoiceCommandActivatedEventArgs^>(args)->Result;
         TraceVerbose(TAG, L"Received voice command with argument - %s", argResult->Text->Data());
+
         if (initiateAppLaunch) {
             _ApplicationMainLaunch(ActivationTypeVoiceCommand, argResult);
         }
+
         UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
     } else if (args->Kind == ActivationKind::Protocol) {
         Windows::Foundation::Uri^ argUri = safe_cast<ProtocolActivatedEventArgs^>(args)->Uri;
         TraceVerbose(TAG, L"Received protocol with uri- %s", argUri->ToString()->Data());
+
         if (initiateAppLaunch) {
             _ApplicationMainLaunch(ActivationTypeProtocol, argUri);
         }
+
         UIApplicationMainHandleProtocolEvent(reinterpret_cast<IInspectable*>(argUri));
     } else {
+        TraceVerbose(TAG, L"Received unhandled activation kind - %d", args->Kind);
+        
         if (initiateAppLaunch) {
             _ApplicationMainLaunch(ActivationTypeNone, nullptr);
         }
@@ -170,12 +178,7 @@ extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Obje
     Xaml::Window::Current->Activate();
 
     auto startupRect = Xaml::Window::Current->Bounds;
-    if (activationType == ActivationTypeToast) {
-        RunApplicationMainWithString(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height,
-            activationType, static_cast<Platform::String^>(activationArg));
-    } else {
-        RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
-    }
+    RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
 }
 
 // This is the actual entry point from the app into our framework.

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -95,6 +95,20 @@ void App::OnActivated(IActivatedEventArgs^ args) {
             _ApplicationMainLaunch(ActivationTypeToast, argsString);
         }
         UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
+    } else if (args->Kind == ActivationKind::VoiceCommand) {
+        Windows::Media::SpeechRecognition::SpeechRecognitionResult^ argResult = safe_cast<VoiceCommandActivatedEventArgs^>(args)->Result;
+        TraceVerbose(TAG, L"Received voice command with argument - %s", argResult->Text->Data());
+        if (initiateAppLaunch) {
+            _ApplicationMainLaunch(ActivationTypeVoiceCommand, argResult);
+        }
+        UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
+    } else if (args->Kind == ActivationKind::Protocol) {
+        Windows::Foundation::Uri^ argUri = safe_cast<ProtocolActivatedEventArgs^>(args)->Uri;
+        TraceVerbose(TAG, L"Received protocol with uri- %s", argUri->ToString()->Data());
+        if (initiateAppLaunch) {
+            _ApplicationMainLaunch(ActivationTypeProtocol, argUri);
+        }
+        UIApplicationMainHandleProtocolEvent(reinterpret_cast<IInspectable*>(argUri));
     } else {
         if (initiateAppLaunch) {
             _ApplicationMainLaunch(ActivationTypeNone, nullptr);
@@ -102,7 +116,7 @@ void App::OnActivated(IActivatedEventArgs^ args) {
     }
 }
 
-void App::_ApplicationMainLaunch(ActivationType activationType, Platform::String^ activationArg) {
+void App::_ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg) {
     _ApplicationLaunch(activationType, activationArg);
     _RegisterEventHandlers();
 }
@@ -145,7 +159,7 @@ void App::_OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::Sus
     TraceVerbose(TAG, L"Suspending event received");
 }
 
-extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::String^ activationArg) {
+extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg) {
     auto uiElem = ref new Xaml::Controls::Grid();
     auto rootFrame = ref new Xaml::Controls::Frame();
     rootFrame->Content = uiElem;
@@ -156,7 +170,12 @@ extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Stri
     Xaml::Window::Current->Activate();
 
     auto startupRect = Xaml::Window::Current->Bounds;
-    RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
+    if (activationType == ActivationTypeToast) {
+        RunApplicationMainWithString(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height,
+            activationType, static_cast<Platform::String^>(activationArg));
+    } else {
+        RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
+    }
 }
 
 // This is the actual entry point from the app into our framework.

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
@@ -24,6 +24,8 @@
 typedef enum {
     ActivationTypeNone = 0,
     ActivationTypeToast = 1,
+    ActivationTypeVoiceCommand = 2,
+    ActivationTypeProtocol = 3,
 } ActivationType;
 
 #ifdef __cplusplus_winrt
@@ -41,7 +43,7 @@ public:
 private:
     XamlTypeInfo::InfoProvider::XamlTypeInfoProvider^ _provider;
 
-    void _ApplicationMainLaunch(ActivationType activationType, Platform::String^ activationArg);
+    void _ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg);
     void _RegisterEventHandlers();
     void _OnAppVisibilityChanged(Platform::Object^ sender, Windows::UI::Core::VisibilityChangedEventArgs^ args);
     void _OnAppMemoryUsageChanged(Platform::Object^ sender, Platform::Object^ args);
@@ -49,7 +51,7 @@ private:
     void _OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ args);
 };
 
-extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::String^ activationArg);
+extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
 
 #endif
 

--- a/Frameworks/UIKit/UIApplication.mm
+++ b/Frameworks/UIKit/UIApplication.mm
@@ -52,6 +52,8 @@
 
 #include "RingBuffer.h"
 
+#include <UWP/WindowsMediaSpeechRecognition.h>
+#include <UWP/WindowsFoundation.h>
 #include "UWP/WindowsUINotifications.h"
 #include "LoggingNative.h"
 #include "UIApplicationMainInternal.h"
@@ -97,6 +99,8 @@ NSString* const UIApplicationLaunchOptionsSourceApplicationKey = @"UIApplication
 NSString* const UIApplicationLaunchOptionsRemoteNotificationKey = @"UIApplicationLaunchOptionsRemoteNotificationKey";
 NSString* const UIApplicationLaunchOptionsAnnotationKey = @"UIApplicationLaunchOptionsAnnotationKey";
 NSString* const UIApplicationLaunchOptionsLocalNotificationKey = @"UIApplicationLaunchOptionsLocalNotificationKey";
+NSString* const UIApplicationLaunchOptionsVoiceCommandKey = @"UIApplicationLaunchOptionsVoiceCommandKey";
+NSString* const UIApplicationLaunchOptionsProtocolKey = @"UIApplicationLaunchOptionsProtocolKey";
 NSString* const UIApplicationLaunchOptionsLocationKey = @"UIApplicationLaunchOptionsLocationKey";
 
 NSString* const UIApplicationDidReceiveMemoryWarningNotification = @"UIApplicationDidReceiveMemoryWarningNotification";
@@ -1634,6 +1638,18 @@ static void _sendMemoryWarningToViewControllers(UIView* subview) {
 
     // TODO::
     // todo-nithishm-05262016 - Implement UILocalNotification and call LocalNotification delegate here.
+}
+
+- (void)_sendVoiceCommandReceivedEvent:(WMSSpeechRecognitionResult*)voiceCommandResult {
+    if ([self.delegate respondsToSelector:@selector(application:didReceiveVoiceCommand:)]) {
+        [self.delegate application:sharedApplication didReceiveVoiceCommand:voiceCommandResult];
+    }
+}
+
+- (void)_sendProtocolReceivedEvent:(WFUri*)protocolUri {
+    if ([self.delegate respondsToSelector:@selector(application:didReceiveProtocol:)]) {
+        [self.delegate application:sharedApplication didReceiveProtocol:protocolUri];
+    }
 }
 
 - (void)_sendHighMemoryWarning {

--- a/Frameworks/UIKit/UIApplicationMain.mm
+++ b/Frameworks/UIKit/UIApplicationMain.mm
@@ -38,6 +38,8 @@
 #import "UIDeviceInternal.h"
 #import <MainDispatcher.h>
 #import <CACompositor.h>
+#import <UWP/WindowsMediaSpeechRecognition.h>
+#import <UWP/WindowsFoundation.h>
 
 static const wchar_t* TAG = L"UIApplicationMain";
 
@@ -118,7 +120,7 @@ int UIApplicationMainInit(NSString* principalClassName,
                           NSString* delegateClassName,
                           UIInterfaceOrientation defaultOrientation,
                           int activationType,
-                          NSString* activationArg) {
+                          id activationArg) {
     // Make sure we reference classes we need:
     void ForceInclusion();
     ForceInclusion();
@@ -246,6 +248,12 @@ int UIApplicationMainInit(NSString* principalClassName,
             [launchOption setValue:activationArg forKey:UIApplicationLaunchOptionsRemoteNotificationKey];
             [launchOption setValue:activationArg forKey:UIApplicationLaunchOptionsLocalNotificationKey];
             break;
+        case ActivationTypeVoiceCommand:
+            [launchOption setValue:activationArg forKey:UIApplicationLaunchOptionsVoiceCommandKey];
+            break;
+        case ActivationTypeProtocol:
+            [launchOption setValue:activationArg forKey:UIApplicationLaunchOptionsProtocolKey];
+            break;
         default:
             break;
     }
@@ -315,4 +323,14 @@ extern "C" void UIApplicationMainHandleHighMemoryUsageEvent() {
 extern "C" void UIApplicationMainHandleToastNotificationEvent(const char* notificationData) {
     NSString* data = Strings::IsEmpty<const char*>(notificationData) ? nil : [[NSString alloc] initWithCString:notificationData];
     [[UIApplication sharedApplication] _sendNotificationReceivedEvent:data];
+}
+
+extern "C" void UIApplicationMainHandleVoiceCommandEvent(IInspectable* voiceCommandResult) {
+    WMSSpeechRecognitionResult* speechResult = [WMSSpeechRecognitionResult createWith:voiceCommandResult];
+    [[UIApplication sharedApplication] _sendVoiceCommandReceivedEvent:speechResult];
+}
+
+extern "C" void UIApplicationMainHandleProtocolEvent(IInspectable* protocolUri) {
+    WFUri* protocolResult = [WFUri createWith:protocolUri];
+    [[UIApplication sharedApplication] _sendProtocolReceivedEvent:protocolResult];
 }

--- a/Frameworks/UIKit/UIApplicationMainInternal.h
+++ b/Frameworks/UIKit/UIApplicationMainInternal.h
@@ -19,3 +19,5 @@ extern "C" int UIApplicationMainLoop();
 extern "C" void UIApplicationMainHandleHighMemoryUsageEvent();
 extern "C" void UIApplicationMainHandleWindowVisibilityChangeEvent(bool isVisible);
 extern "C" void UIApplicationMainHandleToastNotificationEvent(const char* notificationData);
+extern "C" void UIApplicationMainHandleVoiceCommandEvent(IInspectable* voiceCommandResult);
+extern "C" void UIApplicationMainHandleProtocolEvent(IInspectable* protocolUri);

--- a/Frameworks/include/MockClass.h
+++ b/Frameworks/include/MockClass.h
@@ -107,8 +107,11 @@ ASSERT_EQ(HRESULT_FROM_WIN32(ERROR_OUT_OF_PAPER), result);
 }
 */ /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+////////////////////////////////////////////////////////////////
+// Class definition must be placed inside macro to mock in Objective C++
 // Clang doesn't allow unqualified methods to be mocked so we need to attach the class name to it when mocking
 // A namespace is created around the class to allow this to be used more than once
+////////////////////////////////////////////////////////////////
 #define MOCK_CLASS(CLASS_NAME, ...)                       \
     namespace BUILD_VARIABLE_NAME(CLASS_NAME, _PRIVATE) { \
         class CLASS_NAME;                                 \

--- a/Frameworks/include/MockClass.h
+++ b/Frameworks/include/MockClass.h
@@ -1,0 +1,824 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//*****************************************************************************/
+#pragma once
+
+#define Nil Nil2
+#define __alignof alignof
+#include "ParameterTypes.h"
+#include "Windows.h"
+#include "WexTestClass.h"
+
+#include <functional>
+#include <wrl/implements.h>
+#include <wrl/client.h>
+
+/*/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+This header includes a number of macros that can be used to create mock classes for use in unit testing. The macros
+follow the format of MOCK_METHOD_n(functionName), where "n" is the number of parameters and "functionName" is the
+name of a function in one of the interfaces that the mock class implements.
+
+Internally these macros will implement the interface methods given as well as create a Set[functionName]
+setter per implemented function so that test code can set a custom C++ lambda that will be executed in place of
+the given interface function.
+
+Note: There are two sets of macros; one set for regular C++, and one set for high level C++/CX (see next section).
+
+This is all best explained with some sample code:
+
+struct Foo
+{
+int a;
+int b;
+};
+
+struct Bar
+{
+int a;
+int b;
+};
+
+class ISession
+{
+public:
+virtual void VoidNoArgs() = 0;
+virtual HRESULT AddMessageChannelListener(const Foo& foo) const = 0;
+virtual HRESULT RemoveMessageChannelListener(const Bar& bar, const Foo& foo) = 0;
+virtual HRESULT SendOnMessageChannel(const wchar_t* psz1, int x, char w, long long xyz) = 0;
+};
+
+class MockSessionWithLambdas : public ISession
+{
+public:
+MOCK_METHOD_0(VoidNoArgs);
+MOCK_CONST_METHOD_1(AddMessageChannelListener);
+MOCK_METHOD_2(RemoveMessageChannelListener);
+MOCK_METHOD_4(SendOnMessageChannel);
+
+MockSessionWithLambdas()
+{
+// Initialize callbacks
+SetVoidNoArgs([]() { });
+SetAddMessageChannelListener([](const Foo& foo){ return E_NOTIMPL; });
+SetRemoveMessageChannelListener([](const Bar& bar, const Foo& foo){ return E_NOTIMPL; });
+SetSendOnMessageChannel([](const wchar_t* psz1, int x, char w, long long xyz){ return E_NOTIMPL; });
+}
+};
+
+TEST_METHOD(InterfaceMockingSample)
+{
+MockSessionWithLambdas x;
+HRESULT result = x.AddMessageChannelListener(Foo());
+
+// In this example, result should now be "E_NOTIMPL" based on the default mock implementation of
+// AddMessageChannelListener.
+
+x.SetAddMessageChannelListenerCallback([](const Foo& foo)
+{
+VERIFY_ARE_EQUAL(32, foo.a); // Perform validation within the callback
+return HRESULT_FROM_WIN32(ERROR_OUT_OF_PAPER);
+});
+
+result = x.AddMessageChannelListener(Foo());
+
+// Now, result should be "HRESULT_FROM_WIN32(ERROR_OUT_OF_PAPER)" based on the lambda provided. In a real test
+// the MockSessionWithLambdas would passed to other classes that rely on ISession objects. Then, as those other
+// objects interact with the ISession interface, all of the provided lambdas will be executed, allowing
+// fine-grained control of how the other objects behave.
+
+VERIFY_ARE_EQUAL(HRESULT_FROM_WIN32(ERROR_OUT_OF_PAPER), result);
+}
+*/ /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#define MOCK_CLASS(CLASS_NAME, ...)                       \
+    namespace BUILD_VARIABLE_NAME(CLASS_NAME, _PRIVATE) { \
+        class CLASS_NAME;                                 \
+        using MOCK_CLASS_NAME = CLASS_NAME;               \
+        class CLASS_NAME : __VA_ARGS__;                   \
+    };                                                    \
+    using CLASS_NAME = BUILD_VARIABLE_NAME(CLASS_NAME, _PRIVATE)::CLASS_NAME;
+
+////////////////////////////////////////////////////////////////
+// Macros for mocking non-const methods in low level C++
+////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg non-const method in low level C++
+#define MOCK_METHOD_0(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 0, false)
+
+// Mock a one-arg non-const methods in low level C++
+#define MOCK_METHOD_1(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 1, false)
+
+// Mock a two-arg non-const method in low level C++
+#define MOCK_METHOD_2(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 2, false)
+
+// Mock a three-arg non-const method in low level C++
+#define MOCK_METHOD_3(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 3, false)
+
+// Mock a four-arg non-const method in low level C++
+#define MOCK_METHOD_4(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 4, false)
+
+// Mock a five-arg non-const method in low level C++
+#define MOCK_METHOD_5(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 5, false)
+
+// Mock a six-arg non-const method in low level C++
+#define MOCK_METHOD_6(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 6, false)
+
+// Mock a seven-arg non-const method in low level C++
+#define MOCK_METHOD_7(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 7, false)
+
+// Mock an eight-arg non-const method in low level C++
+#define MOCK_METHOD_8(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 8, false)
+
+// Mock a nine-arg non-const method in low level C++
+#define MOCK_METHOD_9(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 9, false)
+
+// Mock a ten-arg non-const method in low level C++
+#define MOCK_METHOD_10(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 10, false)
+
+////////////////////////////////////////////////////////////////
+// Macros for mocking const methods in low level C++
+////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg const method in low level C++
+#define MOCK_CONST_METHOD_0(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 0, true)
+
+// Mock a one-arg const method in low level C++
+#define MOCK_CONST_METHOD_1(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 1, true)
+
+// Mock a two-arg const method in low level C++
+#define MOCK_CONST_METHOD_2(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 2, true)
+
+// Mock a three-arg const method in low level C++
+#define MOCK_CONST_METHOD_3(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 3, true)
+
+// Mock a four-arg const method in low level C++
+#define MOCK_CONST_METHOD_4(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 4, true)
+
+// Mock a five-arg const method in low level C++
+#define MOCK_CONST_METHOD_5(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 5, true)
+
+// Mock a six-arg const method in low level C++
+#define MOCK_CONST_METHOD_6(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 6, true)
+
+// Mock a seven-arg const method in low level C++
+#define MOCK_CONST_METHOD_7(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 7, true)
+
+// Mock an eight-arg const method in low level C++
+#define MOCK_CONST_METHOD_8(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 8, true)
+
+// Mock a nine-arg const method in low level C++
+#define MOCK_CONST_METHOD_9(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 9, true)
+
+// Mock a ten-arg const method in low level C++
+#define MOCK_CONST_METHOD_10(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 10, true)
+
+///////////////////////////////////////////////////////////////////
+// Macros for mocking non-const __stdcall methods in low level C++
+///////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_0(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 0, false, __stdcall)
+
+// Mock a one-arg non-const methods in low level C++
+#define MOCK_STDCALL_METHOD_1(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 1, false, __stdcall)
+
+// Mock a two-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_2(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 2, false, __stdcall)
+
+// Mock a three-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_3(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 3, false, __stdcall)
+
+// Mock a four-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_4(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 4, false, __stdcall)
+
+// Mock a five-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_5(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 5, false, __stdcall)
+
+// Mock a six-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_6(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 6, false, __stdcall)
+
+// Mock a seven-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_7(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 7, false, __stdcall)
+
+// Mock an eight-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_8(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 8, false, __stdcall)
+
+// Mock a nine-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_9(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 9, false, __stdcall)
+
+// Mock a ten-arg non-const method in low level C++
+#define MOCK_STDCALL_METHOD_10(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 10, false, __stdcall)
+
+///////////////////////////////////////////////////////////////////
+// Macros for mocking const __stdcall methods in low level C++
+///////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_0(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 0, true, __stdcall)
+
+// Mock a one-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_1(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 1, true, __stdcall)
+
+// Mock a two-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_2(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 2, true, __stdcall)
+
+// Mock a three-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_3(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 3, true, __stdcall)
+
+// Mock a four-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_4(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 4, true, __stdcall)
+
+// Mock a five-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_5(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 5, true, __stdcall)
+
+// Mock a six-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_6(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 6, true, __stdcall)
+
+// Mock a seven-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_7(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 7, true, __stdcall)
+
+// Mock an eight-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_8(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 8, true, __stdcall)
+
+// Mock a nine-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_9(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 9, true, __stdcall)
+
+// Mock a ten-arg const method in low level C++
+#define MOCK_CONST_STDCALL_METHOD_10(METHOD_NAME) BUILD_MOCK_METHOD_IMPL(METHOD_NAME, 10, true, __stdcall)
+
+/*/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+C++/CX usage is slightly different than it is for low level C++:
+
+1. Due to an issue in the compiler, you must first call CX_MOCK_INTERFACE before any of the CX_MOCK* macros will compile.
+
+CX_MOCK_INTERFACE(AnotherNamespace::ITestInterface);
+
+2. You must specify the interface name in addition to the name of the method that you're stubbing out.
+
+CX_MOCK_METHOD_0(ITestInterface, SomeMethod);
+
+This is all best explained with some sample code:
+
+namespace SomeNamespace
+{
+interface class ISession
+{
+public:
+virtual void SomeMethod(int x);
+
+property int SomeProperty
+{
+int get();
+void set(int);
+}
+};
+}
+
+CX_MOCK_INTERFACE(SomeNamespace::ISession); // Necessary for CX_MOCK_METHOD_* calls to compile
+ref class MockSessionWithLambdas : public SomeNamespace::ISession
+{
+public:
+CX_MOCK_METHOD_1(SomeNamespace::ISession, SomeMethod);
+CX_MOCK_PROPERTY(SomeNamespace::ISession, SomeProperty);
+
+MockSessionWithLambdas()
+{
+// Initialize callbacks
+SetSomeMethod([](int){ });
+SetSomePropertyGetter([] () { return 0; });
+SetSomePropertySetter([] (int) { });
+}
+};
+
+TEST_METHOD(InterfaceMockingSample)
+{
+auto mockSession = ref new MockSessionWithLambdas();
+int callCount = 0;
+mockSession->SetSomeMethod([&](int x)
+{
+VERIFY_ARE_EQUAL(32, x); // Perform validation within the callback
+++callCount;
+});
+
+mockSession->SomeMethod(32);
+
+VERIFY_ARE_EQUAL(1, callCount);
+}
+*/ /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Macros for mocking C++/CX interface methods
+// Be sure to call CX_MOCK_INTERFACE(YourInterface) first.
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+// This macro must be called per-interface before any of the CX_MOCK_METHOD* calls will compile for it.
+// Be sure to fully qualify your interface name; for example: Arcadia::TestFoundation::Tests::ITestInterface.
+#define CX_MOCK_INTERFACE(FULLY_QUALIFIED_INTERFACE_NAME) CX_MOCK_INTERFACE_DISPATCHER_IMPL(FULLY_QUALIFIED_INTERFACE_NAME, __cdecl)
+
+////////////////////////////////////////////////////////////////
+// Macros for mocking C++/CX interface methods
+////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg method in high level C++/CX
+#define CX_MOCK_METHOD_0(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 0, INTERFACE_CLASS, public)
+
+// Mock a one-arg method in high level C++/CX
+#define CX_MOCK_METHOD_1(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 1, INTERFACE_CLASS, public)
+
+// Mock a two-arg method in high level C++/CX
+#define CX_MOCK_METHOD_2(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 2, INTERFACE_CLASS, public)
+
+// Mock a three-arg method in high level C++/CX
+#define CX_MOCK_METHOD_3(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 3, INTERFACE_CLASS, public)
+
+// Mock a four-arg method in high level C++/CX
+#define CX_MOCK_METHOD_4(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 4, INTERFACE_CLASS, public)
+
+// Mock a five-arg method in high level C++/CX
+#define CX_MOCK_METHOD_5(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 5, INTERFACE_CLASS, public)
+
+// Mock a six-arg method in high level C++/CX
+#define CX_MOCK_METHOD_6(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 6, INTERFACE_CLASS, public)
+
+// Mock a seven-arg method in high level C++/CX
+#define CX_MOCK_METHOD_7(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 7, INTERFACE_CLASS, public)
+
+// Mock an eight-arg method in high level C++/CX
+#define CX_MOCK_METHOD_8(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 8, INTERFACE_CLASS, public)
+
+// Mock a nine-arg method in high level C++/CX
+#define CX_MOCK_METHOD_9(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 9, INTERFACE_CLASS, public)
+
+// Mock a ten-arg method in high level C++/CX
+#define CX_MOCK_METHOD_10(INTERFACE_NAME, METHOD_NAME) CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 10, INTERFACE_CLASS, public)
+
+// Mock a read/write property getter/setter
+#define CX_MOCK_PROPERTY(INTERFACE_NAME, PROPERTY_NAME) CX_BUILD_MOCK_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, INTERFACE_CLASS, public)
+
+// Mock a readonly property getter
+#define CX_MOCK_READONLY_PROPERTY(INTERFACE_NAME, PROPERTY_NAME) \
+    CX_BUILD_MOCK_READONLY_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, INTERFACE_CLASS, public)
+
+////////////////////////////////////////////////////////////////
+// Macros for mocking public C++/CX abstract class methods
+////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_0(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 0, ABSTRACT_CLASS, public)
+
+// Mock a one-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_1(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 1, ABSTRACT_CLASS, public)
+
+// Mock a two-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_2(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 2, ABSTRACT_CLASS, public)
+
+// Mock a three-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_3(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 3, ABSTRACT_CLASS, public)
+
+// Mock a four-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_4(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 4, ABSTRACT_CLASS, public)
+
+// Mock a five-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_5(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 5, ABSTRACT_CLASS, public)
+
+// Mock a six-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_6(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 6, ABSTRACT_CLASS, public)
+
+// Mock a seven-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_7(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 7, ABSTRACT_CLASS, public)
+
+// Mock an eight-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_8(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 8, ABSTRACT_CLASS, public)
+
+// Mock a nine-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_9(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 9, ABSTRACT_CLASS, public)
+
+// Mock a ten-arg public abstract class method in high level C++/CX
+#define CX_MOCK_ABSTRACT_METHOD_10(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 10, ABSTRACT_CLASS, public)
+
+// Mock a public abstract read/write property getter/setter
+#define CX_MOCK_ABSTRACT_PROPERTY(INTERFACE_NAME, PROPERTY_NAME) \
+    CX_BUILD_MOCK_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, ABSTRACT_CLASS, public)
+
+// Mock a public abstract readonly property getter
+#define CX_MOCK_ABSTRACT_READONLY_PROPERTY(INTERFACE_NAME, PROPERTY_NAME) \
+    CX_BUILD_MOCK_READONLY_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, ABSTRACT_CLASS, public)
+
+////////////////////////////////////////////////////////////////
+// Macros for mocking internal C++/CX abstract class methods
+////////////////////////////////////////////////////////////////
+
+// Mock a zero-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_0(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 0, ABSTRACT_CLASS, internal)
+
+// Mock a one-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_1(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 1, ABSTRACT_CLASS, internal)
+
+// Mock a two-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_2(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 2, ABSTRACT_CLASS, internal)
+
+// Mock a three-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_3(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 3, ABSTRACT_CLASS, internal)
+
+// Mock a four-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_4(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 4, ABSTRACT_CLASS, internal)
+
+// Mock a five-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_5(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 5, ABSTRACT_CLASS, internal)
+
+// Mock a six-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_6(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 6, ABSTRACT_CLASS, internal)
+
+// Mock a seven-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_7(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 7, ABSTRACT_CLASS, internal)
+
+// Mock an eight-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_8(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 8, ABSTRACT_CLASS, internal)
+
+// Mock a nine-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_9(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 9, ABSTRACT_CLASS, internal)
+
+// Mock a ten-arg internal abstract class method in high level C++/CX
+#define CX_MOCK_INTERNAL_ABSTRACT_METHOD_10(INTERFACE_NAME, METHOD_NAME) \
+    CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, 10, ABSTRACT_CLASS, internal)
+
+// Mock an internal abstract read/write property getter/setter
+#define CX_MOCK_INTERNAL_ABSTRACT_PROPERTY(INTERFACE_NAME, PROPERTY_NAME) \
+    CX_BUILD_MOCK_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, ABSTRACT_CLASS, internal)
+
+// Mock an internal abstract readonly property getter
+#define CX_MOCK_INTERNAL_ABSTRACT_READONLY_PROPERTY(INTERFACE_NAME, PROPERTY_NAME) \
+    CX_BUILD_MOCK_READONLY_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, ABSTRACT_CLASS, internal)
+
+//*********************************************************************************************************************
+// DO NOT directly call any of the private helper macros/functions below.
+//*********************************************************************************************************************
+
+/////////////////////////////////////////////////////////////
+// Validates that a callback has been set before invoking it.
+/////////////////////////////////////////////////////////////
+#if !defined CUSTOM_MOCK_CALLBACK_VALIDATOR
+namespace Arcadia {
+namespace TestFoundation {
+template <typename TFunctor>
+void ValidateCallback(const TFunctor& functor, const wchar_t* name) {
+    WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+    VERIFY_IS_NOT_NULL(functor, WEX::Common::String().Format(L"The callback for %s has not been set!", name));
+}
+}
+}
+#endif
+
+//*********************************************************************************************************************
+// Internal/private low level C++ support
+//*********************************************************************************************************************
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Macros used to build out the parameter types passed to the method and the contained std::function
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define MOCK_NAMED_ARGS_0(METHOD_NAME)
+
+#define MOCK_NAMED_ARGS_1(METHOD_NAME) WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1
+
+#define MOCK_NAMED_ARGS_2(METHOD_NAME)                                                   \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2
+
+#define MOCK_NAMED_ARGS_3(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3
+
+#define MOCK_NAMED_ARGS_4(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4
+
+#define MOCK_NAMED_ARGS_5(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter5 p5
+
+#define MOCK_NAMED_ARGS_6(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter5 p5, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter6 p6
+
+#define MOCK_NAMED_ARGS_7(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter5 p5, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter6 p6, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter7 p7
+
+#define MOCK_NAMED_ARGS_8(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter5 p5, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter6 p6, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter7 p7, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter8 p8
+
+#define MOCK_NAMED_ARGS_9(METHOD_NAME)                                                       \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter5 p5, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter6 p6, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter7 p7, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter8 p8, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter9 p9
+
+#define MOCK_NAMED_ARGS_10(METHOD_NAME)                                                      \
+    WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter1 p1,     \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter2 p2, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter3 p3, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter4 p4, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter5 p5, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter6 p6, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter7 p7, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter8 p8, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter9 p9, \
+        WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::Parameter10 p10
+
+////////////////////////////////////////////////////
+// Macros to build out function call parameter list
+////////////////////////////////////////////////////
+#define MOCK_CALL_ARGS_0
+#define MOCK_CALL_ARGS_1 p1
+#define MOCK_CALL_ARGS_2 p1, p2
+#define MOCK_CALL_ARGS_3 p1, p2, p3
+#define MOCK_CALL_ARGS_4 p1, p2, p3, p4
+#define MOCK_CALL_ARGS_5 p1, p2, p3, p4, p5
+#define MOCK_CALL_ARGS_6 p1, p2, p3, p4, p5, p6
+#define MOCK_CALL_ARGS_7 p1, p2, p3, p4, p5, p6, p7
+#define MOCK_CALL_ARGS_8 p1, p2, p3, p4, p5, p6, p7, p8
+#define MOCK_CALL_ARGS_9 p1, p2, p3, p4, p5, p6, p7, p8, p9
+#define MOCK_CALL_ARGS_10 p1, p2, p3, p4, p5, p6, p7, p8, p9, p10
+
+/////////////////////////////////////////////////////////////
+// Internally used by MOCK_* macros; do not call directly.
+/////////////////////////////////////////////////////////////
+#define BUILD_MOCK_METHOD_IMPL(METHOD_NAME, PARAMETER_COUNT, IS_CONST, ...)                                                               \
+private:                                                                                                                                  \
+    std::function<WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::ReturnType(                                       \
+        BUILD_VARIABLE_NAME(MOCK_NAMED_ARGS_, PARAMETER_COUNT)(METHOD_NAME))> BUILD_VARIABLE_NAME(m_, METHOD_NAME);                       \
+                                                                                                                                          \
+public:                                                                                                                                   \
+    virtual WEX::Common::ParameterTypes<decltype(&MOCK_CLASS_NAME::METHOD_NAME)>::ReturnType __VA_ARGS__ METHOD_NAME(                     \
+        BUILD_VARIABLE_NAME(MOCK_NAMED_ARGS_, PARAMETER_COUNT)(METHOD_NAME)) BUILD_VARIABLE_NAME(MEMBER_PARAMETER_TYPES_CONST_, IS_CONST) \
+        override {                                                                                                                        \
+        Arcadia::TestFoundation::ValidateCallback(BUILD_VARIABLE_NAME(m_, METHOD_NAME), TAEF_WIDEN(TAEF_STRINGIZE(METHOD_NAME)));         \
+        return BUILD_VARIABLE_NAME(m_, METHOD_NAME)(BUILD_VARIABLE_NAME(MOCK_CALL_ARGS_, PARAMETER_COUNT));                               \
+    }                                                                                                                                     \
+    void BUILD_VARIABLE_NAME(Set, METHOD_NAME)(const decltype(BUILD_VARIABLE_NAME(m_, METHOD_NAME))& callback) {                          \
+        BUILD_VARIABLE_NAME(m_, METHOD_NAME) = callback;                                                                                  \
+    }
+
+//*********************************************************************************************************************
+// Internal/private high level C++/CX support
+//*********************************************************************************************************************
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Macros used to build out the parameter types passed to the custom ParameterTypes instantiations
+// that are made in CX_MOCK_INTERFACE_IMPL for high-level C++/CX interface mocks.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_0 template <typename TR>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_1 template <typename TR, typename T1>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_2 template <typename TR, typename T1, typename T2>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_3 template <typename TR, typename T1, typename T2, typename T3>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_4 template <typename TR, typename T1, typename T2, typename T3, typename T4>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_5 template <typename TR, typename T1, typename T2, typename T3, typename T4, typename T5>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_6 \
+    template <typename TR, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_7 \
+    template <typename TR, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_8 \
+    template <typename TR, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_9 \
+    template <typename TR,                   \
+              typename T1,                   \
+              typename T2,                   \
+              typename T3,                   \
+              typename T4,                   \
+              typename T5,                   \
+              typename T6,                   \
+              typename T7,                   \
+              typename T8,                   \
+              typename T9>
+#define CX_MEMBER_PARAMETER_TYPES_TEMPLATE_10 \
+    template <typename TR,                    \
+              typename T1,                    \
+              typename T2,                    \
+              typename T3,                    \
+              typename T4,                    \
+              typename T5,                    \
+              typename T6,                    \
+              typename T7,                    \
+              typename T8,                    \
+              typename T9,                    \
+              typename T10>
+
+////////////////////////////////////////////////////////////////////////
+// Internally used by CX_MOCK_INTERFACE_ macro; do not call directly.
+////////////////////////////////////////////////////////////////////////
+#define CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, PARAMETER_COUNT, CALLING_CONVENTION)                                                      \
+    BUILD_VARIABLE_NAME(CX_MEMBER_PARAMETER_TYPES_TEMPLATE_, PARAMETER_COUNT)                                                            \
+    struct MockInterfaceCalled<TR (CALLING_CONVENTION INTERFACE_NAME::*)(BUILD_VARIABLE_NAME(PARAMETER_TYPES_ARGS_, PARAMETER_COUNT))> { \
+        static const bool result = true;                                                                                                 \
+    };                                                                                                                                   \
+    BUILD_VARIABLE_NAME(CX_MEMBER_PARAMETER_TYPES_TEMPLATE_, PARAMETER_COUNT)                                                            \
+    struct WEX::Common::ParameterTypes<TR (CALLING_CONVENTION INTERFACE_NAME::*)(                                                        \
+        BUILD_VARIABLE_NAME(PARAMETER_TYPES_ARGS_, PARAMETER_COUNT))> {                                                                  \
+        typedef TR ReturnType;                                                                                                           \
+        typedef typename INTERFACE_NAME ClassType;                                                                                       \
+        static const unsigned short ParameterCount = PARAMETER_COUNT;                                                                    \
+        static const bool IsConstMethod = false;                                                                                         \
+        typedef BUILD_VARIABLE_NAME(PARAMETER_TYPES_TYPELIST_, PARAMETER_COUNT) Parameters;                                              \
+        typedef typename WEX::Common::TypeAt<Parameters, 0>::Result Parameter1;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 1>::Result Parameter2;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 2>::Result Parameter3;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 3>::Result Parameter4;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 4>::Result Parameter5;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 5>::Result Parameter6;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 6>::Result Parameter7;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 7>::Result Parameter8;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 8>::Result Parameter9;                                                          \
+        typedef typename WEX::Common::TypeAt<Parameters, 9>::Result Parameter10;                                                         \
+    };
+
+/////////////////////////////////////////////////////////////////////
+// Internally used by CX_MOCK_INTERFACE_ macro; do not call directly.
+/////////////////////////////////////////////////////////////////////
+#define CX_MOCK_INTERFACE_DISPATCHER_IMPL(INTERFACE_NAME, CALLING_CONVENTION) \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 0, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 1, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 2, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 3, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 4, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 5, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 6, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 7, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 8, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 9, CALLING_CONVENTION)             \
+    CX_MOCK_INTERFACE_IMPL(INTERFACE_NAME, 10, CALLING_CONVENTION)
+
+/////////////////////////////////////////////////////////////
+// Internally used by CX_MOCK_* macros; do not call directly.
+/////////////////////////////////////////////////////////////
+template <typename TPrototype>
+struct MockInterfaceCalled {
+    static const bool result = false;
+};
+
+/////////////////////////////////////////////////////////////
+// Builds out C++/CX interface method implementations
+/////////////////////////////////////////////////////////////
+#define MOCK_OVERRIDE_INTERFACE_CLASS
+#define MOCK_OVERRIDE_ABSTRACT_CLASS override
+
+#define CX_BUILD_MOCK_METHOD_IMPL(INTERFACE_NAME, METHOD_NAME, PARAMETER_COUNT, MOCK_TYPE, ACCESS)                                  \
+    static_assert(MockInterfaceCalled<decltype(&INTERFACE_NAME::METHOD_NAME)>::result,                                              \
+                  "You must add a single call to CX_MOCK_INTERFACE(" TAEF_STRINGIZE(                                                \
+                      INTERFACE_NAME) ") before this CX_MOCK_METHOD_" TAEF_STRINGIZE(PARAMETER_COUNT) " call will compile.");       \
+    typedef WEX::Common::ParameterTypes<decltype(&INTERFACE_NAME::METHOD_NAME)> BUILD_VARIABLE_NAME(METHOD_NAME, PARAMETER_TYPES);  \
+    static_assert(PARAMETER_COUNT == BUILD_VARIABLE_NAME(METHOD_NAME, PARAMETER_TYPES)::ParameterCount,                             \
+                  "Incorrect macro called for function; parameter count doesn't match!");                                           \
+                                                                                                                                    \
+private:                                                                                                                            \
+    std::function<BUILD_VARIABLE_NAME(METHOD_NAME, PARAMETER_TYPES)::ReturnType(                                                    \
+        BUILD_VARIABLE_NAME(MOCK_NAMED_ARGS_, PARAMETER_COUNT)(INTERFACE_NAME::METHOD_NAME))> BUILD_VARIABLE_NAME(m_, METHOD_NAME); \
+    ACCESS:                                                                                                                         \
+    virtual BUILD_VARIABLE_NAME(METHOD_NAME, PARAMETER_TYPES)::ReturnType METHOD_NAME(                                              \
+        BUILD_VARIABLE_NAME(MOCK_NAMED_ARGS_, PARAMETER_COUNT)(INTERFACE_NAME::METHOD_NAME))                                        \
+        BUILD_VARIABLE_NAME(MOCK_OVERRIDE_, MOCK_TYPE) {                                                                            \
+        Arcadia::TestFoundation::ValidateCallback(BUILD_VARIABLE_NAME(m_, METHOD_NAME), TAEF_WIDEN(TAEF_STRINGIZE(METHOD_NAME)));   \
+        return BUILD_VARIABLE_NAME(m_, METHOD_NAME)(BUILD_VARIABLE_NAME(MOCK_CALL_ARGS_, PARAMETER_COUNT));                         \
+    }                                                                                                                               \
+    internal:                                                                                                                       \
+    void BUILD_VARIABLE_NAME(Set, METHOD_NAME)(const decltype(BUILD_VARIABLE_NAME(m_, METHOD_NAME))& callback) {                    \
+        BUILD_VARIABLE_NAME(m_, METHOD_NAME) = callback;                                                                            \
+    }
+
+/////////////////////////////////////////////////////////////
+// Builds out C++/CX read/write property implementations
+/////////////////////////////////////////////////////////////
+#define CX_BUILD_MOCK_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, MOCK_TYPE, ACCESS)                                         \
+    static_assert(MockInterfaceCalled<decltype(&INTERFACE_NAME::PROPERTY_NAME::get)>::result,                                 \
+                  "You must add a single call to CX_MOCK_INTERFACE(" TAEF_STRINGIZE(                                          \
+                      INTERFACE_NAME) ") before this CX_MOCK_METHOD_" TAEF_STRINGIZE(PARAMETER_COUNT) " call will compile."); \
+    typedef WEX::Common::ParameterTypes<decltype(&INTERFACE_NAME::PROPERTY_NAME::get)>                                        \
+        BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES);                                        \
+    static_assert(0 == BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ParameterCount,         \
+                  "Incorrect macro called for function; parameter count doesn't match!");                                     \
+    static_assert(MockInterfaceCalled<decltype(&INTERFACE_NAME::PROPERTY_NAME::set)>::result,                                 \
+                  "You must add a single call to CX_MOCK_INTERFACE(" TAEF_STRINGIZE(                                          \
+                      INTERFACE_NAME) ") before this CX_MOCK_METHOD_" TAEF_STRINGIZE(PARAMETER_COUNT) " call will compile."); \
+    typedef WEX::Common::ParameterTypes<decltype(&INTERFACE_NAME::PROPERTY_NAME::set)>                                        \
+        BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, set), PARAMETER_TYPES);                                        \
+    static_assert(1 == BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, set), PARAMETER_TYPES)::ParameterCount,         \
+                  "Incorrect macro called for function; parameter count doesn't match!");                                     \
+                                                                                                                              \
+private:                                                                                                                      \
+    std::function<BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ReturnType()>                \
+        BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get));                                                     \
+    std::function<void(BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, set), PARAMETER_TYPES)::Parameter1 p1)>         \
+        BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, set));                                                     \
+    ACCESS:                                                                                                                   \
+    property BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ReturnType PROPERTY_NAME {        \
+        virtual BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ReturnType get()               \
+            BUILD_VARIABLE_NAME(MOCK_OVERRIDE_, MOCK_TYPE) {                                                                  \
+            Arcadia::TestFoundation::ValidateCallback(BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get)),       \
+                                                      TAEF_WIDEN(TAEF_STRINGIZE(PROPERTY_NAME))L"::get");                     \
+            return BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get))();                                        \
+        }                                                                                                                     \
+        virtual void set(BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, set), PARAMETER_TYPES)::Parameter1 p1)        \
+            BUILD_VARIABLE_NAME(MOCK_OVERRIDE_, MOCK_TYPE) {                                                                  \
+            Arcadia::TestFoundation::ValidateCallback(BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, set)),       \
+                                                      TAEF_WIDEN(TAEF_STRINGIZE(PROPERTY_NAME))L"::set");                     \
+            return BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, set))(p1);                                      \
+        }                                                                                                                     \
+    }                                                                                                                         \
+    internal:                                                                                                                 \
+    void BUILD_VARIABLE_NAME(Set, BUILD_VARIABLE_NAME(PROPERTY_NAME, Getter))(                                                \
+        const decltype(BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get)))& callback) {                         \
+        BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get)) = callback;                                          \
+    }                                                                                                                         \
+    void BUILD_VARIABLE_NAME(Set, BUILD_VARIABLE_NAME(PROPERTY_NAME, Setter))(                                                \
+        const decltype(BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, set)))& callback) {                         \
+        BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, set)) = callback;                                          \
+    }
+
+/////////////////////////////////////////////////////////////
+// Builds out C++/CX readonly property implementations
+/////////////////////////////////////////////////////////////
+#define CX_BUILD_MOCK_READONLY_PROPERTY_IMPL(INTERFACE_NAME, PROPERTY_NAME, MOCK_TYPE, ACCESS)                                \
+    static_assert(MockInterfaceCalled<decltype(&INTERFACE_NAME::PROPERTY_NAME::get)>::result,                                 \
+                  "You must add a single call to CX_MOCK_INTERFACE(" TAEF_STRINGIZE(                                          \
+                      INTERFACE_NAME) ") before this CX_MOCK_METHOD_" TAEF_STRINGIZE(PARAMETER_COUNT) " call will compile."); \
+    typedef WEX::Common::ParameterTypes<decltype(&INTERFACE_NAME::PROPERTY_NAME::get)>                                        \
+        BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES);                                        \
+    static_assert(0 == BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ParameterCount,         \
+                  "Incorrect macro called for function; parameter count doesn't match!");                                     \
+                                                                                                                              \
+private:                                                                                                                      \
+    std::function<BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ReturnType()>                \
+        BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get));                                                     \
+    ACCESS:                                                                                                                   \
+    property BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ReturnType PROPERTY_NAME {        \
+        virtual BUILD_VARIABLE_NAME(BUILD_VARIABLE_NAME(PROPERTY_NAME, get), PARAMETER_TYPES)::ReturnType get()               \
+            BUILD_VARIABLE_NAME(MOCK_OVERRIDE_, MOCK_TYPE) {                                                                  \
+            Arcadia::TestFoundation::ValidateCallback(BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get)),       \
+                                                      TAEF_WIDEN(TAEF_STRINGIZE(PROPERTY_NAME))L"::get");                     \
+            return BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get))();                                        \
+        }                                                                                                                     \
+    }                                                                                                                         \
+    internal:                                                                                                                 \
+    void BUILD_VARIABLE_NAME(Set, BUILD_VARIABLE_NAME(PROPERTY_NAME, Getter))(                                                \
+        const decltype(BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get)))& callback) {                         \
+        BUILD_VARIABLE_NAME(m_, BUILD_VARIABLE_NAME(PROPERTY_NAME, get)) = callback;                                          \
+    }

--- a/Frameworks/include/UIApplicationInternal.h
+++ b/Frameworks/include/UIApplicationInternal.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #import <UIKit/UIApplication.h>
+#import <UWP/WindowsMediaSpeechRecognition.h>
+#import <UWP/WindowsFoundation.h>
 
 @interface UIApplication (internal)
 - (UIWindow*)_popupWindow;
@@ -25,6 +27,8 @@
 - (void)_bringToForeground:(NSURL*)url;
 - (void)_sendHighMemoryWarning;
 - (void)_sendNotificationReceivedEvent:(NSString*)notificationData;
+- (void)_sendVoiceCommandReceivedEvent:(WMSSpeechRecognitionResult*)voiceCommandResult;
+- (void)_sendProtocolReceivedEvent:(WFUri*)protocolUri;
 @end
 
 @interface WOCDisplayMode (internal)
@@ -45,5 +49,5 @@
 // UIApplicationMainInit is declared here instead of UIApplicationMainInternal.h because it uses NS* types and cannot be defined in
 // in a file that gets included in C++/CX sources.
 UIKIT_EXPORT int UIApplicationMainInit(
-    NSString* pClassName, NSString* dClassName, UIInterfaceOrientation defaultOrientation, int activationType, NSString* activationArg);
+    NSString* pClassName, NSString* dClassName, UIInterfaceOrientation defaultOrientation, int activationType, id activationArg);
 void _UIApplicationShutdown();

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -121,7 +121,7 @@
       <AdditionalDependencies>Wex.Logger.lib;Wex.Common.lib;TE.Common.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
-      <IncludePaths>..\..\..\include;..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;%(AdditionalIncludeDirectories)</IncludePaths>
+      <IncludePaths>..\..\..\include;..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;..\..\..\deps\prebuilt\include\TAEF;%(AdditionalIncludeDirectories)</IncludePaths>
       <CompileAs>CompileAsObjCpp</CompileAs>
       <OtherCPlusPlusFlags>-fmsvc-real-char -Wdeprecated-declarations</OtherCPlusPlusFlags>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUG=1;FUNCTIONAL_TEST_FRAMEWORK</PreprocessorDefinitions>
@@ -150,7 +150,7 @@
       <AdditionalDependencies>Wex.Logger.lib;Wex.Common.lib;TE.Common.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
-      <IncludePaths>..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;%(AdditionalIncludeDirectories)</IncludePaths>
+      <IncludePaths>..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;..\..\..\deps\prebuilt\include\TAEF;%(AdditionalIncludeDirectories)</IncludePaths>
       <CompileAs>CompileAsObjCpp</CompileAs>
       <OtherCPlusPlusFlags>-fmsvc-real-char -Wdeprecated-declarations</OtherCPlusPlusFlags>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUG=1;FUNCTIONAL_TEST_FRAMEWORK</PreprocessorDefinitions>
@@ -175,7 +175,7 @@
       <AdditionalDependencies>Wex.Logger.lib;Wex.Common.lib;TE.Common.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
-      <IncludePaths>..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;%(AdditionalIncludeDirectories)</IncludePaths>
+      <IncludePaths>..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;..\..\..\deps\prebuilt\include\TAEF;%(AdditionalIncludeDirectories)</IncludePaths>
       <CompileAs>CompileAsObjCpp</CompileAs>
       <OtherCPlusPlusFlags>-fmsvc-real-char -Wdeprecated-declarations</OtherCPlusPlusFlags>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUG=1;FUNCTIONAL_TEST_FRAMEWORK</PreprocessorDefinitions>
@@ -204,7 +204,7 @@
       <AdditionalDependencies>Wex.Logger.lib;Wex.Common.lib;TE.Common.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
-      <IncludePaths>..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;%(AdditionalIncludeDirectories)</IncludePaths>
+      <IncludePaths>..\..\..\Frameworks\include;..\..\..\tests\frameworks\include;..\..\..\tests\functionaltests;..\..\..\tests\frameworks\gtest;..\..\..\tests\frameworks\gtest\include;..\..\..\deps\prebuilt\include\TAEF;%(AdditionalIncludeDirectories)</IncludePaths>
       <CompileAs>CompileAsObjCpp</CompileAs>
       <OtherCPlusPlusFlags>-fmsvc-real-char -Wdeprecated-declarations</OtherCPlusPlusFlags>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;DEBUG=1;FUNCTIONAL_TEST_FRAMEWORK</PreprocessorDefinitions>
@@ -233,6 +233,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSUserDefaultsTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSBundleTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\SampleTest.mm" />
+    <ClangCompile Include="..\..\..\tests\functionaltests\Tests\CortanaTests.mm" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURL.AppxManifest.xml" />

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -233,7 +233,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSUserDefaultsTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSBundleTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\SampleTest.mm" />
-    <ClangCompile Include="..\..\..\tests\functionaltests\Tests\CortanaTests.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\CortanaTests.mm" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURL.AppxManifest.xml" />

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
@@ -42,7 +42,7 @@
       <Filter>Tests</Filter>
     </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSUserDefaultsTests.mm" />
-    <ClangCompile Include="..\..\..\tests\functionaltests\Tests\CortanaTests.mm">
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\CortanaTests.mm">
       <Filter>Tests</Filter>
     </ClangCompile>
   </ItemGroup>

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
@@ -41,9 +41,10 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSBundleTests.mm">
       <Filter>Tests</Filter>
     </ClangCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSUserDefaultsTests.mm" />
+    <ClangCompile Include="..\..\..\tests\functionaltests\Tests\CortanaTests.mm">
+      <Filter>Tests</Filter>
+    </ClangCompile>
   </ItemGroup>
   <ItemGroup>
     <Xml Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURL.AppxManifest.xml">

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -74,6 +74,7 @@
     </SBResourceCopy>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\MockClass.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\unittests\Tests.Shared\ByteUtils.h" />
   </ItemGroup>
 </Project>

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -288,6 +288,8 @@ LIBRARY UIKit
         UIApplicationLaunchOptionsSourceApplicationKey DATA
         UIApplicationLaunchOptionsRemoteNotificationKey DATA
         UIApplicationLaunchOptionsLocalNotificationKey DATA
+        UIApplicationLaunchOptionsVoiceCommandKey DATA
+        UIApplicationLaunchOptionsProtocolKey DATA
         UIApplicationLaunchOptionsAnnotationKey DATA
         UIApplicationLaunchOptionsLocationKey DATA
         UIApplicationLaunchOptionsNewsstandDownloadsKey DATA

--- a/docs/Foundation/CortanaForegroundActivation.md
+++ b/docs/Foundation/CortanaForegroundActivation.md
@@ -1,0 +1,88 @@
+#Windows Bridge for iOS
+
+##[Cortana Foreground Activation]
+
+###DEV DESIGN specification
+
+
+##Owner
+**Dev**	AJ Ballway; alballw
+
+##Overview
+This document covers details on how Cortana will be integrated with apps built mainly in iOS code which also want to leverage Windows specific features to launch apps from Cortana.  
+
+###Feature Summary
+Cortana is capable of activating an app in the foreground or interacting with it in the background.  Foreground activation can contain parameters for the app to handle, and be done by both Voice Command and Protocol.
+
+###Document Terms
+**Term**	Definition  
+**UWP**	Universal Windows Platform  
+**VCD**	Voice Command Definition - file used to define commands for Cortana integration  
+**Voice Command**	Activation of the app by giving some command to Cortana.  It can be written, it does not need to be an oral command.  
+**Protocol**	Activation of the app by clicking on a card while using Cortana.  
+
+###Requirements
+When a command is given or a card is clicked, the app should be activated in the foreground with the parameters given to Cortana.
+
+###Technology/Architecture Decisions
+We will create new OnApplicationLaunchOptions as well as new delegate methods for Cortana.  These will need to be publicly documented for developer use.
+
+##Design
+
+###Architecture Overview
+
+We will need to convert C++/CX Windows::Media::SpeechRecognition::SpeechRecognitionResult^ and Windows::Foundation::Uri^ to Objective C Projections WMSSpeechRecognitionResult\* and WFUri\* respectively by passing them as Iinspectable\* through C functions between the two languages.  Because Platform::String^ is not an IInspectable\*, we will need a branching path to handle the conversion from Platform::String^ as an HSTRING to NSString\* before joining the two  paths in _ApplicationMainStart.
+
+###Language Decisions
+We will use Objective-C projection as well as C++/CX wrappers as appropriate for functionality with Islandwood
+
+##Detailed Design
+
+The diagram below illustrates the code flow for activating an app via Cortana.
+
+
+![Diagram of Activation path](./mediaCortana_Foreground_Activation.png)
+
+
+
+Adding Cortana activation does not require any changes to the current flow of activation beyond splitting the path and rejoining after converting to Objective C projections, so the only changes will be additions of internal methods and enums to correctly call delegate methods, public constants and new delegate methods so developers will be able to respond to Cortana activation, and refactoring of the current activation path to handle Cortana activation objects VoiceCommandActivatedEventArgs and ProtocolActivatedEventArgs. 
+
+This will add:  
+* UIApplication.mm:
+	* UIApplicationLaunchOptionsVoiceCommandKey
+	* UIApplicationLaunchOptionsProtocolKey
+	* _sendVoiceCommandReceivedEvent
+	* _sendProtocolReceivedEvent
+* UIApplicationMain.mm:
+	* UIApplicationMainHandleVoiceCommandEvent
+	* UIApplicationMainHandleProtocolEvent
+* UIApplicationDelegate.h:
+	* application:didReceiveVoiceCommand:
+	* application:didReceiveProtocol:
+* StarboardXaml.h:
+	* ActivationTypeVoiceCommand
+	* ActivationTypeProtocol
+
+And these will need to be publicly documented for developers to use these features:
++ UIApplication.mm
+	* UIApplicationLaunchOptionsVoiceCommandKey
+	* UIApplicationLaunchOptionsProtocolKey
++ UIApplicationDelegate.h
+	* didReceiveVoiceCommand:
+	* didReceiveProtocol:
+
+
+
+##Interfaces and Interactions
+
+###Public APIs Added
+UIApplicationDelegate.h: 
+*	 application:didReceiveVoiceCommand:
+* application:didReceiveProtocol:
+
+
+##Functional and Unit Testing
+
+###Test Approach
+
+Functionally testing the onActivated path will require a large addition of path code to allow testing to hook in at different points, or possibly a restructuring of startup code to allow the test to get ownership of the app.

--- a/docs/Foundation/CortanaForegroundActivation.md
+++ b/docs/Foundation/CortanaForegroundActivation.md
@@ -41,7 +41,7 @@ We will use Objective-C projection as well as C++/CX wrappers as appropriate for
 The diagram below illustrates the code flow for activating an app via Cortana.
 
 
-![Diagram of Activation path](./mediaCortana_Foreground_Activation.png)
+![Diagram of Activation path](./media/Cortana_Foreground_Activation.png)
 
 
 

--- a/docs/Foundation/CortanaForegroundActivation.md
+++ b/docs/Foundation/CortanaForegroundActivation.md
@@ -34,7 +34,7 @@ We will create new OnApplicationLaunchOptions as well as new delegate methods fo
 We will need to convert C++/CX Windows::Media::SpeechRecognition::SpeechRecognitionResult^ and Windows::Foundation::Uri^ to Objective C Projections WMSSpeechRecognitionResult\* and WFUri\* respectively by passing them as Iinspectable\* through C functions between the two languages.  Because Platform::String^ is not an IInspectable\*, we will need a branching path to handle the conversion from Platform::String^ as an HSTRING to NSString\* before joining the two  paths in _ApplicationMainStart.
 
 ###Language Decisions
-We will use Objective-C projection as well as C++/CX wrappers as appropriate for functionality with Islandwood
+We will use Objective-C projection as well as C++/CX wrappers as appropriate for functionality with WinObjC
 
 ##Detailed Design
 
@@ -85,4 +85,4 @@ UIApplicationDelegate.h:
 
 ###Test Approach
 
-Functionally testing the onActivated path will require a large addition of path code to allow testing to hook in at different points, or possibly a restructuring of startup code to allow the test to get ownership of the app.
+Functionally testing the onActivated path will require a large addition of path code to allow testing to hook in at different points, or possibly a restructuring of startup code to allow the test to get ownership of the app.  Currently this is being tested manually.

--- a/docs/Foundation/CortanaForegroundActivation.md
+++ b/docs/Foundation/CortanaForegroundActivation.md
@@ -6,20 +6,20 @@
 
 
 ##Owner
-**Dev**	AJ Ballway; alballw
+**Dev** AJ Ballway; alballw
 
 ##Overview
-This document covers details on how Cortana will be integrated with apps built mainly in iOS code which also want to leverage Windows specific features to launch apps from Cortana.  
+This document covers details on how Cortana will be integrated with apps built mainly in iOS code which also want to leverage Windows specific features to launch apps from Cortana.
 
 ###Feature Summary
 Cortana is capable of activating an app in the foreground or interacting with it in the background.  Foreground activation can contain parameters for the app to handle, and be done by both Voice Command and Protocol.
 
 ###Document Terms
-**Term**	Definition  
-**UWP**	Universal Windows Platform  
-**VCD**	Voice Command Definition - file used to define commands for Cortana integration  
-**Voice Command**	Activation of the app by giving some command to Cortana.  It can be written, it does not need to be an oral command.  
-**Protocol**	Activation of the app by clicking on a card while using Cortana.  
+**Term**    Definition
+**UWP** Universal Windows Platform
+**VCD** Voice Command Definition - file used to define commands for Cortana integration
+**Voice Command**   Activation of the app by giving some command to Cortana.  It can be written, it does not need to be an oral command.
+**Protocol**    Activation of the app by clicking on a card while using Cortana.
 
 ###Requirements
 When a command is given or a card is clicked, the app should be activated in the foreground with the parameters given to Cortana.
@@ -45,40 +45,40 @@ The diagram below illustrates the code flow for activating an app via Cortana.
 
 
 
-Adding Cortana activation does not require any changes to the current flow of activation beyond splitting the path and rejoining after converting to Objective C projections, so the only changes will be additions of internal methods and enums to correctly call delegate methods, public constants and new delegate methods so developers will be able to respond to Cortana activation, and refactoring of the current activation path to handle Cortana activation objects VoiceCommandActivatedEventArgs and ProtocolActivatedEventArgs. 
+Adding Cortana activation does not require any changes to the current flow of activation beyond splitting the path and rejoining after converting to Objective C projections, so the only changes will be additions of internal methods and enums to correctly call delegate methods, public constants and new delegate methods so developers will be able to respond to Cortana activation, and refactoring of the current activation path to handle Cortana activation objects VoiceCommandActivatedEventArgs and ProtocolActivatedEventArgs.
 
-This will add:  
+This will add:
 * UIApplication.mm:
-	* UIApplicationLaunchOptionsVoiceCommandKey
-	* UIApplicationLaunchOptionsProtocolKey
-	* _sendVoiceCommandReceivedEvent
-	* _sendProtocolReceivedEvent
+    * UIApplicationLaunchOptionsVoiceCommandKey
+    * UIApplicationLaunchOptionsProtocolKey
+    * _sendVoiceCommandReceivedEvent
+    * _sendProtocolReceivedEvent
 * UIApplicationMain.mm:
-	* UIApplicationMainHandleVoiceCommandEvent
-	* UIApplicationMainHandleProtocolEvent
+    * UIApplicationMainHandleVoiceCommandEvent
+    * UIApplicationMainHandleProtocolEvent
 * UIApplicationDelegate.h:
-	* application:didReceiveVoiceCommand:
-	* application:didReceiveProtocol:
+    * application:didReceiveVoiceCommand:
+    * application:didReceiveProtocol:
 * StarboardXaml.h:
-	* ActivationTypeVoiceCommand
-	* ActivationTypeProtocol
+    * ActivationTypeVoiceCommand
+    * ActivationTypeProtocol
 
 And these will need to be publicly documented for developers to use these features:
 + UIApplication.mm
-	* UIApplicationLaunchOptionsVoiceCommandKey
-	* UIApplicationLaunchOptionsProtocolKey
+    * UIApplicationLaunchOptionsVoiceCommandKey
+    * UIApplicationLaunchOptionsProtocolKey
 + UIApplicationDelegate.h
-	* didReceiveVoiceCommand:
-	* didReceiveProtocol:
+    * didReceiveVoiceCommand:
+    * didReceiveProtocol:
 
 
 
 ##Interfaces and Interactions
 
 ###Public APIs Added
-UIApplicationDelegate.h: 
-*	 application:didReceiveVoiceCommand:
-* application:didReceiveProtocol:
+UIApplicationDelegate.h:
+*   application:didReceiveVoiceCommand:
+*   application:didReceiveProtocol:
 
 
 ##Functional and Unit Testing

--- a/docs/Foundation/media/Cortana_Foreground_Activation.png
+++ b/docs/Foundation/media/Cortana_Foreground_Activation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0318656186866b0778ca3fe82ced6ca938054958463a3c4e5e58f1603c20f404
+size 24287

--- a/include/UIKit/UIApplication.h
+++ b/include/UIKit/UIApplication.h
@@ -52,6 +52,8 @@ UIKIT_EXPORT NSString* const UIApplicationSignificantTimeChangeNotification;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsURLKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsSourceApplicationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsRemoteNotificationKey;
+UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsVoiceCommandKey;
+UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsProtocolKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsAnnotationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsLocalNotificationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsLocationKey;

--- a/include/UIKit/UIApplicationDelegate.h
+++ b/include/UIKit/UIApplicationDelegate.h
@@ -41,6 +41,8 @@ UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsURLKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsSourceApplicationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsRemoteNotificationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsLocalNotificationKey;
+UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsVoiceCommandKey;
+UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsProtocolKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsAnnotationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsLocationKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsNewsstandDownloadsKey;

--- a/include/UIKit/UIApplicationDelegate.h
+++ b/include/UIKit/UIApplicationDelegate.h
@@ -35,7 +35,7 @@
 #import <UIKit/UIApplication.h>
 
 @class NSString, UIApplication, NSDictionary, NSCoder, UIViewController, NSArray, UIUserNotificationSettings, UILocalNotification, NSData,
-    NSError, NSUserActivity, UIApplicationShortcutItem, NSURL, UIWindow;
+    NSError, NSUserActivity, UIApplicationShortcutItem, NSURL, UIWindow, WMSSpeechRecognitionResult, WFUri;
 
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsURLKey;
 UIKIT_EXPORT NSString* const UIApplicationLaunchOptionsSourceApplicationKey;
@@ -118,6 +118,8 @@ UIKIT_EXPORT NSString* const UIApplicationOpenURLOptionsOpenInPlaceKey;
          forRemoteNotification:(NSDictionary*)userInfo
              completionHandler:(void (^)(void))completionHandler;
 - (void)application:(UIApplication*)application didReceiveRemoteNotification:(NSDictionary*)userInfo;
+- (void)application:(UIApplication*)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result;
+- (void)application:(UIApplication*)application didReceiveProtocol:(WFUri*)uri;
 - (void)application:(UIApplication*)application
     handleActionWithIdentifier:(NSString*)identifier
           forLocalNotification:(UILocalNotification*)notification

--- a/include/UIKit/UIApplicationDelegate.h
+++ b/include/UIKit/UIApplicationDelegate.h
@@ -33,6 +33,12 @@
 #import <UIKit/UIKitExport.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIApplication.h>
+/* TODO 7328699::
+ * Projection headers cannot currenly be included in modules, so we must forward declare classes for now
+ * App developers should import the following files to use methods requiring projected classes
+ * #import <UWP/WindowsFoundation.h>
+ * #import <UWP/WindowsMediaSpeechRecognition.h>
+*/
 
 @class NSString, UIApplication, NSDictionary, NSCoder, UIViewController, NSArray, UIUserNotificationSettings, UILocalNotification, NSData,
     NSError, NSUserActivity, UIApplicationShortcutItem, NSURL, UIWindow, WMSSpeechRecognitionResult, WFUri;

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -19,8 +19,6 @@
 #include "Framework/Framework.h"
 #include <WexTestClass.h>
 #include <ErrorHandling.h>
-#include "MockClass.h"
-#include <windows.applicationModel.activation.h>
 
 using namespace WEX::Logging;
 using namespace WEX::TestExecution;

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -19,6 +19,8 @@
 #include "Framework/Framework.h"
 #include <WexTestClass.h>
 #include <ErrorHandling.h>
+#include "MockClass.h"
+#include <windows.applicationModel.activation.h>
 
 using namespace WEX::Logging;
 using namespace WEX::TestExecution;
@@ -277,5 +279,28 @@ public:
 
     TEST_METHOD(NSBundle_MSAppxURL) {
         NSBundleMSAppxURL();
+    }
+}; /* class NSBundle */
+
+//
+// Cortana Activation Tests
+//
+
+extern void CortanaTestVoiceCommandForegroundActivation();
+
+class Cortana {
+public:
+    BEGIN_TEST_CLASS(Cortana)
+    TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
+    TEST_CLASS_PROPERTY(L"UAP:Host", L"Xaml")
+    TEST_CLASS_PROPERTY(L"Ignore", L"true")
+    END_TEST_CLASS()
+
+    TEST_CLASS_SETUP(CortanaTestClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationMainTest));
+    }
+
+    TEST_METHOD(CortanaTest_VoiceCommandForegroundActivation) {
+        CortanaTestVoiceCommandForegroundActivation();
     }
 }; /* class NSBundle */

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -16,11 +16,13 @@
 
 #include <TestFramework.h>
 #include <Foundation/Foundation.h>
+
 #include <COMIncludes.h>
 #include "MockClass.h"
 #include <windows.applicationModel.activation.h>
 #include <windows.media.speechRecognition.h>
 #include <COMIncludes_End.h>
+
 #include <UWP/WindowsApplicationModelActivation.h>
 #include <UWP/WindowsMediaSpeechRecognition.h>
 #include <UWP/WindowsUIXaml.h>
@@ -31,10 +33,13 @@ using namespace ABI::Windows::ApplicationModel::Activation;
 using namespace ABI::Windows::Media::SpeechRecognition;
 using namespace Microsoft::WRL;
 
+
 MOCK_CLASS(MockSpeechRecognitionResult,
            public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, ISpeechRecognitionResult, ISpeechRecognitionResult2> {
-               InspectableClass(RuntimeClass_Windows_Media_SpeechRecognition_SpeechRecognitionResult,
-                                BaseTrust); // claim to be the implementation for the real system RuntimeClass for SpeechRecognitionResult.
+
+              // Claim to be the implementation for the real system RuntimeClass for SpeechRecognitionResult.
+              InspectableClass(RuntimeClass_Windows_Media_SpeechRecognition_SpeechRecognitionResult,
+                                BaseTrust);
 
            public:
                MOCK_STDCALL_METHOD_1(get_Status);
@@ -52,8 +57,10 @@ MOCK_CLASS(MockSpeechRecognitionResult,
 MOCK_CLASS(
     MockVoiceCommandActivatedEventArgs,
     public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IVoiceCommandActivatedEventArgs, IActivatedEventArgs> {
+
+        // Claim to be the implementation for the real system RuntimeClass for VoiceCommandActivatedEventArgs.
         InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_VoiceCommandActivatedEventArgs,
-                         BaseTrust); // claim to be the implementation for the real system RuntimeClass for VoiceCommandActivatedEventArgs.
+                         BaseTrust);
 
     public:
         MOCK_STDCALL_METHOD_1(get_Result);
@@ -64,8 +71,10 @@ MOCK_CLASS(
 
 MOCK_CLASS(MockProtocolActivatedEventArgs,
            public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IProtocolActivatedEventArgs, IActivatedEventArgs> {
-               InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_ProtocolActivatedEventArgs,
-                                BaseTrust); // claim to be the implementation for the real system RuntimeClass for Accel.
+
+                // Claim to be the implementation for the real system RuntimeClass for Accel.
+                InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_ProtocolActivatedEventArgs,
+                                BaseTrust);
 
            public:
                MOCK_STDCALL_METHOD_1(get_Uri);
@@ -77,8 +86,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
 // TODO: 8008558 Test handling foreground activation parameters from Cortana
 TEST(CortanaTest, VoiceCommandForegroundActivation) {
     LOG_INFO("CortanaTest Voice Command Foreground Activation Test: ");
-    // Get current application to test on
-    WXApplication* app = [WXApplication current];
+
     // Create mocked data to pass into application
     auto fakeSpeechRecognitionResult = Make<MockSpeechRecognitionResult>();
     fakeSpeechRecognitionResult->Setget_Text([](HSTRING* text) {
@@ -87,15 +95,18 @@ TEST(CortanaTest, VoiceCommandForegroundActivation) {
         *text = value.Detach();
         return S_OK;
     });
+
     auto fakeVoiceCommandActivatedEventArgs = Make<MockVoiceCommandActivatedEventArgs>();
     fakeVoiceCommandActivatedEventArgs->Setget_Result([&fakeSpeechRecognitionResult](ISpeechRecognitionResult** result) {
         fakeSpeechRecognitionResult.CopyTo(result);
         return S_OK;
     });
+
     fakeVoiceCommandActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
         *kind = ActivationKind_VoiceCommand;
         return S_OK;
     });
+    
     fakeVoiceCommandActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
         *state = ApplicationExecutionState_NotRunning;
         return S_OK;

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -72,7 +72,7 @@ MOCK_CLASS(
 MOCK_CLASS(MockProtocolActivatedEventArgs,
            public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IProtocolActivatedEventArgs, IActivatedEventArgs> {
 
-                // Claim to be the implementation for the real system RuntimeClass for Accel.
+                // Claim to be the implementation for the real system RuntimeClass for ProtocolActivatedEventArgs.
                 InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_ProtocolActivatedEventArgs,
                                 BaseTrust);
 

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -1,0 +1,103 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <TestFramework.h>
+#include <Foundation/Foundation.h>
+#include <COMIncludes.h>
+#include "MockClass.h"
+#include <windows.applicationModel.activation.h>
+#include <windows.media.speechRecognition.h>
+#include <COMIncludes_End.h>
+#include <UWP/WindowsApplicationModelActivation.h>
+#include <UWP/WindowsMediaSpeechRecognition.h>
+#include <UWP/WindowsUIXaml.h>
+#include "StringHelpers.h"
+#include "UIKit/UIApplication.h"
+
+using namespace ABI::Windows::ApplicationModel::Activation;
+using namespace ABI::Windows::Media::SpeechRecognition;
+using namespace Microsoft::WRL;
+
+MOCK_CLASS(MockSpeechRecognitionResult,
+           public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, ISpeechRecognitionResult, ISpeechRecognitionResult2> {
+               InspectableClass(RuntimeClass_Windows_Media_SpeechRecognition_SpeechRecognitionResult,
+                                BaseTrust); // claim to be the implementation for the real system RuntimeClass for SpeechRecognitionResult.
+
+           public:
+               MOCK_STDCALL_METHOD_1(get_Status);
+               MOCK_STDCALL_METHOD_1(get_Text);
+               MOCK_STDCALL_METHOD_1(get_Confidence);
+               MOCK_STDCALL_METHOD_1(get_SemanticInterpretation);
+               MOCK_STDCALL_METHOD_2(GetAlternates);
+               MOCK_STDCALL_METHOD_1(get_Constraint);
+               MOCK_STDCALL_METHOD_1(get_RulePath);
+               MOCK_STDCALL_METHOD_1(get_RawConfidence);
+               MOCK_STDCALL_METHOD_1(get_PhraseStartTime);
+               MOCK_STDCALL_METHOD_1(get_PhraseDuration);
+           });
+
+MOCK_CLASS(
+    MockVoiceCommandActivatedEventArgs,
+    public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IVoiceCommandActivatedEventArgs, IActivatedEventArgs> {
+        InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_VoiceCommandActivatedEventArgs,
+                         BaseTrust); // claim to be the implementation for the real system RuntimeClass for VoiceCommandActivatedEventArgs.
+
+    public:
+        MOCK_STDCALL_METHOD_1(get_Result);
+        MOCK_STDCALL_METHOD_1(get_Kind);
+        MOCK_STDCALL_METHOD_1(get_PreviousExecutionState);
+        MOCK_STDCALL_METHOD_1(get_SplashScreen);
+    });
+
+MOCK_CLASS(MockProtocolActivatedEventArgs,
+           public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IProtocolActivatedEventArgs, IActivatedEventArgs> {
+               InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_ProtocolActivatedEventArgs,
+                                BaseTrust); // claim to be the implementation for the real system RuntimeClass for Accel.
+
+           public:
+               MOCK_STDCALL_METHOD_1(get_Uri);
+               MOCK_STDCALL_METHOD_1(get_Kind);
+               MOCK_STDCALL_METHOD_1(get_PreviousExecutionState);
+               MOCK_STDCALL_METHOD_1(get_SplashScreen);
+           });
+
+// TODO: 8008558 Test handling foreground activation parameters from Cortana
+TEST(CortanaTest, VoiceCommandForegroundActivation) {
+    LOG_INFO("CortanaTest Voice Command Foreground Activation Test: ");
+    // Get current application to test on
+    WXApplication* app = [WXApplication current];
+    // Create mocked data to pass into application
+    auto fakeSpeechRecognitionResult = Make<MockSpeechRecognitionResult>();
+    fakeSpeechRecognitionResult->Setget_Text([](HSTRING* text) {
+        Wrappers::HString value;
+        value.Set(L"CORTANA_TEST");
+        *text = value.Detach();
+        return S_OK;
+    });
+    auto fakeVoiceCommandActivatedEventArgs = Make<MockVoiceCommandActivatedEventArgs>();
+    fakeVoiceCommandActivatedEventArgs->Setget_Result([&fakeSpeechRecognitionResult](ISpeechRecognitionResult** result) {
+        fakeSpeechRecognitionResult.CopyTo(result);
+        return S_OK;
+    });
+    fakeVoiceCommandActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
+        *kind = ActivationKind_VoiceCommand;
+        return S_OK;
+    });
+    fakeVoiceCommandActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
+        *state = ApplicationExecutionState_NotRunning;
+        return S_OK;
+    });
+}


### PR DESCRIPTION
Allow Cortana to activate apps via voice command or protocol

Supports onActivated path for Voice Command and protocol activation with Objective C delegate handling.  Also adds mocking for Objective C++ classes.