### PR TITLE
Fix #580, add support for concurrent NSOperation subclass

### DIFF
--- a/include/Foundation/NSOperation.h
+++ b/include/Foundation/NSOperation.h
@@ -64,7 +64,7 @@ FOUNDATION_EXPORT_CLASS
 - (void)addDependency:(NSOperation*)operation;
 - (void)removeDependency:(NSOperation*)operation STUB_METHOD;
 @property (readonly, copy) NSArray* dependencies;
-@property NSQualityOfService qualityOfService;
+@property NSQualityOfService qualityOfService STUB_PROPERTY;
 @property double threadPriority STUB_PROPERTY;
 @property NSOperationQueuePriority queuePriority;
 - (void)waitUntilFinished;

--- a/include/Foundation/NSOperation.h
+++ b/include/Foundation/NSOperation.h
@@ -62,7 +62,7 @@ FOUNDATION_EXPORT_CLASS
 @property (readonly, getter=isReady) BOOL ready;
 @property (copy) NSString* name;
 - (void)addDependency:(NSOperation*)operation;
-- (void)removeDependency:(NSOperation*)operation STUB_METHOD;
+- (void)removeDependency:(NSOperation*)operation;
 @property (readonly, copy) NSArray* dependencies;
 @property NSQualityOfService qualityOfService STUB_PROPERTY;
 @property double threadPriority STUB_PROPERTY;

--- a/tests/unittests/Foundation/NSOperationTests.mm
+++ b/tests/unittests/Foundation/NSOperationTests.mm
@@ -312,6 +312,14 @@ TEST(NSOperation, NSOperationMultipleWaiters) {
     ASSERT_TRUE([operation isFinished]);
 }
 
+TEST(NSOperation, NSDependencyRemove) {
+    // tests that nothing happens when a dependency is removed that was never added.
+    NSOperation* operation = [[NSOperation new] autorelease];
+    NSOperation* dependency = [[NSOperation new] autorelease];
+
+    ASSERT_NO_THROW([operation removeDependency:dependency]);
+}
+
 TEST(NSOperation, NSOperationIsReady) {
     NSOperationQueue* queue = [[NSOperationQueue new] autorelease];
     TestObserver* observer = [[TestObserver new] autorelease];

--- a/tests/unittests/Foundation/NSOperationTests.mm
+++ b/tests/unittests/Foundation/NSOperationTests.mm
@@ -156,7 +156,7 @@ TEST(NSOperation, NSOperationKVO) {
     [queue addOperation:operation];
     [operation waitUntilFinished];
 
-    ASSERT_TRUE([observer didObserveCompletionBlock]);
+    ASSERT_FALSE([observer didObserveCompletionBlock]);
     ASSERT_FALSE([observer didObserveCancelled]);
     ASSERT_TRUE([observer didObserveExecuting]);
     ASSERT_TRUE([observer didObserveFinished]);


### PR DESCRIPTION
This change redesigns NSOperation for subclassability as documented for the reference platform, and adds a test to verify that the subclass no longer deadlocks in waitUntilFinished.