### PR TITLE
Fix CommonCrypto headers to compile as Objective C

### DIFF
--- a/build/Tests/UnitTests/Starboard/Starboard.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Starboard/Starboard.UnitTests.vcxproj
@@ -236,6 +236,9 @@
     <ClangCompile Include="..\..\..\..\tests\unittests\Starboard\objcrt_sanity.m" />
     <ClangCompile Include="..\..\..\..\tests\unittests\Starboard\PthreadTests.mm" />
     <ClangCompile Include="..\..\..\..\tests\unittests\Starboard\ProjectionsTests.mm" />
+    <ClangCompile Include="..\..\..\..\tests\unittests\Starboard\CommonCryptoTests.m">
+        <CompileAs>CompileAsObjC</CompileAs>
+    </ClangCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\tests\unittests\Starboard\LifetimeCounting.h" />

--- a/include/CommonCrypto/CommonCryptor.h
+++ b/include/CommonCrypto/CommonCryptor.h
@@ -17,6 +17,7 @@
 
 #include <StarboardExport.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <StubIncludes.h>
 
 #define CC_MD2_DIGEST_LENGTH 16
@@ -90,15 +91,15 @@ SB_IMPEXP CCCryptorStatus CCCryptorCreate(
     CCOperation op, CCAlgorithm alg, CCOptions options, const void* key, size_t keyLength, const void* iv, CCCryptorRef* cryptorRef);
 
 SB_IMPEXP CCCryptorStatus CCCryptorCreateFromData(CCOperation op,
-                                        CCAlgorithm alg,
-                                        CCOptions options,
-                                        const void* key,
-                                        size_t keyLength,
-                                        const void* iv,
-                                        const void* data,
-                                        size_t dataLength,
-                                        CCCryptorRef* cryptorRef,
-                                        size_t* dataUsed);
+                                                  CCAlgorithm alg,
+                                                  CCOptions options,
+                                                  const void* key,
+                                                  size_t keyLength,
+                                                  const void* iv,
+                                                  const void* data,
+                                                  size_t dataLength,
+                                                  CCCryptorRef* cryptorRef,
+                                                  size_t* dataUsed);
 
 SB_IMPEXP CCCryptorStatus CCCryptorRelease(CCCryptorRef cryptorRef);
 
@@ -112,15 +113,15 @@ SB_IMPEXP size_t CCCryptorGetOutputLength(CCCryptorRef cryptorRef, size_t inputL
 SB_IMPEXP CCCryptorStatus CCCryptorReset(CCCryptorRef cryptorRef, const void* iv);
 
 SB_IMPEXP CCCryptorStatus CCCrypt(CCOperation op,
-                        CCAlgorithm alg,
-                        CCOptions options,
-                        const void* key,
-                        size_t keyLength,
-                        const void* iv,
-                        const void* dataIn,
-                        size_t dataInLength,
-                        void* dataOut,
-                        size_t dataOutAvailable,
-                        size_t* dataOutMoved);
+                                  CCAlgorithm alg,
+                                  CCOptions options,
+                                  const void* key,
+                                  size_t keyLength,
+                                  const void* iv,
+                                  const void* dataIn,
+                                  size_t dataInLength,
+                                  void* dataOut,
+                                  size_t dataOutAvailable,
+                                  size_t* dataOutMoved);
 
 SB_EXTERNC_END

--- a/tests/unittests/Starboard/CommonCryptoTests.m
+++ b/tests/unittests/Starboard/CommonCryptoTests.m
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/unittests/Starboard/CommonCryptoTests.m
+++ b/tests/unittests/Starboard/CommonCryptoTests.m
@@ -1,0 +1,17 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <CommonCrypto\CommonCrypto.h>


### PR DESCRIPTION
bool isn't defined for ObjC. Fix that and add unit tests (just compile) headers as OBJC (our default is OBJCPP, hence we missed this).