### PR TITLE
Fix NSRangeFromString to match reference platform

### DIFF
--- a/Frameworks/Foundation/NSRange.mm
+++ b/Frameworks/Foundation/NSRange.mm
@@ -49,15 +49,12 @@ NSString* NSStringFromRange(NSRange range) {
  @Status Interoperable
 */
 NSRange NSRangeFromString(NSString* s) {
-    static NSCharacterSet* numbers = [NSCharacterSet characterSetWithCharactersInString:@"1234567890"];
-    NSScanner* scanner = [NSScanner scannerWithString:s];
     unsigned long long position = 0;
     unsigned long long length = 0;
 
-    [scanner scanUpToCharactersFromSet:numbers intoString:nullptr];
-    if ([scanner scanUnsignedLongLong:&position]) {
-        [scanner scanUpToCharactersFromSet:numbers intoString:nullptr];
-        [scanner scanUnsignedLongLong:&length];
+    const char* input = strpbrk([s UTF8String], "0123456789");
+    if (input) {
+        sscanf(input, "%llu%*[^0-9]%llu", &position, &length);
     }
 
     return NSMakeRange(position, length);

--- a/Frameworks/Foundation/NSRange.mm
+++ b/Frameworks/Foundation/NSRange.mm
@@ -49,33 +49,18 @@ NSString* NSStringFromRange(NSRange range) {
  @Status Interoperable
 */
 NSRange NSRangeFromString(NSString* s) {
-    static NSCharacterSet* trimChars = [NSCharacterSet characterSetWithCharactersInString:@"{}- "];
+    static NSCharacterSet* numbers = [NSCharacterSet characterSetWithCharactersInString:@"1234567890"];
+    NSScanner* scanner = [NSScanner scannerWithString:s];
+    unsigned long long position = 0;
+    unsigned long long length = 0;
 
-    // Valid string begins with '{' and ends with '}'
-    if ([s characterAtIndex:0] == '{' && [s characterAtIndex:([s length] - 1)] == '}') {
-        NSArray* components = [s componentsSeparatedByString:@","];
-
-        // The two components are position and length - any other number of components is invalid.
-        if ([components count] != 2) {
-            return NSMakeRange(0, 0);
-        }
-
-        unsigned long long position;
-        NSScanner* scanner = [NSScanner scannerWithString:[components[0] stringByTrimmingCharactersInSet:trimChars]];
-        if (![scanner scanUnsignedLongLong:&position]) {
-            return NSMakeRange(0, 0);
-        }
-
-        unsigned long long length;
-        scanner = [NSScanner scannerWithString:[components[1] stringByTrimmingCharactersInSet:trimChars]];
-        if (![scanner scanUnsignedLongLong:&length]) {
-            return NSMakeRange(0, 0);
-        }
-
-        return NSMakeRange(position, length);
+    [scanner scanUpToCharactersFromSet:numbers intoString:nullptr];
+    if ([scanner scanUnsignedLongLong:&position]) {
+        [scanner scanUpToCharactersFromSet:numbers intoString:nullptr];
+        [scanner scanUnsignedLongLong:&length];
     }
 
-    return NSMakeRange(0, 0);
+    return NSMakeRange(position, length);
 }
 
 /**

--- a/Frameworks/Foundation/NSRange.mm
+++ b/Frameworks/Foundation/NSRange.mm
@@ -54,7 +54,7 @@ NSRange NSRangeFromString(NSString* s) {
 
     const char* input = strpbrk([s UTF8String], "0123456789");
     if (input) {
-        sscanf(input, "%llu%*[^0-9]%llu", &position, &length);
+        sscanf_s(input, "%llu%*[^0-9]%llu", &position, &length);
     }
 
     return NSMakeRange(position, length);

--- a/tests/unittests/Foundation/NSRangeTests.mm
+++ b/tests/unittests/Foundation/NSRangeTests.mm
@@ -19,19 +19,19 @@
 
 void testStringFromRange(NSString* testString, NSRange expectedRange) {
     NSRange actualRange = NSRangeFromString(testString);
-    ASSERT_EQ(expectedRange.location, actualRange.location);
-    ASSERT_EQ(expectedRange.length, actualRange.length);
+    EXPECT_EQ(expectedRange.location, actualRange.location);
+    EXPECT_EQ(expectedRange.length, actualRange.length);
 }
 
 TEST(NSRange, NSRangeTests) {
     testStringFromRange(@"{1, 2}", { 1, 2 });
-    testStringFromRange(@"1, 2}", { 0, 0 });
-    testStringFromRange(@"{1, 2", { 0, 0 });
-    testStringFromRange(@"{a, 2}", { 0, 0 });
-    testStringFromRange(@"{1,, 2}", { 0, 0 });
-    testStringFromRange(@"{1.3, 2}", { 1, 2 });
+    testStringFromRange(@"1, 2}", { 1, 2 });
+    testStringFromRange(@"{1, 2", { 1, 2 });
+    testStringFromRange(@"{a, 2}", { 2, 0 });
+    testStringFromRange(@"{1,, 2}", { 1, 2 });
+    testStringFromRange(@"{1.3, 2}", { 1, 3 });
     testStringFromRange(@"{2147483648, 2}", { 2147483648, 2 });
-    testStringFromRange(@"\r\n{1, 2}", { 0, 0 });
+    testStringFromRange(@"\r\n{1, 2}", { 1, 2 });
     testStringFromRange(@"{  2, 4  }", { 2, 4 });
     testStringFromRange(@"{-1, -2}", { 1, 2 });
 }

--- a/tests/unittests/Foundation/NSRangeTests.mm
+++ b/tests/unittests/Foundation/NSRangeTests.mm
@@ -34,4 +34,7 @@ TEST(NSRange, NSRangeTests) {
     testStringFromRange(@"\r\n{1, 2}", { 1, 2 });
     testStringFromRange(@"{  2, 4  }", { 2, 4 });
     testStringFromRange(@"{-1, -2}", { 1, 2 });
+    testStringFromRange(@"1 2", { 1, 2 });
+    testStringFromRange(@"{1,2,3}", { 1, 2 });
+    testStringFromRange(@"", { 0, 0 });
 }


### PR DESCRIPTION
Our NSRangeFromString was much more strict than the reference platform's.  This changes NSRangeFromString to accept the first two integers it finds in the string.