### PR TITLE
Fix the mutation rules in NSObject's mutableArrayValueForKeyPath: adapter.

### DIFF
--- a/Frameworks/Foundation/NSObject_NSKeyValueArrayAdapter.mm
+++ b/Frameworks/Foundation/NSObject_NSKeyValueArrayAdapter.mm
@@ -39,8 +39,9 @@
 *     - The instance Variables _xx or xx.
 *     - valueForKey:@"xx"
 * - If we used an ivar or valueForKey:, values of nil become empty arrays, @[].
-* - A mutable copy of the object we get back is made.
+* - If we used a getter, a mutable copy of the object we get back is made.
 * - The mutation is attempted.
+*     - If we used an ivar, this will fail for immutable members.
 * - If a method mutated the copy of xx, setters cascade as follows:
 *     - The setter setXx:
 *     - Directly into the instance variable _xx or xx.
@@ -158,10 +159,6 @@ struct ProxyInfo {
         } else {
             object = [_target valueForKey:_key];
         }
-
-        if (!object && _treatNilValueAsEmptyArray) {
-            object = [NSArray array];
-        }
         return object;
     }
 
@@ -179,7 +176,7 @@ struct ProxyInfo {
     void _getMutateAndSet(SEL cmd, Args... args) {
         id currentValue = _get();
 
-        if (!currentValue) {
+        if (!currentValue && !_treatNilValueAsEmptyArray) {
             [NSException raise:NSInvalidArgumentException
                         format:@"-[_NSKeyProxyArray %@]: value for key %@ on object %p is nil",
                                NSStringFromSelector(cmd),
@@ -187,7 +184,11 @@ struct ProxyInfo {
                                static_cast<id>(_target)];
         }
 
-        currentValue = [[currentValue mutableCopy] autorelease];
+        if (currentValue && !_ivar) {
+            currentValue = [[currentValue mutableCopy] autorelease];
+        } else if (!currentValue && _treatNilValueAsEmptyArray) {
+            currentValue = [NSMutableArray array];
+        }
 
         auto imp = objc_msg_lookup(currentValue, cmd);
         reinterpret_cast<void (*)(id, SEL, Args...)>(imp)(currentValue, cmd, args...);

--- a/tests/unittests/Foundation/NSObject_NSKeyValueArrayAdaptersTests.mm
+++ b/tests/unittests/Foundation/NSObject_NSKeyValueArrayAdaptersTests.mm
@@ -24,6 +24,12 @@
 
     BOOL fakeMutableInserted;
 
+    // Named such to hide it from KVC.
+    NSArray* _internal_immutableWithAccessors;
+    BOOL immutableWithAccessorsSet;
+    NSArray* _internal_immutableThroughKVC;
+    BOOL immutableThroughKVCSet;
+
     NSObject* backedByIvar;
 }
 @end
@@ -34,6 +40,8 @@
     alreadyMutable = [[NSMutableArray alloc] init];
     [alreadyMutable addObject:@"testObject"];
     immutable = @[ @"y" ];
+    _internal_immutableWithAccessors = @[ @"y" ];
+    _internal_immutableThroughKVC = @[ @"y" ];
     notAnArray = [NSObject new];
     return self;
 }
@@ -58,8 +66,45 @@
     fakeMutableInserted = true;
 }
 
+- (void)removeObjectFromFakeMutableCollectionAtIndex:(NSUInteger)index {
+    // no-op: exists only to ensure that this class is KVC-compliant for fakeMutableCollection.
+}
+
 - (BOOL)fakeMutableInserted {
     return fakeMutableInserted;
+}
+
+- (NSArray*)immutableWithAccessors {
+    return _internal_immutableWithAccessors;
+}
+
+- (void)setImmutableWithAccessors:(NSArray*)value {
+    _internal_immutableWithAccessors = [[value copy] autorelease];
+    immutableWithAccessorsSet = YES;
+}
+
+- (BOOL)immutableWithAccessorsSet {
+    return immutableWithAccessorsSet;
+}
+
+- (id)valueForKey:(NSString*)key {
+    if ([@"immutableThroughKVC" isEqual:key]) {
+        return _internal_immutableThroughKVC;
+    }
+    return [super valueForKey:key];
+}
+
+- (void)setValue:(id)value forKey:(NSString*)key {
+    if ([@"immutableThroughKVC" isEqual:key]) {
+        _internal_immutableThroughKVC = [[value copy] autorelease];
+        immutableThroughKVCSet = YES;
+        return;
+    }
+    return [super setValue:value forKey:key];
+}
+
+- (BOOL)immutableThroughKVCSet {
+    return immutableThroughKVCSet;
 }
 @end
 
@@ -69,39 +114,74 @@ TEST(NSObject, KeyPathLookup) {
     EXPECT_OBJCEQ(@(1), [testDictionary valueForKeyPath:@"key.subkey.subkey2"]);
 }
 
-TEST(NSObject, KVCArrayAdapters) {
+TEST(NSObject, KVCArrayAdapters_CompliantIndexedAccessors) {
     TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
 
     NSArray* fakeCollection = [testObject valueForKey:@"fakeCollection"];
     EXPECT_OBJCEQ(@(3), [fakeCollection objectAtIndex:3]);
 }
 
-TEST(NSObject, KVCArrayMutableAdapters) {
+TEST(NSObject, KVCArrayMutableAdapters_CompliantIndexedAccessors) {
     TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
     NSMutableArray* fakeMutableCollection = [testObject mutableArrayValueForKey:@"fakeMutableCollection"];
-    EXPECT_NO_THROW([fakeMutableCollection addObject:@(10)]);
+    ([fakeMutableCollection addObject:@(10)]);
     EXPECT_OBJCEQ(@(10), [fakeMutableCollection objectAtIndex:10]);
     EXPECT_TRUE([testObject fakeMutableInserted]);
 
-    id mutableMutable = [testObject mutableArrayValueForKey:@"alreadyMutable"];
-    EXPECT_TRUE([mutableMutable isKindOfClass:[NSMutableArray class]]);
+}
 
-    id mutableImmutable = [testObject mutableArrayValueForKey:@"immutable"];
+TEST(NSObject, KVCArrayMutableAdapters_ImmutableWithBasicAccessors) {
+    TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
+    id mutableImmutable = [testObject mutableArrayValueForKey:@"immutableWithAccessors"];
     EXPECT_TRUE([mutableImmutable isKindOfClass:[NSMutableArray class]]);
     EXPECT_NO_THROW([mutableImmutable addObject:@"Whatever"]);
 
-    // The setter should have stomped the original value of immutable, thus mutating it.
-    EXPECT_TRUE([[testObject valueForKey:@"immutable"] containsObject:@"Whatever"]);
+    ASSERT_TRUE([testObject immutableWithAccessorsSet]);
+    EXPECT_TRUE([[testObject immutableWithAccessors] containsObject:@"Whatever"]);
+}
 
+TEST(NSObject, KVCArrayMutableAdapters_ImmutableThroughKVC) {
+    TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
+    id mutableImmutable = [testObject mutableArrayValueForKey:@"immutableThroughKVC"];
+    EXPECT_TRUE([mutableImmutable isKindOfClass:[NSMutableArray class]]);
+    EXPECT_NO_THROW([mutableImmutable addObject:@"Whatever"]);
+
+    ASSERT_TRUE([testObject immutableThroughKVCSet]);
+    EXPECT_TRUE([[testObject valueForKey:@"immutableThroughKVC"] containsObject:@"Whatever"]);
+}
+
+TEST(NSObject, KVCArrayMutableAdapters_MutableArrayIvar) {
+    TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
+    id mutableMutable = [testObject mutableArrayValueForKey:@"alreadyMutable"];
+    EXPECT_TRUE([mutableMutable isKindOfClass:[NSMutableArray class]]);
+}
+
+TEST(NSObject, KVCArrayMutableAdapters_ImmutableArrayIvar) {
+    TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
+    id mutableImmutable = [testObject mutableArrayValueForKey:@"immutable"];
+    EXPECT_TRUE([mutableImmutable isKindOfClass:[NSMutableArray class]]);
+    EXPECT_ANY_THROW([mutableImmutable addObject:@"Whatever"]);
+
+    // The setter should have not stomped the original value of immutable, since it is an ivar.
+    EXPECT_FALSE([[testObject valueForKey:@"immutable"] containsObject:@"Whatever"]);
+}
+
+TEST(NSObject, KVCArrayMutableAdapters_NonArrayIvar) {
+    TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
     id mutableObject = [testObject mutableArrayValueForKey:@"notAnArray"];
     EXPECT_TRUE([mutableObject isKindOfClass:[NSMutableArray class]]);
     EXPECT_ANY_THROW([mutableObject addObject:@"Whatever"]);
+}
 
+TEST(NSObject, KVCArrayMutableAdapters_ImmutableArrayDictionaryLeaf) {
     NSDictionary* testDictionary = @{ @"key" : @{ @"subkey" : @{ @"subkey2" : @[ @"hello" ] } } };
     NSMutableArray* mutableSubArray = [testDictionary mutableArrayValueForKeyPath:@"key.subkey.subkey2"];
     EXPECT_TRUE([mutableSubArray isKindOfClass:[NSMutableArray class]]);
     EXPECT_ANY_THROW([mutableSubArray addObject:@"Invalid"]);
+}
 
+TEST(NSObject, KVCArrayMutableAdapters_EmptyIvar) {
+    TestArrayAdapterObject* testObject = [[[TestArrayAdapterObject alloc] init] autorelease];
     NSMutableArray* mutableWasNil = [testObject mutableArrayValueForKey:@"backedByIvar"];
     EXPECT_NO_THROW([mutableWasNil addObject:@"Hello"]);
     EXPECT_OBJCEQ(@"Hello", [[testObject valueForKey:@"backedByIvar"] firstObject]);


### PR DESCRIPTION
Previously, we would mutate a field if it was accessed via
ivar (instead of via getter or valueForKey:).

On the reference platform, instance variables accessed directly
are not copied and mutated.

This pull request also splits the tests into more fine-grained units, all of which pass on both platforms.