### PR TITLE
CGBitmapContext const updates and unit tests

### DIFF
--- a/Frameworks/CoreGraphics/CGBitmapContext.mm
+++ b/Frameworks/CoreGraphics/CGBitmapContext.mm
@@ -49,7 +49,8 @@ CGImageRef CGBitmapContextCreateImage(CGContextRef context) {
 
 /**
  @Status Caveat
- @Notes tied to underlying implementation caveats in CGImageGetBitmapInfo. 
+ @Notes tied to underlying implementation caveats in CGImageGetBitmapInfo.
+ From CGImage.mm: "Only returns kCGImageAlpha information"
 */
 CGBitmapInfo CGBitmapContextGetBitmapInfo(CGContextRef context) {
 	CGImageRef imageRef = context->Backing()->DestImage();
@@ -84,8 +85,8 @@ size_t CGBitmapContextGetBitsPerComponent(CGContextRef context) {
 */
 size_t CGBitmapContextGetBitsPerPixel(CGContextRef context) {
     CGImageRef imageRef = context->Backing()->DestImage();
-    size_t bytesPerPixel = imageRef->Backing()->BytesPerPixel();
-    size_t bitsPerByte = 8;
+    const size_t bytesPerPixel = imageRef->Backing()->BytesPerPixel();
+    const size_t bitsPerByte = 8;
     return bytesPerPixel * bitsPerByte;
 }
 

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -28,6 +28,7 @@ TEST(CGBitmapContext, BitmapInfoAPIs_CMYK) {
 
     // The following causes a crash since CGImage only supports RGB right now
     // IF the quick return is removed, these tests should be reinstated
+    // TODO:: GitHub Issue: https://github.com/Microsoft/WinObjC/issues/594
     // EXPECT_EQ(CGBitmapContextGetBitmapInfo(context), 0);
     EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
     EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 8);
@@ -52,6 +53,7 @@ TEST(CGBitmapContext, BitmapInfoAPIs_Gray) {
 
     // The following causes a crash since CGImage only supports RGB right now
     // IF the quick return is removed, these tests should be reinstated
+    // TODO:: GitHub Issue: https://github.com/Microsoft/WinObjC/issues/594
     // EXPECT_EQ(CGBitmapContextGetBitmapInfo(context), 0);
     EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
     EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 8);

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -14,7 +14,47 @@
 //
 //******************************************************************************
 
-#import <TestFramework.h>
-#import <Starboard.h>
+#import "CGContextInternal.h"
+#import <CoreGraphics/CGContext.h>
+#import <CoreGraphics/CGImage.h>
 #import <CoreGraphics\CGBitmapContext.h>
 #import <Foundation\Foundation.h>
+#import <Starboard.h>
+#import <TestFramework.h>
+
+TEST(CGBitmapContext, BitmapInfoAPIs_CMYK) {
+    CGColorSpaceRef cmykColorSpace = CGColorSpaceCreateDeviceCMYK();
+    CGContextRef context = CGBitmapContextCreate(0, 0, 0, 8, 0, cmykColorSpace, 0);
+
+    // The following causes a crash since CGImage only supports RGB right now
+    // IF the quick return is removed, these tests should be reinstated
+    // EXPECT_EQ(CGBitmapContextGetBitmapInfo(context), 0);
+    EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
+    EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 8);
+
+    CGContextRelease(context);
+}
+
+TEST(CGBitmapContext, BitmapInfoAPIs_RGB) {
+    CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(0, 0, 0, 8, 0, rgbColorSpace, 0);
+
+    EXPECT_EQ(CGBitmapContextGetBitmapInfo(context), 0);
+    EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
+    EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 24);
+
+    CGContextRelease(context);
+}
+
+TEST(CGBitmapContext, BitmapInfoAPIs_Gray) {
+    CGColorSpaceRef grayColorSpace = CGColorSpaceCreateDeviceGray();
+    CGContextRef context = CGBitmapContextCreate(0, 0, 0, 8, 0, grayColorSpace, 0);
+
+    // The following causes a crash since CGImage only supports RGB right now
+    // IF the quick return is removed, these tests should be reinstated
+    // EXPECT_EQ(CGBitmapContextGetBitmapInfo(context), 0);
+    EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
+    EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 8);
+
+    CGContextRelease(context);
+}

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -33,6 +33,7 @@ TEST(CGBitmapContext, BitmapInfoAPIs_CMYK) {
     EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
     EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 8);
 
+    CGColorSpaceRelease(cmykColorSpace);
     CGContextRelease(context);
 }
 
@@ -44,6 +45,7 @@ TEST(CGBitmapContext, BitmapInfoAPIs_RGB) {
     EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
     EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 24);
 
+    CGColorSpaceRelease(rgbColorSpace);
     CGContextRelease(context);
 }
 
@@ -58,5 +60,6 @@ TEST(CGBitmapContext, BitmapInfoAPIs_Gray) {
     EXPECT_EQ(CGBitmapContextGetBitsPerComponent(context), 8);
     EXPECT_EQ(CGBitmapContextGetBitsPerPixel(context), 8);
 
+    CGColorSpaceRelease(grayColorSpace);
     CGContextRelease(context);
 }


### PR DESCRIPTION
Adds const keywords in implementation per review notes. Also, adds basic unit tests that will help for regression testing later. Interoperability of APIs with iOS is NOT tested for since underlying implementations are not Interoperable.