### PR TITLE
Make NSURLSessionDelegate methods optional

### DIFF
--- a/include/Foundation/NSURLSession.h
+++ b/include/Foundation/NSURLSession.h
@@ -147,6 +147,7 @@ FOUNDATION_EXPORT_CLASS
 
 /* Session Delegates */
 @protocol NSURLSessionDelegate <NSObject>
+@optional
 - (void)URLSession:(NSURLSession*)session didBecomeInvalidWithError:(NSError*)error;
 - (void)URLSession:(NSURLSession*)session
     didReceiveChallenge:(NSURLAuthenticationChallenge*)challenge


### PR DESCRIPTION
Prevents compiler from giving warnings about unimplemented methods.

Fixes #672