### PR TITLE
UIColor now stores ColorQuad (which has same layout as an array of 4 …

### DIFF
--- a/Frameworks/CoreGraphics/CGColor.mm
+++ b/Frameworks/CoreGraphics/CGColor.mm
@@ -62,8 +62,8 @@ CGColorRef CGColorCreateCopy(CGColorRef color) {
  @Status Interoperable
 */
 CGColorRef CGColorCreateCopyWithAlpha(CGColorRef color, float alpha) {
-    static ColorQuad defaultColor{ 0.0f, 0.0f, 0.0f, 0.0f };
-    const ColorQuad* curColor = [(UIColor*)color _getColors];
+    static __CGColorQuad defaultColor{ 0.0f, 0.0f, 0.0f, 0.0f };
+    const __CGColorQuad* curColor = [(UIColor*)color _getColors];
     if (!curColor) {
         curColor = &defaultColor;
     }
@@ -90,8 +90,8 @@ bool CGColorEqualToColor(CGColorRef color1, CGColorRef color2) {
     if (!color1 || !color2) {
         return false;
     }
-    const ColorQuad* components1 = [(UIColor*)color1 _getColors];
-    const ColorQuad* components2 = [(UIColor*)color2 _getColors];
+    const __CGColorQuad* components1 = [(UIColor*)color1 _getColors];
+    const __CGColorQuad* components2 = [(UIColor*)color2 _getColors];
 
     return ((components1->r == components2->r) && (components1->g == components2->g) && (components1->b == components2->b) &&
             (components1->a == components2->a));
@@ -101,10 +101,10 @@ bool CGColorEqualToColor(CGColorRef color1, CGColorRef color2) {
  @Status Interoperable
 */
 CGFloat CGColorGetAlpha(CGColorRef color) {
-    const ColorQuad* curColor = [(UIColor*)color _getColors];
+    const __CGColorQuad* curColor = [(UIColor*)color _getColors];
 
     if (curColor) {
-        return [(UIColor*)color _getColors]->a;
+        return curColor->a;
     }
     return 0.0f;
 }

--- a/Frameworks/CoreGraphics/CGColor.mm
+++ b/Frameworks/CoreGraphics/CGColor.mm
@@ -62,11 +62,13 @@ CGColorRef CGColorCreateCopy(CGColorRef color) {
  @Status Interoperable
 */
 CGColorRef CGColorCreateCopyWithAlpha(CGColorRef color, float alpha) {
-    ColorQuad curColor;
+    static ColorQuad defaultColor{ 0.0f, 0.0f, 0.0f, 0.0f };
+    const ColorQuad* curColor = [(UIColor*)color _getColors];
+    if (!curColor) {
+        curColor = &defaultColor;
+    }
 
-    [(UIColor*)color getColors:&curColor];
-
-    return static_cast<CGColorRef>([[_LazyUIColor colorWithRed:curColor.r green:curColor.g blue:curColor.b alpha:alpha] retain]);
+    return static_cast<CGColorRef>([[_LazyUIColor colorWithRed:curColor->r green:curColor->g blue:curColor->b alpha:alpha] retain]);
 }
 
 /**
@@ -82,25 +84,29 @@ CGColorRef CGColorCreateWithPattern(CGColorSpaceRef colorSpace, CGPatternRef pat
  @Status Interoperable
 */
 bool CGColorEqualToColor(CGColorRef color1, CGColorRef color2) {
-    ColorQuad components1{};
-    ColorQuad components2{};
+    if (color1 == color2) {
+        return true;
+    }
+    if (!color1 || !color2) {
+        return false;
+    }
+    const ColorQuad* components1 = [(UIColor*)color1 _getColors];
+    const ColorQuad* components2 = [(UIColor*)color2 _getColors];
 
-    [(UIColor*)color1 getColors:&components1];
-    [(UIColor*)color2 getColors:&components2];
-
-    return ((components1.r == components1.r) && (components1.g == components1.g) && (components1.b == components1.b) &&
-            (components1.a == components1.a));
+    return ((components1->r == components2->r) && (components1->g == components2->g) && (components1->b == components2->b) &&
+            (components1->a == components2->a));
 }
 
 /**
  @Status Interoperable
 */
 CGFloat CGColorGetAlpha(CGColorRef color) {
-    ColorQuad components;
+    const ColorQuad* curColor = [(UIColor*)color _getColors];
 
-    [(UIColor*)color getColors:&components];
-
-    return (CGFloat)components.a;
+    if (curColor) {
+        return [(UIColor*)color _getColors]->a;
+    }
+    return 0.0f;
 }
 
 /**
@@ -114,16 +120,10 @@ CGColorSpaceRef CGColorGetColorSpace(CGColorRef color) {
 
 /**
  @Status Caveat
- @Notes Works as expected for RGBA only, but returns a client-freed buffer.
+ @Notes Works as expected for RGBA only.
 */
 const CGFloat* CGColorGetComponents(CGColorRef color) {
-    float* ret = (float*)IwMalloc(sizeof(float) * 4);
-    ColorQuad colorComponents;
-    [(UIColor*)color getColors:&colorComponents];
-
-    ColorQuadToFloatArray(colorComponents, ret);
-
-    return ret;
+    return (const CGFloat*)[(UIColor*)color _getColors];
 }
 
 /**

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -212,13 +212,12 @@ void CGContextCairo::_cairoContextStrokePathShadow() {
     cairo_append_path(ctx, path);
 
     NSUInteger componentsNum = CGColorGetNumberOfComponents(curState->shadowColor);
-    CGFloat* components = (CGFloat*)CGColorGetComponents(curState->shadowColor);
+    const CGFloat* components = CGColorGetComponents(curState->shadowColor);
     if (componentsNum == 2) {
         cairo_set_source_rgba(ctx, components[0], components[0], components[0], components[1]);
     } else if (componentsNum == 4) {
         cairo_set_source_rgba(ctx, components[0], components[1], components[2], components[3]);
     }
-    IwFree(components);
 
     // Make the stroke style same as _drawContext
     cairo_set_line_width(ctx, cairo_get_line_width(_drawContext));
@@ -700,12 +699,20 @@ void CGContextCairo::CGContextSetStrokeColor(float* components) {
 }
 
 void CGContextCairo::CGContextSetStrokeColorWithColor(id color) {
-    [(UIColor*)color getColors:&curState->curStrokeColor];
+    if (color) {
+        curState->curStrokeColor = *[(UIColor*)color _getColors];
+    } else {
+        _ClearColorQuad(curState->curStrokeColor);
+    }
 }
 
 void CGContextCairo::CGContextSetFillColorWithColor(id color) {
     if ((int)[(UIColor*)color _type] == solidBrush) {
-        [(UIColor*)color getColors:&curState->curFillColor];
+        if (color) {
+            curState->curFillColor = *[(UIColor*)color _getColors];
+        } else {
+            _ClearColorQuad(curState->curFillColor);
+        }
         curState->curFillColorObject = nil;
     } else {
         curState->curFillColorObject = [color retain];

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -702,7 +702,7 @@ void CGContextCairo::CGContextSetStrokeColorWithColor(id color) {
     if (color) {
         curState->curStrokeColor = *[(UIColor*)color _getColors];
     } else {
-        _Clear__CGColorQuad(curState->curStrokeColor);
+        _ClearColorQuad(curState->curStrokeColor);
     }
 }
 
@@ -711,7 +711,7 @@ void CGContextCairo::CGContextSetFillColorWithColor(id color) {
         if (color) {
             curState->curFillColor = *[(UIColor*)color _getColors];
         } else {
-            _Clear__CGColorQuad(curState->curFillColor);
+            _ClearColorQuad(curState->curFillColor);
         }
         curState->curFillColorObject = nil;
     } else {

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -702,7 +702,7 @@ void CGContextCairo::CGContextSetStrokeColorWithColor(id color) {
     if (color) {
         curState->curStrokeColor = *[(UIColor*)color _getColors];
     } else {
-        _ClearColorQuad(curState->curStrokeColor);
+        _Clear__CGColorQuad(curState->curStrokeColor);
     }
 }
 
@@ -711,7 +711,7 @@ void CGContextCairo::CGContextSetFillColorWithColor(id color) {
         if (color) {
             curState->curFillColor = *[(UIColor*)color _getColors];
         } else {
-            _ClearColorQuad(curState->curFillColor);
+            _Clear__CGColorQuad(curState->curFillColor);
         }
         curState->curFillColorObject = nil;
     } else {

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -353,12 +353,20 @@ void CGContextImpl::CGContextSetStrokeColor(float* components) {
 }
 
 void CGContextImpl::CGContextSetStrokeColorWithColor(id color) {
-    [(UIColor*)color getColors:&curState->curStrokeColor];
+    if (color) {
+        curState->curStrokeColor = *[(UIColor*)color _getColors];
+    } else {
+        _ClearColorQuad(curState->curStrokeColor);
+    }
 }
 
 void CGContextImpl::CGContextSetFillColorWithColor(id color) {
     if ((int)[(UIColor*)color _type] == solidBrush) {
-        [(UIColor*)color getColors:&curState->curFillColor];
+        if (color) {
+            curState->curFillColor = *[(UIColor*)color _getColors];
+        } else {
+            _ClearColorQuad(curState->curFillColor);
+        }
         curState->curFillColorObject = nil;
     } else {
         curState->curFillColorObject = [color retain];

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -356,7 +356,7 @@ void CGContextImpl::CGContextSetStrokeColorWithColor(id color) {
     if (color) {
         curState->curStrokeColor = *[(UIColor*)color _getColors];
     } else {
-        _ClearColorQuad(curState->curStrokeColor);
+        _Clear__CGColorQuad(curState->curStrokeColor);
     }
 }
 
@@ -365,7 +365,7 @@ void CGContextImpl::CGContextSetFillColorWithColor(id color) {
         if (color) {
             curState->curFillColor = *[(UIColor*)color _getColors];
         } else {
-            _ClearColorQuad(curState->curFillColor);
+            _Clear__CGColorQuad(curState->curFillColor);
         }
         curState->curFillColorObject = nil;
     } else {

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -356,7 +356,7 @@ void CGContextImpl::CGContextSetStrokeColorWithColor(id color) {
     if (color) {
         curState->curStrokeColor = *[(UIColor*)color _getColors];
     } else {
-        _Clear__CGColorQuad(curState->curStrokeColor);
+        _ClearColorQuad(curState->curStrokeColor);
     }
 }
 
@@ -365,7 +365,7 @@ void CGContextImpl::CGContextSetFillColorWithColor(id color) {
         if (color) {
             curState->curFillColor = *[(UIColor*)color _getColors];
         } else {
-            _Clear__CGColorQuad(curState->curFillColor);
+            _ClearColorQuad(curState->curFillColor);
         }
         curState->curFillColorObject = nil;
     } else {

--- a/Frameworks/CoreGraphics/CGGradient.mm
+++ b/Frameworks/CoreGraphics/CGGradient.mm
@@ -121,7 +121,7 @@ void __CGGradient::initWithColors(CFArrayRef componentsArr, const float* locatio
         UIColor* curColor = [components objectAtIndex:i];
 
         if (curColor) {
-            const ColorQuad* color = [curColor _getColors];
+            const __CGColorQuad* color = [curColor _getColors];
             memcpy(&_components[i * componentCount], color, sizeof(CGFloat) * componentCount);
         } else {
             memset(&_components[i * componentCount], 0, sizeof(CGFloat) * componentCount);

--- a/Frameworks/CoreGraphics/CGGradient.mm
+++ b/Frameworks/CoreGraphics/CGGradient.mm
@@ -115,18 +115,17 @@ void __CGGradient::initWithColors(CFArrayRef componentsArr, const float* locatio
 
     int count = [components count];
 
-    _components = new float[count * componentCount];
+    _components = new CGFloat[count * componentCount];
 
     for (int i = 0; i < count; i++) {
         UIColor* curColor = [components objectAtIndex:i];
 
-        float colorArray[4];
-        ColorQuad color;
-        [curColor getColors:&color];
-
-        ColorQuadToFloatArray(color, colorArray);
-
-        memcpy(&_components[i * componentCount], colorArray, sizeof(float) * componentCount);
+        if (curColor) {
+            const ColorQuad* color = [curColor _getColors];
+            memcpy(&_components[i * componentCount], color, sizeof(CGFloat) * componentCount);
+        } else {
+            memset(&_components[i * componentCount], 0, sizeof(CGFloat) * componentCount);
+        }
     }
 
     _locations = new float[count];

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -1696,7 +1696,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     if (color != nil) {
         priv->backgroundColor = *[static_cast<UIColor*>(color) _getColors];
     } else {
-        _Clear__CGColorQuad(priv->backgroundColor);
+        _ClearColorQuad(priv->backgroundColor);
     }
 
     [CATransaction _setPropertyForLayer:self name:@"backgroundColor" value:(NSObject*)color];
@@ -1718,7 +1718,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     if (newColor != nil) {
         priv->contentColor = *[static_cast<UIColor*>(newColor) _getColors];
     } else {
-        _Clear__CGColorQuad(priv->contentColor);
+        _ClearColorQuad(priv->contentColor);
     }
     [CATransaction _setPropertyForLayer:self name:@"contentColor" value:static_cast<UIColor*>(newColor)];
 }
@@ -1731,7 +1731,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     if (color != nil) {
         priv->borderColor = *[static_cast<UIColor*>(color) _getColors];
     } else {
-        _Clear__CGColorQuad(priv->borderColor);
+        _ClearColorQuad(priv->borderColor);
     }
 
     CGColorRef old = priv->_borderColor;

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -1694,12 +1694,9 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
 */
 - (void)setBackgroundColor:(CGColorRef)color {
     if (color != nil) {
-        [static_cast<UIColor*>(color) getColors:&priv->backgroundColor];
+        priv->backgroundColor = *[static_cast<UIColor*>(color) _getColors];
     } else {
-        priv->backgroundColor.r = 0.0f;
-        priv->backgroundColor.g = 0.0f;
-        priv->backgroundColor.b = 0.0f;
-        priv->backgroundColor.a = 0.0f;
+        _ClearColorQuad(priv->backgroundColor);
     }
 
     [CATransaction _setPropertyForLayer:self name:@"backgroundColor" value:(NSObject*)color];
@@ -1718,7 +1715,11 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
 }
 
 - (void)_setContentColor:(CGColorRef)newColor {
-    [static_cast<UIColor*>(newColor) getColors:&priv->contentColor];
+    if (newColor != nil) {
+        priv->contentColor = *[static_cast<UIColor*>(newColor) _getColors];
+    } else {
+        _ClearColorQuad(priv->contentColor);
+    }
     [CATransaction _setPropertyForLayer:self name:@"contentColor" value:static_cast<UIColor*>(newColor)];
 }
 
@@ -1728,12 +1729,9 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
 - (void)setBorderColor:(CGColorRef)color {
     UNIMPLEMENTED();
     if (color != nil) {
-        [static_cast<UIColor*>(color) getColors:&priv->borderColor];
+        priv->borderColor = *[static_cast<UIColor*>(color) _getColors];
     } else {
-        priv->borderColor.r = 0.0f;
-        priv->borderColor.g = 0.0f;
-        priv->borderColor.b = 0.0f;
-        priv->borderColor.a = 0.0f;
+        _ClearColorQuad(priv->borderColor);
     }
 
     CGColorRef old = priv->_borderColor;

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -1696,7 +1696,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     if (color != nil) {
         priv->backgroundColor = *[static_cast<UIColor*>(color) _getColors];
     } else {
-        _ClearColorQuad(priv->backgroundColor);
+        _Clear__CGColorQuad(priv->backgroundColor);
     }
 
     [CATransaction _setPropertyForLayer:self name:@"backgroundColor" value:(NSObject*)color];
@@ -1718,7 +1718,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     if (newColor != nil) {
         priv->contentColor = *[static_cast<UIColor*>(newColor) _getColors];
     } else {
-        _ClearColorQuad(priv->contentColor);
+        _Clear__CGColorQuad(priv->contentColor);
     }
     [CATransaction _setPropertyForLayer:self name:@"contentColor" value:static_cast<UIColor*>(newColor)];
 }
@@ -1731,7 +1731,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     if (color != nil) {
         priv->borderColor = *[static_cast<UIColor*>(color) _getColors];
     } else {
-        _ClearColorQuad(priv->borderColor);
+        _Clear__CGColorQuad(priv->borderColor);
     }
 
     CGColorRef old = priv->_borderColor;

--- a/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
+++ b/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
@@ -47,6 +47,7 @@
 
 #import <UWP/WindowsUIViewManagement.h>
 #import <UWP/WindowsDevicesInput.h>
+#import "UIColorInternal.h"
 
 static const wchar_t* TAG = L"CompositorInterface";
 
@@ -337,10 +338,11 @@ public:
         _insets[2] = edgeInsets.right;
         _insets[3] = edgeInsets.bottom;
 
-        ColorQuad colorComponents;
-        [color getColors:&colorComponents];
-
-        ColorQuadToFloatArray(colorComponents, _color);
+        if (color) {
+            memcpy(_color, [color _getColors], sizeof(_color));
+        } else {
+            memset(_color, 0, sizeof(_color));
+        }
 
         _fontSize = [font pointSize];
         _centerVertically = centerVertically;
@@ -1081,9 +1083,12 @@ public:
         } else if (strcmp(name, "sublayerTransform") == 0) {
             UNIMPLEMENTED_WITH_MSG("sublayerTransform not implemented");
         } else if (strcmp(name, "backgroundColor") == 0) {
-            ColorQuad color{};
-            [(UIColor*)newValue getColors:&color];
-            SetBackgroundColor(color.r, color.g, color.b, color.a);
+            const ColorQuad* color = [(UIColor*)newValue _getColors];
+            if (color) {
+                SetBackgroundColor(color->r, color->g, color->b, color->a);
+            } else {
+                SetBackgroundColor(0.0f, 0.0f, 0.0f, 0.0f);
+            }
         } else {
             FAIL_FAST_HR(E_NOTIMPL);
         }

--- a/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
+++ b/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
@@ -1083,7 +1083,7 @@ public:
         } else if (strcmp(name, "sublayerTransform") == 0) {
             UNIMPLEMENTED_WITH_MSG("sublayerTransform not implemented");
         } else if (strcmp(name, "backgroundColor") == 0) {
-            const ColorQuad* color = [(UIColor*)newValue _getColors];
+            const __CGColorQuad* color = [(UIColor*)newValue _getColors];
             if (color) {
                 SetBackgroundColor(color->r, color->g, color->b, color->a);
             } else {

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -37,7 +37,7 @@ struct buttonState {
 @end
 
 @implementation UIButton {
-    ColorQuad _backgroundColor;
+    __CGColorQuad _backgroundColor;
     StrongId<UIColor> _defaultColor;
     buttonState* _states;
     UIEdgeInsets titleInsets, imageInsets, contentInsets;
@@ -122,7 +122,7 @@ static void setLabelProperties(UIButton* self) {
 static void setImageProperties(UIButton* self) {
     [self->_imageView setImage:getImage(self)];
 
-    ColorQuad contentColor = self->_backgroundColor;
+    __CGColorQuad contentColor = self->_backgroundColor;
     if (self->_adjustsImageWhenHighlighted && self->_curState == UIControlStateHighlighted &&
         self->_states[UIControlStateHighlighted].image == nil) {
         contentColor.r = 0.5f;
@@ -990,7 +990,7 @@ static CGRect calcImageRect(UIButton* self, CGRect bounds) {
     if (image != nil) {
         UIImageSetLayerContents([self layer], image);
 
-        ColorQuad contentColor = _backgroundColor;
+        __CGColorQuad contentColor = _backgroundColor;
         if (_adjustsImageWhenHighlighted && _curState == UIControlStateHighlighted && _states[UIControlStateHighlighted].image == nil) {
             contentColor.r = 0.5f;
             contentColor.g = 0.5f;
@@ -1074,7 +1074,7 @@ static CGRect calcImageRect(UIButton* self, CGRect bounds) {
  @Status Interoperable
 */
 - (CGSize)intrinsicContentSize {
-    CGSize ret = {0};
+    CGSize ret = { 0 };
     UIImage* img = _states[UIControlStateNormal].image;
 
     if (img != nil) {

--- a/Frameworks/UIKit/UIColor.mm
+++ b/Frameworks/UIKit/UIColor.mm
@@ -216,7 +216,7 @@ rgb hsv2rgb(hsv in) {
     enum BrushType _type;
     UIImage* _image;
     id _pattern;
-    ColorQuad _components;
+    __CGColorQuad _components;
 }
 
 /**
@@ -244,7 +244,10 @@ rgb hsv2rgb(hsv in) {
         return [[[self class] performSelector:NSSelectorFromString(pattern)] retain];
     } else {
         if ([coder containsValueForKey:@"UIWhite"]) {
-            _components.r = _components.g = _components.b = [coder decodeFloatForKey:@"UIWhite"];
+            const CGFloat uiWhite = [coder decodeFloatForKey:@"UIWhite"];
+            _components.r = uiWhite;
+            _components.g = uiWhite;
+            _components.b = uiWhite;
         } else {
             _components.r = [coder decodeFloatForKey:@"UIRed"];
             _components.g = [coder decodeFloatForKey:@"UIGreen"];
@@ -504,7 +507,7 @@ callbacks.version = 0;
 callbacks.releaseInfo = 0;
 callbacks.drawPattern = __UIColorPatternFill;
 
-_pattern = (id) CGPatternCreateColorspace(self, bounds, m, bounds.size.width, bounds.size.height, 0, FALSE, &callbacks, pImg->_has32BitAlpha ? _ColorRGBA : _ColorRGB);
+_pattern = (id) CGPatternCreateColorspace(self, bounds, m, bounds.size.width, bounds.size.height, 0, NO, &callbacks, pImg->_has32BitAlpha ? _ColorRGBA : _ColorRGB);
 } else {
 _pattern = (id) CGPatternCreateFromImage(pImg);
 }
@@ -514,10 +517,10 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
     _image = [image retain];
     _type = cgPatternBrush;
 
-    _components.r = 0;
-    _components.g = 0;
-    _components.b = 0;
-    _components.a = 0;
+    _components.r = 0.0f;
+    _components.g = 0.0f;
+    _components.b = 0.0f;
+    _components.a = 0.0f;
 
     return self;
 }
@@ -599,7 +602,7 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
     return [ret autorelease];
 }
 
-- (const ColorQuad*)_getColors {
+- (const __CGColorQuad*)_getColors {
     return &_components;
 }
 
@@ -713,7 +716,7 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
         *a = _components.a;
     }
 
-    return TRUE;
+    return YES;
 }
 
 /**
@@ -733,7 +736,7 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
         *a = _components.a;
     }
 
-    return TRUE;
+    return YES;
 }
 
 /**
@@ -741,14 +744,14 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
 */
 - (BOOL)isEqual:(UIColor*)other {
     if (![other isKindOfClass:[UIColor class]]) {
-        return FALSE;
+        return NO;
     }
 
     if (_type == other->_type && _image == other->_image && _pattern == other->_pattern && _components.r == other->_components.r &&
         _components.g == other->_components.g && _components.b == other->_components.b) {
-        return TRUE;
+        return YES;
     } else {
-        return FALSE;
+        return NO;
     }
 }
 

--- a/Frameworks/UIKit/UIColor.mm
+++ b/Frameworks/UIKit/UIColor.mm
@@ -216,7 +216,7 @@ rgb hsv2rgb(hsv in) {
     enum BrushType _type;
     UIImage* _image;
     id _pattern;
-    float _r, _g, _b, _a;
+    ColorQuad _components;
 }
 
 /**
@@ -244,16 +244,16 @@ rgb hsv2rgb(hsv in) {
         return [[[self class] performSelector:NSSelectorFromString(pattern)] retain];
     } else {
         if ([coder containsValueForKey:@"UIWhite"]) {
-            _r = _g = _b = [coder decodeFloatForKey:@"UIWhite"];
+            _components.r = _components.g = _components.b = [coder decodeFloatForKey:@"UIWhite"];
         } else {
-            _r = [coder decodeFloatForKey:@"UIRed"];
-            _g = [coder decodeFloatForKey:@"UIGreen"];
-            _b = [coder decodeFloatForKey:@"UIBlue"];
+            _components.r = [coder decodeFloatForKey:@"UIRed"];
+            _components.g = [coder decodeFloatForKey:@"UIGreen"];
+            _components.b = [coder decodeFloatForKey:@"UIBlue"];
         }
         if ([coder containsValueForKey:@"UIAlpha"]) {
-            _a = [coder decodeFloatForKey:@"UIAlpha"];
+            _components.a = [coder decodeFloatForKey:@"UIAlpha"];
         } else {
-            _a = 1.0f;
+            _components.a = 1.0f;
         }
 
         return self;
@@ -266,10 +266,10 @@ rgb hsv2rgb(hsv in) {
 - (void)encodeWithCoder:(NSCoder*)coder {
     assert(_type == solidBrush);
 
-    [coder encodeFloat:_r forKey:@"UIRed"];
-    [coder encodeFloat:_g forKey:@"UIGreen"];
-    [coder encodeFloat:_b forKey:@"UIBlue"];
-    [coder encodeFloat:_a forKey:@"UIAlpha"];
+    [coder encodeFloat:_components.r forKey:@"UIRed"];
+    [coder encodeFloat:_components.g forKey:@"UIGreen"];
+    [coder encodeFloat:_components.b forKey:@"UIBlue"];
+    [coder encodeFloat:_components.a forKey:@"UIAlpha"];
 }
 
 /**
@@ -428,10 +428,10 @@ rgb hsv2rgb(hsv in) {
 */
 + (UIColor*)colorWithRed:(float)r green:(float)g blue:(float)b alpha:(float)a {
     UIColor* ret = [self alloc];
-    ret->_r = r;
-    ret->_g = g;
-    ret->_b = b;
-    ret->_a = a;
+    ret->_components.r = r;
+    ret->_components.g = g;
+    ret->_components.b = b;
+    ret->_components.a = a;
     ret->_type = solidBrush;
 
     return [ret autorelease];
@@ -459,10 +459,10 @@ rgb hsv2rgb(hsv in) {
 
     out = hsv2rgb(in);
 
-    _r = (float)out.r;
-    _g = (float)out.g;
-    _b = (float)out.b;
-    _a = (float)a;
+    _components.r = (float)out.r;
+    _components.g = (float)out.g;
+    _components.b = (float)out.b;
+    _components.a = (float)a;
     _type = solidBrush;
 
     return self;
@@ -472,10 +472,10 @@ rgb hsv2rgb(hsv in) {
  @Status Interoperable
 */
 - (UIColor*)initWithRed:(float)r green:(float)g blue:(float)b alpha:(float)a {
-    _r = r;
-    _g = g;
-    _b = b;
-    _a = a;
+    _components.r = r;
+    _components.g = g;
+    _components.b = b;
+    _components.a = a;
     _type = solidBrush;
     return self;
 }
@@ -514,10 +514,10 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
     _image = [image retain];
     _type = cgPatternBrush;
 
-    _r = 0;
-    _g = 0;
-    _b = 0;
-    _a = 0;
+    _components.r = 0;
+    _components.g = 0;
+    _components.b = 0;
+    _components.a = 0;
 
     return self;
 }
@@ -558,7 +558,7 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
  @Status Interoperable
 */
 - (UIColor*)colorWithAlphaComponent:(float)alpha {
-    return [UIColor colorWithRed:_r green:_g blue:_b alpha:alpha];
+    return [UIColor colorWithRed:_components.r green:_components.g blue:_components.b alpha:alpha];
 }
 
 + (UIColor*)colorWithColor:(UIColor*)copyclr {
@@ -570,10 +570,10 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
 
     ret->_type = copyclr->_type;
     ret->_pattern = [copyclr->_pattern retain];
-    ret->_r = copyclr->_r;
-    ret->_g = copyclr->_g;
-    ret->_b = copyclr->_b;
-    ret->_a = copyclr->_a;
+    ret->_components.r = copyclr->_components.r;
+    ret->_components.g = copyclr->_components.g;
+    ret->_components.b = copyclr->_components.b;
+    ret->_components.a = copyclr->_components.a;
 
     return [ret autorelease];
 }
@@ -591,21 +591,16 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
 
     ret->_type = copyclr->_type;
     ret->_pattern = [copyclr->_pattern retain];
-    ret->_r = copyclr->_r;
-    ret->_g = copyclr->_g;
-    ret->_b = copyclr->_b;
-    ret->_a = copyclr->_a;
+    ret->_components.r = copyclr->_components.r;
+    ret->_components.g = copyclr->_components.g;
+    ret->_components.b = copyclr->_components.b;
+    ret->_components.a = copyclr->_components.a;
 
     return [ret autorelease];
 }
 
-- (void)getColors:(ColorQuad*)colors {
-    if (colors) {
-        colors->r = _r;
-        colors->g = _g;
-        colors->b = _b;
-        colors->a = _a;
-    }
+- (const ColorQuad*)_getColors {
+    return &_components;
 }
 
 /**
@@ -699,9 +694,9 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
     hsv out;
     rgb in;
 
-    in.r = _r;
-    in.b = _b;
-    in.g = _g;
+    in.r = _components.r;
+    in.b = _components.b;
+    in.g = _components.g;
 
     out = rgb2hsv(in);
 
@@ -715,7 +710,7 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
         *v = (float)out.v;
     }
     if (a) {
-        *a = _a;
+        *a = _components.a;
     }
 
     return TRUE;
@@ -726,16 +721,16 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
 */
 - (BOOL)getRed:(float*)r green:(float*)g blue:(float*)b alpha:(float*)a {
     if (r) {
-        *r = _r;
+        *r = _components.r;
     }
     if (g) {
-        *g = _g;
+        *g = _components.g;
     }
     if (b) {
-        *b = _b;
+        *b = _components.b;
     }
     if (a) {
-        *a = _a;
+        *a = _components.a;
     }
 
     return TRUE;
@@ -749,8 +744,8 @@ _pattern = (id) CGPatternCreateFromImage(pImg);
         return FALSE;
     }
 
-    if (_type == other->_type && _image == other->_image && _pattern == other->_pattern && _r == other->_r && _g == other->_g &&
-        _b == other->_b) {
+    if (_type == other->_type && _image == other->_image && _pattern == other->_pattern && _components.r == other->_components.r &&
+        _components.g == other->_components.g && _components.b == other->_components.b) {
         return TRUE;
     } else {
         return FALSE;

--- a/Frameworks/UIKit/UITableViewCell.mm
+++ b/Frameworks/UIKit/UITableViewCell.mm
@@ -822,7 +822,7 @@ static void updateBackgroundView(UITableViewCell* self, bool forceRefresh = fals
 
 static void setInternalAccessoryColor(UITableViewCell* self) {
     if (self->_internalAccessoryView != nil) {
-        ColorQuad contentColor;
+        __CGColorQuad contentColor;
         contentColor.r = 0.13f;
         contentColor.g = 0.24f;
         contentColor.b = 0.44f;
@@ -1087,7 +1087,7 @@ static id getCurrentAccessoryView(UITableViewCell* self) {
 
 - (void)_addBottomBorder:(UITableView*)parentTable {
     if (_borderView == nil) {
-        const ColorQuad* color = [[parentTable backgroundColor] _getColors];
+        const __CGColorQuad* color = [[parentTable backgroundColor] _getColors];
         UIColor* backgroundColor = nil;
 
         if ((color == nullptr) || (color->a == 0.0f) || (color->r == 1.0f && color->g == 1.0f && color->b == 1.0f && color->a == 1.0f)) {

--- a/Frameworks/UIKit/UITableViewCell.mm
+++ b/Frameworks/UIKit/UITableViewCell.mm
@@ -1087,12 +1087,10 @@ static id getCurrentAccessoryView(UITableViewCell* self) {
 
 - (void)_addBottomBorder:(UITableView*)parentTable {
     if (_borderView == nil) {
-        ColorQuad color = { 0 };
-
-        [[parentTable backgroundColor] getColors:&color];
+        const ColorQuad* color = [[parentTable backgroundColor] _getColors];
         UIColor* backgroundColor = nil;
 
-        if ((color.a == 0.0f) || (color.r == 1.0f && color.g == 1.0f && color.b == 1.0f && color.a == 1.0f)) {
+        if ((color == nullptr) || (color->a == 0.0f) || (color->r == 1.0f && color->g == 1.0f && color->b == 1.0f && color->a == 1.0f)) {
             backgroundColor = [UIColor grayColor];
         } else {
             backgroundColor = [UIColor whiteColor];

--- a/Frameworks/include/CALayerInternal.h
+++ b/Frameworks/include/CALayerInternal.h
@@ -20,6 +20,7 @@
 #import <LinkedList.h>
 #import <AccessibilityInternal.h>
 #import <UIKit/UIImage.h>
+#import "UIColorInternal.h"
 
 @class CAAnimation, CALayerContext;
 

--- a/Frameworks/include/CALayerInternal.h
+++ b/Frameworks/include/CALayerInternal.h
@@ -44,7 +44,7 @@ public:
 
     CATransform3D transform;
     CATransform3D sublayerTransform;
-    ColorQuad backgroundColor, borderColor, contentColor;
+    __CGColorQuad backgroundColor, borderColor, contentColor;
     float borderWidth, cornerRadius;
     float opacity;
 };

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -28,6 +28,7 @@
 #include "CoreGraphics/CGShading.h"
 #include "UIKit/UIColor.h"
 #include "UIKit/UIFont.h"
+#import "UIColorInternal.h"
 
 typedef struct {
     id curFillColorObject;
@@ -58,7 +59,8 @@ private:
 #define MAX_CG_STATES 16
 
 class CGContextImpl {
-__CGCONTEXTIMPL_TEST_FRIENDS;
+    __CGCONTEXTIMPL_TEST_FRIENDS;
+
 protected:
     CGContextRef _rootContext;
     CGImageRef _imgDest;

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -32,8 +32,8 @@
 
 typedef struct {
     id curFillColorObject;
-    ColorQuad curFillColor, curTextColor, curStrokeColor;
-    ColorQuad curPenColor, curForegroundColor;
+    __CGColorQuad curFillColor, curTextColor, curStrokeColor;
+    __CGColorQuad curPenColor, curForegroundColor;
     CGImageRef _imgClip, _imgMask;
     CGRect _imgMaskRect;
     CGAffineTransform curTransform;

--- a/Frameworks/include/CGVectorImage.h
+++ b/Frameworks/include/CGVectorImage.h
@@ -39,10 +39,10 @@ public:
     CGRect _src, _dest;
     CGPoint _start, _end;
     float _lineWidth;
-    ColorQuad _color;
+    __CGColorQuad _color;
 
     CGVectorDrawingCommand(CGImageRef image, CGRect src, CGRect dst);
-    CGVectorDrawingCommand(CGPoint lineStart, CGPoint lineEnd, ColorQuad color, float lineWidth);
+    CGVectorDrawingCommand(CGPoint lineStart, CGPoint lineEnd, __CGColorQuad color, float lineWidth);
     ~CGVectorDrawingCommand();
 };
 
@@ -76,5 +76,5 @@ public:
     void SetFreeWhenDone(bool freeWhenDone);
 
     void DrawImage(CGImageRef image, CGRect src, CGRect dst);
-    void StrokePath(id path, ColorQuad color, float lineWidth, CGAffineTransform* t);
+    void StrokePath(id path, __CGColorQuad color, float lineWidth, CGAffineTransform* t);
 };

--- a/Frameworks/include/CGVectorImage.h
+++ b/Frameworks/include/CGVectorImage.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#import "UIColorInternal.h"
+
 class CGVectorImageBacking;
 
 class CGVectorImage : public __CGImage {

--- a/Frameworks/include/EbrGLES.h
+++ b/Frameworks/include/EbrGLES.h
@@ -66,7 +66,7 @@ bool EbrGLESInitShaders(ID3D11Device* device);
 void EbrGLESDestroyShaders();
 void EbrGLESInitDraw();
 void EbrGLESSetTexturing(TextureMode mode);
-void EbrGLESSetArrays(CAPoint3D* verts, CGPoint* uvs, ColorQuad* colors, float* texNums);
+void EbrGLESSetArrays(CAPoint3D* verts, CGPoint* uvs, __CGColorQuad* colors, float* texNums);
 void EbrGLESSet2DArrays(CGPoint* verts, CGPoint* uvs);
 void EbrGLESSetColor(float* colorArray); // of size 4
 void EbrGLESSetTransform(ID3D11DeviceContext* ctx, float* matrix); // of size 16, row-major.

--- a/Frameworks/include/UIColorInternal.h
+++ b/Frameworks/include/UIColorInternal.h
@@ -17,13 +17,27 @@
 #pragma once
 
 #import <UIKit/UIColor.h>
-#import <CoreGraphics/CGPattern.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+typedef struct {
+    CGFloat r;
+    CGFloat g;
+    CGFloat b;
+    CGFloat a;
+} ColorQuad;
+
+inline void _ClearColorQuad(ColorQuad& color) {
+    color.r = 0.0f;
+    color.g = 0.0f;
+    color.b = 0.0f;
+    color.a = 0.0f;
+}
 
 @interface UIColor (Internal) {
 }
 + (UIColor*)_colorWithCGPattern:(CGPatternRef)pattern;
 + (UIColor*)_windowsTableViewCellSelectionBackgroundColor;
 
-- (void)getColors:(ColorQuad*)colors;
+- (const ColorQuad*)_getColors;
 - (BrushType)_type;
 @end

--- a/Frameworks/include/UIColorInternal.h
+++ b/Frameworks/include/UIColorInternal.h
@@ -26,7 +26,7 @@ typedef struct {
     CGFloat a;
 } __CGColorQuad;
 
-inline void _Clear__CGColorQuad(__CGColorQuad& color) {
+inline void _ClearColorQuad(__CGColorQuad& color) {
     color.r = 0.0f;
     color.g = 0.0f;
     color.b = 0.0f;

--- a/Frameworks/include/UIColorInternal.h
+++ b/Frameworks/include/UIColorInternal.h
@@ -24,9 +24,9 @@ typedef struct {
     CGFloat g;
     CGFloat b;
     CGFloat a;
-} ColorQuad;
+} __CGColorQuad;
 
-inline void _ClearColorQuad(ColorQuad& color) {
+inline void _Clear__CGColorQuad(__CGColorQuad& color) {
     color.r = 0.0f;
     color.g = 0.0f;
     color.b = 0.0f;
@@ -38,6 +38,6 @@ inline void _ClearColorQuad(ColorQuad& color) {
 + (UIColor*)_colorWithCGPattern:(CGPatternRef)pattern;
 + (UIColor*)_windowsTableViewCellSelectionBackgroundColor;
 
-- (const ColorQuad*)_getColors;
+- (const __CGColorQuad*)_getColors;
 - (BrushType)_type;
 @end

--- a/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
@@ -238,6 +238,7 @@
     <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics\CGPathTests.mm" />
     <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics\CGContextTests.mm" />
     <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics\CGBitmapContextTests.mm" />
+    <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics\CGColorTests.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/include/CoreGraphics/CGColor.h
+++ b/include/CoreGraphics/CGColor.h
@@ -19,15 +19,6 @@
 #import <CoreGraphics/CGColorSpace.h>
 #import <CoreGraphics/CGPattern.h>
 
-typedef struct { float r, g, b, a; } ColorQuad;
-
-inline void ColorQuadToFloatArray(ColorQuad color, float* colorArray) {
-    colorArray[0] = color.r;
-    colorArray[1] = color.g;
-    colorArray[2] = color.b;
-    colorArray[3] = color.a;
-}
-
 COREGRAPHICS_EXPORT CGColorRef CGColorRetain(CGColorRef color);
 COREGRAPHICS_EXPORT void CGColorRelease(CGColorRef color);
 COREGRAPHICS_EXPORT CGColorRef CGColorCreate(CGColorSpaceRef space, const CGFloat* components);

--- a/tests/unittests/CoreGraphics/CGColorTests.mm
+++ b/tests/unittests/CoreGraphics/CGColorTests.mm
@@ -1,0 +1,64 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <TestFramework.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+#define EXPECT_EQ_COMPONENTS(a, b) \
+    EXPECT_EQ((a)[0], (b)[0]);     \
+    EXPECT_EQ((a)[1], (b)[1]);     \
+    EXPECT_EQ((a)[2], (b)[2]);     \
+    EXPECT_EQ((a)[3], (b)[3])
+
+TEST(CGColor, CGColorGetComponents) {
+    CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
+
+    CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
+    CGColorRef clr = CGColorCreate(clrRgb, colors);
+    CGColorRef copy = CGColorCreateCopyWithAlpha(clr, 0.5); // transparent red
+
+    const CGFloat* components = CGColorGetComponents(copy);
+    CGFloat expected[] = { 1, 0, 0, 0.5 };
+    EXPECT_EQ_COMPONENTS(components, expected);
+
+    components = CGColorGetComponents(clr);
+    EXPECT_EQ_COMPONENTS(components, colors);
+
+    CGColorRelease(clr);
+    CGColorRelease(copy);
+    CGColorSpaceRelease(clrRgb);
+}
+
+TEST(CGColor, CGColorEquals) {
+    CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
+
+    CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
+    CGColorRef clr1 = CGColorCreate(clrRgb, colors);
+    CGColorRef clr2 = CGColorCreateCopy(clr1);
+    CGColorRef clr3 = CGColorCreateCopyWithAlpha(clr1, 0.9);
+    CGColorRef clr4 = CGColorCreate(clrRgb, colors);
+
+    EXPECT_TRUE(CGColorEqualToColor(clr1, clr1));
+    EXPECT_TRUE(CGColorEqualToColor(clr1, clr2));
+    EXPECT_TRUE(CGColorEqualToColor(clr1, clr4));
+    EXPECT_FALSE(CGColorEqualToColor(clr1, clr3));
+
+    CGColorRelease(clr1);
+    CGColorRelease(clr2);
+    CGColorRelease(clr3);
+    CGColorRelease(clr4);
+    CGColorSpaceRelease(clrRgb);
+}


### PR DESCRIPTION
UIColor now stores ColorQuad (which has same layout as an array of 4 floats).  This can then be used by CGColor.

The correct long terms solution will involve CGColor holding the colors and UIColor using it, but this is a first step towards that.  In the process, also cleaned up the internal methods and removed some unnecessary copies.

Also found and fixed bug in CGColorEqualsColor.

Fix #652, Fix #657