### PR TITLE
Issue 786: NSString tests fail on OSX (integer formatting-related)

### DIFF
--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -779,7 +779,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSString, NSStringPrototype, CFStringGetTypeID);
 /**
  @Status Interoperable
 */
-- (int)intValue {
+- (int32_t)intValue {
     char* str = (char*)[self UTF8String];
     return strtol(str, nullptr, 10);
 }
@@ -788,7 +788,8 @@ BASE_CLASS_REQUIRED_IMPLS(NSString, NSStringPrototype, CFStringGetTypeID);
  @Status Interoperable
 */
 - (NSInteger)integerValue {
-    return [self intValue];
+    char* str = (char*)[self UTF8String];
+    return strtol(str, nullptr, 10);
 }
 
 /**

--- a/include/Foundation/NSString.h
+++ b/include/Foundation/NSString.h
@@ -228,7 +228,7 @@ FOUNDATION_EXPORT_CLASS
 @property (readonly, copy) NSString* precomposedStringWithCompatibilityMapping;
 @property (readonly) double doubleValue;
 @property (readonly) float floatValue;
-@property (readonly) int intValue;
+@property (readonly) int32_t intValue;
 @property (readonly) NSInteger integerValue;
 @property (readonly) long long longLongValue;
 @property (readonly) BOOL boolValue;

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSString.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSString.mm
@@ -85,10 +85,10 @@ TEST(NSString, IntegerValue) {
     ASSERT_EQ([string8 integerValue], 0);
 
     NSString* string9 = @"999999999999999999999999999999";
-    ASSERT_EQ([string9 integerValue], INT_MAX);
+    ASSERT_EQ([string9 integerValue], LONG_MAX);
 
     NSString* string10 = @"-999999999999999999999999999999";
-    ASSERT_EQ([string10 integerValue], INT_MIN);
+    ASSERT_EQ([string10 integerValue], LONG_MIN);
 }
 
 TEST(NSString, IntValue) {
@@ -117,10 +117,10 @@ TEST(NSString, IntValue) {
     ASSERT_EQ([string8 intValue], 0);
 
     NSString* string9 = @"999999999999999999999999999999";
-    ASSERT_EQ([string9 intValue], LONG_MAX);
+    ASSERT_EQ([string9 intValue], INT_MAX);
 
     NSString* string10 = @"-999999999999999999999999999999";
-    ASSERT_EQ([string10 intValue], LONG_MIN);
+    ASSERT_EQ([string10 intValue], INT_MIN);
 }
 
 TEST(NSString, IsEqualToStringWithSwiftString) {


### PR DESCRIPTION
Description:
Fix issue with NSString intValue needing to always return 32bit values.

How Verified: passes on both WinObjC and reference platform.

Reviewed-by: DHowett-MSFT, ms-jihua