### PR TITLE
Fix NSData tests on reference platform

### DIFF
--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -450,7 +450,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
     // Documentation states that invalid input should return nil, but reference platform tests show it returns an empty NSData object
     auto ret = [self initWithBase64EncodedString:base64String options:0];
     if (!ret) {
-        ret = [self initWithBase64EncodedString:@"" options:0];
+        ret = [self init];
     }
     return ret;
 }

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -614,10 +614,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
     // length * 2   = 2 chars (hex representation) for each byte
     // length / 4   = spaces - one every 4 bytes
     // 16           = <> and misc
-    // if the length > 1024, describe only the first 512 bytes and the last 512 bytes,
-    // and add a "... " (4 bytes) in the middle
-    const NSUInteger lengthToUse = std::min(1024u, length);
-    const int tmpBufSize = 16 + lengthToUse * 2 + (lengthToUse / 4) + (length > 1024 ? 4 : 0);
+    const int tmpBufSize = 16 + length * 2 + (length / 4);
 
     std::vector<char> tmpBuf(tmpBufSize);
     int tmpBufLen = 0;
@@ -625,16 +622,6 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
     tmpBuf[tmpBufLen++] = '<';
 
     for (auto i = 0; i < length;) {
-        // skip the middle portion, if length > 1024, and go directly to the last 512 bytes
-        if ((length > 1024) && (i == 512)) {
-            tmpBuf[tmpBufLen++] = '.';
-            tmpBuf[tmpBufLen++] = '.';
-            tmpBuf[tmpBufLen++] = '.';
-            tmpBuf[tmpBufLen++] = ' ';
-            i = length - 512;
-            continue;
-        }
-
         int outDigit = ((bytes[i] & 0xF0) >> 4);
         if (outDigit < 10) {
             tmpBuf[tmpBufLen++] = '0' + outDigit;
@@ -649,8 +636,8 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
             tmpBuf[tmpBufLen++] = 'a' + outDigit - 10;
         }
         assert(tmpBufLen < tmpBufSize);
-        i++;
 
+        ++i;
         if ((i % 4) == 0 && i < length) {
             tmpBuf[tmpBufLen++] = ' ';
             assert(tmpBufLen < tmpBufSize);

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -447,7 +447,12 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
  @Status Interoperable
 */
 - (instancetype)initWithBase64Encoding:(NSString*)base64String {
-    return [self initWithBase64EncodedString:base64String options:0];
+    // Documentation states that invalid input should return nil, but reference platform tests show it returns an empty NSData object
+    auto ret = [self initWithBase64EncodedString:base64String options:0];
+    if (!ret) {
+        ret = [self initWithBase64EncodedString:@"" options:0];
+    }
+    return ret;
 }
 
 /**

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -97,9 +97,9 @@ TEST(NSData, Base64EncodeWithOptions) {
 }
 
 TEST(NSData, Base64DecodeWithOptions) {
-    // Invalid input should return nil
+    // Documentation states that invalid input should return nil, but reference platform tests show it returns an empty NSData object
     StrongId<NSData> invalidDecoded = [[[NSData alloc] initWithBase64Encoding:@"%"] autorelease];
-    ASSERT_OBJCEQ(nil, invalidDecoded);
+    ASSERT_OBJCEQ(@"<>", [invalidDecoded description]);
 
     // Basic testing
     testDecode(@"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
@@ -285,30 +285,30 @@ TEST(NSData, MutableCopyExpandBeyondCapacity) {
 TEST(NSData, Copying_NSMutableData) {
     NSMutableData* mutableData = [NSMutableData dataWithBytes:"hello" length:5];
     NSData* copiedData = [[mutableData copy] autorelease];
-    
+
     // A mutable->immutable copy should result in a different pointer...
     ASSERT_NE(copiedData, mutableData);
     // ...which points to identical data...
     ASSERT_OBJCEQ(copiedData, mutableData);
     // ...but does not reflect mutations...
-    [mutableData replaceBytesInRange:(NSRange){0,1} withBytes:"good" length:4];
+    [mutableData replaceBytesInRange:(NSRange) { 0, 1 } withBytes:"good" length:4];
     ASSERT_OBJCNE(copiedData, mutableData);
 }
 
 TEST(NSData, Copying_CustomBufferWithOwnership) {
     woc::unique_iw<char> backingBuffer(IwStrDup("hello world"));
-    NSData *originalOwningData = [NSData dataWithBytesNoCopy:backingBuffer.release() length:11 freeWhenDone:YES];
+    NSData* originalOwningData = [NSData dataWithBytesNoCopy:backingBuffer.release() length:11 freeWhenDone:YES];
     NSData* copiedData = [[originalOwningData copy] autorelease];
-    
+
     // An owning->immutable copy should result in the same pointer...
     ASSERT_EQ(copiedData, originalOwningData);
 }
 
 TEST(NSData, Copying_CustomBufferWithoutOwnership) {
     woc::unique_iw<char> backingBuffer(IwStrDup("hello world"));
-    NSData *originalNonOwningData = [NSData dataWithBytesNoCopy:backingBuffer.get() length:11 freeWhenDone:NO];
+    NSData* originalNonOwningData = [NSData dataWithBytesNoCopy:backingBuffer.get() length:11 freeWhenDone:NO];
     NSData* copiedData = [[originalNonOwningData copy] autorelease];
-    
+
     // An un-owning->immutable copy should result in a different pointer...
     ASSERT_NE(copiedData, originalNonOwningData);
     // ...which does not reflect changes to the backing buffer...

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -96,13 +96,14 @@ TEST(NSData, Base64EncodeWithOptions) {
                       base64EncodedStringWithOptions:NSDataBase64Encoding76CharacterLineLength | NSDataBase64EncodingEndLineWithLineFeed]);
 }
 
-TEST(NSData, Base64EncodingWithoutOptions) {
+TEST(NSData, Base64InvalidInitialization) {
     // Documentation states that invalid input should return nil, but reference platform tests show it returns an empty NSData object
-    StrongId<NSData> invalidDecoded = [[[NSData alloc] initWithBase64Encoding:@"%"] autorelease];
+    StrongId<NSString> invalidString = @"%";
+    StrongId<NSData> invalidDecoded = [[[NSData alloc] initWithBase64Encoding:invalidString] autorelease];
     ASSERT_OBJCEQ(@"<>", [invalidDecoded description]);
 
     // Should match documentation and return nil
-    invalidDecoded = [[[NSData alloc] initWithBase64EncodedString:@"%" options:0] autorelease];
+    invalidDecoded = [[[NSData alloc] initWithBase64EncodedString:invalidString options:0] autorelease];
     ASSERT_OBJCEQ(nil, invalidDecoded);
 }
 

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -96,11 +96,17 @@ TEST(NSData, Base64EncodeWithOptions) {
                       base64EncodedStringWithOptions:NSDataBase64Encoding76CharacterLineLength | NSDataBase64EncodingEndLineWithLineFeed]);
 }
 
-TEST(NSData, Base64DecodeWithOptions) {
+TEST(NSData, Base64EncodingWithoutOptions) {
     // Documentation states that invalid input should return nil, but reference platform tests show it returns an empty NSData object
     StrongId<NSData> invalidDecoded = [[[NSData alloc] initWithBase64Encoding:@"%"] autorelease];
     ASSERT_OBJCEQ(@"<>", [invalidDecoded description]);
 
+    // Should match documentation and return nil
+    invalidDecoded = [[[NSData alloc] initWithBase64EncodedString:@"%" options:0] autorelease];
+    ASSERT_OBJCEQ(nil, invalidDecoded);
+}
+
+TEST(NSData, Base64DecodeWithOptions) {
     // Basic testing
     testDecode(@"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
                @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSData.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSData.mm
@@ -106,6 +106,35 @@ TEST(NSData, DebugDescription) {
     ASSERT_OBJCEQ(data.debugDescription, expected);
 }
 
+// These tests were changed from the Swift versions because of a difference in functionality between Objective C and Swift
+// The Swift version would only print the first and last 512 bytes while the Objective C version will print all of the data
+TEST(NSData, LimitDebugDescription) {
+    auto expected =
+        @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
+        @"ffffffff ffffffff ffffffff ffffffff>";
+
+    std::vector<uint8_t> bytes(1024, 0xff);
+    NSData* data = [NSData dataWithBytes:bytes.data() length:bytes.size()];
+    ASSERT_OBJCEQ(data.debugDescription, expected);
+}
+
 TEST(NSData, LongDebugDescription) {
     auto expected =
         @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSData.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSData.mm
@@ -106,7 +106,7 @@ TEST(NSData, DebugDescription) {
     ASSERT_OBJCEQ(data.debugDescription, expected);
 }
 
-TEST(NSData, LimitDebugDescription) {
+TEST(NSData, LongDebugDescription) {
     auto expected =
         @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
@@ -133,7 +133,7 @@ TEST(NSData, LimitDebugDescription) {
     ASSERT_OBJCEQ(data.debugDescription, expected);
 }
 
-TEST(NSData, LongDebugDescription) {
+TEST(NSData, NoCopyDescription) {
     auto expected =
         @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
@@ -144,61 +144,7 @@ TEST(NSData, LongDebugDescription) {
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ... ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff>";
-
-    std::vector<uint8_t> bytes(100000, 0xff);
-    NSData* data = [NSData dataWithBytes:bytes.data() length:bytes.size()];
-    ASSERT_OBJCEQ(data.debugDescription, expected);
-}
-
-TEST(NSData, EdgeDebugDescription) {
-    auto expected =
-        @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ... ffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ff>";
-
-    std::vector<uint8_t> bytes(1025, 0xff);
-    NSData* data = [NSData dataWithBytes:bytes.data() length:bytes.size()];
-    ASSERT_OBJCEQ(data.debugDescription, expected);
-}
-
-TEST(NSData, EdgeNoCopyDescription) {
-    auto expected =
-        @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ... ffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSData.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSData.mm
@@ -126,14 +126,14 @@ TEST(NSData, LongDebugDescription) {
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
-        @"ffffffff ffffffff ffffffff ffffffff>";
+        @"ffffffff ffffffff ffffffff ffffffff ff>";
 
-    std::vector<uint8_t> bytes(1024, 0xff);
+    std::vector<uint8_t> bytes(1025, 0xff);
     NSData* data = [NSData dataWithBytes:bytes.data() length:bytes.size()];
     ASSERT_OBJCEQ(data.debugDescription, expected);
 }
 
-TEST(NSData, NoCopyDescription) {
+TEST(NSData, NoCopyLongDebugDescription) {
     auto expected =
         @"<ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "
         @"ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff "


### PR DESCRIPTION
Fix NSData description so it returns the same values as reference platform's version, and change initWithBase64Encoding to return an empty NSData object when given invalid input rather than nil as documentaiton suggests

Fixes #748 and #749 NSData.Base64DecodeWithOptions test failure