### PR TITLE
Fix NSUrlCredential tests on reference platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tmp
 
 # User-specific files
 *.suo
+*.swp
 *.user
 *.sln.docstates
 *.lock.json
@@ -60,7 +61,7 @@ ehthumbs.db
 Generated/
 Generated Files/
 
-# Ignore all CF public headers. They get copied in from the Frameworks directory as a pre build step. 
+# Ignore all CF public headers. They get copied in from the Frameworks directory as a pre build step.
 Include/CoreFoundation/CFStream.h
 Include/CoreFoundation/CFStringEncodingExt.h
 Include/CoreFoundation/CoreFoundation.h
@@ -106,7 +107,7 @@ Include/CoreFoundation/CFData.h
 Include/CoreFoundation/CFAttributedString.h
 Include/CoreFoundation/module.modulemap
 
-# Ignore all CF shared private headers. They get copied in from the Frameworks directory as a pre build step. 
+# Ignore all CF shared private headers. They get copied in from the Frameworks directory as a pre build step.
 Frameworks/Include/ForFoundationOnly.h
 Frameworks/Include/CFBundlePriv.h
 Frameworks/Include/CFPriv.h

--- a/Frameworks/Foundation/NSURLCredential.mm
+++ b/Frameworks/Foundation/NSURLCredential.mm
@@ -75,6 +75,7 @@
 - (instancetype)initWithTrust:(SecTrustRef)trust {
     if (self = [super init]) {
         _trust = trust;
+        _persistence = NSURLCredentialPersistenceForSession;
     }
     return self;
 }

--- a/Frameworks/Foundation/NSURLCredential.mm
+++ b/Frameworks/Foundation/NSURLCredential.mm
@@ -58,7 +58,7 @@
 - (instancetype)initWithIdentity:(SecIdentityRef)identity
                     certificates:(NSArray*)certArray
                      persistence:(NSURLCredentialPersistence)persistence {
-    if (!identity) {
+    if (!identity || !certArray || !certArray.count) {
         [self release];
         return nil;
     }

--- a/Frameworks/Foundation/NSURLCredential.mm
+++ b/Frameworks/Foundation/NSURLCredential.mm
@@ -73,9 +73,8 @@
  @Status Interoperable
 */
 - (instancetype)initWithTrust:(SecTrustRef)trust {
-    if (self = [super init]) {
+    if (self = [self _initWithPersistence:NSURLCredentialPersistenceForSession]) {
         _trust = trust;
-        _persistence = NSURLCredentialPersistenceForSession;
     }
     return self;
 }

--- a/Frameworks/Foundation/NSURLCredential.mm
+++ b/Frameworks/Foundation/NSURLCredential.mm
@@ -58,6 +58,10 @@
 - (instancetype)initWithIdentity:(SecIdentityRef)identity
                     certificates:(NSArray*)certArray
                      persistence:(NSURLCredentialPersistence)persistence {
+    if (!identity) {
+        [self release];
+        return nil;
+    }
     if (self = [self _initWithPersistence:persistence]) {
         _identity = identity;
         _certificates = [certArray copy];

--- a/tests/unittests/Foundation/NSURLCredentialTests.mm
+++ b/tests/unittests/Foundation/NSURLCredentialTests.mm
@@ -51,7 +51,7 @@ TEST(NSURLCredential, credentialForTrust) {
     ASSERT_TRUE_MSG(credential != nil, "FAILED: credential should be non-null!");
     ASSERT_EQ_MSG(nil, [credential user], "FAILED: User name is not null");
     ASSERT_EQ_MSG(nil, [credential password], "FAILED: password is not null");
-    ASSERT_EQ_MSG(NSURLCredentialPersistenceNone, [credential persistence], "FAILED: persistence is not valid");
+    ASSERT_EQ_MSG(NSURLCredentialPersistenceForSession, [credential persistence], "FAILED: persistence is not valid");
     ASSERT_EQ_MSG(NO, [credential hasPassword], "FAILED: hasPassword is not the expected value");
     ASSERT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
 }

--- a/tests/unittests/Foundation/NSURLCredentialTests.mm
+++ b/tests/unittests/Foundation/NSURLCredentialTests.mm
@@ -22,7 +22,7 @@ TEST(NSURLCredential, credentialWithUser) {
     NSString* user = @"user";
     NSString* pass = @"pass";
     NSURLCredential* credential = [NSURLCredential credentialWithUser:user password:pass persistence:NSURLCredentialPersistenceForSession];
-    ASSERT_TRUE_MSG(credential != NULL, "FAILED: credential should be non-null!");
+    ASSERT_NE_MSG(nil, credential, "FAILED: credential should be non-null!");
 
     ASSERT_OBJCEQ_MSG(user, [credential user], "FAILED: User name is not valid");
     ASSERT_OBJCEQ_MSG(pass, [credential password], "FAILED: password is not valid");
@@ -32,28 +32,26 @@ TEST(NSURLCredential, credentialWithUser) {
     ASSERT_EQ_MSG(nil, [credential certificates], "FAILED: certificates not null");
 }
 
+// We do not currently have SecIdentity implemented so this cannot be tested further
 TEST(NSURLCredential, credentialWithIdentity) {
     NSArray* certs = [NSMutableArray array];
     NSURLCredential* credential =
         [NSURLCredential credentialWithIdentity:nullptr certificates:(NSArray*)certs persistence:NSURLCredentialPersistencePermanent];
 
-    ASSERT_TRUE_MSG(credential != NULL, "FAILED: credential should be non-null!");
-    ASSERT_EQ_MSG(nil, [credential user], "FAILED: User name is not null");
-    ASSERT_EQ_MSG(nil, [credential password], "FAILED: password is not null");
-    ASSERT_EQ_MSG(NSURLCredentialPersistencePermanent, [credential persistence], "FAILED: persistence is not valid");
-    ASSERT_EQ_MSG(NO, [credential hasPassword], "FAILED: hasPassword is not the expected value");
-    ASSERT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
-    ASSERT_TRUE_MSG(([credential certificates] != nil), "FAILED: certificates should be non null");
+    NSURLCredential* initCredential =
+        [[NSURLCredential alloc] initWithIdentity:nullptr certificates:(NSArray*)certs persistence:NSURLCredentialPersistencePermanent];
+
+    ASSERT_EQ_MSG(nil, credential, "FAILED: credential should be null when created without any identity!");
+    ASSERT_EQ_MSG(nil, initCredential, "FAILED: initCredential should be null when created without any identity!");
 }
 
 TEST(NSURLCredential, credentialForTrust) {
     NSURLCredential* credential = [NSURLCredential credentialForTrust:nullptr];
 
-    ASSERT_TRUE_MSG(credential != NULL, "FAILED: credential should be non-null!");
+    ASSERT_TRUE_MSG(credential != nil, "FAILED: credential should be non-null!");
     ASSERT_EQ_MSG(nil, [credential user], "FAILED: User name is not null");
     ASSERT_EQ_MSG(nil, [credential password], "FAILED: password is not null");
     ASSERT_EQ_MSG(NSURLCredentialPersistenceNone, [credential persistence], "FAILED: persistence is not valid");
     ASSERT_EQ_MSG(NO, [credential hasPassword], "FAILED: hasPassword is not the expected value");
     ASSERT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
-    ASSERT_EQ_MSG(nil, [credential trust], "FAILED: trust not null");
 }

--- a/tests/unittests/Foundation/NSURLCredentialTests.mm
+++ b/tests/unittests/Foundation/NSURLCredentialTests.mm
@@ -24,12 +24,12 @@ TEST(NSURLCredential, credentialWithUser) {
     NSURLCredential* credential = [NSURLCredential credentialWithUser:user password:pass persistence:NSURLCredentialPersistenceForSession];
     ASSERT_NE_MSG(nil, credential, "FAILED: credential should be non-null!");
 
-    ASSERT_OBJCEQ_MSG(user, [credential user], "FAILED: User name is not valid");
-    ASSERT_OBJCEQ_MSG(pass, [credential password], "FAILED: password is not valid");
-    ASSERT_EQ_MSG(NSURLCredentialPersistenceForSession, [credential persistence], "FAILED: persistence is not valid");
-    ASSERT_EQ_MSG(YES, [credential hasPassword], "FAILED: hasPassword is not the expected value");
-    ASSERT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
-    ASSERT_EQ_MSG(nil, [credential certificates], "FAILED: certificates not null");
+    EXPECT_OBJCEQ_MSG(user, [credential user], "FAILED: User name is not valid");
+    EXPECT_OBJCEQ_MSG(pass, [credential password], "FAILED: password is not valid");
+    EXPECT_EQ_MSG(NSURLCredentialPersistenceForSession, [credential persistence], "FAILED: persistence is not valid");
+    EXPECT_EQ_MSG(YES, [credential hasPassword], "FAILED: hasPassword is not the expected value");
+    EXPECT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
+    EXPECT_EQ_MSG(nil, [credential certificates], "FAILED: certificates not null");
 }
 
 // We do not currently have SecIdentity implemented so this cannot be tested further
@@ -41,17 +41,17 @@ TEST(NSURLCredential, credentialWithIdentity) {
     NSURLCredential* initCredential =
         [[NSURLCredential alloc] initWithIdentity:nullptr certificates:(NSArray*)certs persistence:NSURLCredentialPersistencePermanent];
 
-    ASSERT_EQ_MSG(nil, credential, "FAILED: credential should be null when created without any identity!");
-    ASSERT_EQ_MSG(nil, initCredential, "FAILED: initCredential should be null when created without any identity!");
+    EXPECT_EQ_MSG(nil, credential, "FAILED: credential should be null when created without any identity!");
+    EXPECT_EQ_MSG(nil, initCredential, "FAILED: initCredential should be null when created without any identity!");
 }
 
 TEST(NSURLCredential, credentialForTrust) {
     NSURLCredential* credential = [NSURLCredential credentialForTrust:nullptr];
 
-    ASSERT_TRUE_MSG(credential != nil, "FAILED: credential should be non-null!");
-    ASSERT_EQ_MSG(nil, [credential user], "FAILED: User name is not null");
-    ASSERT_EQ_MSG(nil, [credential password], "FAILED: password is not null");
-    ASSERT_EQ_MSG(NSURLCredentialPersistenceForSession, [credential persistence], "FAILED: persistence is not valid");
-    ASSERT_EQ_MSG(NO, [credential hasPassword], "FAILED: hasPassword is not the expected value");
-    ASSERT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
+    ASSERT_NE_MSG(nil, credential, "FAILED: credential should be non-null!");
+    EXPECT_EQ_MSG(nil, [credential user], "FAILED: User name is not null");
+    EXPECT_EQ_MSG(nil, [credential password], "FAILED: password is not null");
+    EXPECT_EQ_MSG(NSURLCredentialPersistenceForSession, [credential persistence], "FAILED: persistence is not valid");
+    EXPECT_EQ_MSG(NO, [credential hasPassword], "FAILED: hasPassword is not the expected value");
+    EXPECT_EQ_MSG(nil, [credential identity], "FAILED: identity not null");
 }


### PR DESCRIPTION
Trying to create a NSURLCredential without an identity should return nil. The default persistence when creating with trust should be NSURLCredentialPersistenceForSession.

Fixes #774 