### PR TITLE
Fixed NSUserDefaults setBool: using incorrect bool objects.

### DIFF
--- a/Frameworks/Foundation/NSUserDefaults.mm
+++ b/Frameworks/Foundation/NSUserDefaults.mm
@@ -306,7 +306,7 @@ FOUNDATION_EXPORT NSString* const NSUserDefaultsDidChangeNotification = @"NSUser
  @Status Interoperable
 */
 - (void)setBool:(int)value forKey:(NSString*)defaultName {
-    [self setObject:value ? @"YES" : @"NO" forKey:defaultName];
+    [self setObject:(value ? @YES : @NO) forKey:defaultName];
 }
 
 /**


### PR DESCRIPTION
-setBool: was setting an NSString instead of bool NSNumber.