### PR TITLE
Change NSURLSessionConfiguration initialization to match reference platform

### DIFF
--- a/Frameworks/Foundation/NSURLSessionConfiguration.mm
+++ b/Frameworks/Foundation/NSURLSessionConfiguration.mm
@@ -71,7 +71,7 @@
 */
 - (id)copyWithZone:(NSZone*)zone {
     NSURLSessionConfiguration* copy = [[[self class] allocWithZone:zone] init];
-    copy.identifier = [_identifier copy];
+    copy.identifier = _identifier;
     copy.networkServiceType = _networkServiceType;
     copy.allowsCellularAccess = _allowsCellularAccess;
     copy.timeoutIntervalForRequest = _timeoutIntervalForRequest;

--- a/Frameworks/Foundation/NSURLSessionConfiguration.mm
+++ b/Frameworks/Foundation/NSURLSessionConfiguration.mm
@@ -123,4 +123,11 @@
     return [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
 }
 
+- (void)dealloc {
+    [_HTTPCookieStorage release];
+    [_URLCache release];
+    [_URLCredentialStorage release];
+    [super dealloc];
+}
+
 @end

--- a/Frameworks/Foundation/NSURLSessionConfiguration.mm
+++ b/Frameworks/Foundation/NSURLSessionConfiguration.mm
@@ -28,7 +28,7 @@
     if (self = [super init]) {
         _allowsCellularAccess = YES;
         _timeoutIntervalForRequest = 60;
-        _timeoutIntervalForResource = 7;
+        _timeoutIntervalForResource = 7 * 24 * 60 * 60;
         _HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain;
         _HTTPCookieStorage = [[NSHTTPCookieStorage sharedHTTPCookieStorage] retain];
         _HTTPShouldSetCookies = YES;
@@ -41,22 +41,13 @@
     return self;
 }
 
-- (instancetype)_initTLSAndCache {
-    if (self = [self _initWithSharedDefaults]) {
-        _TLSMaximumSupportedProtocol = kTLSProtocol12;
-        _TLSMinimumSupportedProtocol = kTLSProtocol1;
-        _URLCache = [[NSURLCache sharedURLCache] retain];
-    }
-    return self;
-}
-
 /**
  @Status Interoperable
 */
 - (instancetype)init {
     if (self = [self _initWithSharedDefaults]) {
         _TLSMaximumSupportedProtocol = kTLSProtocol12;
-        _TLSMinimumSupportedProtocol = kSSLProtocol3;
+        _TLSMinimumSupportedProtocol = kTLSProtocol1;
     }
     return self;
 }
@@ -65,7 +56,9 @@
  @Status Interoperable
 */
 - (instancetype)initEphemeralSession {
-    self = [self _initTLSAndCache];
+    if (self = [self init]) {
+        _URLCache = [[NSURLCache sharedURLCache] retain];
+    }
     return self;
 }
 
@@ -73,7 +66,7 @@
  @Status Interoperable
 */
 - (instancetype)initBackgroundSession:(NSString*)identifier {
-    if (self = [self _initTLSAndCache]) {
+    if (self = [self init]) {
         _identifier = identifier;
     }
     return self;

--- a/Frameworks/Foundation/NSURLSessionConfiguration.mm
+++ b/Frameworks/Foundation/NSURLSessionConfiguration.mm
@@ -40,7 +40,7 @@
         _HTTPMaximumConnectionsPerHost = 6;
         _TLSMaximumSupportedProtocol = kTLSProtocol12;
         _TLSMinimumSupportedProtocol = kTLSProtocol1;
-        //_URLCredentialStorage = [[NSURLCredentialStorage sharedCredentialStorage] retain];
+        _URLCredentialStorage = [[NSURLCredentialStorage sharedCredentialStorage] retain];
     }
 
     return self;
@@ -61,7 +61,7 @@
 */
 - (instancetype)initBackgroundSession:(NSString*)identifier {
     if (self = [self init]) {
-        _identifier = identifier;
+        _identifier = [identifier copy];
     }
     return self;
 }
@@ -71,7 +71,7 @@
 */
 - (id)copyWithZone:(NSZone*)zone {
     NSURLSessionConfiguration* copy = [[[self class] allocWithZone:zone] init];
-    copy.identifier = _identifier;
+    copy.identifier = [_identifier copy];
     copy.networkServiceType = _networkServiceType;
     copy.allowsCellularAccess = _allowsCellularAccess;
     copy.timeoutIntervalForRequest = _timeoutIntervalForRequest;
@@ -127,6 +127,7 @@
     [_HTTPCookieStorage release];
     [_URLCache release];
     [_URLCredentialStorage release];
+    [_identifier release];
     [super dealloc];
 }
 

--- a/Frameworks/Foundation/NSURLSessionConfiguration.mm
+++ b/Frameworks/Foundation/NSURLSessionConfiguration.mm
@@ -124,10 +124,14 @@
 }
 
 - (void)dealloc {
-    [_HTTPCookieStorage release];
-    [_URLCache release];
-    [_URLCredentialStorage release];
     [_identifier release];
+    [_HTTPAdditionalHeaders release];
+    [_sharedContainerIdentifier release];
+    [_HTTPCookieStorage release];
+    [_URLCredentialStorage release];
+    [_URLCache release];
+    [_protocolClasses release];
+    [_connectionProxyDictionary release];
     [super dealloc];
 }
 

--- a/Frameworks/Foundation/NSURLSessionConfiguration.mm
+++ b/Frameworks/Foundation/NSURLSessionConfiguration.mm
@@ -24,7 +24,10 @@
 
 @implementation NSURLSessionConfiguration
 
-- (instancetype)_initWithSharedDefaults {
+/**
+ @Status Interoperable
+*/
+- (instancetype)init {
     if (self = [super init]) {
         _allowsCellularAccess = YES;
         _timeoutIntervalForRequest = 60;
@@ -35,20 +38,11 @@
         _networkServiceType = NSURLNetworkServiceTypeDefault;
         _requestCachePolicy = NSURLRequestUseProtocolCachePolicy;
         _HTTPMaximumConnectionsPerHost = 6;
+        _TLSMaximumSupportedProtocol = kTLSProtocol12;
+        _TLSMinimumSupportedProtocol = kTLSProtocol1;
         //_URLCredentialStorage = [[NSURLCredentialStorage sharedCredentialStorage] retain];
     }
 
-    return self;
-}
-
-/**
- @Status Interoperable
-*/
-- (instancetype)init {
-    if (self = [self _initWithSharedDefaults]) {
-        _TLSMaximumSupportedProtocol = kTLSProtocol12;
-        _TLSMinimumSupportedProtocol = kTLSProtocol1;
-    }
     return self;
 }
 

--- a/tests/unittests/Foundation/NSURLCredentialStorageTests.m
+++ b/tests/unittests/Foundation/NSURLCredentialStorageTests.m
@@ -68,8 +68,8 @@ TEST(NSURLCredentialStorage, NonDefaultSession) {
     ASSERT_OBJCEQ_MSG(@"user", [[creden objectForKey:@"user"] user], "FAILED: Invalid username.");
 
     [storage removeCredential:credential forProtectionSpace:protectionSpace];
-    ASSERT_EQ_MSG(YES, [[storage credentialsForProtectionSpace:protectionSpace] count] == 0, "FAILED credentialsForProtectionSpace should be empty");
+    ASSERT_EQ_MSG(YES,
+                  [[storage credentialsForProtectionSpace:protectionSpace] count] == 0,
+                  "FAILED credentialsForProtectionSpace should be empty");
     [protectionSpace release];
-    [storage release];
-    [creden release];
 }

--- a/tests/unittests/Foundation/NSURLSessionConfigurationTests.m
+++ b/tests/unittests/Foundation/NSURLSessionConfigurationTests.m
@@ -19,71 +19,74 @@
 
 TEST(NSURLSessionConfiguration, initValues) {
     NSURLSessionConfiguration* sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    ASSERT_TRUE_MSG(sessionConfiguration != NULL, "FAILED: sessionConfiguration should be non-null!");
+    ASSERT_NE_MSG(nil, sessionConfiguration, "FAILED: sessionConfiguration should be non-null!");
 
-    ASSERT_EQ_MSG(YES, sessionConfiguration.allowsCellularAccess, "FAILED: allowsCellularAccess should be YES");
-    ASSERT_EQ_MSG(60, sessionConfiguration.timeoutIntervalForRequest, "FAILED: timeoutIntervalForRequest should be %d", 60);
-    ASSERT_EQ_MSG(7, sessionConfiguration.timeoutIntervalForResource, "FAILED: timeoutIntervalForResource should be %d", 7);
-    ASSERT_EQ_MSG(NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain,
+    EXPECT_EQ_MSG(YES, sessionConfiguration.allowsCellularAccess, "FAILED: allowsCellularAccess should be YES");
+    EXPECT_EQ_MSG(60, sessionConfiguration.timeoutIntervalForRequest, "FAILED: timeoutIntervalForRequest should be %d", 60);
+    EXPECT_EQ_MSG(7 * 24 * 60 * 60,
+                  sessionConfiguration.timeoutIntervalForResource,
+                  "FAILED: timeoutIntervalForResource should be %d",
+                  7 * 24 * 60 * 60);
+    EXPECT_EQ_MSG(NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain,
                   sessionConfiguration.HTTPCookieAcceptPolicy,
                   "FAILED: HTTPCookieAcceptPolicy should be %d",
                   NSHTTPCookieAcceptPolicyOnlyFromMainDocumentDomain);
-    ASSERT_EQ_MSG(YES, sessionConfiguration.HTTPShouldSetCookies, "FAILED: HTTPShouldSetCookies should be YES");
-    ASSERT_EQ_MSG(NSURLNetworkServiceTypeDefault,
+    EXPECT_EQ_MSG(YES, sessionConfiguration.HTTPShouldSetCookies, "FAILED: HTTPShouldSetCookies should be YES");
+    EXPECT_EQ_MSG(NSURLNetworkServiceTypeDefault,
                   sessionConfiguration.networkServiceType,
                   "FAILED: networkServiceType should be %d",
                   NSURLNetworkServiceTypeDefault);
-    ASSERT_EQ_MSG(NSURLRequestUseProtocolCachePolicy,
+    EXPECT_EQ_MSG(NSURLRequestUseProtocolCachePolicy,
                   sessionConfiguration.requestCachePolicy,
                   "FAILED: requestCachePolicy should be %d",
                   NSURLRequestUseProtocolCachePolicy);
-    ASSERT_EQ_MSG(6, sessionConfiguration.HTTPMaximumConnectionsPerHost, "FAILED: HTTPMaximumConnectionsPerHost should be %d", 6);
-    ASSERT_TRUE_MSG(sessionConfiguration.HTTPCookieStorage != NULL, "FAILED: HTTPCookieStorage should be non-null");
+    EXPECT_EQ_MSG(6, sessionConfiguration.HTTPMaximumConnectionsPerHost, "FAILED: HTTPMaximumConnectionsPerHost should be %d", 6);
+    EXPECT_NE_MSG(nil, sessionConfiguration.HTTPCookieStorage, "FAILED: HTTPCookieStorage should be non-null");
 }
 
 TEST(NSURLSessionConfiguration, defaultSessionConfiguration) {
     NSURLSessionConfiguration* sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    ASSERT_TRUE_MSG(sessionConfiguration != NULL, "FAILED: sessionConfiguration should be non-null!");
+    ASSERT_NE_MSG(nil, sessionConfiguration, "FAILED: sessionConfiguration should be non-null!");
 
-    ASSERT_EQ_MSG(YES, sessionConfiguration.allowsCellularAccess, "FAILED: allowsCellularAccess should be YES");
-    ASSERT_EQ_MSG(kTLSProtocol12,
+    EXPECT_EQ_MSG(YES, sessionConfiguration.allowsCellularAccess, "FAILED: allowsCellularAccess should be YES");
+    EXPECT_EQ_MSG(kTLSProtocol12,
                   sessionConfiguration.TLSMaximumSupportedProtocol,
                   "FAILED: TLSMaximumSupportedProtocol should be %d",
                   kTLSProtocol12);
-    ASSERT_EQ_MSG(kSSLProtocol3,
+    EXPECT_EQ_MSG(kTLSProtocol1,
                   sessionConfiguration.TLSMinimumSupportedProtocol,
                   "FAILED: TLSMinimumSupportedProtocol should be %d",
-                  kSSLProtocol3);
+                  kTLSProtocol1);
 }
 
 TEST(NSURLSessionConfiguration, ephemeralSessionConfiguration) {
     NSURLSessionConfiguration* sessionConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-    ASSERT_TRUE_MSG(sessionConfiguration != NULL, "FAILED: sessionConfiguration should be non-null!");
+    ASSERT_NE_MSG(nil, sessionConfiguration, "FAILED: sessionConfiguration should be non-null!");
 
-    ASSERT_EQ_MSG(kTLSProtocol12,
+    EXPECT_EQ_MSG(kTLSProtocol12,
                   sessionConfiguration.TLSMaximumSupportedProtocol,
                   "FAILED: TLSMaximumSupportedProtocol should be %d",
                   kTLSProtocol12);
-    ASSERT_EQ_MSG(kTLSProtocol1,
+    EXPECT_EQ_MSG(kTLSProtocol1,
                   sessionConfiguration.TLSMinimumSupportedProtocol,
                   "FAILED: TLSMinimumSupportedProtocol should be %d",
                   kTLSProtocol1);
-    ASSERT_TRUE_MSG(sessionConfiguration.URLCache != NULL, "FAILED: URLCache should be non-null");
+    EXPECT_NE_MSG(nil, sessionConfiguration.URLCache, "FAILED: URLCache should be non-null");
 }
 
 TEST(NSURLSessionConfiguration, backgroundSessionConfigurationWithIdentifier) {
     NSString* identifier = @"Microsoft";
     NSURLSessionConfiguration* sessionConfiguration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
-    ASSERT_TRUE_MSG(sessionConfiguration != NULL, "FAILED: sessionConfiguration should be non-null!");
+    ASSERT_NE_MSG(nil, sessionConfiguration, "FAILED: sessionConfiguration should be non-null!");
 
-    ASSERT_EQ_MSG(kTLSProtocol12,
+    EXPECT_EQ_MSG(kTLSProtocol12,
                   sessionConfiguration.TLSMaximumSupportedProtocol,
                   "FAILED: TLSMaximumSupportedProtocol should be %d",
                   kTLSProtocol12);
-    ASSERT_EQ_MSG(kTLSProtocol1,
+    EXPECT_EQ_MSG(kTLSProtocol1,
                   sessionConfiguration.TLSMinimumSupportedProtocol,
                   "FAILED: TLSMinimumSupportedProtocol should be %d",
                   kTLSProtocol1);
-    ASSERT_OBJCEQ_MSG(identifier, sessionConfiguration.identifier, "FAILED: identifier should be %d", identifier);
-    ASSERT_TRUE_MSG(sessionConfiguration.URLCache != NULL, "FAILED: URLCache should be non-null");
+    EXPECT_OBJCEQ_MSG(identifier, sessionConfiguration.identifier, "FAILED: identifier should be %d", identifier);
+    EXPECT_EQ_MSG(nil, sessionConfiguration.URLCache, "FAILED: URLCache should be nil for background sessions");
 }


### PR DESCRIPTION
Changes default values to match reference platform:
* timeoutIntervalForResource is in seconds, not days
* Contrary to the documentation, TLSMinimumSupportedProtocol is kTLSProtocol1, rather than KSSLProtocol3
* Background session configurations have no URLCache

Fixes #776 