### PR TITLE
Correct NSPropertyListSerializationTest

### DIFF
--- a/docs/Testing/OSXWinObjCTests.md
+++ b/docs/Testing/OSXWinObjCTests.md
@@ -47,9 +47,9 @@ While it's possible to checkout a separate git enlistment on an OSX machine and 
 #### Current known failures:
 
 
-    * [==========] 821 tests from 74 test cases ran. (56608 ms total)
-    * [  PASSED  ] 698 tests.
-    * [  FAILED  ] 123 tests, listed below:
+    * [==========] 833 tests from 74 test cases ran. (58373 ms total)
+    * [  PASSED  ] 707 tests.
+    * [  FAILED  ] 126 tests, listed below:
     * [  FAILED  ] Archival.NSKeyedUnarchiver_Secure
     * [  FAILED  ] KVO.DerivedKeyOnSubpath1
     * [  FAILED  ] KVO.RemoveWithoutContext
@@ -137,11 +137,12 @@ While it's possible to checkout a separate git enlistment on an OSX machine and 
     * [  FAILED  ] NSPredicate.Like
     * [  FAILED  ] NSProgress.IsIndeterminate
     * [  FAILED  ] NSProgress.ChainImplicit
+    * [  FAILED  ] NSProgress.SingleParentEvenAcrossThreads
     * [  FAILED  ] NSProgress.CancelPauseResume
     * [  FAILED  ] NSProgress.LocalizedDescription
-    * [  FAILED  ] NSPropertyListSerialization.PropertyListForDate
     * [  FAILED  ] NSRange.NSRangeTests
     * [  FAILED  ] NSRegularExpression.NSMatchingOptionsTest
+    * [  FAILED  ] NSSet.ObjectsPassingTest
     * [  FAILED  ] NSString.NSStringTests
     * [  FAILED  ] NSString.IntegerValue
     * [  FAILED  ] NSString.IntValue
@@ -168,12 +169,13 @@ While it's possible to checkout a separate git enlistment on an OSX machine and 
     * [  FAILED  ] NSValue.arbitraryStructCanBeSerializedAndDeserialized
     * [  FAILED  ] NSPropertyList.Decode
     * [  FAILED  ] NSPropertyList.DecodeMutable
+    * [  FAILED  ] NSURLResponse.canBeArchived
     * [  FAILED  ] NSHTTPURLResponse.SuggestedFilename_3
     * [  FAILED  ] NSHTTPURLResponse.SuggestedFilename_4
+    * [  FAILED  ] NSHTTPURLResponse.canBeArchived
     * [  FAILED  ] NSString/StringsFormatPropertyList.CanDeserialize/0, where GetParam() = L"\xFEFFkey1=value1;\n\"key2\"=\"value2\";"
     * [  FAILED  ] NSString/StringsFormatPropertyList.CanDeserialize/1, where GetParam() = L"key1=value1;\n\"key2\"=\"value2\";"
-    * [  FAILED  ] NSString/ComparisonTests.PrefixSuffix/8, where GetParam() = (0x105cd4388, 0x105cd43c8, '\x1' (1), '\0', '\x1' (1), '\x1' (1), '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0')
+    * [  FAILED  ] NSString/ComparisonTests.PrefixSuffix/8, where GetParam() = (, , '\x1' (1), '\0', '\x1' (1), '\x1' (1), '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0')
 
-    * 123 FAILED TESTS
-    *  YOU HAVE 9 DISABLED TESTS
-
+    * 126 FAILED TESTS
+    *   YOU HAVE 9 DISABLED TESTS

--- a/tests/unittests/Foundation/NSPropertyListSerializationTests.mm
+++ b/tests/unittests/Foundation/NSPropertyListSerializationTests.mm
@@ -29,10 +29,7 @@ TEST(NSPropertyListSerialization, PropertyListForDate) {
     });
     ASSERT_NE(nil, plistDict);
 
-    NSDateFormatter* formatter = [[NSDateFormatter new] autorelease];
-    ASSERT_NE(nil, formatter);
-    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
-    NSDate* date = [formatter dateFromString:@"2014-12-15T19:48:38Z"];
+    NSDate* date = [NSDate dateWithTimeIntervalSinceReferenceDate:440365718]; // Mon Dec 15 2014 19:48:38 GMT
     ASSERT_NE(nil, date);
     ASSERT_OBJCEQ(date, plistDict[@"Date Modified"]);
 


### PR DESCRIPTION
 - Test was written incorrectly.
   [NSDateFormatter dateFromString] interprets the string in local time,
   (this error also repros on Windows with https://github.com/Microsoft/WinObjC/pull/701)
   causing the dates to be off by 8 hrs when run in PST.

   Corrected by switching to using an NSDate initializer that takes an absolute time.

Fixes #785