### PR TITLE
Fix crash when posting notification to notification center from dealloc

### DIFF
--- a/Frameworks/Foundation/NSNotification.mm
+++ b/Frameworks/Foundation/NSNotification.mm
@@ -27,26 +27,14 @@
  @Status Interoperable
 */
 + (NSNotification*)notificationWithName:(NSString*)name object:(id)obj {
-    NSNotification* ret = [self alloc];
-
-    ret->notificationName = [name retain];
-    ret->notificationObj = [obj retain];
-    ret->userInfo = nil;
-
-    return [ret autorelease];
+    return [self notificationWithName:name object:obj userInfo:nil];
 }
 
 /**
  @Status Interoperable
 */
 + (NSNotification*)notificationWithName:(NSString*)name object:(id)obj userInfo:(NSDictionary*)info {
-    NSNotification* ret = [self alloc];
-
-    ret->notificationName = [name retain];
-    ret->notificationObj = [obj retain];
-    ret->userInfo = [info retain];
-
-    return [ret autorelease];
+    return [[[self alloc] initWithName:name object:obj userInfo:info] autorelease];
 }
 
 /**
@@ -74,8 +62,8 @@
  @Status Interoperable
 */
 - (void)dealloc {
-    [notificationName release];
     [notificationObj release];
+    [notificationName release];
     [userInfo release];
 
     [super dealloc];
@@ -85,9 +73,13 @@
  @Status Stub
  @Notes
 */
-- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)userInfo {
-    UNIMPLEMENTED();
-    return StubReturn();
+- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {
+    if ((self = [super init]) != nil) {
+        notificationObj = [object retain];
+        notificationName = [aName copy];
+        userInfo = [userInfo retain];
+    }
+    return self;
 }
 
 /**

--- a/Frameworks/Foundation/NSNotification.mm
+++ b/Frameworks/Foundation/NSNotification.mm
@@ -17,11 +17,7 @@
 #import <StubReturn.h>
 #import <Foundation/NSNotification.h>
 
-@implementation NSNotification {
-    NSString* notificationName;
-    id notificationObj;
-    id userInfo;
-}
+@implementation NSNotification
 
 /**
  @Status Interoperable
@@ -40,31 +36,10 @@
 /**
  @Status Interoperable
 */
-- (id)object {
-    return notificationObj;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSString*)name {
-    return notificationName;
-}
-
-/**
- @Status Interoperable
-*/
-- (NSDictionary*)userInfo {
-    return userInfo;
-}
-
-/**
- @Status Interoperable
-*/
 - (void)dealloc {
-    [notificationObj release];
-    [notificationName release];
-    [userInfo release];
+    [_object release];
+    [_name release];
+    [_userInfo release];
 
     [super dealloc];
 }
@@ -75,9 +50,9 @@
 */
 - (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {
     if ((self = [super init]) != nil) {
-        notificationObj = [object retain];
-        notificationName = [aName copy];
-        userInfo = [userInfo retain];
+        _object = [object retain];
+        _name = [aName copy];
+        _userInfo = [info retain];
     }
     return self;
 }

--- a/Frameworks/Foundation/NSNotification.mm
+++ b/Frameworks/Foundation/NSNotification.mm
@@ -45,7 +45,7 @@
 }
 
 /**
- @Status Stub
+ @Status interoperable
  @Notes
 */
 - (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {

--- a/Frameworks/Foundation/NSNotification.mm
+++ b/Frameworks/Foundation/NSNotification.mm
@@ -45,7 +45,7 @@
 }
 
 /**
- @Status interoperable
+ @Status Interoperable
  @Notes
 */
 - (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {

--- a/Frameworks/Foundation/NSNotification.mm
+++ b/Frameworks/Foundation/NSNotification.mm
@@ -52,7 +52,7 @@
     if ((self = [super init]) != nil) {
         _object = [object retain];
         _name = [aName copy];
-        _userInfo = [info retain];
+        _userInfo = [info copy];
     }
     return self;
 }

--- a/Frameworks/Foundation/NSNotificationCenter.mm
+++ b/Frameworks/Foundation/NSNotificationCenter.mm
@@ -79,8 +79,9 @@ static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* k
  @Status Interoperable
 */
 - (void)postNotificationName:(NSString*)name object:(NSObject*)sender {
-    NSNotification* notification = [NSNotification notificationWithName:name object:sender];
+    NSNotification* notification = [[NSNotification alloc] initWithName:name object:sender userInfo: nil];
     [self postNotification:notification];
+    [notification release];
 }
 
 /**

--- a/Frameworks/Foundation/NSNotificationCenter.mm
+++ b/Frameworks/Foundation/NSNotificationCenter.mm
@@ -79,7 +79,7 @@ static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* k
  @Status Interoperable
 */
 - (void)postNotificationName:(NSString*)name object:(NSObject*)sender {
-    NSNotification* notification = [[NSNotification alloc] initWithName:name object:sender userInfo: nil];
+    NSNotification* notification = [[NSNotification alloc] initWithName:name object:sender userInfo:nil];
     [self postNotification:notification];
     [notification release];
 }

--- a/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
@@ -318,6 +318,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSIndexSetTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSThreadTests.m" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSGenericsTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSNotificationTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\ReferenceFoundation\TestNSArray.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\ReferenceFoundation\TestNSBundle.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\ReferenceFoundation\TestNSData.mm" />

--- a/include/Foundation/NSNotification.h
+++ b/include/Foundation/NSNotification.h
@@ -25,7 +25,7 @@ FOUNDATION_EXPORT_CLASS
 @interface NSNotification : NSObject <NSCoding, NSCopying>
 + (instancetype)notificationWithName:(NSString*)aName object:(id)anObject;
 + (instancetype)notificationWithName:(NSString*)aName object:(id)anObject userInfo:(NSDictionary*)userInfo;
-- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)userInfo STUB_METHOD;
+- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)userInfo;
 @property (readonly, copy) NSString* name;
 @property (readonly, retain) id object;
 @property (readonly, copy) NSDictionary* userInfo;

--- a/tests/unittests/Foundation/NSNotificationTests.mm
+++ b/tests/unittests/Foundation/NSNotificationTests.mm
@@ -1,0 +1,32 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <TestFramework.h>
+#import <Foundation/Foundation.h>
+@interface TestObjectA : NSObject
+@end
+
+@implementation TestObjectA
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"MOOSENOTIFICATION" object:self];
+    [super dealloc];
+}
+
+@end
+
+TEST(NSNotificationCenter, PostNotificationFromDealloc) {
+    TestObjectA* obj = [[TestObjectA new] autorelease];
+}


### PR DESCRIPTION
NSNotificationCenter was using an auto released NSNotification object, which was in turn holding a reference to an object that is going away.  This change removes the usage of autorelease to make the api compatible with reference platform.

Fixes #577
