### PR TITLE
NSPredicate copy should be done through static method.

### DIFF
--- a/tests/unittests/Foundation/NSCompoundPredicateTests.m
+++ b/tests/unittests/Foundation/NSCompoundPredicateTests.m
@@ -388,7 +388,7 @@ TEST(NSCompoundPredicate, ArchiveAndUnarchiveObject) {
 }
 
 TEST(Foundation, NSCompoundPredicate_copy) {
-    NSPredicate* predicate = [[NSPredicate alloc] init];
+    NSPredicate* predicate = [NSPredicate predicateWithFormat:@"10 >= 30"];
     NSCompoundPredicate* compoundPredicate = [NSCompoundPredicate notPredicateWithSubpredicate:predicate];
     ASSERT_TRUE_MSG(compoundPredicate != nil, "FAILED: compoundPredicate should be non-null!");
 
@@ -403,6 +403,5 @@ TEST(Foundation, NSCompoundPredicate_copy) {
                   [copyObj compoundPredicateType],
                   "FAILED: compoundPredicateType do not match.");
 
-    [predicate release];
     [copyObj release];
 }


### PR DESCRIPTION
It seems as on reference platform NSPredicate{*} classes are not concrete instance, thus doing an alloc/init will not return a copy-able object.
Since our backing implementation is different, it gives us the freedom to do the that. 

Changing the test to be compatible with the reference platform.

fix #704