### PR TITLE
Fix #623: Fixing CGPathElementInternal Pointers

### DIFF
--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -162,6 +162,11 @@ void _CGPathAddElement(
     if (path->_count + 1 >= path->_max) {
         path->_max += 32;
         path->_elements = (CGPathElementInternal*)IwRealloc(path->_elements, path->_max * sizeof(CGPathElementInternal));
+        // Re-init all existing elements
+        for (int i = 0; i < path->_count; i++) {
+            CGPathElementInternal* element = &path->_elements[i];
+            element->init();
+        }
     }
     CGPathElementInternal* element = &path->_elements[path->_count];
     // The new element needs to call init

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -281,6 +281,38 @@ TEST(CGPath, CGPathEqualToPath) {
     CGPathRelease(path1);
 }
 
+TEST(CGPath, CGPathApplyAddManyRects) {
+    CGMutablePathRef path = CGPathCreateMutable();
+    NSMutableArray* expected = [NSMutableArray array];
+    for (int i = 0; i < 100; i++) {
+        CGRect rect = CGRectMake(i, 4, 8, 16);
+
+        CGPathAddRect(path, NULL, rect);
+
+        NSArray* expectedRect = @[
+            @{ kTypeKey : @(kCGPathElementMoveToPoint),
+               kPointsKey : @[ @(i), @4 ] },
+            @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+               kPointsKey : @[ @(i + 8), @4 ] },
+            @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+               kPointsKey : @[ @(i + 8), @20 ] },
+            @{ kTypeKey : @(kCGPathElementAddLineToPoint),
+               kPointsKey : @[ @(i), @20 ] },
+            @{ kTypeKey : @(kCGPathElementCloseSubpath),
+               kPointsKey : [NSArray array] }
+        ];
+        [expected addObjectsFromArray:expectedRect];
+    }
+
+    NSMutableArray* result = [NSMutableArray array];
+
+    CGPathApply(path, result, cgPathApplierFunction);
+
+    cgPathCompare(expected, result);
+
+    CGPathRelease(path);
+}
+
 TEST(CGPath, CGPathAddPath) {
     CGMutablePathRef path1 = CGPathCreateMutable();
 


### PR DESCRIPTION
Fix for issue #623. CGPathElementInternal points array pointers are now reset after the
realloc occurs in _CGPathAddElement. A Unit test has been added to test
adding 100 rects to a path and verifying the resulting path.