### PR TITLE
Add activation functional tests for Cortana

### DIFF
--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -79,49 +79,8 @@ void App::OnLaunched(LaunchActivatedEventArgs^ args) {
 }
 
 void App::OnActivated(IActivatedEventArgs^ args) {
-    TraceVerbose(TAG, L"OnActivated event received for %d. Previous app state was %d", args->Kind, args->PreviousExecutionState);
-
-    bool initiateAppLaunch = false;
-    if ((args->PreviousExecutionState != ApplicationExecutionState::Running) &&
-        (args->PreviousExecutionState != ApplicationExecutionState::Suspended)) {
-        TraceVerbose(TAG, L"Initializing application");
-        initiateAppLaunch = true;
-    }
-
-    if (args->Kind == ActivationKind::ToastNotification) {
-        Platform::String^ argsString = safe_cast<ToastNotificationActivatedEventArgs^>(args)->Argument;
-        TraceVerbose(TAG, L"Received toast notification with argument - %s", argsString->Data());
-
-        if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeToast, argsString);
-        }
-
-        UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
-    } else if (args->Kind == ActivationKind::VoiceCommand) {
-        Windows::Media::SpeechRecognition::SpeechRecognitionResult^ argResult = safe_cast<VoiceCommandActivatedEventArgs^>(args)->Result;
-        TraceVerbose(TAG, L"Received voice command with argument - %s", argResult->Text->Data());
-
-        if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeVoiceCommand, argResult);
-        }
-
-        UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
-    } else if (args->Kind == ActivationKind::Protocol) {
-        Windows::Foundation::Uri^ argUri = safe_cast<ProtocolActivatedEventArgs^>(args)->Uri;
-        TraceVerbose(TAG, L"Received protocol with uri- %s", argUri->ToString()->Data());
-
-        if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeProtocol, argUri);
-        }
-
-        UIApplicationMainHandleProtocolEvent(reinterpret_cast<IInspectable*>(argUri));
-    } else {
-        TraceVerbose(TAG, L"Received unhandled activation kind - %d", args->Kind);
-        
-        if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeNone, nullptr);
-        }
-    }
+        _ApplicationActivate(args);
+        _RegisterEventHandlers();
 }
 
 void App::_ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg) {
@@ -181,6 +140,52 @@ extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Obje
     RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
 }
 
+extern "C" void _ApplicationActivate(Platform::Object^ arguments) {
+    IActivatedEventArgs^ args = static_cast<IActivatedEventArgs^>(arguments);
+    TraceVerbose(TAG, L"OnActivated event received for %d. Previous app state was %d", args->Kind, args->PreviousExecutionState);
+    bool initiateAppLaunch = false;
+    if ((args->PreviousExecutionState != ApplicationExecutionState::Running) &&
+        (args->PreviousExecutionState != ApplicationExecutionState::Suspended)) {
+        TraceVerbose(TAG, L"Initializing application");
+        initiateAppLaunch = true;
+    }
+
+    if (args->Kind == ActivationKind::ToastNotification) {
+        Platform::String^ argsString = safe_cast<ToastNotificationActivatedEventArgs^>(args)->Argument;
+        TraceVerbose(TAG, L"Received toast notification with argument - %s", argsString->Data());
+
+        if (initiateAppLaunch) {
+            _ApplicationLaunch(ActivationTypeToast, argsString);
+        }
+
+        UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
+    } else if (args->Kind == ActivationKind::VoiceCommand) {
+        Windows::Media::SpeechRecognition::SpeechRecognitionResult^ argResult = safe_cast<VoiceCommandActivatedEventArgs^>(args)->Result;
+        TraceVerbose(TAG, L"Received voice command with argument - %s", argResult->Text->Data());
+
+        if (initiateAppLaunch) {
+            _ApplicationLaunch(ActivationTypeVoiceCommand, argResult);
+        }
+
+        UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
+    } else if (args->Kind == ActivationKind::Protocol) {
+        Windows::Foundation::Uri^ argUri = safe_cast<ProtocolActivatedEventArgs^>(args)->Uri;
+        TraceVerbose(TAG, L"Received protocol with uri- %s", argUri->ToString()->Data());
+
+        if (initiateAppLaunch) {
+            _ApplicationLaunch(ActivationTypeProtocol, argUri);
+        }
+
+        UIApplicationMainHandleProtocolEvent(reinterpret_cast<IInspectable*>(argUri));
+    } else {
+        TraceVerbose(TAG, L"Received unhandled activation kind - %d", args->Kind);
+        
+        if (initiateAppLaunch) {
+            _ApplicationLaunch(ActivationTypeNone, nullptr);
+        }
+    }
+}
+
 // This is the actual entry point from the app into our framework.
 // Note: principalClassName and delegateClassName are actually NSString*s.
 UIKIT_EXPORT
@@ -231,6 +236,17 @@ void UIApplicationInitialize(const wchar_t* principalClassName, const wchar_t* d
     }
 
     _ApplicationLaunch(ActivationTypeNone, nullptr);
+}
+
+UIKIT_EXPORT
+void UIApplicationActivationTest(IInspectable* activationArgs){
+    // Initialize COM on this thread
+    ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+
+    // Register tracelogging
+    TraceRegister();
+
+    _ApplicationActivate(reinterpret_cast<Platform::Object^>(activationArgs));
 }
 
 // clang-format on

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -79,8 +79,8 @@ void App::OnLaunched(LaunchActivatedEventArgs^ args) {
 }
 
 void App::OnActivated(IActivatedEventArgs^ args) {
-        _ApplicationActivate(args);
-        _RegisterEventHandlers();
+    _ApplicationActivate(args);
+    _RegisterEventHandlers();
 }
 
 void App::_ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg) {

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -229,10 +229,14 @@ void UIApplicationInitialize(const wchar_t* principalClassName, const wchar_t* d
 
     if (principalClassName != nullptr) {
         g_principalClassName = ref new Platform::String(principalClassName);
+    } else {
+        g_principalClassName = ref new Platform::String();
     }
 
     if (delegateClassName != nullptr) {
         g_delegateClassName = ref new Platform::String(delegateClassName);
+    } else {
+        g_delegateClassName = ref new Platform::String();
     }
 
     _ApplicationLaunch(ActivationTypeNone, nullptr);
@@ -250,6 +254,8 @@ void UIApplicationActivationTest(IInspectable* activationArgs, void* delegateCla
     if (delegateClassName) {
         auto rawString = _RawBufferFromNSString(delegateClassName);
         g_delegateClassName = reinterpret_cast<Platform::String^>(Strings::NarrowToWide<HSTRING>(rawString).Detach());
+    } else {
+        g_delegateClassName = ref new Platform::String();
     }
 
     _ApplicationActivate(reinterpret_cast<Platform::Object^>(activationArgs));

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -152,7 +152,7 @@ extern "C" void _ApplicationActivate(Platform::Object^ arguments) {
 
     if (args->Kind == ActivationKind::ToastNotification) {
         Platform::String^ argsString = safe_cast<ToastNotificationActivatedEventArgs^>(args)->Argument;
-        TraceVerbose(TAG, L"Received toast notification with argument - %s", argsString->Data());
+        TraceVerbose(TAG, L"Received toast notification with argument - %ls", argsString->Data());
 
         if (initiateAppLaunch) {
             _ApplicationLaunch(ActivationTypeToast, argsString);
@@ -161,7 +161,7 @@ extern "C" void _ApplicationActivate(Platform::Object^ arguments) {
         UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
     } else if (args->Kind == ActivationKind::VoiceCommand) {
         Windows::Media::SpeechRecognition::SpeechRecognitionResult^ argResult = safe_cast<VoiceCommandActivatedEventArgs^>(args)->Result;
-        TraceVerbose(TAG, L"Received voice command with argument - %s", argResult->Text->Data());
+        TraceVerbose(TAG, L"Received voice command with argument - %ls", argResult->Text->Data());
 
         if (initiateAppLaunch) {
             _ApplicationLaunch(ActivationTypeVoiceCommand, argResult);
@@ -170,7 +170,7 @@ extern "C" void _ApplicationActivate(Platform::Object^ arguments) {
         UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
     } else if (args->Kind == ActivationKind::Protocol) {
         Windows::Foundation::Uri^ argUri = safe_cast<ProtocolActivatedEventArgs^>(args)->Uri;
-        TraceVerbose(TAG, L"Received protocol with uri- %s", argUri->ToString()->Data());
+        TraceVerbose(TAG, L"Received protocol with uri- %ls", argUri->ToString()->Data());
 
         if (initiateAppLaunch) {
             _ApplicationLaunch(ActivationTypeProtocol, argUri);
@@ -245,7 +245,7 @@ void UIApplicationActivationTest(IInspectable* activationArgs, wchar_t* delegate
 
     // Register tracelogging
     TraceRegister();
-	g_delegateClassName = ref new Platform::String(delegateName);
+    g_delegateClassName = ref new Platform::String(delegateName);
     _ApplicationActivate(reinterpret_cast<Platform::Object^>(activationArgs));
 }
 

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -238,14 +238,20 @@ void UIApplicationInitialize(const wchar_t* principalClassName, const wchar_t* d
     _ApplicationLaunch(ActivationTypeNone, nullptr);
 }
 
+// Note: Like UIApplicationMain, delegateClassName is actually an NSString*.
 UIKIT_EXPORT
-void UIApplicationActivationTest(IInspectable* activationArgs, wchar_t* delegateName){
+void UIApplicationActivationTest(IInspectable* activationArgs, void* delegateClassName){
     // Initialize COM on this thread
     ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
     // Register tracelogging
     TraceRegister();
-    g_delegateClassName = ref new Platform::String(delegateName);
+
+    if (delegateClassName) {
+        auto rawString = _RawBufferFromNSString(delegateClassName);
+        g_delegateClassName = reinterpret_cast<Platform::String^>(Strings::NarrowToWide<HSTRING>(rawString).Detach());
+    }
+
     _ApplicationActivate(reinterpret_cast<Platform::Object^>(activationArgs));
 }
 

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -239,13 +239,13 @@ void UIApplicationInitialize(const wchar_t* principalClassName, const wchar_t* d
 }
 
 UIKIT_EXPORT
-void UIApplicationActivationTest(IInspectable* activationArgs){
+void UIApplicationActivationTest(IInspectable* activationArgs, wchar_t* delegateName){
     // Initialize COM on this thread
     ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
     // Register tracelogging
     TraceRegister();
-
+	g_delegateClassName = ref new Platform::String(delegateName);
     _ApplicationActivate(reinterpret_cast<Platform::Object^>(activationArgs));
 }
 

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
@@ -52,6 +52,8 @@ private:
 };
 
 extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
+extern "C" void _ApplicationActivate(Platform::Object^ args);
+
 
 #endif
 

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -238,6 +238,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\SampleTest.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\CortanaTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIViewTests.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\FunctionalTestHelpers.mm" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURL.AppxManifest.xml" />

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
@@ -56,9 +56,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\ProjectionTests\*.mm">
       <Filter>Tests\ProjectionTests</Filter>
     </ClangCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\FunctionalTestHelpers.mm" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURL.AppxManifest.xml">

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -3,7 +3,7 @@ LIBRARY UIKit
         ; Application entry points (StarboardXAML)
         UIApplicationMain
         UIApplicationInitialize
-		UIApplicationActivationTest
+        UIApplicationActivationTest
 
         ; NSAttributedString
         NSFontAttributeName DATA

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -3,6 +3,7 @@ LIBRARY UIKit
         ; Application entry points (StarboardXAML)
         UIApplicationMain
         UIApplicationInitialize
+		UIApplicationActivationTest
 
         ; NSAttributedString
         NSFontAttributeName DATA

--- a/docs/Foundation/CortanaForegroundActivation.md
+++ b/docs/Foundation/CortanaForegroundActivation.md
@@ -85,4 +85,4 @@ UIApplicationDelegate.h:
 
 ###Test Approach
 
-Functionally testing the onActivated path will require a large addition of path code to allow testing to hook in at different points, or possibly a restructuring of startup code to allow the test to get ownership of the app.  Currently this is being tested manually.
+We are using the functional test framework to test Cortana foreground activation.  We can create a test app shell which activates with given arguments, which we can use to test that all delegate methods are called and with the correct data.

--- a/tests/functionaltests/FunctionalTestHelpers.mm
+++ b/tests/functionaltests/FunctionalTestHelpers.mm
@@ -1,0 +1,22 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include "UIKit/UIApplication.h"
+
+// Prevents UIApplication state from carrying over between functional tests
+void FunctionalTestCleanupUIApplication() {
+    [[UIApplication sharedApplication] _destroy];
+}

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -31,6 +31,9 @@ static void UIApplicationDefaultInitialize() {
     UIApplicationInitialize(nullptr, nullptr);
 }
 
+// Cleanup method to call after every test class to prevent leaking UIApplication
+extern void FunctionalTestCleanupUIApplication();
+
 //
 // How is functional test organized?
 //
@@ -183,6 +186,11 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
+    TEST_METHOD_CLEANUP(NSURLCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
     //
     // NSURLConnection
     //
@@ -255,6 +263,11 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
+    TEST_METHOD_CLEANUP(NSUserDefaultsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
     TEST_METHOD(NSUserDefaults_Basic) {
         NSUserDefaultsBasic();
     }
@@ -289,6 +302,11 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
+    TEST_METHOD_CLEANUP(NSBundleCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
     TEST_METHOD(NSBundle_MSAppxURL) {
         NSBundleMSAppxURL();
     }
@@ -313,6 +331,11 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestVoiceCommandForegroundActivation));
     }
 
+    TEST_METHOD_CLEANUP(CortanaVoiceCommandForegroundCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
     TEST_METHOD(Cortana_VoiceCommandForegroundActivationDelegateMethodsCalled) {
         CortanaTestVoiceCommandForegroundActivationDelegateMethodsCalled();
     }
@@ -331,6 +354,11 @@ public:
     TEST_CLASS_SETUP(CortanaProtocolForegroundTestClassSetup) {
         // The class setup allows us to activate the app in our test method, but can only be done once per class
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestProtocolForegroundActivation));
+    }
+
+    TEST_METHOD_CLEANUP(CortanaProtocolForegroundCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(Cortana_ProtocolForegroundActivationDelegateMethodsCalled) {
@@ -353,6 +381,11 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
+    TEST_METHOD_CLEANUP(UIViewCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
     TEST_METHOD(UIViewTests_Create) {
         UIViewTestsCreate();
     }
@@ -373,7 +406,8 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
-    TEST_CLASS_CLEANUP(ProjectionTestClassCleanup) {
+    TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
+        FunctionalTestCleanupUIApplication();
         return true;
     }
 

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -299,24 +299,24 @@ public:
 //
 
 extern void CortanaTestVoiceCommandForegroundActivation();
+extern void CortanaTestDelegateMethodsCalled();
 
 class Cortana {
 public:
     BEGIN_TEST_CLASS(Cortana)
     TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
     TEST_CLASS_PROPERTY(L"UAP:Host", L"Xaml")
-    TEST_CLASS_PROPERTY(L"Ignore", L"true")
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(CortanaTestClassSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+        // The class setup allows us to activate the app in our test method, but can only be done once per class
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestVoiceCommandForegroundActivation));
     }
 
-    TEST_METHOD(CortanaTest_VoiceCommandForegroundActivation) {
-        CortanaTestVoiceCommandForegroundActivation();
+    TEST_METHOD(Cortana_DelegateMethodsCalled) {
+        CortanaTestDelegateMethodsCalled();
     }
-}; /* class NSBundle */
-
+}; /* class Cortana*/
 // UIViewTests
 //
 extern void UIViewTestsCreate();

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -299,24 +299,45 @@ public:
 //
 
 extern void CortanaTestVoiceCommandForegroundActivation();
-extern void CortanaTestDelegateMethodsCalled();
+extern void CortanaTestVoiceCommandForegroundActivationDelegateMethodsCalled();
 
-class Cortana {
+class CortanaVoiceCommandForeground {
 public:
-    BEGIN_TEST_CLASS(Cortana)
+    BEGIN_TEST_CLASS(CortanaVoiceCommandForeground)
     TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
     TEST_CLASS_PROPERTY(L"UAP:Host", L"Xaml")
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(CortanaTestClassSetup) {
+    TEST_CLASS_SETUP(CortanaVoiceCommandForegroundTestClassSetup) {
         // The class setup allows us to activate the app in our test method, but can only be done once per class
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestVoiceCommandForegroundActivation));
     }
 
-    TEST_METHOD(Cortana_DelegateMethodsCalled) {
-        CortanaTestDelegateMethodsCalled();
+    TEST_METHOD(Cortana_VoiceCommandForegroundActivationDelegateMethodsCalled) {
+        CortanaTestVoiceCommandForegroundActivationDelegateMethodsCalled();
     }
-}; /* class Cortana*/
+}; /* class CortanaVoiceCommandForeground*/
+
+extern void CortanaTestProtocolForegroundActivation();
+extern void CortanaTestProtocolForegroundActivationDelegateMethodsCalled();
+
+class CortanaProtocolForeground {
+public:
+    BEGIN_TEST_CLASS(CortanaProtocolForeground)
+    TEST_CLASS_PROPERTY(L"RunAs", L"UAP")
+    TEST_CLASS_PROPERTY(L"UAP:Host", L"Xaml")
+    END_TEST_CLASS()
+
+    TEST_CLASS_SETUP(CortanaProtocolForegroundTestClassSetup) {
+        // The class setup allows us to activate the app in our test method, but can only be done once per class
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestProtocolForegroundActivation));
+    }
+
+    TEST_METHOD(Cortana_ProtocolForegroundActivationDelegateMethodsCalled) {
+        CortanaTestProtocolForegroundActivationDelegateMethodsCalled();
+    }
+}; /* class CortanaProtocolForeground*/
+
 // UIViewTests
 //
 extern void UIViewTestsCreate();

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -36,7 +36,7 @@ using namespace ABI::Windows::Foundation;
 using namespace Microsoft::WRL;
 
 // Method to call in tests to activate app
-extern "C" void UIApplicationActivationTest(IInspectable* args, wchar_t* delegateName);
+extern "C" void UIApplicationActivationTest(IInspectable* args, void* delegateClassName);
 
 MOCK_CLASS(MockSpeechRecognitionResult,
            public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, ISpeechRecognitionResult, ISpeechRecognitionResult2> {
@@ -231,7 +231,8 @@ TEST(CortanaTest, VoiceCommandForegroundActivation) {
 
     // Pass activation argument to method which activates the app
     auto args = fakeVoiceCommandActivatedEventArgs.Detach();
-    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(args), L"CortanaVoiceCommandForegroundTestDelegate");
+    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(args),
+                                NSStringFromClass([CortanaVoiceCommandForegroundTestDelegate class]));
 }
 
 TEST(CortanaTest, VoiceCommandForegroundActivationDelegateMethodsCalled) {
@@ -274,7 +275,7 @@ TEST(CortanaTest, ProtocolForegroundActivation) {
 
     // Pass activation argument to method which activates the app
     auto args = fakeProtocolActivatedEventArgs.Detach();
-    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(args), L"CortanaProtocolForegroundTestDelegate");
+    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(args), NSStringFromClass([CortanaProtocolForegroundTestDelegate class]));
 }
 
 TEST(CortanaTest, ProtocolForegroundActivationDelegateMethodsCalled) {

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -141,7 +141,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     ASSERT_TRUE(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]);
     WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
     ASSERT_STREQ("CORTANA_TEST", [result.text UTF8String]);
-    [[self methodsCalled] setObject:@(YES) forKey:NSStringFromSelector(_cmd)];
+    _methodsCalled[NSStringFromSelector(_cmd)] = @(YES);
     return true;
 }
 
@@ -149,7 +149,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     ASSERT_TRUE(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]);
     WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
     ASSERT_STREQ("CORTANA_TEST", [result.text UTF8String]);
-    [[self methodsCalled] setObject:@(YES) forKey:NSStringFromSelector(_cmd)];
+    _methodsCalled[NSStringFromSelector(_cmd)] = @(YES);
     return true;
 }
 
@@ -157,7 +157,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     // Delegate method should only be called once
     ASSERT_EQ([[self methodsCalled] objectForKey:NSStringFromSelector(_cmd)], nil);
     ASSERT_STREQ("CORTANA_TEST", [result.text UTF8String]);
-    [[self methodsCalled] setObject:@(YES) forKey:NSStringFromSelector(_cmd)];
+    _methodsCalled[NSStringFromSelector(_cmd)] = @(YES);
     return true;
 }
 
@@ -180,7 +180,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     ASSERT_TRUE(launchOptions[UIApplicationLaunchOptionsProtocolKey]);
     WFUri* uri = launchOptions[UIApplicationLaunchOptionsProtocolKey];
     ASSERT_STREQ("CORTANA_TEST", [uri.toString UTF8String]);
-    [[self methodsCalled] setObject:@(YES) forKey:NSStringFromSelector(_cmd)];
+    _methodsCalled[NSStringFromSelector(_cmd)] = @(YES);
     return true;
 }
 
@@ -188,7 +188,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     ASSERT_TRUE(launchOptions[UIApplicationLaunchOptionsProtocolKey]);
     WFUri* uri = launchOptions[UIApplicationLaunchOptionsProtocolKey];
     ASSERT_STREQ("CORTANA_TEST", [uri.toString UTF8String]);
-    [[self methodsCalled] setObject:@(YES) forKey:NSStringFromSelector(_cmd)];
+    _methodsCalled[NSStringFromSelector(_cmd)] = @(YES);
     return true;
 }
 
@@ -196,7 +196,7 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     // Delegate method should only be called once
     ASSERT_EQ([[self methodsCalled] objectForKey:NSStringFromSelector(_cmd)], nil);
     ASSERT_STREQ("CORTANA_TEST", [uri.toString UTF8String]);
-    [[self methodsCalled] setObject:@(YES) forKey:NSStringFromSelector(_cmd)];
+    _methodsCalled[NSStringFromSelector(_cmd)] = @(YES);
     return true;
 }
 @end

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -33,13 +33,19 @@ using namespace ABI::Windows::ApplicationModel::Activation;
 using namespace ABI::Windows::Media::SpeechRecognition;
 using namespace Microsoft::WRL;
 
+// Method to call in tests to activate app
+extern "C" void UIApplicationActivationTest(IInspectable* args);
+
+// These are for testing that delegate methods are actually called
+static bool willFinishLaunchingWithOptionsCalled = false;
+static bool didFinishLaunchingWithOptionsCalled = false;
+static bool didReceiveVoiceCommandCalled = false;
 
 MOCK_CLASS(MockSpeechRecognitionResult,
            public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, ISpeechRecognitionResult, ISpeechRecognitionResult2> {
 
-              // Claim to be the implementation for the real system RuntimeClass for SpeechRecognitionResult.
-              InspectableClass(RuntimeClass_Windows_Media_SpeechRecognition_SpeechRecognitionResult,
-                                BaseTrust);
+               // Claim to be the implementation for the real system RuntimeClass for SpeechRecognitionResult.
+               InspectableClass(RuntimeClass_Windows_Media_SpeechRecognition_SpeechRecognitionResult, BaseTrust);
 
            public:
                MOCK_STDCALL_METHOD_1(get_Status);
@@ -54,27 +60,24 @@ MOCK_CLASS(MockSpeechRecognitionResult,
                MOCK_STDCALL_METHOD_1(get_PhraseDuration);
            });
 
-MOCK_CLASS(
-    MockVoiceCommandActivatedEventArgs,
-    public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IVoiceCommandActivatedEventArgs, IActivatedEventArgs> {
+MOCK_CLASS(MockVoiceCommandActivatedEventArgs,
+           public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IVoiceCommandActivatedEventArgs, IActivatedEventArgs> {
 
-        // Claim to be the implementation for the real system RuntimeClass for VoiceCommandActivatedEventArgs.
-        InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_VoiceCommandActivatedEventArgs,
-                         BaseTrust);
+               // Claim to be the implementation for the real system RuntimeClass for VoiceCommandActivatedEventArgs.
+               InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_VoiceCommandActivatedEventArgs, BaseTrust);
 
-    public:
-        MOCK_STDCALL_METHOD_1(get_Result);
-        MOCK_STDCALL_METHOD_1(get_Kind);
-        MOCK_STDCALL_METHOD_1(get_PreviousExecutionState);
-        MOCK_STDCALL_METHOD_1(get_SplashScreen);
-    });
+           public:
+               MOCK_STDCALL_METHOD_1(get_Result);
+               MOCK_STDCALL_METHOD_1(get_Kind);
+               MOCK_STDCALL_METHOD_1(get_PreviousExecutionState);
+               MOCK_STDCALL_METHOD_1(get_SplashScreen);
+           });
 
 MOCK_CLASS(MockProtocolActivatedEventArgs,
            public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IProtocolActivatedEventArgs, IActivatedEventArgs> {
 
-                // Claim to be the implementation for the real system RuntimeClass for ProtocolActivatedEventArgs.
-                InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_ProtocolActivatedEventArgs,
-                                BaseTrust);
+               // Claim to be the implementation for the real system RuntimeClass for ProtocolActivatedEventArgs.
+               InspectableClass(RuntimeClass_Windows_ApplicationModel_Activation_ProtocolActivatedEventArgs, BaseTrust);
 
            public:
                MOCK_STDCALL_METHOD_1(get_Uri);
@@ -83,7 +86,47 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
                MOCK_STDCALL_METHOD_1(get_SplashScreen);
            });
 
-// TODO: 8008558 Test handling foreground activation parameters from Cortana
+// Delegate for testing Cortana foreground activation
+// Use text value to guarantee it is the same argument we create
+@interface CortanaForegroundTestDelegate : NSObject <UIApplicationDelegate>
+@end
+
+@implementation CortanaForegroundTestDelegate
+- (BOOL)application:(UIApplication*)application willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    ASSERT_TRUE(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]);
+    WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+    ASSERT_STREQ("CORTANA_TEST", [result.text UTF8String]);
+    willFinishLaunchingWithOptionsCalled = true;
+    return true;
+}
+
+- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    ASSERT_TRUE(launchOptions[UIApplicationLaunchOptionsVoiceCommandKey]);
+    WMSSpeechRecognitionResult* result = launchOptions[UIApplicationLaunchOptionsVoiceCommandKey];
+    ASSERT_STREQ("CORTANA_TEST", [result.text UTF8String]);
+    didFinishLaunchingWithOptionsCalled = true;
+    return true;
+}
+
+- (BOOL)application:(UIApplication*)application didReceiveVoiceCommand:(WMSSpeechRecognitionResult*)result {
+    ASSERT_STREQ("CORTANA_TEST", [result.text UTF8String]);
+    didReceiveVoiceCommandCalled = true;
+    return true;
+}
+@end
+
+// Create method in UIApplication to swizzle setDelegate: so we can use our delegate for testing
+@interface UIApplication (CortanaForegroundTest)
+- (void)swizzleDelegate:(id)delegateAddr;
+@end
+
+@implementation UIApplication (CortanaForegroundTest)
+- (void)swizzleDelegate:(id)delegateAddr {
+    [self swizzleDelegate:[CortanaForegroundTestDelegate new]];
+}
+@end
+
+// Creates test method which we call in TEST_CLASS_SETUP to activate app
 TEST(CortanaTest, VoiceCommandForegroundActivation) {
     LOG_INFO("CortanaTest Voice Command Foreground Activation Test: ");
 
@@ -106,9 +149,27 @@ TEST(CortanaTest, VoiceCommandForegroundActivation) {
         *kind = ActivationKind_VoiceCommand;
         return S_OK;
     });
-    
+
     fakeVoiceCommandActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
         *state = ApplicationExecutionState_NotRunning;
         return S_OK;
     });
+
+    // Swizzle method to use our delegate for testing
+    Method originalMethod = class_getInstanceMethod([UIApplication class], @selector(setDelegate:));
+    Method swizzledMethod = class_getInstanceMethod([UIApplication class], @selector(swizzleDelegate:));
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+
+    // Pass activation argument to method which activates the app
+    auto args = fakeVoiceCommandActivatedEventArgs.Detach();
+    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(args));
+
+	// Un-Swizzle the methods now that we are done
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+}
+
+TEST(CortanaTest, DelegateMethodsCalled) {
+    ASSERT_TRUE(willFinishLaunchingWithOptionsCalled);
+    ASSERT_TRUE(didFinishLaunchingWithOptionsCalled);
+    ASSERT_TRUE(didReceiveVoiceCommandCalled);
 }


### PR DESCRIPTION
Changes activation code to allow functional tests to activate with custom arguments and adds test for Cortana foreground activation.