### PR TITLE
Update gtest-api.h to allow OSX ASSERT_OBJCEQ macros to print correctly

### DIFF
--- a/tests/frameworks/gtest/include/gtest-api.h
+++ b/tests/frameworks/gtest/include/gtest-api.h
@@ -97,12 +97,8 @@ std::vector<char> Format(NSString* message, Args ... args)
 }
 }
 
-namespace testing {
-namespace internal {
 inline std::ostream& operator<<(std::ostream& os, const id& object) {
     return os << (char*)([[object description] UTF8String]);
-}
-}
 }
 
 namespace woc {


### PR DESCRIPTION
Update gtest-api.h to allow ASSERT_OBJCEQ macros to print descriptions instead of pointer addresses on OSX

Fixes #705