### PR TITLE
Include the CoreFoundation unicode mapping tables in every AppX package.

### DIFF
--- a/build/Package/Package.nativeproj
+++ b/build/Package/Package.nativeproj
@@ -67,6 +67,7 @@
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.winmd" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.bitmap" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.data" />
+      <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.mapping" />
 
       <!-- Files in these directories ship both Debug and Release varieties -->
       <SBLibsWin10Win32 Include="..\Win32\Debug\Universal Windows\Debug\*.lib">
@@ -105,6 +106,7 @@
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.winmd" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.bitmap" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.data" />
+      <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.mapping" />
 
       <!-- Files in these directories ship both Debug and Release varieties -->
       <SBLibsWin10ARM Include="..\ARM\Debug\Universal Windows\Debug\*.lib">

--- a/msvc/sbclang.targets
+++ b/msvc/sbclang.targets
@@ -58,6 +58,8 @@
       <!-- CoreFoundation resource files -->
       <SBResourceCopy Include="$(StarboardLibDirs)\CFCharacterSetBitmaps.bitmap" />
       <SBResourceCopy Include="$(StarboardLibDirs)\CFUniCharPropertyDatabase.data" />
+      <SBResourceCopy Include="$(StarboardLibDirs)\CFUnicodeData-B.mapping" />
+      <SBResourceCopy Include="$(StarboardLibDirs)\CFUnicodeData-L.mapping" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #643.

This was caught by neither functional tests _nor_ unit tests, as the
CoreFoundation unicode mapping tables were unequivocally copied into the
test library directory. The only place this failed, therefore, was in a
real AppX deployment scenario.

This fixes, among other things, `-[NSString lowercaseString]`.