### PR TITLE
Change message when cancelled download task cannot be resumed

### DIFF
--- a/samples/WOCCatalog/WOCCatalog/URLSessionViewController.mm
+++ b/samples/WOCCatalog/WOCCatalog/URLSessionViewController.mm
@@ -77,13 +77,19 @@
     int nbuttons = 0;
 
     UIButton* dataTaskButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    dataTaskButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_WIDTH, BUTTON_ROW_HEIGHT };
+    dataTaskButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW),
+                                     BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW),
+                                     BUTTON_ROW_ITEM_WIDTH,
+                                     BUTTON_ROW_HEIGHT };
     [dataTaskButton setTitle:@"Data" forState:UIControlStateNormal];
     [dataTaskButton addTarget:self action:@selector(dataTaskButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:dataTaskButton];
 
     UIButton* downloadTaskButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    downloadTaskButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_WIDTH, BUTTON_ROW_HEIGHT };
+    downloadTaskButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW),
+                                         BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW),
+                                         BUTTON_ROW_ITEM_WIDTH,
+                                         BUTTON_ROW_HEIGHT };
     [downloadTaskButton setTitle:@"Download" forState:UIControlStateNormal];
     [downloadTaskButton addTarget:self action:@selector(downloadTaskButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:downloadTaskButton];
@@ -107,19 +113,28 @@
     [self.view addSubview:_blockSwitchContainer];
 
     UIButton* cancelLastButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    cancelLastButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_WIDTH, BUTTON_ROW_HEIGHT };
+    cancelLastButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW),
+                                       BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW),
+                                       BUTTON_ROW_ITEM_WIDTH,
+                                       BUTTON_ROW_HEIGHT };
     [cancelLastButton setTitle:@"Cancel" forState:UIControlStateNormal];
     [cancelLastButton addTarget:self action:@selector(cancelLastButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:cancelLastButton];
 
     UIButton* resumeLastButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    resumeLastButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_WIDTH, BUTTON_ROW_HEIGHT };
+    resumeLastButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW),
+                                       BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW),
+                                       BUTTON_ROW_ITEM_WIDTH,
+                                       BUTTON_ROW_HEIGHT };
     [resumeLastButton setTitle:@"Resume" forState:UIControlStateNormal];
     [resumeLastButton addTarget:self action:@selector(resumeLastButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:resumeLastButton];
 
     UIButton* legacyDownloadButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-    legacyDownloadButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW), BUTTON_ROW_ITEM_WIDTH, BUTTON_ROW_HEIGHT };
+    legacyDownloadButton.frame = (CGRect){ BUTTON_ROW_ITEM_X(nbuttons % BUTTON_NUM_IN_ROW),
+                                           BUTTON_ROW_ITEM_Y(nbuttons++ / BUTTON_NUM_IN_ROW),
+                                           BUTTON_ROW_ITEM_WIDTH,
+                                           BUTTON_ROW_HEIGHT };
     [legacyDownloadButton setTitle:@"Legacy" forState:UIControlStateNormal];
     [legacyDownloadButton addTarget:self action:@selector(legacyDownloadButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:legacyDownloadButton];
@@ -246,8 +261,12 @@
 - (void)cancelLastButtonPressed:(id)sender {
     if ([_lastTask isKindOfClass:[NSURLSessionDownloadTask class]]) {
         [(NSURLSessionDownloadTask*)_lastTask cancelByProducingResumeData:^(NSData* resumeData) {
-            [self _printOutput:@"Download task produced resume data (size %d)\n", resumeData.length];
-            _lastResumeData = resumeData;
+            if (resumeData == nil) {
+                [self _printOutput:@"Download task was cancelled but cannot be resumed"];
+            } else {
+                [self _printOutput:@"Download task was cancelled and produced resume data (size %d)\n", resumeData.length];
+                _lastResumeData = resumeData;
+            }
         }];
     } else {
         [_lastTask cancel];

--- a/samples/WOCCatalog/WOCCatalog/URLSessionViewController.mm
+++ b/samples/WOCCatalog/WOCCatalog/URLSessionViewController.mm
@@ -265,8 +265,8 @@
                 [self _printOutput:@"Download task was cancelled but cannot be resumed"];
             } else {
                 [self _printOutput:@"Download task was cancelled and produced resume data (size %d)\n", resumeData.length];
-                _lastResumeData = resumeData;
             }
+            _lastResumeData = resumeData;
         }];
     } else {
         [_lastTask cancel];

--- a/samples/WOCCatalog/WOCCatalog/URLSessionViewController.mm
+++ b/samples/WOCCatalog/WOCCatalog/URLSessionViewController.mm
@@ -264,7 +264,7 @@
             if (resumeData == nil) {
                 [self _printOutput:@"Download task was cancelled but cannot be resumed"];
             } else {
-                [self _printOutput:@"Download task was cancelled and produced resume data (size %d)\n", resumeData.length];
+                [self _printOutput:@"Download task was cancelled and produced resume data (size %lu)\n", resumeData.length];
             }
             _lastResumeData = resumeData;
         }];


### PR DESCRIPTION
The previous message did not specify that the cancelled download task could be resumed, making it seem that the resume button was not functioning correctly.  