### PR TITLE
Fix a handful of OS X test failures around KVO, KVC, and Keyed Unarchival.

### DIFF
--- a/tests/unittests/Foundation/ArchivalTests.mm
+++ b/tests/unittests/Foundation/ArchivalTests.mm
@@ -126,145 +126,174 @@ TEST(Archival, NSKeyedUnarchiver) {
     [insecureUnarchiver release];
 }
 
-TEST(Archival, NSKeyedUnarchiver_Secure) {
+// The following test is disabled because OS X violates the contract set out in
+// https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSKeyedUnarchiver_Class/#//apple_ref/occ/instm/NSKeyedUnarchiver/setRequiresSecureCoding:
+// > Once enabled, attempting to call setRequiresSecureCoding: with a value of NO will throw an exception.
+//   This is to prevent classes from selectively turning secure coding off. 
+OSX_DISABLED_TEST(NSKeyedUnarchiverSecure, SecureCodingCannotBeTurnedOff) { // it should be impossible to turn secure coding off once it's on.
     NSData* archive = createTestArchive();
     [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW_MSG(secureUnarchiver.requiresSecureCoding = NO, "It should be impossible to turn off secure coding.");
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    EXPECT_EQ([TestCreationSignallingClass creationCount], 0);
+TEST(NSKeyedUnarchiverSecure, RequestIncorrectClass) { // requesting an object with the wrong class should not result in the creation of the original object
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[InsecureObject class] forKey:@"creationSignalling"]);
+    EXPECT_EQ(0, [TestCreationSignallingClass creationCount]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // it should be impossible to turn secure coding off once it's on.
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW_MSG(secureUnarchiver.requiresSecureCoding = NO, "It should be impossible to turn off secure coding.");
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, PODTypesDoNotRequireCheck) { // POD types should be passed through unharmed
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_EQ([secureUnarchiver decodeInt64ForKey:@"int64"], 84LL);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // requesting an object with the wrong class should not result in the creation of the original object
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[InsecureObject class] forKey:@"creationSignalling"]);
-        EXPECT_EQ(0, [TestCreationSignallingClass creationCount]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSStringDoesNotRequireCheck) { // NSString should be passed through without a class check
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    id stringVal = nil;
+    EXPECT_NO_THROW(stringVal = [secureUnarchiver decodeObjectForKey:@"string"]);
+    EXPECT_OBJCEQ(stringVal, @"Hello");
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // POD types should be passed through unharmed
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_EQ([secureUnarchiver decodeInt64ForKey:@"int64"], 84LL);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSNumberDoesNotRequireCheck) { // NSNumber should be passed through without a class check
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_OBJCEQ([secureUnarchiver decodeObjectForKey:@"number"], @40);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // NSString should be passed through without a class check
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        id stringVal = nil;
-        EXPECT_NO_THROW(stringVal = [secureUnarchiver decodeObjectForKey:@"string"]);
-        EXPECT_OBJCEQ(stringVal, @"Hello");
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSDataRequiresCheck) { // NSData requires a class check
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    NSData* data = nil;
+    EXPECT_NO_THROW(data = [secureUnarchiver decodeObjectOfClass:[NSData class] forKey:@"data"]);
+    EXPECT_OBJCNE(nil, data);
+    EXPECT_EQ(sizeof(unsigned), [data length]);
+    unsigned rawValue = 0;
+    [data getBytes:&rawValue length:sizeof(unsigned)];
+    EXPECT_EQ(0xDEADBEEF, rawValue);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // NSNumber should be passed through without a class check
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_OBJCEQ([secureUnarchiver decodeObjectForKey:@"number"], @40);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, RequestDictionaryAsArray) { // A dictionary should not be requestable as an array
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"dictionary"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // NSData requires a class check
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        NSData* data = nil;
-        EXPECT_NO_THROW(data = [secureUnarchiver decodeObjectOfClass:[NSData class] forKey:@"data"]);
-        EXPECT_OBJCNE(nil, data);
-        EXPECT_EQ(sizeof(unsigned), [data length]);
-        unsigned rawValue = 0;
-        [data getBytes:&rawValue length:sizeof(unsigned)];
-        EXPECT_EQ(0xDEADBEEF, rawValue);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NoClassesSpecified) { // requesting no classes is tantamount to requesting exceptions constantly
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectForKey:@"dictionary"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // A dictionary should not be requestable as an array
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"dictionary"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSArrayWithBasicEnclosedType) { // NSArray containing NSNumber should pass through
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_NO_THROW([secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"array"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // requesting no classes is tantamount to requesting exceptions constantly
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectForKey:@"dictionary"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, CustomClass) { // TestCreationSignallingClass (NSKeyedUnarchiverSecure) should pass through and create one instance
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_NO_THROW([secureUnarchiver decodeObjectOfClass:[TestCreationSignallingClass class] forKey:@"creationSignalling"]);
+    EXPECT_EQ(1, [TestCreationSignallingClass creationCount]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // NSArray containing NSNumber should pass through
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_NO_THROW([secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"array"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, ObjectThatDoesNotConform) { // An object that does not conform to NSKeyedUnarchiverSecure cannot be decoded
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[InsecureObject class] forKey:@"insecureObject"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // TestCreationSignallingClass (NSSecureCoding) should pass through and create one instance
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_NO_THROW([secureUnarchiver decodeObjectOfClass:[TestCreationSignallingClass class] forKey:@"creationSignalling"]);
-        EXPECT_EQ(1, [TestCreationSignallingClass creationCount]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSArrayWithCustomEnclosedType1) { // Arrays must be decoded by specifying their enclosing AND enclosed types
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[TestCreationSignallingClass class] forKey:@"arrayOfSecureTypes"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // An object that does not conform to NSSecureCoding cannot be decoded
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[InsecureObject class] forKey:@"insecureObject"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSArrayWithoutEnclosedTypeSpecified) { // Arrays must be decoded by specifying their enclosing AND enclosed types
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"arrayOfSecureTypes"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // Arrays must be decoded by specifying their enclosing AND enclosed types
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[TestCreationSignallingClass class] forKey:@"arrayOfSecureTypes"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+TEST(NSKeyedUnarchiverSecure, NSArrayWithCustomEnclosedType2) { // Arrays must be decoded by specifying their enclosing AND enclosed types
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    NSSet* allowedClasses = [NSSet setWithObjects:[TestCreationSignallingClass class], [NSArray class], nil];
+    EXPECT_NO_THROW([secureUnarchiver decodeObjectOfClasses:allowedClasses forKey:@"arrayOfSecureTypes"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
+}
 
-    { // Arrays must be decoded by specifying their enclosing AND enclosed types
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"arrayOfSecureTypes"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
-
-    { // Arrays must be decoded by specifying their enclosing AND enclosed types
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        NSSet* allowedClasses = [NSSet setWithObjects:[TestCreationSignallingClass class], [NSArray class], nil];
-        EXPECT_NO_THROW([secureUnarchiver decodeObjectOfClasses:allowedClasses forKey:@"arrayOfSecureTypes"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
-
-    { // Once a bad decode has occurred, all requests must return nil
-        NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
-        secureUnarchiver.requiresSecureCoding = YES;
-        EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[InsecureObject class] forKey:@"insecureObject"]);
-        EXPECT_OBJCEQ(nil, [secureUnarchiver decodeObjectOfClass:[NSDictionary class] forKey:@"dictionary"]);
-        EXPECT_OBJCEQ(nil, [secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"array"]);
-        EXPECT_OBJCEQ(nil, [secureUnarchiver decodeObjectOfClass:[NSNumber class] forKey:@"number"]);
-        [secureUnarchiver finishDecoding];
-        [secureUnarchiver release];
-    }
+// This is testing an implementation detail, but one that was true on OS X 10.10.
+// It fails on 10.11.
+OSX_DISABLED_TEST(NSKeyedUnarchiverSecure, BadDecodeLeavesUnarchiverInBadState) { // Once a bad decode has occurred, all requests must return nil
+    NSData* archive = createTestArchive();
+    [TestCreationSignallingClass resetCreationCount];
+    NSKeyedUnarchiver* secureUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:archive];
+    secureUnarchiver.requiresSecureCoding = YES;
+    EXPECT_ANY_THROW([secureUnarchiver decodeObjectOfClass:[InsecureObject class] forKey:@"insecureObject"]);
+    EXPECT_OBJCEQ(nil, [secureUnarchiver decodeObjectOfClass:[NSDictionary class] forKey:@"dictionary"]);
+    EXPECT_OBJCEQ(nil, [secureUnarchiver decodeObjectOfClass:[NSArray class] forKey:@"array"]);
+    EXPECT_OBJCEQ(nil, [secureUnarchiver decodeObjectOfClass:[NSNumber class] forKey:@"number"]);
+    [secureUnarchiver finishDecoding];
+    [secureUnarchiver release];
 }
 
 @interface NSKAInstanceOriginalClass : NSObject <NSCoding>

--- a/tests/unittests/Foundation/FoundationTests.m
+++ b/tests/unittests/Foundation/FoundationTests.m
@@ -333,8 +333,8 @@ TEST(KVO, BasicChangeNotification) { // Basic change notification
     EXPECT_OBJCEQ_MSG([[[[observer changesForKeypath:@"basicObjectProperty"] anyObject] info] objectForKey:NSKeyValueChangeNewKey],
                       @"Hello",
                       "The new value stored in the change notification should be Hello.");
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, ExclusiveChangeNotification) { // Exclusive change notification
@@ -357,9 +357,9 @@ TEST(KVO, ExclusiveChangeNotification) { // Exclusive change notification
                   0,
                   "No changes on basicPodProperty for second observer should have fired.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [observed removeObserver:observer2 forKeyPath:@"basicPodProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer2 forKeyPath:@"basicPodProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, ManualChangeNotification) { // Manual change notification.
@@ -379,8 +379,8 @@ TEST(KVO, ManualChangeNotification) { // Manual change notification.
                       @(1),
                       "The new value stored in the change notification should be a boxed 1.");
 
-    [observed removeObserver:observer forKeyPath:@"manuallyNotifyingIntegerProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"manuallyNotifyingIntegerProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, BasicChangeCaptureOld) { // Basic change notification with Old Value
@@ -397,8 +397,8 @@ TEST(KVO, BasicChangeCaptureOld) { // Basic change notification with Old Value
                       [NSNull null],
                       "The old value stored in the change notification should be null.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, CascadingNotificationWithEmptyLeaf) { // Cascading change notification testing subscribing to nil AND
@@ -446,8 +446,8 @@ TEST(KVO, CascadingNotificationWithEmptyLeaf) { // Cascading change notification
                       @"Hello",
                       "The old value stored in the change notification should be Hello.");
 
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, PriorNotification) { // Basic change notification with a Prior notification requested
@@ -469,8 +469,8 @@ TEST(KVO, PriorNotification) { // Basic change notification with a Prior notific
                       [NSNull null],
                       "The old value stored in the change notification should be null or nil.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DependentKeyNotification) { // Derived change notification (dependent keys)
@@ -487,12 +487,12 @@ TEST(KVO, DependentKeyNotification) { // Derived change notification (dependent 
     EXPECT_EQ_MSG([[observer changesForKeypath:@"derivedObjectProperty"] count],
                   1,
                   "One change on derivedObjectProperty should have fired.");
-    [observed removeObserver:observer forKeyPath:@"derivedObjectProperty"];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"derivedObjectProperty"]);
 
     EXPECT_OBJCEQ_MSG([[[[observer changesForKeypath:@"derivedObjectProperty"] anyObject] info] objectForKey:NSKeyValueChangeNewKey],
                       @"!!!Hello!!!",
                       "The new value stored in the change notification should be !!!Hello!!! (the derived object).");
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, PODNotification) { // Notification on a plain old data property (non-object)
@@ -512,8 +512,8 @@ TEST(KVO, PODNotification) { // Notification on a plain old data property (non-o
                       @(10),
                       "The new value stored in the change notification should be a boxed 10.");
 
-    [observed removeObserver:observer forKeyPath:@"basicPodProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicPodProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, StructNotification) { // Basic change notification on a struct type
@@ -534,8 +534,8 @@ TEST(KVO, StructNotification) { // Basic change notification on a struct type
                      @encode(TestKVOStruct),
                      "The new objc type stored in the change notification should have an objc type matching our Struct.");
 
-    [observed removeObserver:observer forKeyPath:@"structProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"structProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DisabledNotification) { // No notification for non-notifying keypaths.
@@ -550,8 +550,8 @@ TEST(KVO, DisabledNotification) { // No notification for non-notifying keypaths.
                   0,
                   "No changes for nonNotifyingObjectProperty should have fired.");
 
-    [observed removeObserver:observer forKeyPath:@"nonNotifyingObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"nonNotifyingObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DisabledInitialNotification) { // Initial notification for non-notifying keypaths.
@@ -569,8 +569,8 @@ TEST(KVO, DisabledInitialNotification) { // Initial notification for non-notifyi
     EXPECT_EQ(@(NSKeyValueChangeSetting),
               [[[[observer changesForKeypath:@"nonNotifyingObjectProperty"] anyObject] info] objectForKey:NSKeyValueChangeKindKey]);
 
-    [observed removeObserver:observer forKeyPath:@"nonNotifyingObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"nonNotifyingObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SetValueForKeyIvarNotification) { // Notification of ivar change through setValue:forKey:
@@ -589,8 +589,8 @@ TEST(KVO, SetValueForKeyIvarNotification) { // Notification of ivar change throu
                       @(1024),
                       "The new value stored in the change notification should a boxed 1024.");
 
-    [observed removeObserver:observer forKeyPath:@"ivarWithoutSetter"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"ivarWithoutSetter"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SetValueForKeyPropertyNotification) { // Notification through setValue:forKey: to make sure that we do
@@ -610,8 +610,8 @@ TEST(KVO, SetValueForKeyPropertyNotification) { // Notification through setValue
                       @(1024),
                       "The new value stored in the change notification should a boxed 1024.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DictionaryNotification) { // Basic notification on a dictionary, which does not have properties or ivars.
@@ -636,9 +636,9 @@ TEST(KVO, DictionaryNotification) { // Basic notification on a dictionary, which
                   1,
                   "On a NSMutableDictionary, a change notification for subKey.basicObjectProperty.");
 
-    [observed removeObserver:observer forKeyPath:@"arbitraryValue"];
-    [observed removeObserver:observer forKeyPath:@"subKey.basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"arbitraryValue"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"subKey.basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, BasicDeregistration) { // Deregistration test
@@ -647,7 +647,7 @@ TEST(KVO, BasicDeregistration) { // Deregistration test
     TestKVOObserver* observer = [[[TestKVOObserver alloc] init] autorelease];
 
     [observed addObserver:observer forKeyPath:@"basicObjectProperty" options:NSKeyValueObservingOptionNew context:NULL];
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:NULL];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:NULL]);
     observed.basicObjectProperty = @"Hello";
 
     EXPECT_EQ_MSG([[observer changesForKeypath:@"basicObjectProperty"] count], 0, "No changes on basicObjectProperty should have fired.");
@@ -656,14 +656,14 @@ TEST(KVO, BasicDeregistration) { // Deregistration test
     observed.cascadableKey = subObject;
 
     [observed addObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty" options:NSKeyValueObservingOptionNew context:NULL];
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty" context:NULL];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty" context:NULL]);
 
     subObject.basicObjectProperty = @"Hello";
 
     EXPECT_EQ_MSG([[observer changesForKeypath:@"cascadableKey.basicObjectProperty"] count],
                   0,
                   "No changes on cascadableKey.basicObjectProperty should have fired.");
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DerivedKeyOnSubpath1) {
@@ -689,7 +689,7 @@ TEST(KVO, DerivedKeyOnSubpath1) {
                       @(11),
                       "The new value stored in the change notification should a boxed 11.");
 
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.derivedObjectProperty.length" context:NULL];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.derivedObjectProperty.length" context:NULL]);
 
     [observer clear];
 
@@ -703,7 +703,7 @@ TEST(KVO, DerivedKeyOnSubpath1) {
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
 
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, Subpath1) { // Test normally-nested observation and value replacement
@@ -724,7 +724,7 @@ TEST(KVO, Subpath1) { // Test normally-nested observation and value replacement
     EXPECT_NO_THROW([child release]);
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathSubpath) { // Test deeply-nested observation
@@ -747,7 +747,7 @@ TEST(KVO, SubpathSubpath) { // Test deeply-nested observation
 
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathWithHeadReplacement) { // Test key value replacement and re-registration (1)
@@ -768,7 +768,7 @@ TEST(KVO, SubpathWithHeadReplacement) { // Test key value replacement and re-reg
 
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathWithTailAndHeadReplacement) { // Test key value replacement and re-registration (2)
@@ -793,7 +793,7 @@ TEST(KVO, SubpathWithTailAndHeadReplacement) { // Test key value replacement and
 
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathWithMultipleReplacement) { // Test key value replacement and re-registration (3)
@@ -817,7 +817,7 @@ TEST(KVO, SubpathWithMultipleReplacement) { // Test key value replacement and re
 
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathWithMultipleReplacement2) { // Test a more complex nested observation system
@@ -850,7 +850,7 @@ TEST(KVO, SubpathWithMultipleReplacement2) { // Test a more complex nested obser
 
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathsWithInitialNotification) { // Test initial observation on nested keys
@@ -883,10 +883,10 @@ TEST(KVO, SubpathsWithInitialNotification) { // Test initial observation on nest
                   [[[[observer changesForKeypath:@"cascadableKey.derivedObjectProperty"] anyObject] info]
                       objectForKey:NSKeyValueChangeNewKey]);
 
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty"];
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.basicPodProperty"];
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.derivedObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.basicPodProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.derivedObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, CyclicDependency) { // Make sure that dependency loops don't cause crashes.
@@ -903,7 +903,7 @@ TEST(KVO, CyclicDependency) { // Make sure that dependency loops don't cause cra
 
     EXPECT_NO_THROW([observer release]);
     EXPECT_NO_THROW([observed release]);
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, ObserveAllProperties) {
@@ -928,13 +928,13 @@ TEST(KVO, ObserveAllProperties) {
 
     EXPECT_EQ_MSG([observer numberOfObservedChanges], 6, "There should have been 6 observed changes on the observer.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [observed removeObserver:observer forKeyPath:@"basicPodProperty"];
-    [observed removeObserver:observer forKeyPath:@"structProperty"];
-    [observed removeObserver:observer forKeyPath:@"derivedObjectProperty"];
-    [observed removeObserver:observer forKeyPath:@"cascadableKey"];
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicPodProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"structProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"derivedObjectProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey"]);
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, RemoveWithoutContext) { // Test removal without specifying context.
@@ -951,7 +951,7 @@ TEST(KVO, RemoveWithoutContext) { // Test removal without specifying context.
                   options:NSKeyValueObservingOptionNew
                   context:reinterpret_cast<void*>(2)];
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
 
     observed.basicObjectProperty = @"";
 
@@ -959,10 +959,10 @@ TEST(KVO, RemoveWithoutContext) { // Test removal without specifying context.
                   1,
                   "There should be only one change notification despite registering two with contexts.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(2)];
-    [observed release];
-    [observer release];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([observed release]);
+    EXPECT_NO_THROW([observer release]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, RemoveWithDuplicateContext) { // Test adding duplicate contexts
@@ -983,7 +983,7 @@ TEST(KVO, RemoveWithDuplicateContext) { // Test adding duplicate contexts
 
     EXPECT_EQ_MSG([observer numberOfObservedChanges], 2, "There should be two observed changes, despite the identical registration.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(1)];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(1)]);
 
     observed.basicObjectProperty = @"";
 
@@ -991,8 +991,8 @@ TEST(KVO, RemoveWithDuplicateContext) { // Test adding duplicate contexts
                   3,
                   "There should be one additional observed change; the removal should have only effected one.");
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(1)];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(1)]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, RemoveOneOfTwoObservers) { // Test adding duplicate contexts
@@ -1009,7 +1009,7 @@ TEST(KVO, RemoveOneOfTwoObservers) { // Test adding duplicate contexts
     EXPECT_EQ_MSG([observer numberOfObservedChanges], 1, "There should be one observed change per observer.");
     EXPECT_EQ_MSG([observer2 numberOfObservedChanges], 1, "There should be one observed change per observer.");
 
-    [observed removeObserver:observer2 forKeyPath:@"basicObjectProperty"];
+    EXPECT_NO_THROW([observed removeObserver:observer2 forKeyPath:@"basicObjectProperty"]);
 
     observed.basicObjectProperty = @"";
 
@@ -1019,19 +1019,18 @@ TEST(KVO, RemoveOneOfTwoObservers) { // Test adding duplicate contexts
 
     EXPECT_EQ([observer2 numberOfObservedChanges], 1);
 
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
-TEST(KVO, RemoveUnregistered) { // Test removing an urnegistered observer[observed removeObserver:observer
-    // forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(1)];
+TEST(KVO, RemoveUnregistered) { // Test removing an urnegistered observer
     NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
     TestKVOObject* observed = [[[TestKVOObject alloc] init] autorelease];
     TestKVOObserver* observer = [[[TestKVOObserver alloc] init] autorelease];
 
     EXPECT_ANY_THROW_MSG([observed removeObserver:observer forKeyPath:@"basicObjectProperty" context:reinterpret_cast<void*>(1)],
                          "Removing an unregistered observer should throw an exception.");
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SelfObservationDealloc) { // Test deallocation of an object that is its own observer
@@ -1052,8 +1051,8 @@ TEST(KVO, DeepSubpathWithCompleteTree) {
     observed.cascadableKey = child;
     EXPECT_EQ([observer numberOfObservedChanges], 1);
 
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.dictionaryProperty.floatGuy.someFloat"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.dictionaryProperty.floatGuy.someFloat"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DeepSubpathWithIncompleteTree) {
@@ -1073,8 +1072,8 @@ TEST(KVO, DeepSubpathWithIncompleteTree) {
 
     EXPECT_EQ([observer numberOfObservedChanges], 2);
 
-    [observed removeObserver:observer forKeyPath:@"cascadableKey.dictionaryProperty.floatGuy.someFloat"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"cascadableKey.dictionaryProperty.floatGuy.someFloat"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathOnDerivedKey) {
@@ -1094,8 +1093,8 @@ TEST(KVO, SubpathOnDerivedKey) {
 
     EXPECT_EQ(2, [observer numberOfObservedChanges]);
 
-    [observed removeObserver:observer forKeyPath:@"derivedCascadableKey.dictionaryProperty.Key1"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"derivedCascadableKey.dictionaryProperty.Key1"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, SubpathWithDerivedKeyBasedOnSubpath) {
@@ -1119,8 +1118,8 @@ TEST(KVO, SubpathWithDerivedKeyBasedOnSubpath) {
 
     EXPECT_EQ(3, [observer numberOfObservedChanges]);
 
-    [observed removeObserver:observer forKeyPath:@"keyDependentOnSubKeypath.floatGuy"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"keyDependentOnSubKeypath.floatGuy"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, MultipleObservers) {
@@ -1157,10 +1156,10 @@ TEST(KVO, MultipleObservers) {
                       "There should be no old value included in the change notification.");
     EXPECT_OBJCEQ([[[[observer2 changesForKeypath:@"basicObjectProperty"] anyObject] info] objectForKey:NSKeyValueChangeNewKey],
                   @"Goodbye");
-    [observed removeObserver:observer forKeyPath:@"basicObjectProperty"];
-    [observed removeObserver:observer2 forKeyPath:@"basicObjectProperty"];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"basicObjectProperty"]);
+    EXPECT_NO_THROW([observed removeObserver:observer2 forKeyPath:@"basicObjectProperty"]);
 
-    [pool release];
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DerivedKeyDependentOnDerivedKey) {
@@ -1188,8 +1187,8 @@ TEST(KVO, DerivedKeyDependentOnDerivedKey) {
     EXPECT_OBJCEQ([[[[observer changesForKeypath:@"keyDerivedTwoTimes"] anyObject] info] objectForKey:NSKeyValueChangeNewKey],
                   @"---!!!$$$!!!---");
 
-    [observed removeObserver:observer forKeyPath:@"keyDerivedTwoTimes"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"keyDerivedTwoTimes"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DerivedKeyDependentOnTwoKeys) {
@@ -1210,8 +1209,8 @@ TEST(KVO, DerivedKeyDependentOnTwoKeys) {
     EXPECT_EQ(1, [observer numberOfObservedChanges]);
     EXPECT_OBJCEQ(@YES, [[[[observer changesForKeypath:@"dependsOnTwoKeys"] anyObject] info] objectForKey:NSKeyValueChangeNewKey]);
 
-    [observed removeObserver:observer forKeyPath:@"dependsOnTwoKeys"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"dependsOnTwoKeys"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(KVO, DerivedKeyDependentOnTwoSubKeys) {
@@ -1238,8 +1237,8 @@ TEST(KVO, DerivedKeyDependentOnTwoSubKeys) {
     EXPECT_EQ(1, [observer numberOfObservedChanges]);
     EXPECT_OBJCEQ(@YES, [[[[observer changesForKeypath:@"dependsOnTwoSubKeys"] anyObject] info] objectForKey:NSKeyValueChangeNewKey]);
 
-    [observed removeObserver:observer forKeyPath:@"dependsOnTwoSubKeys"];
-    [pool release];
+    EXPECT_NO_THROW([observed removeObserver:observer forKeyPath:@"dependsOnTwoSubKeys"]);
+    EXPECT_NO_THROW([pool release]);
 }
 
 TEST(Foundation, NSSearchPathForDirectoriesInDomains) {

--- a/tests/unittests/Foundation/FoundationTests.m
+++ b/tests/unittests/Foundation/FoundationTests.m
@@ -17,6 +17,7 @@
 #import <TestFramework.h>
 #import <Foundation/Foundation.h>
 #import <mach/mach_time.h>
+#import <Starboard/SmartTypes.h>
 
 TEST(Sanity, SanityTest) {
     LOG_INFO("Foundation sanity test: ");
@@ -198,8 +199,8 @@ struct TestKVOStruct {
 };
 
 @interface TestKVOObject : NSObject {
-    NSString *_internal_derivedObjectProperty;
-    NSString *_internal_keyDerivedTwoTimes;
+    StrongId<NSString> _internal_derivedObjectProperty;
+    StrongId<NSString> _internal_keyDerivedTwoTimes;
     int _manuallyNotifyingIntegerProperty;
     int _ivarWithoutSetter;
 }
@@ -232,8 +233,6 @@ struct TestKVOStruct {
 @implementation TestKVOObject
 - (void)dealloc {
     [_cascadableKey release];
-    [_internal_derivedObjectProperty release];
-    [_internal_keyDerivedTwoTimes release];
     [_nonNotifyingObjectProperty release];
     [_basicObjectProperty release];
     [_recursiveDependent1 release];
@@ -303,8 +302,8 @@ struct TestKVOStruct {
 - (void)setBasicObjectProperty:(NSString*)basicObjectProperty {
     [_basicObjectProperty release];
     _basicObjectProperty = [basicObjectProperty retain];
-    _internal_derivedObjectProperty = [[NSString stringWithFormat:@"!!!%@!!!", _basicObjectProperty] retain];
-    _internal_keyDerivedTwoTimes = [[NSString stringWithFormat:@"---%@---", [self derivedObjectProperty]] retain];
+    _internal_derivedObjectProperty = [NSString stringWithFormat:@"!!!%@!!!", _basicObjectProperty];
+    _internal_keyDerivedTwoTimes = [NSString stringWithFormat:@"---%@---", [self derivedObjectProperty]];
 }
 
 - (NSString*)keyDerivedTwoTimes {

--- a/tests/unittests/Foundation/NSKeyValueCodingTests.mm
+++ b/tests/unittests/Foundation/NSKeyValueCodingTests.mm
@@ -17,6 +17,10 @@
 #import <TestFramework.h>
 #import <Foundation/Foundation.h>
 
+// Many of the tests in this file are disabled pending a fix for GH#800.
+// In short, we have known incompatibilities with aggregate function support vis-a-vis the reference platform.
+// Until we've fixed them, we're disabling the tests that are noncompliant.
+
 @interface KVCTestCoin : NSObject
 @property (assign) NSInteger coinValue;
 @property (retain) NSObject* testObj;
@@ -50,32 +54,32 @@ static NSMutableSet* obtainSetOfCoins(unsigned int start, unsigned int end) {
     return  [NSMutableSet setWithArray:obtainArrayOfCoins(start,end)];
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionSum) {
+TEST(NSKeyValueCoding, AggregateFunctionSum) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_EQ(45, [[coins valueForKeyPath:@"@sum.coinValue"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionCount) {
+TEST(NSKeyValueCoding, AggregateFunctionCount) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_EQ(10, [[coins valueForKeyPath:@"@count"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionMax) {
+TEST(NSKeyValueCoding, AggregateFunctionMax) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_EQ(9, [[coins valueForKeyPath:@"@max.coinValue"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionMin) {
+TEST(NSKeyValueCoding, AggregateFunctionMin) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_EQ(0, [[coins valueForKeyPath:@"@min.coinValue"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionAvg) {
+TEST(NSKeyValueCoding, AggregateFunctionAvg) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_EQ(4.5, [[coins valueForKeyPath:@"@avg.coinValue"] doubleValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfObjects) {
+TEST(NSKeyValueCoding, AggregateFunctionDistinctUnionOfObjects) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
 
     for (int i = 0; i < 5; ++i) {
@@ -86,7 +90,7 @@ TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfObjects) {
     ASSERT_EQ(10, [[coins valueForKeyPath:@"@distinctUnionOfObjects.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionUnionOfObjects) {
+TEST(NSKeyValueCoding, AggregateFunctionUnionOfObjects) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
 
     for (int i = 0; i < 5; ++i) {
@@ -97,7 +101,7 @@ TEST(NSKeyValueCoding, AggerateFunctionUnionOfObjects) {
     ASSERT_EQ(15, [[coins valueForKeyPath:@"@unionOfObjects.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfArrays) {
+TEST(NSKeyValueCoding, AggregateFunctionDistinctUnionOfArrays) {
     NSMutableArray* lowValueCoins = obtainArrayOfCoins(0, 10);
     NSMutableArray* highValueCoins = obtainArrayOfCoins(5, 10);
 
@@ -106,7 +110,7 @@ TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfArrays) {
     ASSERT_EQ(10, [[result valueForKeyPath:@"@distinctUnionOfArrays.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionUnionOfArrays) {
+TEST(NSKeyValueCoding, AggregateFunctionUnionOfArrays) {
     NSMutableArray* lowValueCoins = obtainArrayOfCoins(0, 10);
     NSMutableArray* highValueCoins = obtainArrayOfCoins(5, 10);
     NSArray* result = @[ lowValueCoins, highValueCoins, lowValueCoins ];
@@ -114,7 +118,7 @@ TEST(NSKeyValueCoding, AggerateFunctionUnionOfArrays) {
     ASSERT_EQ(25, [[result valueForKeyPath:@"@unionOfArrays.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfSets) {
+TEST(NSKeyValueCoding, AggregateFunctionDistinctUnionOfSets) {
     NSMutableSet* lowValueCoins = obtainSetOfCoins(0, 10);
     NSMutableSet* highValueCoins = obtainSetOfCoins(5, 10);
 
@@ -125,32 +129,32 @@ TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfSets) {
     ASSERT_EQ(10, [[result valueForKeyPath:@"@distinctUnionOfSets.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionSumSet) {
+TEST(NSKeyValueCoding, AggregateFunctionSumSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
     ASSERT_EQ(45, [[coins valueForKeyPath:@"@sum.coinValue"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionCountSet) {
+TEST(NSKeyValueCoding, AggregateFunctionCountSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
     ASSERT_EQ(10, [[coins valueForKeyPath:@"@count"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionMaxSet) {
+TEST(NSKeyValueCoding, AggregateFunctionMaxSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
     ASSERT_EQ(9, [[coins valueForKeyPath:@"@max.coinValue"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionMinSet) {
+TEST(NSKeyValueCoding, AggregateFunctionMinSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
     ASSERT_EQ(0, [[coins valueForKeyPath:@"@min.coinValue"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionAvgSet) {
+TEST(NSKeyValueCoding, AggregateFunctionAvgSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
     ASSERT_EQ(4.5, [[coins valueForKeyPath:@"@avg.coinValue"] doubleValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfObjectsSet) {
+TEST(NSKeyValueCoding, AggregateFunctionDistinctUnionOfObjectsSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
 
     for (int i = 0; i < 5; ++i) {
@@ -161,7 +165,7 @@ TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfObjectsSet) {
     ASSERT_EQ(10, [[coins valueForKeyPath:@"@distinctUnionOfObjects.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionUnionOfObjectsSet) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionUnionOfObjectsSet) {
     NSMutableSet* coins = obtainSetOfCoins(0, 10);
 
     for (int i = 0; i < 5; ++i) {
@@ -172,72 +176,77 @@ TEST(NSKeyValueCoding, AggerateFunctionUnionOfObjectsSet) {
     ASSERT_EQ(10, [[coins valueForKeyPath:@"@unionOfObjects.coinValue"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionSumDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionSumDict) {
     NSDictionary* inventory = @{
         @"testKey" : @[ @1, @2, @3, @10 ],
     };
     ASSERT_EQ(16, [[inventory valueForKeyPath:@"@sum.testKey"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionCountDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionCountDict) {
     NSDictionary* inventory = @{
         @"testKey" : @[ @1, @2, @3, @10 ],
     };
     ASSERT_EQ(1, [[inventory valueForKeyPath:@"@count"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionMaxDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionMaxDict) {
     NSDictionary* inventory = @{
         @"testKey" : @[ @1, @2, @3, @10 ],
     };
     ASSERT_EQ(10, [[inventory valueForKeyPath:@"@max.testKey"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionMinDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionMinDict) {
     NSDictionary* inventory = @{
         @"testKey" : @[ @1, @2, @3, @10 ],
     };
     ASSERT_EQ(1, [[inventory valueForKeyPath:@"@min.testKey"] intValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionAvgDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionAvgDict) {
     NSDictionary* inventory = @{
         @"testKey" : @[ @1, @2, @3, @10 ],
     };
     ASSERT_EQ(4, [[inventory valueForKeyPath:@"@avg.testKey"] doubleValue]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionDistinctUnionOfObjectsDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionDistinctUnionOfObjectsDict) {
     NSDictionary* inventory = @{
-        @"testKey" : @[ @1, @2, @3, @10 ],
+        @"testKey" : @[ @1, @2, @3, @3, @10 ],
     };
 
     ASSERT_EQ(4, [[inventory valueForKeyPath:@"@distinctUnionOfObjects.testKey"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionUnionOfObjectsDict) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionUnionOfObjectsDict) {
     NSDictionary* inventory = @{
-        @"testKey" : @[ @1, @2, @3, @10 ],
+        @"testKey" : @[ @1, @2, @3, @3, @10 ],
     };
 
-    ASSERT_EQ(1, [[inventory valueForKeyPath:@"@count"] intValue]);
+    ASSERT_EQ(5, [[inventory valueForKeyPath:@"@unionOfObjects.testKey"] count]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionNullLeafArray) {
+// The following two tests are disabled because OS X violates the contract set out for these functions in
+// https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/KeyValueCoding/Articles/CollectionOperators.html
+// > @unionOfArrays
+// >   Important: This operator raises an exception if any of the leaf objects is nil. 
+// Evidence shows that it does, in fact, not raise an exception if any of the leaf objects is nil.
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionNullLeafUnionArray) {
     NSMutableArray* result = obtainArrayOfCoins(0, 2);
     ASSERT_ANY_THROW([result valueForKeyPath:@"@unionOfArrays.testObj"]);
     ASSERT_ANY_THROW([result valueForKeyPath:@"@unionOfObjects.testObj"]);
     ASSERT_ANY_THROW([result valueForKeyPath:@"@distinctUnionOfObjects.testObj"]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionNullLeafSet) {
+OSX_DISABLED_TEST(NSKeyValueCoding, AggregateFunctionNullLeafUnionSet) {
     NSMutableSet* result = obtainSetOfCoins(0, 2);
     ASSERT_ANY_THROW([result valueForKeyPath:@"@distinctUnionOfSets.testObj"]);
     ASSERT_ANY_THROW([result valueForKeyPath:@"@unionOfObjects.testObj"]);
     ASSERT_ANY_THROW([result valueForKeyPath:@"@distinctUnionOfObjects.testObj"]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionNullLeafSet2) {
+TEST(NSKeyValueCoding, AggregateFunctionNullLeaf) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_EQ(10, [[coins valueForKeyPath:@"@count.testObj"] intValue]);
     ASSERT_EQ(0, [[coins valueForKeyPath:@"@avg.testObj"] intValue]);
@@ -246,7 +255,7 @@ TEST(NSKeyValueCoding, AggerateFunctionNullLeafSet2) {
 	ASSERT_EQ(nil, [coins valueForKeyPath:@"@min.testObj"]);
 }
 
-TEST(NSKeyValueCoding, AggerateFunctionInvalid) {
+TEST(NSKeyValueCoding, AggregateFunctionInvalid) {
     NSMutableArray* coins = obtainArrayOfCoins(0, 10);
     ASSERT_ANY_THROW([coins valueForKeyPath:@"@foobar.coinValue"]);
 }


### PR DESCRIPTION
* Fix our illegal implementation of an observed KVO property.

    Since KVO relies heavily on tracking object state, it is illegal for an
    observed property getter to return a new object every time it is called.
    This breaks the accounting for those objects, as the first result will
    be observed, the second will be modified, the third will attempt
    deregistration, and so on.

    Fixes #703.

* Split NSSecureCoding tests, disable ones where OS X does not comply with docs. Fixes #702.
* Fix #755 by disabling 50% of our KVC aggregate tests. (Tracked in #800.)
* Fix the KVO removal-without-context test to not be implementation-dependent.

    Previously, it would expect that a widlcard context remove would take
    out the first observer, leaving the second. This is not a valid
    assumption, as the implementation is free to do as it wishes.

    Additionally, this commit wraps some statements that should absolutely
    not fail in EXPECT_NO_THROW so that we get proper test logging instead
    of generic exception handling.

    Refer to #703.