### PR TITLE
Basic ReplacePathWithStrokedPath Implementation

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -59,7 +59,7 @@ __CGContext::__CGContext(CGImageRef pDest) {
 #ifdef DEBUG_CONTEXT_COUNT
     TraceVerbose(TAG, L"contextCount: %d", contextCount);
 #endif
-    object_setClass((id)this, [CGNSContext class]);
+    object_setClass((id) this, [CGNSContext class]);
     scale = 1.0f;
     _backing = pDest->Backing()->CreateDrawingContext(this);
 }
@@ -689,11 +689,11 @@ void CGContextSetShadow(CGContextRef context, CGSize offset, float blur) {
 }
 
 /**
- @Status Stub
+ @Status Caveat
+ @Notes Converts curves to lines. Endpoint and line join settings are ignored.
 */
 void CGContextReplacePathWithStrokedPath(CGContextRef context) {
-    UNIMPLEMENTED();
-    TraceWarning(TAG, L"CGContextReplacePathWithStrokedPath not implemented");
+    context->Backing()->CGContextReplacePathWithStrokedPath(context);
 }
 
 /**

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -1848,7 +1848,6 @@ void CGContextCairo::CGContextReplacePathWithStrokedPath(CGContextRef context) {
     cairo_path_t* flatPath = cairo_copy_path_flat(_drawContext);
     double lineWidth = cairo_get_line_width(_drawContext);
     cairo_new_path(_drawContext);
-    cairo_set_line_width(_drawContext, 1);
     _CGContextDrawStrokedPath(flatPath, 0, 0, flatPath->num_data, lineWidth);
     cairo_path_destroy(flatPath);
 

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -680,6 +680,9 @@ void CGContextImpl::CGContextSetLineWidth(float width) {
 void CGContextImpl::CGContextSetShouldAntialias(DWORD shouldAntialias) {
 }
 
+void CGContextImpl::CGContextReplacePathWithStrokedPath(CGContextRef context) {
+}
+
 void CGContextImpl::CGContextClip() {
 }
 

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -22,6 +22,8 @@ struct _cairo;
 typedef struct _cairo cairo_t;
 typedef enum _cairo_filter cairo_filter_t;
 typedef struct _cairo_pattern cairo_pattern_t;
+struct cairo_path;
+typedef struct cairo_path cairo_path_t;
 
 class CGContextCairo : public CGContextImpl {
 private:
@@ -31,6 +33,8 @@ private:
     // reset the filter as well.
     // pattern: The pattern for which current filter should be assigned.
     void _assignAndResetFilter(cairo_pattern_t* pattern);
+    void _CGContextDrawStrokedPath(cairo_path_t* flatPath, int i, int prev, int total, CGFloat lineWidth);
+    static CGPoint _extendPoint(CGPoint a, CGPoint b, CGFloat length);
 
     void _cairoImageSurfaceBlur(cairo_surface_t* surface);
     void _cairoContextStrokePathShadow();
@@ -117,6 +121,7 @@ public:
     virtual void CGContextSetLineCap(DWORD lineCap);
     virtual void CGContextSetLineWidth(float width);
     virtual void CGContextSetShouldAntialias(DWORD shouldAntialias);
+    virtual void CGContextReplacePathWithStrokedPath(CGContextRef context);
     virtual void CGContextClip();
     virtual void CGContextGetClipBoundingBox(CGRect* ret);
     virtual void CGContextGetPathBoundingBox(CGRect* ret);

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -58,7 +58,8 @@ private:
 #define MAX_CG_STATES 16
 
 class CGContextImpl {
-__CGCONTEXTIMPL_TEST_FRIENDS;
+    __CGCONTEXTIMPL_TEST_FRIENDS;
+
 protected:
     CGContextRef _rootContext;
     CGImageRef _imgDest;
@@ -154,6 +155,7 @@ public:
     virtual void CGContextSetLineCap(DWORD lineCap);
     virtual void CGContextSetLineWidth(float width);
     virtual void CGContextSetShouldAntialias(DWORD shouldAntialias);
+    virtual void CGContextReplacePathWithStrokedPath(CGContextRef context);
     virtual void CGContextClip();
     virtual void CGContextGetClipBoundingBox(CGRect* ret);
     virtual void CGContextGetPathBoundingBox(CGRect* ret);

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGContextReplacePathWithStrokedPath.m
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGContextReplacePathWithStrokedPath.m
@@ -24,14 +24,12 @@ static const CGFloat c_LineWidth = 20;
 
 @end
 
-
 typedef NS_ENUM(NSInteger, StrokedPathType) {
     StrokedPathTypeLine = 0,
     StrokedPathTypeCopyStroke,
-    StrokedPathTypeReplaceStroke,   // Left to right drawing
-    StrokedPathTypeReplaceStroke2   // Right to left drawing
+    StrokedPathTypeReplaceStroke, // Left to right drawing
+    StrokedPathTypeReplaceStroke2 // Right to left drawing
 };
-
 
 @interface StrokeView : UIView
 
@@ -41,7 +39,6 @@ typedef NS_ENUM(NSInteger, StrokedPathType) {
 @property (weak, nonatomic, nullable) id<DrawRectCompletionDelegate> delegate;
 
 @end
-
 
 @implementation StrokeView
 
@@ -63,29 +60,28 @@ typedef NS_ENUM(NSInteger, StrokedPathType) {
     CGContextSetLineCap(context, kCGLineCapRound);
     CGContextSetLineJoin(context, kCGLineJoinMiter);
     CGContextSetMiterLimit(context, 1);
-    
-    if( self.strokedPathType == StrokedPathTypeReplaceStroke2 ) {
+
+    if (self.strokedPathType == StrokedPathTypeReplaceStroke2) {
         CGPathMoveToPoint(path, NULL, maxWidth / 2, maxHeight / 4);
         CGPathAddLineToPoint(path, NULL, 16, 16);
     } else {
-        CGPathMoveToPoint(path, NULL, 16, 16);
-        CGPathAddLineToPoint(path, NULL, maxWidth / 2, maxHeight / 4);
+        CGPathMoveToPoint(path, NULL, 50, 50);
+        CGPathAddLineToPoint(path, NULL, 100, 100);
     }
-    
-    if( self.strokedPathType == StrokedPathTypeReplaceStroke2 ) {
-        
+
+    if (self.strokedPathType == StrokedPathTypeReplaceStroke2) {
         CGPathMoveToPoint(path, NULL, maxWidth - 16, 16);
         CGPathAddQuadCurveToPoint(path, NULL, maxWidth * 3 / 4, maxHeight * 1 / 4, maxWidth / 2, maxHeight * 3 / 4);
-        CGPathAddArcToPoint(path, NULL, maxWidth/2, maxHeight*1.25, 0, maxHeight/4, 50);
+        CGPathAddArcToPoint(path, NULL, maxWidth / 2, maxHeight * 1.25, 0, maxHeight / 4, 50);
         CGPathAddLineToPoint(path, NULL, maxWidth / 4, maxHeight / 2);
         CGPathAddLineToPoint(path, NULL, 10, maxHeight / 2);
     } else {
-        CGPathMoveToPoint(path, NULL, 10, maxHeight / 2);
-        CGPathAddLineToPoint(path, NULL, maxWidth / 4, maxHeight / 2);
-        CGPathAddArcToPoint(path, NULL, maxWidth / 4 + 50, maxHeight * 2 + 50, maxWidth / 2, maxHeight * 3 / 4, 50);
-        CGPathAddQuadCurveToPoint(path, NULL, maxWidth * 3 / 4, maxHeight * 1 / 4, maxWidth - 10, 10);
+        CGPathMoveToPoint(path, NULL, 200, 200);
+        CGPathAddLineToPoint(path, NULL, 260, 100);
+        CGPathAddArcToPoint(path, NULL, 500, 500, 450, 450, 50);
+        CGPathAddQuadCurveToPoint(path, NULL, 100, 200, 200, 300);
     }
-    
+
     // Log original path info
     [self.logs addObject:@"Original Path:"];
     params = @{ @"logs" : self.logs, @"points" : originalPoints };
@@ -97,58 +93,52 @@ typedef NS_ENUM(NSInteger, StrokedPathType) {
     // Draw the path
     NSMutableArray<NSValue*>* points;
     switch (self.strokedPathType) {
-        case StrokedPathTypeLine:
-        {
+        case StrokedPathTypeLine: {
             CGContextSetStrokeColorWithColor(context, [UIColor greenColor].CGColor);
             CGContextAddPath(context, path);
             CGContextStrokePath(context);
             points = originalPoints;
-        }
-        break;
-            
-        case StrokedPathTypeCopyStroke:
-        {
+        } break;
+
+        case StrokedPathTypeCopyStroke: {
             NSMutableArray<NSValue*>* strokedPoints = [NSMutableArray new];
             CGPathRef newPath = CGPathCreateCopyByStrokingPath(path, NULL, c_LineWidth, kCGLineCapRound, kCGLineJoinMiter, 1);
             [self.logs addObject:@"Copy Stroke Path:"];
             params = @{ @"logs" : self.logs, @"points" : strokedPoints };
             CGPathApply(newPath, (__bridge void*)params, _Applier);
-            
+
             CGContextSetFillColorWithColor(context, [UIColor blueColor].CGColor);
             CGContextAddPath(context, newPath);
             CGContextFillPath(context);
-            
+
             points = strokedPoints;
             CGPathRelease(newPath);
-        }
-        break;
+        } break;
 
         case StrokedPathTypeReplaceStroke2:
-        case StrokedPathTypeReplaceStroke:
-        {
+        case StrokedPathTypeReplaceStroke: {
             CGContextSetStrokeColorWithColor(context, [UIColor purpleColor].CGColor);
             CGContextAddPath(context, path);
             CGContextReplacePathWithStrokedPath(context);
-            
+
             CGPathRef newPath = CGContextCopyPath(context);
             NSMutableArray<NSValue*>* strokedPoints = [NSMutableArray new];
             [self.logs addObject:@"Replace Stroke:"];
             params = @{ @"logs" : self.logs, @"points" : strokedPoints };
             CGPathApply(newPath, (__bridge void*)params, _Applier);
-            
-            if( self.strokedPathType == StrokedPathTypeReplaceStroke )
+
+            if (self.strokedPathType == StrokedPathTypeReplaceStroke)
                 CGContextSetFillColorWithColor(context, [UIColor orangeColor].CGColor);
             else
                 CGContextSetFillColorWithColor(context, [UIColor purpleColor].CGColor);
-            
-            CGContextFillPath(context);
-            
+
+            CGContextStrokePath(context);
+
             points = strokedPoints;
             CGPathRelease(newPath);
-        }
-        break;
+        } break;
     }
-    
+
     // Draw connecting points of elements
     CGContextSetLineWidth(context, 1);
     CGContextSetFillColorWithColor(context, [UIColor blackColor].CGColor);
@@ -264,9 +254,7 @@ void _Applier(void* info, const CGPathElement* element) {
     [self.view addSubview:self.consoleView];
 }
 
-
--(void)segmentedControlValueDidChange:(UISegmentedControl *)segment
-{
+- (void)segmentedControlValueDidChange:(UISegmentedControl*)segment {
     switch (segment.selectedSegmentIndex) {
         default:
         case 0:
@@ -282,12 +270,10 @@ void _Applier(void* info, const CGPathElement* element) {
             self.customView.strokedPathType = StrokedPathTypeReplaceStroke2;
             break;
     }
-    
+
     self.customView.highlightedPoint = CGPointMake(0, 0);
     [self.customView setNeedsDisplay];
 }
-
-
 
 #pragma mark UITableViewDataSource
 

--- a/samples/CGCatalog/CGCatalog/Samples/CGCCGContextReplacePathWithStrokedPath.m
+++ b/samples/CGCatalog/CGCatalog/Samples/CGCCGContextReplacePathWithStrokedPath.m
@@ -24,14 +24,23 @@ static const CGFloat c_LineWidth = 20;
 
 @end
 
+
+typedef NS_ENUM(NSInteger, StrokedPathType) {
+    StrokedPathTypeLine = 0,
+    StrokedPathTypeCopyStroke,
+    StrokedPathTypeReplaceStroke
+};
+
+
 @interface StrokeView : UIView
 
-@property (assign, nonatomic) BOOL drawStrokedPath;
+@property (assign, nonatomic) StrokedPathType strokedPathType;
 @property (strong, atomic, nullable) NSMutableArray<NSString*>* logs;
 @property (assign, nonatomic) CGPoint highlightedPoint;
 @property (weak, nonatomic, nullable) id<DrawRectCompletionDelegate> delegate;
 
 @end
+
 
 @implementation StrokeView
 
@@ -50,6 +59,9 @@ static const CGFloat c_LineWidth = 20;
     NSMutableArray<NSValue*>* originalPoints = [NSMutableArray new];
     CGMutablePathRef path = CGPathCreateMutable();
     CGContextSetLineWidth(context, c_LineWidth);
+    CGContextSetLineCap(context, kCGLineCapRound);
+    CGContextSetLineJoin(context, kCGLineJoinMiter);
+    CGContextSetMiterLimit(context, 1);
     CGPathMoveToPoint(path, NULL, 10, maxHeight / 2);
     CGPathAddLineToPoint(path, NULL, maxWidth / 4, maxHeight / 2);
     CGPathAddArcToPoint(path, NULL, maxWidth / 4 + 50, maxHeight * 2 + 50, maxWidth / 2, maxHeight * 3 / 4, 50);
@@ -61,27 +73,57 @@ static const CGFloat c_LineWidth = 20;
 
     // Create stroked path
     // TODO: Change this to use CGContextReplacePathWithStrokedPath()
-    NSMutableArray<NSValue*>* strokedPoints = [NSMutableArray new];
-    CGPathRef newPath = CGPathCreateCopyByStrokingPath(path, NULL, c_LineWidth, kCGLineCapButt, kCGLineJoinMiter, 1);
-    // Log stroked path info
-    [self.logs addObject:@"New Path:"];
-    params = @{ @"logs" : self.logs, @"points" : strokedPoints };
-    CGPathApply(newPath, (__bridge void*)params, _Applier);
 
     // Draw the path
     NSMutableArray<NSValue*>* points;
-    if (self.drawStrokedPath) {
-        CGContextSetFillColorWithColor(context, [UIColor blueColor].CGColor);
-        CGContextAddPath(context, newPath);
-        CGContextFillPath(context);
-        points = strokedPoints;
-    } else {
-        CGContextSetStrokeColorWithColor(context, [UIColor greenColor].CGColor);
-        CGContextAddPath(context, path);
-        CGContextStrokePath(context);
-        points = originalPoints;
-    }
+    switch (self.strokedPathType) {
+        case StrokedPathTypeLine:
+        {
+            CGContextSetStrokeColorWithColor(context, [UIColor greenColor].CGColor);
+            CGContextAddPath(context, path);
+            CGContextStrokePath(context);
+            points = originalPoints;
+        }
+        break;
+            
+        case StrokedPathTypeCopyStroke:
+        {
+            NSMutableArray<NSValue*>* strokedPoints = [NSMutableArray new];
+            CGPathRef newPath = CGPathCreateCopyByStrokingPath(path, NULL, c_LineWidth, kCGLineCapRound, kCGLineJoinMiter, 1);
+            [self.logs addObject:@"Copy Stroke Path:"];
+            params = @{ @"logs" : self.logs, @"points" : strokedPoints };
+            CGPathApply(newPath, (__bridge void*)params, _Applier);
+            
+            CGContextSetFillColorWithColor(context, [UIColor blueColor].CGColor);
+            CGContextAddPath(context, newPath);
+            CGContextFillPath(context);
+            
+            points = strokedPoints;
+            CGPathRelease(newPath);
+        }
+        break;
 
+        case StrokedPathTypeReplaceStroke:
+        {
+            CGContextSetStrokeColorWithColor(context, [UIColor purpleColor].CGColor);
+            CGContextAddPath(context, path);
+            CGContextReplacePathWithStrokedPath(context);
+            
+            CGPathRef newPath = CGContextCopyPath(context);
+            NSMutableArray<NSValue*>* strokedPoints = [NSMutableArray new];
+            [self.logs addObject:@"Replace Stroke:"];
+            params = @{ @"logs" : self.logs, @"points" : strokedPoints };
+            CGPathApply(newPath, (__bridge void*)params, _Applier);
+            
+            CGContextSetFillColorWithColor(context, [UIColor orangeColor].CGColor);
+            CGContextFillPath(context);
+            
+            points = strokedPoints;
+            CGPathRelease(newPath);
+        }
+        break;
+    }
+    
     // Draw connecting points of elements
     CGContextSetLineWidth(context, 1);
     CGContextSetFillColorWithColor(context, [UIColor blackColor].CGColor);
@@ -100,7 +142,6 @@ static const CGFloat c_LineWidth = 20;
     }
 
     CGPathRelease(path);
-    CGPathRelease(newPath);
     if ([self.delegate respondsToSelector:@selector(didFinishDrawing)]) {
         [self.delegate didFinishDrawing];
     }
@@ -153,7 +194,7 @@ void _Applier(void* info, const CGPathElement* element) {
 @interface CGCCGContextReplacePathWithStrokedPath () <UITableViewDataSource, UITableViewDelegate, DrawRectCompletionDelegate>
 
 @property (strong, nonatomic, nullable) StrokeView* customView;
-@property (strong, nonatomic, nullable) UISwitch* pathSwitch;
+@property (strong, nonatomic, nullable) UISegmentedControl* pathSegmentControl;
 @property (strong, nonatomic, nullable) UITableView* consoleView;
 @property (strong, nonatomic, nullable) NSNumberFormatter* formatter;
 
@@ -171,7 +212,7 @@ void _Applier(void* info, const CGPathElement* element) {
 
     self.customView = [[StrokeView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height / 2)];
     self.customView.delegate = self;
-    self.customView.drawStrokedPath = NO;
+    self.customView.strokedPathType = StrokedPathTypeLine;
     self.customView.logs = [NSMutableArray new];
     [self.view addSubview:self.customView];
 
@@ -179,10 +220,13 @@ void _Applier(void* info, const CGPathElement* element) {
     switchLabel.text = @"Show Stroked Path:";
     [self.view addSubview:switchLabel];
 
-    self.pathSwitch = [[UISwitch alloc] initWithFrame:CGRectMake(155, self.view.bounds.size.height / 2, 30, 30)];
-    [self.pathSwitch setOn:NO];
-    [self.pathSwitch addTarget:self action:@selector(pathSwitchValueChanged:) forControlEvents:UIControlEventValueChanged];
-    [self.view addSubview:self.pathSwitch];
+    self.pathSegmentControl = [[UISegmentedControl alloc] initWithFrame:CGRectMake(8, 8, 300, 30)];
+    [self.pathSegmentControl addTarget:self action:@selector(segmentedControlValueDidChange:) forControlEvents:UIControlEventValueChanged];
+    [self.pathSegmentControl insertSegmentWithTitle:@"Line" atIndex:0 animated:false];
+    [self.pathSegmentControl insertSegmentWithTitle:@"CopyStroke" atIndex:1 animated:false];
+    [self.pathSegmentControl insertSegmentWithTitle:@"RepalceStroked" atIndex:2 animated:false];
+    [self.pathSegmentControl setSelectedSegmentIndex:self.customView.strokedPathType];
+    [self.view addSubview:self.self.pathSegmentControl];
 
     self.consoleView = [[UITableView alloc] initWithFrame:CGRectMake(0,
                                                                      self.view.bounds.size.height / 2 + 30,
@@ -194,11 +238,26 @@ void _Applier(void* info, const CGPathElement* element) {
     [self.view addSubview:self.consoleView];
 }
 
-- (void)pathSwitchValueChanged:(UISwitch*)theSwitch {
-    self.customView.drawStrokedPath = [theSwitch isOn];
+
+-(void)segmentedControlValueDidChange:(UISegmentedControl *)segment
+{
+    switch (segment.selectedSegmentIndex) {
+        case 0:
+            self.customView.strokedPathType = StrokedPathTypeLine;
+            break;
+        case 1:
+            self.customView.strokedPathType = StrokedPathTypeCopyStroke;
+            break;
+        case 2:
+            self.customView.strokedPathType = StrokedPathTypeReplaceStroke;
+            break;
+    }
+    
     self.customView.highlightedPoint = CGPointMake(0, 0);
     [self.customView setNeedsDisplay];
 }
+
+
 
 #pragma mark UITableViewDataSource
 

--- a/tests/unittests/CoreGraphics/CGContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGContextTests.mm
@@ -45,13 +45,7 @@ void _DrawCustomPattern(void* info, CGContextRef context) {
 CGContextRef createBitmapContext(size_t width, size_t height) {
     size_t bytesPerRow = width * 4;
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef context = CGBitmapContextCreate(NULL,
-                                                 width,
-                                                 height,
-                                                 8,
-                                                 bytesPerRow,
-                                                 colorSpace,
-                                                 kCGImageAlphaPremultipliedLast);
+    CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, bytesPerRow, colorSpace, kCGImageAlphaPremultipliedLast);
     CGColorSpaceRelease(colorSpace);
     return context;
 }
@@ -65,8 +59,6 @@ TEST(CGContext, CGContextSetPatternPhasePatternIsNil) {
 
     // When
     CGContextSetPatternPhase(ctx, CGSizeMake(100, 100));
-
-
 
     // Then
     ASSERT_EQ(0, backing->curState->curFillColorObject);
@@ -95,12 +87,11 @@ TEST(CGContext, CGContextSetPatternPhasePositiveChange) {
     CGContextRef ctx = CGBitmapContextCreate24(1000, 1000);
     CGContextImpl* backing = CGContextGetBacking(ctx);
 
-    CGRect boundsRect = CGRectMake(0, 0,1000, 1000);
+    CGRect boundsRect = CGRectMake(0, 0, 1000, 1000);
     const CGPatternCallbacks callbacks = { 0, &_DrawCustomPattern, NULL };
     CGFloat alpha = 1;
     CGAffineTransform transform = CGAffineTransformMakeTranslation(10, 10);
-    CGPatternRef pattern = CGPatternCreate(
-        NULL, boundsRect, transform, 50, 50, kCGPatternTilingConstantSpacing, true, &callbacks);
+    CGPatternRef pattern = CGPatternCreate(NULL, boundsRect, transform, 50, 50, kCGPatternTilingConstantSpacing, true, &callbacks);
     CGContextSetFillPattern(ctx, pattern, &alpha);
     CGPatternRelease(pattern);
 
@@ -121,12 +112,11 @@ TEST(CGContext, CGContextSetPatternPhaseNegativeChange) {
     CGContextRef ctx = CGBitmapContextCreate24(1000, 1000);
     CGContextImpl* backing = CGContextGetBacking(ctx);
 
-    CGRect boundsRect = CGRectMake(0, 0,1000, 1000);
+    CGRect boundsRect = CGRectMake(0, 0, 1000, 1000);
     const CGPatternCallbacks callbacks = { 0, &_DrawCustomPattern, NULL };
     CGFloat alpha = 1;
     CGAffineTransform transform = CGAffineTransformMakeTranslation(300, 500);
-    CGPatternRef pattern = CGPatternCreate(
-        NULL, boundsRect, transform, 50, 50, kCGPatternTilingConstantSpacing, true, &callbacks);
+    CGPatternRef pattern = CGPatternCreate(NULL, boundsRect, transform, 50, 50, kCGPatternTilingConstantSpacing, true, &callbacks);
     CGContextSetFillPattern(ctx, pattern, &alpha);
     CGPatternRelease(pattern);
 
@@ -143,12 +133,11 @@ TEST(CGContext, CGContextSetPatternPhaseNegativeChange) {
 }
 
 TEST(CGContext, CGContextReplacePathWithStrokedPathLeftToRightLine) {
-
     CGMutablePathRef path = CGPathCreateMutable();
-    EXPECT_TRUE( path != NULL);
+    EXPECT_TRUE(path != NULL);
 
     CGContextRef context = createBitmapContext(100, 100);
-    EXPECT_TRUE( context != NULL);
+    EXPECT_TRUE(context != NULL);
 
     CGContextSetLineWidth(context, 1);
     CGContextSetLineCap(context, kCGLineCapRound);
@@ -160,5 +149,4 @@ TEST(CGContext, CGContextReplacePathWithStrokedPathLeftToRightLine) {
 
     CGContextAddPath(context, path);
     // TODO: Call CGContextReplacePathWithStrokedPath(context);
-
 }


### PR DESCRIPTION
This initial implementation leverages cairo_copy_path_flat that returns a copy of the current path with all line elements.  The underlying elements for the path may be drastically different because all the curves will be replaced by line elements. Everything else should be similar to iOS behavior, such as order of the points, so functionality like an animation along a path should behave in a similar fashion.

Endcap styles are supported.  Line join styles are not yet implemented.

The included sample is dependent on pull request #617 