### PR TITLE
[tools] Add a script that can update a PR's CI status on GitHub.

### DIFF
--- a/tools/build/Submit-GithubBuildStatus.ps1
+++ b/tools/build/Submit-GithubBuildStatus.ps1
@@ -1,0 +1,103 @@
+<#
+.SYNOPSIS
+    Submits a CI build status to GitHub for the latest SHA1 in a pull request branch.
+#>
+Param (
+	[Parameter(Mandatory=$true, HelpMessage="GitHub Pull Request specifier (<origin> <branch>)")]
+	[string]$PullRequest,
+
+	[Parameter(Mandatory=$true, HelpMessage="Parent repository (<USER/REPO>)")]
+	[string]$Repository,
+
+	[Parameter(Mandatory=$true, HelpMessage="Build Definition Name")]
+	[string]$BuildDefinition,
+
+	[Parameter(Mandatory=$true,ParameterSetName="ManualStatus", HelpMessage="Manually-specified status")]
+	[ValidateSet('pending', 'success', 'failure')]
+	[string]$Status,
+
+	[Parameter(Mandatory=$true,ParameterSetName="AutomaticStatus", HelpMessage="Unit Test XML output directory for automatic status")]
+	[string]$TestXMLDirectory,
+
+	[Parameter(Mandatory=$true, HelpMessage="GitHub username with repo:status scope")]
+	[string]$AuthUsername,
+
+	[Parameter(Mandatory=$true, HelpMessage="GitHub Authentication token")]
+	[string]$AuthToken,
+
+	[Parameter(HelpMessage="Optional description prepended to test results")]
+	[string]$Description,
+
+	[Parameter(HelpMessage="Do not push status to GitHub")]
+	[switch]$OnlyPrintStatus
+)
+
+$ErrorActionPreference = "Stop";
+
+Function Get-LatestRevision {
+	$ret = (& git.exe ls-remote ($PullRequest -Split " "))
+	If ($LASTEXITCODE -NE 0) {
+		Throw "Failed to find latest SHA1 for $PullRequest."
+	}
+	return $ret.Split("`t")[0]
+}
+
+If ($PsCmdlet.ParameterSetName -Eq "AutomaticStatus") {
+	$testCount = 0
+	$failureCount = 0
+	$disabledCount = 0
+	ForEach($xmlItem in (Get-ChildItem $TestXMLDirectory -ErrorAction SilentlyContinue)) {
+		[xml]$xml = Get-Content $xmlItem.FullName
+		ForEach($testSuite in $xml.testsuites.testsuite) {
+			$testCount += $testSuite.tests
+			$failureCount += $testSuite.failures
+			$disabledCount += $testSuite.disabled
+		}
+	}
+
+	$Status = "success"
+	$explanation = "{0} tests, all passed ({1} skipped)" -f $testCount, $disabledCount
+	If ($disabledCount -Gt 0) {
+		$explanation += " ({0} skipped)" -f $disabledCount
+	}
+	If ($testCount -Gt 0 -And $failureCount -Gt 0) {
+		$Status = "failure"
+		$explanation = "{1}/{0} tests failed" -f $testCount, $failureCount
+		If ($disabledCount -Gt 0) {
+			$explanation += " ({0} skipped)" -f $disabledCount
+		}
+	} ElseIf ($testCount -Eq 0) {
+		$Status = "failure"
+		$explanation = "Build failed (no tests run)"
+	}
+
+	If (![string]::IsNullOrWhiteSpace($Description)) {
+		$Description += "; ";
+	}
+	$Description += $explanation
+}
+
+$latestSha1 = Get-LatestRevision
+
+$statusURL = "https://api.github.com/repos/$($Repository)/statuses/$($latestSha1)"
+$newStatus = [PSCustomObject]@{
+	state = $Status;
+	context = $BuildDefinition;
+	description = $(If ([string]::IsNullOrWhiteSpace($Description)) { "" } Else { $Description });
+}
+
+# Bug; GitHub sends a 404 for authentication failures. Unfortunately, Invoke-WebRequest waits for a 401 before retrying with
+# an authentication header. Therefore, we have to build the auth header ourselves.
+# The correct version of this code is:
+#     $authTokenSecureString = (ConvertTo-SecureString -String $AuthToken -AsPlainText -Force)
+#     $authCredential = (New-Object -TypeName "System.Management.Automation.PSCredential" -ArgumentList $AuthUsername, $authTokenSecureString)
+$encodedAuthCredential = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($AuthUsername):$($AuthToken)"))
+$statusHeaders = @{
+	Authorization = "Basic $($encodedAuthCredential)"
+}
+
+If ($OnlyPrintStatus) {
+	$newStatus | Format-List
+} Else {
+	Invoke-WebRequest -Body (ConvertTo-JSON $newStatus) -ContentType "application/json" -Headers $statusHeaders -Method Post -Uri $statusURL | Out-Null
+}


### PR DESCRIPTION
Salient points:
_Status_ can be manually specified or derived from the output of `Run-UnitTests` via _TestXMLDirectory_.
_Description_ is optional, and will be populated with test run results.
_PullRequest_ must take the form `REMOTE BRANCHNAME`
_Repository_ must take the form `USERNAME/REPONAME`