### PR TITLE
Fix activation to create delegate and principal class

### DIFF
--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -111,10 +111,12 @@ void App::Connect(int connectionId, Platform::Object^ target) {
 }
 
 void App::OnLaunched(LaunchActivatedEventArgs^ args) {
-    EbrApplicationActivated(args);
+    TraceVerbose(TAG, L"OnLaunched invoked");
+    EbrApplicationLaunched(args);
 }
 
 void App::OnActivated(IActivatedEventArgs^ args) {
+    TraceVerbose(TAG, L"OnActivated invoked");
     EbrApplicationActivated(args);
 }
 
@@ -122,8 +124,8 @@ void EbrApplicationLaunched(LaunchActivatedEventArgs^ args) {
     // Opt out of prelaunch for now. MSDN guidance is to check the flag and just return.
     // Or skip re-initializing as the app is being resumed from memory.
     bool initiateAppLaunch = (!(args->PrelaunchActivated)
-                                && args->PreviousExecutionState != ApplicationExecutionState::Running
-                                && args->PreviousExecutionState != ApplicationExecutionState::Suspended);
+                                && (args->PreviousExecutionState != ApplicationExecutionState::Running)
+                                && (args->PreviousExecutionState != ApplicationExecutionState::Suspended));
 
     if (initiateAppLaunch) {
         TraceVerbose(TAG, L"Initializing application");
@@ -205,7 +207,7 @@ extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Obje
 UIKIT_EXPORT
 int UIApplicationMain(int argc, char* argv[], void* principalClassName, void* delegateClassName) {
     // Make method only run once
-    static int once = [principalClassName, delegateClassName]()->int{
+    static int once = [principalClassName, delegateClassName] () -> int {
 
         // Initialize COM on this thread
         ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -111,28 +111,24 @@ void App::Connect(int connectionId, Platform::Object^ target) {
 }
 
 void App::OnLaunched(LaunchActivatedEventArgs^ args) {
-    if (EbrApplicationLaunched(args) == true) {
-        _ApplicationMainLaunch(ActivationTypeNone, nullptr);
-    }
+    EbrApplicationActivated(args);
 }
 
 void App::OnActivated(IActivatedEventArgs^ args) {
     EbrApplicationActivated(args);
 }
 
-bool EbrApplicationLaunched(LaunchActivatedEventArgs^ args) {
-    if (args->PrelaunchActivated) {
-        // Opt out of prelaunch for now. MSDN guidance is to check the flag and just return.
-        return false;
-    }
+void EbrApplicationLaunched(LaunchActivatedEventArgs^ args) {
+    // Opt out of prelaunch for now. MSDN guidance is to check the flag and just return.
+    // Or skip re-initializing as the app is being resumed from memory.
+    bool initiateAppLaunch = (!(args->PrelaunchActivated)
+                                && args->PreviousExecutionState != ApplicationExecutionState::Running
+                                && args->PreviousExecutionState != ApplicationExecutionState::Suspended);
 
-    if ((args->PreviousExecutionState == ApplicationExecutionState::Running) ||
-        (args->PreviousExecutionState == ApplicationExecutionState::Suspended)) {
-        // Skip re-initializing as the app is being resumed from memory.
-        return false;
+    if (initiateAppLaunch) {
+        TraceVerbose(TAG, L"Initializing application");
+        _ApplicationMainLaunch(ActivationTypeNone, args);
     }
-
-    return true;
 }
 
 void EbrApplicationActivated(IActivatedEventArgs^ args) {
@@ -185,7 +181,6 @@ void EbrApplicationActivated(IActivatedEventArgs^ args) {
 
 void _ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg) {
     _ApplicationLaunch(activationType, activationArg);
-
     _appEvents = ref new AppEventListener();
     _appEvents->_RegisterEventHandlers();
 }
@@ -204,98 +199,52 @@ extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Obje
     RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
 }
 
-extern "C" void _ApplicationActivate(Platform::Object^ arguments) {
-    IActivatedEventArgs^ args = static_cast<IActivatedEventArgs^>(arguments);
-    TraceVerbose(TAG, L"OnActivated event received for %d. Previous app state was %d", args->Kind, args->PreviousExecutionState);
-    bool initiateAppLaunch = false;
-    if ((args->PreviousExecutionState != ApplicationExecutionState::Running) &&
-        (args->PreviousExecutionState != ApplicationExecutionState::Suspended)) {
-        TraceVerbose(TAG, L"Initializing application");
-        initiateAppLaunch = true;
-    }
-
-    if (args->Kind == ActivationKind::ToastNotification) {
-        Platform::String^ argsString = safe_cast<ToastNotificationActivatedEventArgs^>(args)->Argument;
-        TraceVerbose(TAG, L"Received toast notification with argument - %ls", argsString->Data());
-
-        if (initiateAppLaunch) {
-            _ApplicationLaunch(ActivationTypeToast, argsString);
-        }
-
-        UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
-    } else if (args->Kind == ActivationKind::VoiceCommand) {
-        Windows::Media::SpeechRecognition::SpeechRecognitionResult^ argResult = safe_cast<VoiceCommandActivatedEventArgs^>(args)->Result;
-        TraceVerbose(TAG, L"Received voice command with argument - %ls", argResult->Text->Data());
-
-        if (initiateAppLaunch) {
-            _ApplicationLaunch(ActivationTypeVoiceCommand, argResult);
-        }
-
-        UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
-    } else if (args->Kind == ActivationKind::Protocol) {
-        ProtocolActivatedEventArgs^ protocolArgs = safe_cast<ProtocolActivatedEventArgs^>(args);
-        Windows::Foundation::Uri^ argUri = protocolArgs->Uri;
-        const wchar_t* caller = protocolArgs->CallerPackageFamilyName->Data();
-        TraceVerbose(TAG, L"Received protocol with uri- %ls from %ls", argUri->ToString()->Data(), caller);
-
-        if (initiateAppLaunch) {
-            _ApplicationLaunch(ActivationTypeProtocol, argUri);
-        }
-
-        UIApplicationMainHandleProtocolEvent(reinterpret_cast<IInspectable*>(argUri), caller);
-    } else {
-        TraceVerbose(TAG, L"Received unhandled activation kind - %d", args->Kind);
-
-        if (initiateAppLaunch) {
-            _ApplicationLaunch(ActivationTypeNone, nullptr);
-        }
-    }
-}
 
 // This is the actual entry point from the app into our framework.
 // Note: principalClassName and delegateClassName are actually NSString*s.
 UIKIT_EXPORT
 int UIApplicationMain(int argc, char* argv[], void* principalClassName, void* delegateClassName) {
-    // Initialize COM on this thread
-    ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    // Make method only run once
+    static int once = [principalClassName, delegateClassName]()->int{
 
-    // Register tracelogging
-    TraceRegister();
+        // Initialize COM on this thread
+        ::CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 
-    // Copy the principal and delegate class names into our globals
-    if (principalClassName) {
-        auto rawString = _RawBufferFromNSString(principalClassName);
-        g_principalClassName = reinterpret_cast<Platform::String^>(Strings::NarrowToWide<HSTRING>(rawString).Detach());
-    }
+        // Register tracelogging
+        TraceRegister();
 
-    if (delegateClassName) {
-        auto rawString = _RawBufferFromNSString(delegateClassName);
-        g_delegateClassName = reinterpret_cast<Platform::String^>(Strings::NarrowToWide<HSTRING>(rawString).Detach());
-    }
+        // Copy the principal and delegate class names into our globals
+        if (principalClassName) {
+            auto rawString = _RawBufferFromNSString(principalClassName);
+            g_principalClassName = reinterpret_cast<Platform::String^>(Strings::NarrowToWide<HSTRING>(rawString).Detach());
+        }
 
-    Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IApplicationStatics> appStatics = nullptr;
-    Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IApplication> currentApplication = nullptr;
-    HRESULT hr = RoGetActivationFactory(Platform::StringReference(RuntimeClass_Windows_UI_Xaml_Application).GetHSTRING(),
-        ABI::Windows::UI::Xaml::IID_IApplicationStatics,
-        reinterpret_cast<void **>(appStatics.GetAddressOf()));
+        if (delegateClassName) {
+            auto rawString = _RawBufferFromNSString(delegateClassName);
+            g_delegateClassName = reinterpret_cast<Platform::String^>(Strings::NarrowToWide<HSTRING>(rawString).Detach());
+        }
 
-    if (hr == S_OK && appStatics) {
-        appStatics->get_Current(currentApplication.GetAddressOf());
-    }
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IApplicationStatics> appStatics = nullptr;
+        Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::IApplication> currentApplication = nullptr;
+        HRESULT hr = RoGetActivationFactory(Platform::StringReference(RuntimeClass_Windows_UI_Xaml_Application).GetHSTRING(),
+            ABI::Windows::UI::Xaml::IID_IApplicationStatics,
+            reinterpret_cast<void **>(appStatics.GetAddressOf()));
 
-    if (currentApplication == nullptr) {
-        // Start our application
-        Xaml::Application::Start(
-            ref new Xaml::ApplicationInitializationCallback([](Xaml::ApplicationInitializationCallbackParams^ p) {
-            // Simply creating the app will kick off the rest of the launch sequence
-            auto app = ref new App();
-        }));
-    }
-    else {
-        _ApplicationMainLaunch(ActivationTypeNone, nullptr);
-    }
+        if (hr == S_OK && appStatics) {
+            appStatics->get_Current(currentApplication.GetAddressOf());
+        }
 
-    return 0;
+        if (currentApplication == nullptr) {
+            // Start our application
+            Xaml::Application::Start(
+                ref new Xaml::ApplicationInitializationCallback([](Xaml::ApplicationInitializationCallbackParams^ p) {
+                // Simply creating the app will kick off the rest of the launch sequence
+                auto app = ref new App();
+            }));
+        }
+        return 0;
+    }();
+    return once;
 }
 
 // This is the initialization function for non-Islandwood apps that intend to call into Islandwood:
@@ -339,7 +288,7 @@ void UIApplicationActivationTest(IInspectable* activationArgs, void* delegateCla
         g_delegateClassName = ref new Platform::String();
     }
 
-    _ApplicationActivate(reinterpret_cast<Platform::Object^>(activationArgs));
+    EbrApplicationActivated(static_cast<IActivatedEventArgs^>(reinterpret_cast<Platform::Object^>(activationArgs)));
 }
 
 // clang-format on

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -128,7 +128,8 @@ void OnApplicationLaunched(LaunchActivatedEventArgs^ args) {
                                 && (args->PreviousExecutionState != ApplicationExecutionState::Suspended));
 
     if (initiateAppLaunch) {
-        _ApplicationMainLaunch(ActivationTypeNone, args);
+        TraceVerbose(TAG, L"Initializing application");
+        _ApplicationLaunch(ActivationTypeNone, args);
     }
 }
 
@@ -138,6 +139,7 @@ void OnApplicationActivated(IActivatedEventArgs^ args) {
     bool initiateAppLaunch = false;
     if ((args->PreviousExecutionState != ApplicationExecutionState::Running) &&
         (args->PreviousExecutionState != ApplicationExecutionState::Suspended)) {
+        TraceVerbose(TAG, L"Initializing application");
         initiateAppLaunch = true;
     }
 
@@ -146,7 +148,7 @@ void OnApplicationActivated(IActivatedEventArgs^ args) {
         TraceVerbose(TAG, L"Received toast notification with argument - %s", argsString->Data());
 
         if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeToast, argsString);
+            _ApplicationLaunch(ActivationTypeToast, argsString);
         }
 
         UIApplicationMainHandleToastNotificationEvent(Strings::WideToNarrow(argsString->Data()).c_str());
@@ -155,7 +157,7 @@ void OnApplicationActivated(IActivatedEventArgs^ args) {
         TraceVerbose(TAG, L"Received voice command with argument - %s", argResult->Text->Data());
 
         if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeVoiceCommand, argResult);
+            _ApplicationLaunch(ActivationTypeVoiceCommand, argResult);
         }
 
         UIApplicationMainHandleVoiceCommandEvent(reinterpret_cast<IInspectable*>(argResult));
@@ -166,7 +168,7 @@ void OnApplicationActivated(IActivatedEventArgs^ args) {
         TraceVerbose(TAG, L"Received protocol with uri- %s from %s", argUri->ToString()->Data(), caller);
 
         if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeProtocol, argUri);
+            _ApplicationLaunch(ActivationTypeProtocol, argUri);
         }
 
         UIApplicationMainHandleProtocolEvent(reinterpret_cast<IInspectable*>(argUri), caller);
@@ -174,17 +176,11 @@ void OnApplicationActivated(IActivatedEventArgs^ args) {
         TraceVerbose(TAG, L"Received unhandled activation kind - %d", args->Kind);
 
         if (initiateAppLaunch) {
-            _ApplicationMainLaunch(ActivationTypeNone, nullptr);
+            _ApplicationLaunch(ActivationTypeNone, nullptr);
         }
     }
 }
 
-void _ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg) {
-    TraceVerbose(TAG, L"Initializing application");
-    _ApplicationLaunch(activationType, activationArg);
-    _appEvents = ref new AppEventListener();
-    _appEvents->_RegisterEventHandlers();
-}
 
 void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg) {
     auto uiElem = ref new Xaml::Controls::Grid();
@@ -198,6 +194,9 @@ void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activat
 
     auto startupRect = Xaml::Window::Current->Bounds;
     RunApplicationMain(g_principalClassName, g_delegateClassName, startupRect.Width, startupRect.Height, activationType, activationArg);
+
+    _appEvents = ref new AppEventListener();
+    _appEvents->_RegisterEventHandlers();
 }
 
 

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -111,14 +111,14 @@ void App::Connect(int connectionId, Platform::Object^ target) {
 }
 
 void App::OnLaunched(LaunchActivatedEventArgs^ args) {
-    OnApplicationLaunched(args);
+    UIApplicationLaunched(args);
 }
 
 void App::OnActivated(IActivatedEventArgs^ args) {
-    OnApplicationActivated(args);
+    UIApplicationActivated(args);
 }
 
-void OnApplicationLaunched(LaunchActivatedEventArgs^ args) {
+void UIApplicationLaunched(LaunchActivatedEventArgs^ args) {
     TraceVerbose(TAG, L"OnLaunched event received for %d. Previous app state was %d", args->Kind, args->PreviousExecutionState);
 
     // Opt out of prelaunch for now. MSDN guidance is to check the flag and just return.
@@ -133,7 +133,7 @@ void OnApplicationLaunched(LaunchActivatedEventArgs^ args) {
     }
 }
 
-void OnApplicationActivated(IActivatedEventArgs^ args) {
+void UIApplicationActivated(IActivatedEventArgs^ args) {
     TraceVerbose(TAG, L"OnActivated event received for %d. Previous app state was %d", args->Kind, args->PreviousExecutionState);
 
     bool initiateAppLaunch = false;
@@ -288,7 +288,7 @@ void UIApplicationActivationTest(IInspectable* activationArgs, void* delegateCla
         g_delegateClassName = ref new Platform::String();
     }
 
-    OnApplicationActivated(static_cast<IActivatedEventArgs^>(reinterpret_cast<Platform::Object^>(activationArgs)));
+    UIApplicationActivated(static_cast<IActivatedEventArgs^>(reinterpret_cast<Platform::Object^>(activationArgs)));
 }
 
 // clang-format on

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
@@ -56,8 +56,8 @@ private:
     void _OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ args);
 };
 
-extern "C" void OnApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-extern "C" void OnApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+extern "C" void UIApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
+extern "C" void UIApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
 void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
 
 #endif

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
@@ -59,7 +59,6 @@ private:
 extern "C" void OnApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
 extern "C" void OnApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
 void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
-void _ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg);
 
 #endif
 

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
@@ -58,7 +58,7 @@ private:
 
 extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
 extern "C" void EbrApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-extern "C" bool EbrApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+extern "C" void EbrApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
 void _ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg);
 
 #endif

--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.h
@@ -56,9 +56,9 @@ private:
     void _OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ args);
 };
 
-extern "C" void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
-extern "C" void EbrApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-extern "C" void EbrApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+extern "C" void OnApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
+extern "C" void OnApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+void _ApplicationLaunch(ActivationType activationType, Platform::Object^ activationArg);
 void _ApplicationMainLaunch(ActivationType activationType, Platform::Object^ activationArg);
 
 #endif

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -1164,6 +1164,6 @@ LIBRARY UIKit
         UIRequestTransactionProcessing
         UIOrientationFromString
         UIApplicationDidChangeDisplayModeNofication
-        EbrApplicationActivated
-        EbrApplicationLaunched
+        OnApplicationActivated
+        OnApplicationLaunched
 

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -4,6 +4,8 @@ LIBRARY UIKit
         UIApplicationMain
         UIApplicationInitialize
         UIApplicationActivationTest
+        UIApplicationActivated
+        UIApplicationLaunched
 
         ; NSAttributedString
         NSFontAttributeName DATA
@@ -1164,6 +1166,4 @@ LIBRARY UIKit
         UIRequestTransactionProcessing
         UIOrientationFromString
         UIApplicationDidChangeDisplayModeNofication
-        UIApplicationActivated
-        UIApplicationLaunched
 

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -1164,6 +1164,6 @@ LIBRARY UIKit
         UIRequestTransactionProcessing
         UIOrientationFromString
         UIApplicationDidChangeDisplayModeNofication
-        OnApplicationActivated
-        OnApplicationLaunched
+        UIApplicationActivated
+        UIApplicationLaunched
 

--- a/msvc/vsimporter-templates/WinStore10-App/App.xaml.cpp
+++ b/msvc/vsimporter-templates/WinStore10-App/App.xaml.cpp
@@ -25,8 +25,7 @@ using namespace Windows::UI::Xaml::Navigation;
 /// Initializes the singleton application object.  This is the first line of authored code
 /// executed, and as such is the logical equivalent of main() or WinMain().
 /// </summary>
-App::App()
-{
+App::App() {
     InitializeComponent();
     Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
 }
@@ -34,23 +33,20 @@ App::App()
 extern "C" int main(int argc, char* argv[]);
 extern "C" int __cdecl EbrDefaultXamlMain();
 extern "C" void EbrApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-extern "C" bool EbrApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+extern "C" void EbrApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
 
 /// <summary>
 /// Invoked when the application is launched normally by the end user.  Other entry points
 /// will be used such as when the application is launched to open a specific file.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e)
-{
-    if (EbrApplicationLaunched(e)) {
-        //  Jump default "C" main
-        main(0, NULL);
-    }
+void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) {
+    main(0, NULL);
+    EbrApplicationLaunched(e);
 }
 
-void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e)
-{
+void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e) {
+    main(0, NULL);
     EbrApplicationActivated(e);
 }
 
@@ -61,8 +57,7 @@ void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs
 /// </summary>
 /// <param name="sender">The source of the suspend request.</param>
 /// <param name="e">Details about the suspend request.</param>
-void App::OnSuspending(Object^ /*sender*/, SuspendingEventArgs^ /*e*/)
-{
+void App::OnSuspending(Object^ /*sender*/, SuspendingEventArgs^ /*e*/) {
     // TODO: Save application state and stop any background activity
 }
 
@@ -71,7 +66,6 @@ void App::OnSuspending(Object^ /*sender*/, SuspendingEventArgs^ /*e*/)
 /// </summary>
 /// <param name="sender">The Frame which failed navigation</param>
 /// <param name="e">Details about the navigation failure</param>
-void App::OnNavigationFailed(Platform::Object^ sender, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs^ e)
-{
+void App::OnNavigationFailed(Platform::Object^ sender, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs^ e) {
     throw ref new FailureException("Failed to load Page " + e->SourcePageType.Name);
 }

--- a/msvc/vsimporter-templates/WinStore10-App/App.xaml.cpp
+++ b/msvc/vsimporter-templates/WinStore10-App/App.xaml.cpp
@@ -31,9 +31,8 @@ App::App() {
 }
 
 extern "C" int main(int argc, char* argv[]);
-extern "C" int __cdecl EbrDefaultXamlMain();
-extern "C" void EbrApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-extern "C" void EbrApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+extern "C" void OnApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
+extern "C" void OnApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
 
 /// <summary>
 /// Invoked when the application is launched normally by the end user.  Other entry points
@@ -42,12 +41,12 @@ extern "C" void EbrApplicationLaunched(Windows::ApplicationModel::Activation::La
 /// <param name="e">Details about the launch request and process.</param>
 void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) {
     main(0, NULL);
-    EbrApplicationLaunched(e);
+    OnApplicationLaunched(e);
 }
 
 void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e) {
     main(0, NULL);
-    EbrApplicationActivated(e);
+    OnApplicationActivated(e);
 }
 
 /// <summary>

--- a/msvc/vsimporter-templates/WinStore10-App/App.xaml.cpp
+++ b/msvc/vsimporter-templates/WinStore10-App/App.xaml.cpp
@@ -31,8 +31,8 @@ App::App() {
 }
 
 extern "C" int main(int argc, char* argv[]);
-extern "C" void OnApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
-extern "C" void OnApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
+extern "C" void UIApplicationActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ args);
+extern "C" void UIApplicationLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ args);
 
 /// <summary>
 /// Invoked when the application is launched normally by the end user.  Other entry points
@@ -41,12 +41,12 @@ extern "C" void OnApplicationLaunched(Windows::ApplicationModel::Activation::Lau
 /// <param name="e">Details about the launch request and process.</param>
 void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) {
     main(0, NULL);
-    OnApplicationLaunched(e);
+    UIApplicationLaunched(e);
 }
 
 void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e) {
     main(0, NULL);
-    OnApplicationActivated(e);
+    UIApplicationActivated(e);
 }
 
 /// <summary>


### PR DESCRIPTION
The new way of creating the app does so without calling main for activation, so we were not able to retrieve the name of the delegate or principal class.  This change allows both activation methods to work properly.  