### PR TITLE
Fix #696 by only deep-copying un-owned or mutable instances in -[NSData copyWithZone:]

### DIFF
--- a/Frameworks/CoreFoundation/Collections.subproj/CFData.c
+++ b/Frameworks/CoreFoundation/Collections.subproj/CFData.c
@@ -95,8 +95,9 @@ CF_INLINE Boolean __CFDataBytesInline(CFDataRef data) {return __CFDataGetInfoBit
 CF_INLINE Boolean __CFDataUseAllocator(CFDataRef data) {return __CFDataGetInfoBit(data, __kCFUseAllocator);}
 CF_INLINE Boolean __CFDataAllocatesCollectable(CFDataRef data) {return __CFDataGetInfoBit(data, __kCFAllocatesCollectable);}
 
-// WINOBJC: This function is for Foundation's benefit; no one else should use it.
+// WINOBJC: These functions are for Foundation's benefit; no one else should use them.
 CF_EXPORT Boolean _CFDataIsMutable(CFDataRef data) { return __CFDataIsMutable(data); }
+CF_EXPORT Boolean _CFDataOwnsBuffer(CFDataRef data) { return data->_bytesDeallocator != kCFAllocatorNull; }
 
 CF_INLINE UInt32 __CFMutableVariety(const void *cf) {
     return __CFBitfieldGetValue(((const CFRuntimeBase *)cf)->_cfinfo[CF_INFO_BITS], 1, 0);

--- a/Frameworks/Foundation/NSCFData.mm
+++ b/Frameworks/Foundation/NSCFData.mm
@@ -113,8 +113,8 @@ BRIDGED_CLASS_REQUIRED_IMPLS(CFDataRef, CFDataGetTypeID, NSData, NSCFData)
 }
 
 - (NSObject*)copyWithZone:(NSZone*)zone {
-    if (_CFDataIsMutable(static_cast<CFDataRef>(self))) {
-        return reinterpret_cast<NSCFData*>(static_cast<NSData*>(CFDataCreateCopy(nullptr, static_cast<CFMutableDataRef>(self))));
+    if (_CFDataIsMutable(static_cast<CFDataRef>(self)) || !_CFDataOwnsBuffer(static_cast<CFDataRef>(self))) {
+        return reinterpret_cast<NSCFData*>(static_cast<NSData*>(CFDataCreateCopy(nullptr, static_cast<CFDataRef>(self))));
     }
 
     return [self retain];

--- a/Frameworks/include/CFFoundationInternal.h
+++ b/Frameworks/include/CFFoundationInternal.h
@@ -47,6 +47,7 @@ CF_EXPORT Boolean _CFDictionaryIsMutable(CFDictionaryRef dictionary);
 CF_EXPORT Boolean _CFArrayIsMutable(CFArrayRef array);
 CF_PRIVATE Boolean __CFCharacterSetIsMutable(CFCharacterSetRef cset);
 CF_EXPORT Boolean _CFDataIsMutable(CFDataRef data);
+CF_EXPORT Boolean _CFDataOwnsBuffer(CFDataRef data);
 CF_EXPORT Boolean _CFAttributedStringIsMutable(CFAttributedStringRef attrStr);
 CF_EXPORT Boolean _CFSetIsMutable(CFSetRef hc);
 CF_EXTERN_C_END

--- a/build/CoreFoundation/dll/CoreFoundation.def
+++ b/build/CoreFoundation/dll/CoreFoundation.def
@@ -543,6 +543,7 @@ LIBRARY CoreFoundation
         CFDataIncreaseLength
         CFDataSetLength
         _CFDataIsMutable
+        _CFDataOwnsBuffer
 
         ; CFMutableDictionary.mm
         CFDictionaryCreateMutable


### PR DESCRIPTION
This also adds tests, which were verified on OS X.