### PR TITLE
Issue 745: NSCharacterSet tests fail on OSX

### DIFF
--- a/Frameworks/Foundation/NSMutableCharacterSet.mm
+++ b/Frameworks/Foundation/NSMutableCharacterSet.mm
@@ -27,103 +27,103 @@
 + ALLOC_PROTOTYPE_SUBCLASS_WITH_ZONE(NSMutableCharacterSet, NSMutableCharacterSetPrototype);
 
 + (instancetype)alphanumericCharacterSet {
-    return [[NSCharacterSet alphanumericCharacterSet] mutableCopy];
+    return [[[NSCharacterSet alphanumericCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)capitalizedLetterCharacterSet {
-    return [[NSCharacterSet capitalizedLetterCharacterSet] mutableCopy];
+    return [[[NSCharacterSet capitalizedLetterCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)controlCharacterSet {
-    return [[NSCharacterSet controlCharacterSet] mutableCopy];
+    return [[[NSCharacterSet controlCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)decimalDigitCharacterSet {
-    return [[NSCharacterSet decimalDigitCharacterSet] mutableCopy];
+    return [[[NSCharacterSet decimalDigitCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)decomposableCharacterSet {
-    return [[NSCharacterSet decomposableCharacterSet] mutableCopy];
+    return [[[NSCharacterSet decomposableCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)illegalCharacterSet {
-    return [[NSCharacterSet illegalCharacterSet] mutableCopy];
+    return [[[NSCharacterSet illegalCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)letterCharacterSet {
-    return [[NSCharacterSet letterCharacterSet] mutableCopy];
+    return [[[NSCharacterSet letterCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)lowercaseLetterCharacterSet {
-    return [[NSCharacterSet lowercaseLetterCharacterSet] mutableCopy];
+    return [[[NSCharacterSet lowercaseLetterCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)newlineCharacterSet {
-    return [[NSCharacterSet newlineCharacterSet] mutableCopy];
+    return [[[NSCharacterSet newlineCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)nonBaseCharacterSet {
-    return [[NSCharacterSet nonBaseCharacterSet] mutableCopy];
+    return [[[NSCharacterSet nonBaseCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)punctuationCharacterSet {
-    return [[NSCharacterSet punctuationCharacterSet] mutableCopy];
+    return [[[NSCharacterSet punctuationCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)symbolCharacterSet {
-    return [[NSCharacterSet symbolCharacterSet] mutableCopy];
+    return [[[NSCharacterSet symbolCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)uppercaseLetterCharacterSet {
-    return [[NSCharacterSet uppercaseLetterCharacterSet] mutableCopy];
+    return [[[NSCharacterSet uppercaseLetterCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)whitespaceAndNewlineCharacterSet {
-    return [[NSCharacterSet whitespaceAndNewlineCharacterSet] mutableCopy];
+    return [[[NSCharacterSet whitespaceAndNewlineCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)whitespaceCharacterSet {
-    return [[NSCharacterSet whitespaceCharacterSet] mutableCopy];
+    return [[[NSCharacterSet whitespaceCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)URLFragmentAllowedCharacterSet {
-    return [[NSCharacterSet URLFragmentAllowedCharacterSet] mutableCopy];
+    return [[[NSCharacterSet URLFragmentAllowedCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)URLHostAllowedCharacterSet {
-    return [[NSCharacterSet URLHostAllowedCharacterSet] mutableCopy];
+    return [[[NSCharacterSet URLHostAllowedCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)URLPasswordAllowedCharacterSet {
-    return [[NSCharacterSet URLPasswordAllowedCharacterSet] mutableCopy];
+    return [[[NSCharacterSet URLPasswordAllowedCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)URLPathAllowedCharacterSet {
-    return [[NSCharacterSet URLPathAllowedCharacterSet] mutableCopy];
+    return [[[NSCharacterSet URLPathAllowedCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)URLQueryAllowedCharacterSet {
-    return [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    return [[[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)URLUserAllowedCharacterSet {
-    return [[NSCharacterSet URLUserAllowedCharacterSet] mutableCopy];
+    return [[[NSCharacterSet URLUserAllowedCharacterSet] mutableCopy] autorelease];
 }
 
 + (instancetype)characterSetWithCharactersInString:(NSString*)aString {
-    return [[NSCharacterSet characterSetWithCharactersInString:aString] mutableCopy];
+    return [[[NSCharacterSet characterSetWithCharactersInString:aString] mutableCopy] autorelease];
 }
 
 + (instancetype)characterSetWithRange:(NSRange)aRange {
-    return [[NSCharacterSet characterSetWithRange:aRange] mutableCopy];
+    return [[[NSCharacterSet characterSetWithRange:aRange] mutableCopy] autorelease];
 }
 
 + (instancetype)characterSetWithBitmapRepresentation:(NSData*)data {
-    return [[NSCharacterSet characterSetWithBitmapRepresentation:data] mutableCopy];
+    return [[[NSCharacterSet characterSetWithBitmapRepresentation:data] mutableCopy] autorelease];
 }
 
 + (instancetype)characterSetWithContentsOfFile:(NSString*)path {
-    return [[NSCharacterSet characterSetWithContentsOfFile:path] mutableCopy];
+    return [[[NSCharacterSet characterSetWithContentsOfFile:path] mutableCopy] autorelease];
 }
 
 /**

--- a/tests/unittests/Foundation/NSCharacterSetTests.m
+++ b/tests/unittests/Foundation/NSCharacterSetTests.m
@@ -219,10 +219,4 @@ TEST(NSCharacterSet, Polymorphic_Creators) {
 
     set = [NSMutableCharacterSet characterSetWithRange:NSMakeRange(0, 32)];
     ASSERT_TRUE([set isKindOfClass:[NSMutableCharacterSet class]]);
-
-    set = [NSMutableCharacterSet characterSetWithBitmapRepresentation:nil];
-    ASSERT_TRUE([set isKindOfClass:[NSMutableCharacterSet class]]);
-
-    set = [NSMutableCharacterSet characterSetWithContentsOfFile:nil];
-    ASSERT_TRUE([set isKindOfClass:[NSMutableCharacterSet class]]);
 }

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSCharacterSet.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSCharacterSet.mm
@@ -97,12 +97,14 @@ TEST(NSCharacterSet, Bitmap) {
 
 TEST(NSCharacterSet, Mutables) {
     auto attachmentCharacterUnichar = static_cast<unichar>(0xFFFC);
-
-    NSRange attachmentCharacterRange =
-        NSMakeRange(attachmentCharacterUnichar, (attachmentCharacterUnichar - attachmentCharacterUnichar) + 1);
+    NSRange attachmentCharacterRange = NSMakeRange(attachmentCharacterUnichar, 1);
 
     NSRange initialSetRange = NSMakeRange(0, 0);
-    NSString* string = [[NSString alloc] initWithBytes:&attachmentCharacterUnichar length:2 encoding:NSUnicodeStringEncoding];
+#if defined(__LITTLE_ENDIAN__)
+    NSString* string = [[NSString alloc] initWithBytes:&attachmentCharacterUnichar length:2 encoding:NSUTF16LittleEndianStringEncoding];
+#else
+    NSString* string = [[NSString alloc] initWithBytes:&attachmentCharacterUnichar length:2 encoding:NSUTF16BigEndianStringEncoding];
+#endif
 
     NSMutableCharacterSet* mcset1 = [NSMutableCharacterSet characterSetWithRange:initialSetRange];
     [mcset1 addCharactersInRange:attachmentCharacterRange];


### PR DESCRIPTION
NSCharacterSet tests are failing in a few places. First and foremost, there's
an issue with NSMutableCharacterSet where many of the static initializers
are actually meant to return an immutable version that the user calls mutablecopy
on themselves. Our solution by default was to return a mutable copy. This is
incorrect.

There were a couple tests that were just invalid cases, specifically
characterSetWithBitmapRepresentation and characterSetWithContentsOfFile which
are not valid cases when passed nil.

Finally, a test was failing due to an incorrect encoding being used for
unicode characters. NSUnicodeStringEncoding appears to default to UTF16
Little Endian encoding as where it defaults to UTF16 Big Endian encoding on
the reference platform. This results in the same data representing two
different characters.

Validated by running unit tests and passing.