### PR TITLE
NSString tests fail on OSX (integer formatting-related)

### DIFF
--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -779,7 +779,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSString, NSStringPrototype, CFStringGetTypeID);
 /**
  @Status Interoperable
 */
-- (int)intValue {
+- (int32_t)intValue {
     char* str = (char*)[self UTF8String];
     return strtol(str, nullptr, 10);
 }
@@ -788,7 +788,8 @@ BASE_CLASS_REQUIRED_IMPLS(NSString, NSStringPrototype, CFStringGetTypeID);
  @Status Interoperable
 */
 - (NSInteger)integerValue {
-    return [self intValue];
+    char* str = (char*)[self UTF8String];
+    return strtol(str, nullptr, 10);
 }
 
 /**

--- a/include/Foundation/NSString.h
+++ b/include/Foundation/NSString.h
@@ -228,7 +228,7 @@ FOUNDATION_EXPORT_CLASS
 @property (readonly, copy) NSString* precomposedStringWithCompatibilityMapping;
 @property (readonly) double doubleValue;
 @property (readonly) float floatValue;
-@property (readonly) int intValue;
+@property (readonly) int32_t intValue;
 @property (readonly) NSInteger integerValue;
 @property (readonly) long long longLongValue;
 @property (readonly) BOOL boolValue;

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSString.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSString.mm
@@ -85,10 +85,10 @@ TEST(NSString, IntegerValue) {
     ASSERT_EQ([string8 integerValue], 0);
 
     NSString* string9 = @"999999999999999999999999999999";
-    ASSERT_EQ([string9 integerValue], INT_MAX);
+    ASSERT_EQ([string9 integerValue], LONG_MAX);
 
     NSString* string10 = @"-999999999999999999999999999999";
-    ASSERT_EQ([string10 integerValue], INT_MIN);
+    ASSERT_EQ([string10 integerValue], LONG_MIN);
 }
 
 TEST(NSString, IntValue) {
@@ -117,10 +117,10 @@ TEST(NSString, IntValue) {
     ASSERT_EQ([string8 intValue], 0);
 
     NSString* string9 = @"999999999999999999999999999999";
-    ASSERT_EQ([string9 intValue], LONG_MAX);
+    ASSERT_EQ([string9 intValue], INT_MAX);
 
     NSString* string10 = @"-999999999999999999999999999999";
-    ASSERT_EQ([string10 intValue], LONG_MIN);
+    ASSERT_EQ([string10 intValue], INT_MIN);
 }
 
 TEST(NSString, IsEqualToStringWithSwiftString) {


### PR DESCRIPTION
[ RUN      ] NSString.NSStringTests
Foundation/NSStringTests.m:101: Failure
Value of: actualString
  Actual: ffffffffffffffff 2147483648
Expected: @"ffffffff -2147483648"
Which is: ffffffff -2147483648
[  FAILED  ] NSString.NSStringTests (0 ms)

[ RUN      ] NSString.IntegerValue
Foundation/ReferenceFoundation/TestNSString.mm:88: Failure
Value of: 2147483647
Expected: [string9 integerValue]
Which is: 9223372036854775807
[  FAILED  ] NSString.IntegerValue (1 ms)
[ RUN      ] NSString.IntValue
Foundation/ReferenceFoundation/TestNSString.mm:120: Failure
Value of: 9223372036854775807L
  Actual: 9223372036854775807
Expected: [string9 intValue]
Which is: 2147483647
[  FAILED  ] NSString.IntValue (1 ms)