### PR TITLE
Fire NSOperation's completion block on a background thread after the isFinished notification.

### DIFF
--- a/Frameworks/Foundation/NSOperationInternal.h
+++ b/Frameworks/Foundation/NSOperationInternal.h
@@ -1,0 +1,21 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//****************************************************************************** 
+
+#import <Foundation/NSOperation.h>
+
+@interface NSOperation ()
+@property (nonatomic, assign, getter=_completionQueue, setter=_setCompletionQueue:) dispatch_queue_t _completionQueue;
+@end

--- a/tests/unittests/Foundation/NSOperationTests.mm
+++ b/tests/unittests/Foundation/NSOperationTests.mm
@@ -22,6 +22,20 @@
 #import <condition_variable>
 #import <chrono>
 
+static void (^_completionBlockPopulatingConditionAndFlag(void(^completionBlock)(), NSCondition** condition, BOOL* flag))() {
+    NSCondition* cond = [[NSCondition new] autorelease];
+    *condition = cond;
+    return Block_copy(^{
+        if (completionBlock) {
+            completionBlock();
+        }
+        [cond lock];
+        *flag = YES;
+        [cond broadcast];
+        [cond unlock];
+    });
+}
+
 TEST(NSOperation, NSOperationDealloc) {
     NSOperationQueue* queue = [[NSOperationQueue alloc] init];
     ASSERT_NO_THROW([queue release]);
@@ -35,17 +49,12 @@ TEST(NSOperation, NSOperation) {
 
     NSOperation* operation = [[NSOperation new] autorelease];
 
-    __block NSCondition* completionCondition = [NSCondition new];
-    __block bool completionBlockCalled = false;
-    [operation setCompletionBlock:^{
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
         [operation waitUntilFinished]; // Should not deadlock, but we cannot test this
         ASSERT_TRUE([operation isFinished]);
-
-        [completionCondition lock];
-        completionBlockCalled = true;
-        [completionCondition broadcast];
-        [completionCondition unlock];
-    }];
+    }, &completionCondition, &completionBlockCalled)];
 
     [completionCondition lock];
 
@@ -66,17 +75,12 @@ TEST(NSOperation, NSOperationCancellation) {
 
     NSOperation* cancelledOperation = [[NSOperation new] autorelease];
 
-    __block NSCondition* completionCondition = [NSCondition new];
-    __block bool completionBlockCalled = false;
-    [cancelledOperation setCompletionBlock:^{
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [cancelledOperation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
         [cancelledOperation waitUntilFinished]; // Should not deadlock, but we cannot test this
         ASSERT_TRUE([cancelledOperation isFinished]);
-
-        [completionCondition lock];
-        completionBlockCalled = true;
-        [completionCondition broadcast];
-        [completionCondition unlock];
-    }];
+    }, &completionCondition, &completionBlockCalled)];
 
     [completionCondition lock];
 
@@ -157,7 +161,13 @@ TEST(NSOperation, NSOperationSuspend) {
 
 @end
 
-TEST(NSOperation, NSOperationKVO) {
+// On the reference platform, we cannot observe isFinished immediately.
+// There appears to be a marked laziness in signalling the finished status.
+// waitUntilFinished triggers before didChangeValueForKey:@"isFinished" --
+// sometimes long before it -- and we can jump the gun on the observation.
+// WinObjC updates these flags immediately and only releases a waitUntilFinished when
+// didChangeValueForKey: has already triggered.
+OSX_DISABLED_TEST(NSOperation, NSOperationKVO) {
     NSOperationQueue* queue = [[NSOperationQueue new] autorelease];
     NSOperation* operation = [[NSOperation new] autorelease];
     TestObserver* observer = [[TestObserver new] autorelease];
@@ -256,17 +266,12 @@ TEST(NSOperation, NSOperationConcurrentSubclass) {
 
     NSOperation* operation = [MyConcurrentOperation new];
 
-    __block NSCondition* completionCondition = [NSCondition new];
-    __block bool completionBlockCalled = false;
-    [operation setCompletionBlock:^{
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
         [operation waitUntilFinished]; // Should not deadlock, but we cannot test this
         ASSERT_TRUE([operation isFinished]);
-
-        [completionCondition lock];
-        completionBlockCalled = true;
-        [completionCondition broadcast];
-        [completionCondition unlock];
-    }];
+    }, &completionCondition, &completionBlockCalled)];
 
     [completionCondition lock];
 
@@ -306,17 +311,12 @@ TEST(NSOperation, NSOperationNonconcurrentSubclass) {
 
     MyNonconcurrentOperation* operation = [MyNonconcurrentOperation new];
 
-    __block NSCondition* completionCondition = [NSCondition new];
-    __block bool completionBlockCalled = false;
-    [operation setCompletionBlock:^{
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
         [operation waitUntilFinished]; // Should not deadlock, but we cannot test this
         ASSERT_TRUE([operation isFinished]);
-
-        [completionCondition lock];
-        completionBlockCalled = true;
-        [completionCondition broadcast];
-        [completionCondition unlock];
-    }];
+    }, &completionCondition, &completionBlockCalled)];
 
     [completionCondition lock];
 
@@ -372,7 +372,61 @@ TEST(NSOperation, NSDependencyRemove) {
     ASSERT_NO_THROW([operation removeDependency:dependency]);
 }
 
-TEST(NSOperation, NSOperationIsReady) {
+TEST(NSOperation, NSOperationWithDependenciesDoesRun) {
+    NSOperationQueue* queue = [[NSOperationQueue new] autorelease];
+    TestObserver* observer = [[TestObserver new] autorelease];
+
+    NSCondition* dep1Condition = nil;
+    BOOL dep1Completed = NO;
+    NSOperation* dependency1 = [[NSOperation new] autorelease];
+    [dependency1 setCompletionBlock:_completionBlockPopulatingConditionAndFlag(nil, &dep1Condition, &dep1Completed)];
+
+    NSCondition* dep2Condition = nil;
+    BOOL dep2Completed = NO;
+    NSOperation* dependency2 = [[NSOperation new] autorelease];
+    [dependency2 setCompletionBlock:_completionBlockPopulatingConditionAndFlag(nil, &dep2Condition, &dep2Completed)];
+
+    NSOperation* operation = [[NSOperation new] autorelease];
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(nil, &completionCondition, &completionBlockCalled)];
+
+    [operation addDependency:dependency1];
+    [operation addDependency:dependency2];
+
+    EXPECT_FALSE([operation isReady]);
+
+    // Stage the operation before its dependencies.
+    [queue addOperation:operation];
+
+    [dep1Condition lock];
+    [queue addOperation:dependency1];
+    [dep1Condition wait];
+    [dep1Condition unlock];
+    EXPECT_TRUE(dep1Completed);
+    EXPECT_FALSE(dep2Completed);
+    EXPECT_FALSE(completionBlockCalled);
+
+    [completionCondition lock]; // dep2 will trigger operation to complete.
+    [dep2Condition lock];
+    [queue addOperation:dependency2];
+    [dep2Condition wait];
+    [dep2Condition unlock];
+    EXPECT_TRUE(dep2Completed);
+
+    [completionCondition wait];
+    [completionCondition unlock];
+    EXPECT_TRUE(completionBlockCalled);
+}
+
+// On the reference platform, we cannot observe isReady immediately.
+// There appears to be a marked laziness in signalling the ready status via
+// dependency completion.
+// waitUntilFinished (for dependency2) triggers before didChangeValueForKey:@"isFinished" --
+// sometimes long before it -- and we can jump the gun on the ready observation.
+// WinObjC updates these flags immediately and only releases a waitUntilFinished when
+// didChangeValueForKey: has already triggered.
+OSX_DISABLED_TEST(NSOperation, NSOperationIsReady) {
     NSOperationQueue* queue = [[NSOperationQueue new] autorelease];
     TestObserver* observer = [[TestObserver new] autorelease];
     NSOperation* dependency1 = [[NSOperation new] autorelease];
@@ -410,8 +464,63 @@ TEST(NSOperation, NSOperationIsReady) {
     [operation cancel];
     ASSERT_TRUE([observer didObserveReady]);
     ASSERT_TRUE([operation isReady]);
+    [observer setDidObserveReady:NO];
 
-   [operation removeObserver:observer forKeyPath:@"isReady" context:NULL];
+    [operation removeObserver:observer forKeyPath:@"isReady" context:NULL];
+}
+
+TEST(NSOperation, RunConcurrentOperationManually) {
+    NSOperation* operation = [MyConcurrentOperation new];
+
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
+        [operation waitUntilFinished]; // Should not deadlock, but we cannot test this
+        ASSERT_TRUE([operation isFinished]);
+    }, &completionCondition, &completionBlockCalled)];
+
+    [completionCondition lock];
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [operation start];
+    });
+
+    [operation waitUntilFinished];
+
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition unlock];
+
+    ASSERT_TRUE(completionBlockCalled);
+    ASSERT_TRUE([operation isFinished]);
+    ASSERT_FALSE([operation isExecuting]);
+    ASSERT_NO_THROW([operation release]);
+}
+
+TEST(NSOperation, RunNonconcurrentOperationManually) {
+    NSOperation* operation = [MyNonconcurrentOperation new];
+
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
+        [operation waitUntilFinished]; // Should not deadlock, but we cannot test this
+        ASSERT_TRUE([operation isFinished]);
+    }, &completionCondition, &completionBlockCalled)];
+
+    [completionCondition lock];
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [operation start];
+    });
+
+    [operation waitUntilFinished];
+
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition unlock];
+
+    ASSERT_TRUE(completionBlockCalled);
+    ASSERT_TRUE([operation isFinished]);
+    ASSERT_FALSE([operation isExecuting]);
+    ASSERT_NO_THROW([operation release]);
 }
 
 TEST(NSOperation, NSBlockOperationInQueue) {
@@ -423,18 +532,13 @@ TEST(NSOperation, NSBlockOperationInQueue) {
         executedBlock = YES;
     }];
 
-    __block NSCondition* completionCondition = [NSCondition new];
-    __block bool completionBlockCalled = false;
-    [operation setCompletionBlock:^{
+    NSCondition* completionCondition = nil;
+    BOOL completionBlockCalled = NO;
+    [operation setCompletionBlock:_completionBlockPopulatingConditionAndFlag(^{
         [operation waitUntilFinished]; // Should not deadlock, but we cannot test this
         ASSERT_TRUE([operation isFinished]);
         ASSERT_TRUE(executedBlock);
-
-        [completionCondition lock];
-        completionBlockCalled = true;
-        [completionCondition broadcast];
-        [completionCondition unlock];
-    }];
+    }, &completionCondition, &completionBlockCalled)];
 
     [completionCondition lock];
 

--- a/tests/unittests/Foundation/NSOperationTests.mm
+++ b/tests/unittests/Foundation/NSOperationTests.mm
@@ -62,7 +62,7 @@ TEST(NSOperation, NSOperation) {
 
     [operation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);
@@ -90,7 +90,7 @@ TEST(NSOperation, NSOperationCancellation) {
 
     [cancelledOperation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);
@@ -279,7 +279,7 @@ TEST(NSOperation, NSOperationConcurrentSubclass) {
 
     [operation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);
@@ -323,7 +323,7 @@ TEST(NSOperation, NSOperationNonconcurrentSubclass) {
     [queue addOperation:operation];
     [operation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);
@@ -401,7 +401,7 @@ TEST(NSOperation, NSOperationWithDependenciesDoesRun) {
 
     [dep1Condition lock];
     [queue addOperation:dependency1];
-    [dep1Condition wait];
+    [dep1Condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]];
     [dep1Condition unlock];
     EXPECT_TRUE(dep1Completed);
     EXPECT_FALSE(dep2Completed);
@@ -410,11 +410,11 @@ TEST(NSOperation, NSOperationWithDependenciesDoesRun) {
     [completionCondition lock]; // dep2 will trigger operation to complete.
     [dep2Condition lock];
     [queue addOperation:dependency2];
-    [dep2Condition wait];
+    [dep2Condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]];
     [dep2Condition unlock];
     EXPECT_TRUE(dep2Completed);
 
-    [completionCondition wait];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]];
     [completionCondition unlock];
     EXPECT_TRUE(completionBlockCalled);
 }
@@ -452,6 +452,7 @@ OSX_DISABLED_TEST(NSOperation, NSOperationIsReady) {
 
     [queue addOperation:dependency2];
     [dependency2 waitUntilFinished];
+
     ASSERT_TRUE([observer didObserveReady]);
     ASSERT_TRUE([operation isReady]);
     [observer setDidObserveReady:NO];
@@ -487,7 +488,7 @@ TEST(NSOperation, RunConcurrentOperationManually) {
 
     [operation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);
@@ -514,7 +515,7 @@ TEST(NSOperation, RunNonconcurrentOperationManually) {
 
     [operation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);
@@ -546,7 +547,7 @@ TEST(NSOperation, NSBlockOperationInQueue) {
 
     [operation waitUntilFinished];
 
-    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]];
+    [completionCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]];
     [completionCondition unlock];
 
     ASSERT_TRUE(completionBlockCalled);


### PR DESCRIPTION
This is a fix for #734.

From the documentation on the reference platform,
> The exact execution context for your completion block is not guaranteed but is typically a secondary thread. Therefore, you should not use this block to do any work that requires a very specific execution context. Instead, you should shunt that work to your application’s main thread or to the specific thread that is capable of doing it. For example, if you have a custom thread for coordinating the completion of the operation, you could use the completion block to ping that thread. 

We could take an optimization and call the completion block on the operation queue's thread at the cost of further complicating the code, or always shunt it off to a background thread as we are doing in this pull request.

Every test that had a completion block with an assertion was updated to **actually make sure that completion block was called.**

**Passed OS X UTs** apart from known failures in KVO observation.