### PR TITLE
Fix various test failures in NS*URLResponse

### DIFF
--- a/Frameworks/Foundation/NSHTTPURLResponse.mm
+++ b/Frameworks/Foundation/NSHTTPURLResponse.mm
@@ -85,7 +85,7 @@ static NSMutableDictionary* _constructCaseInsensitiveDictionary(NSDictionary* di
 
         // Parse the filename from the Content-Disposition header field.
         NSString* contentDisposition = [allHeaderFields objectForKey:@"Content-Disposition"];
-        NSRange filenameTagPosition = [contentDisposition rangeOfString:@"filename=" options:NSBackwardsSearch];
+        NSRange filenameTagPosition = [contentDisposition rangeOfString:@"filename=" options:0];
         NSCharacterSet* filenameEndDelimiter;
 
         if (filenameTagPosition.location != NSNotFound) {

--- a/Frameworks/Foundation/NSURLResponse.mm
+++ b/Frameworks/Foundation/NSURLResponse.mm
@@ -30,7 +30,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 @implementation NSURLResponse
 
-static NSString* const s_invalidFileNameChars = @"\\/:;*\"<>|?";
+static NSString* const s_invalidFileNameChars = @"\\/:*\"<>|?";
 static NSString* const s_unknownFileName = @"Unknown";
 static NSString* const s_defaultMimeType = @"application/octet-stream";
 static NSString* const s_NSExpectedContentLength = @"NS.expectedContentLength";

--- a/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
@@ -319,6 +319,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSObject_KeyValueObservationTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\ReferenceFoundation\TestNSNumberFormatter.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSCacheTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSURLResponseTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\ReferenceFoundation\TestNSPropertyList.mm" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/unittests/Foundation/NSURLResponseTests.mm
+++ b/tests/unittests/Foundation/NSURLResponseTests.mm
@@ -17,16 +17,6 @@
 #import <Foundation/Foundation.h>
 #import <TestFramework.h>
 
-// Swift behaviour here does not match OS X; OS X takes the first extension.
-// Matches NSHTTPURLResponse.SuggestedFilename_4
-TEST(NSHTTPURLResponse, SuggestedFilename_MultipleFilenamesInResponse_NonSwift) {
-    NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
-    auto f = @{ @"Content-Disposition" : @"attachment; aa=bb\\; filename=\"wrong.ext\"; filename=\"fname.ext\"; cc=dd" };
-    NSHTTPURLResponse* response =
-        [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
-    ASSERT_OBJCEQ(@"wrong.ext", response.suggestedFilename);
-}
-
 TEST(NSURLResponse, SuggestedFilename_MatchingMIME) {
     NSURL* url = [NSURL URLWithString:@"a/test/name.extension.txt"];
     NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];

--- a/tests/unittests/Foundation/NSURLResponseTests.mm
+++ b/tests/unittests/Foundation/NSURLResponseTests.mm
@@ -1,0 +1,65 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//****************************************************************************** 
+
+#import <Foundation/Foundation.h>
+#import <TestFramework.h>
+
+// Swift behaviour here does not match OS X; OS X takes the first extension.
+// Matches NSHTTPURLResponse.SuggestedFilename_4
+TEST(NSHTTPURLResponse, SuggestedFilename_MultipleFilenamesInResponse_NonSwift) {
+    NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
+    auto f = @{ @"Content-Disposition" : @"attachment; aa=bb\\; filename=\"wrong.ext\"; filename=\"fname.ext\"; cc=dd" };
+    NSHTTPURLResponse* response =
+        [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
+    ASSERT_OBJCEQ(@"wrong.ext", response.suggestedFilename);
+}
+
+TEST(NSURLResponse, SuggestedFilename_MatchingMIME) {
+    NSURL* url = [NSURL URLWithString:@"a/test/name.extension.txt"];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
+    ASSERT_OBJCEQ(@"name.extension.txt", res.suggestedFilename);
+}
+
+TEST(NSURLResponse, SuggestedFilename_QueryParameter_MatchingMIME) {
+    NSURL* url = [NSURL URLWithString:@"a/test/name.extension.txt?foo=bar"];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
+    ASSERT_OBJCEQ(@"name.extension.txt", res.suggestedFilename);
+}
+
+// These are the same tests as NSURLResponse, but with the isEqual: check removed
+// so that we can test the archival behaviour on OS X.
+// On OS X, NSURLResponse isEqual: only does a pointer comparison.
+TEST(NSURLResponse, CanBeArchivedWithoutFullFidelity) {
+    NSURLResponse* expected = [[[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"test"]
+                                                MIMEType:@"text/plain"
+                                                expectedContentLength:100
+                                                textEncodingName:@"utf8"] autorelease];
+
+    id data = nil;
+    EXPECT_NO_THROW(data = [NSKeyedArchiver archivedDataWithRootObject:expected]);
+    EXPECT_NO_THROW([NSKeyedUnarchiver unarchiveObjectWithData:data]);
+}
+
+TEST(NSHTTPURLResponse, CanBeArchivedWithoutFullFidelity) {
+    NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
+    auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
+    NSHTTPURLResponse* expected =
+        [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
+
+    id data = nil;
+    EXPECT_NO_THROW(data = [NSKeyedArchiver archivedDataWithRootObject:expected]);
+    EXPECT_NO_THROW([NSKeyedUnarchiver unarchiveObjectWithData:data]);
+}

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
@@ -83,13 +83,13 @@ OSX_DISABLED_TEST(NSURLResponse, SuggestedFilename) {
 }
 
 // Disabled pending GH#832; we do not respect the incoming MIME type when generating filenames. OS X does.
-OSX_DISABLED_TEST(NSURLResponse, SuggestedFilename_QueryParameter) {
+OSX_DISABLED_TEST(NSURLResponse, SuggestedFilename_2) {
     NSURL* url = [NSURL URLWithString:@"a/test/name.extension?foo=bar"];
     NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
     ASSERT_OBJCEQ(@"name.extension", res.suggestedFilename);
 }
 
-TEST(NSURLResponse, SuggestedFilename_NoFilename) {
+TEST(NSURLResponse, SuggestedFilename_3) {
     NSURL* url = [NSURL URLWithString:@"a://bar"];
     NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
     ASSERT_OBJCEQ(@"Unknown", res.suggestedFilename);
@@ -271,10 +271,11 @@ TEST(NSHTTPURLResponse, SuggestedFilename_3) {
     ASSERT_OBJCEQ(@";.ext", response.suggestedFilename);
 }
 
-// Swift behaviour here does not match OS X; OS X takes the first extension.
-OSX_DISABLED_TEST(NSHTTPURLResponse, SuggestedFilename_4) {
+// WINOBJC: Swift behaviour here does not match OS X; OS X takes the first extension.
+// The test has been updated with the correct behaviour.
+TEST(NSHTTPURLResponse, SuggestedFilename_4) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
-    auto f = @{ @"Content-Disposition" : @"attachment; aa=bb\\; filename=\"wrong.ext\"; filename=\"fname.ext\"; cc=dd" };
+    auto f = @{ @"Content-Disposition" : @"attachment; aa=bb\\; filename=\"fname.ext\"; filename=\"wrong.ext\"; cc=dd" };
     NSHTTPURLResponse* response =
         [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
     ASSERT_OBJCEQ(@"fname.ext", response.suggestedFilename);

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
@@ -239,7 +239,7 @@ TEST(NSHTTPURLResponse, ContentLength_withContentEncodingAndTransferEncoding_2) 
 // present in the filename-parm parameter.
 //
 
-TEST(NSHTTPURLResponse, SuggestedFilename_NotAvailable_1) {
+TEST(NSHTTPURLResponse, SuggestedFilename_notAvailable_1) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = [NSDictionary<NSString*, NSString*> dictionary];
     NSHTTPURLResponse* response =
@@ -247,7 +247,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_NotAvailable_1) {
     ASSERT_OBJCEQ(@"Unknown", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_NotAvailable_2) {
+TEST(NSHTTPURLResponse, SuggestedFilename_notAvailable_2) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"inline" };
     NSHTTPURLResponse* response =
@@ -255,7 +255,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_NotAvailable_2) {
     ASSERT_OBJCEQ(@"Unknown", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename) {
+TEST(NSHTTPURLResponse, SuggestedFilename_1) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\"fname.ext\"" };
     NSHTTPURLResponse* response =
@@ -263,7 +263,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename) {
     ASSERT_OBJCEQ(@"fname.ext", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_Unquoted) {
+TEST(NSHTTPURLResponse, SuggestedFilename_2) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=genome.jpeg; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\";" };
     NSHTTPURLResponse* response =
@@ -271,7 +271,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_Unquoted) {
     ASSERT_OBJCEQ(@"genome.jpeg", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_UnusualCharacter) {
+TEST(NSHTTPURLResponse, SuggestedFilename_3) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\";.ext\"" };
     NSHTTPURLResponse* response =
@@ -287,7 +287,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_MultipleFilenamesInResponse) {
     ASSERT_OBJCEQ(@"wrong.ext", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_InvalidSlashes1) {
+TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_1) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\"/a/b/name\"" };
     NSHTTPURLResponse* response =
@@ -295,7 +295,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_InvalidSlashes1) {
     ASSERT_OBJCEQ(@"_a_b_name", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_InvalidSlashes2) {
+TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_2) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\"a/../b/name\"" };
     NSHTTPURLResponse* response =
@@ -305,7 +305,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_InvalidSlashes2) {
 
 // The MIME type / character encoding
 
-TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Unspecified) {
+TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_1) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Server" : @"Apache" };
     NSHTTPURLResponse* response =
@@ -314,7 +314,7 @@ TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Unspecified) {
     ASSERT_OBJCEQ(nil, response.textEncodingName);
 }
 
-TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_MIMEOnly) {
+TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_2) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/html" };
     NSHTTPURLResponse* response =
@@ -323,7 +323,7 @@ TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_MIMEOnly) {
     ASSERT_OBJCEQ(nil, response.textEncodingName);
 }
 
-TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Both) {
+TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_3) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
     NSHTTPURLResponse* response =
@@ -333,7 +333,7 @@ TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Both) {
 }
 
 // Archival
-TEST(NSURLResponse, CanBeArchived) {
+TEST(NSURLResponse, canBeArchived) {
     NSURLResponse* expected = [[[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"test"]
                                                 MIMEType:@"text/plain"
                                                 expectedContentLength:100
@@ -344,7 +344,7 @@ TEST(NSURLResponse, CanBeArchived) {
     EXPECT_NO_THROW([NSKeyedUnarchiver unarchiveObjectWithData:data]);
 }
 
-TEST(NSHTTPURLResponse, CanBeArchived) {
+TEST(NSHTTPURLResponse, canBeArchived) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
     NSHTTPURLResponse* expected =

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
@@ -339,12 +339,37 @@ TEST(NSURLResponse, CanBeArchived) {
                                                 expectedContentLength:100
                                                 textEncodingName:@"utf8"] autorelease];
 
+    id data = nil;
+    EXPECT_NO_THROW(data = [NSKeyedArchiver archivedDataWithRootObject:expected]);
+    EXPECT_NO_THROW([NSKeyedUnarchiver unarchiveObjectWithData:data]);
+}
+
+TEST(NSHTTPURLResponse, CanBeArchived) {
+    NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
+    auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
+    NSHTTPURLResponse* expected =
+        [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
+
+    id data = nil;
+    EXPECT_NO_THROW(data = [NSKeyedArchiver archivedDataWithRootObject:expected]);
+    EXPECT_NO_THROW([NSKeyedUnarchiver unarchiveObjectWithData:data]);
+}
+
+// These are the same tests as above, with an additional check that the objects returned from unarchival
+// match the ones archived.
+// On the reference platform, NSURLResponse isEqual: only does a pointer comparison.
+OSX_DISABLED_TEST(NSURLResponse, CanBeArchivedWithFullFidelity) {
+    NSURLResponse* expected = [[[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"test"]
+                                                MIMEType:@"text/plain"
+                                                expectedContentLength:100
+                                                textEncodingName:@"utf8"] autorelease];
+
     id data = [NSKeyedArchiver archivedDataWithRootObject:expected];
     id actual = [NSKeyedUnarchiver unarchiveObjectWithData:data];
     ASSERT_OBJCEQ(expected, actual);
 }
 
-TEST(NSHTTPURLResponse, CanBeArchived) {
+OSX_DISABLED_TEST(NSHTTPURLResponse, CanBeArchivedWithFullFidelity) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
     NSHTTPURLResponse* expected =

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
@@ -265,12 +265,12 @@ TEST(NSHTTPURLResponse, SuggestedFilename_3) {
     ASSERT_OBJCEQ(@"_.ext", response.suggestedFilename); // Differs from reference platform because ; is an illegal filename character
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_4) {
+TEST(NSHTTPURLResponse, SuggestedFilename_MultipleFilenamesInResponse) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; aa=bb\\; filename=\"wrong.ext\"; filename=\"fname.ext\"; cc=dd" };
     NSHTTPURLResponse* response =
         [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
-    ASSERT_OBJCEQ(@"fname.ext", response.suggestedFilename);
+    ASSERT_OBJCEQ(@"wrong.ext", response.suggestedFilename);
 }
 
 TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_1) {

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
@@ -225,7 +225,7 @@ TEST(NSHTTPURLResponse, ContentLength_withContentEncodingAndTransferEncoding_2) 
 // present in the filename-parm parameter.
 //
 
-TEST(NSHTTPURLResponse, SuggestedFilename_notAvailable_1) {
+TEST(NSHTTPURLResponse, SuggestedFilename_NotAvailable_1) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = [NSDictionary<NSString*, NSString*> dictionary];
     NSHTTPURLResponse* response =
@@ -233,7 +233,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_notAvailable_1) {
     ASSERT_OBJCEQ(@"Unknown", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_notAvailable_2) {
+TEST(NSHTTPURLResponse, SuggestedFilename_NotAvailable_2) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"inline" };
     NSHTTPURLResponse* response =
@@ -241,7 +241,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_notAvailable_2) {
     ASSERT_OBJCEQ(@"Unknown", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_1) {
+TEST(NSHTTPURLResponse, SuggestedFilename) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\"fname.ext\"" };
     NSHTTPURLResponse* response =
@@ -249,7 +249,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_1) {
     ASSERT_OBJCEQ(@"fname.ext", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_2) {
+TEST(NSHTTPURLResponse, SuggestedFilename_Unquoted) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=genome.jpeg; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\";" };
     NSHTTPURLResponse* response =
@@ -257,7 +257,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_2) {
     ASSERT_OBJCEQ(@"genome.jpeg", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_3) {
+TEST(NSHTTPURLResponse, SuggestedFilename_UnusualCharacter) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\";.ext\"" };
     NSHTTPURLResponse* response =
@@ -273,7 +273,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_MultipleFilenamesInResponse) {
     ASSERT_OBJCEQ(@"wrong.ext", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_1) {
+TEST(NSHTTPURLResponse, SuggestedFilename_InvalidSlashes1) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\"/a/b/name\"" };
     NSHTTPURLResponse* response =
@@ -281,7 +281,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_1) {
     ASSERT_OBJCEQ(@"_a_b_name", response.suggestedFilename);
 }
 
-TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_2) {
+TEST(NSHTTPURLResponse, SuggestedFilename_InvalidSlashes2) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\"a/../b/name\"" };
     NSHTTPURLResponse* response =
@@ -291,7 +291,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_removeSlashes_2) {
 
 // The MIME type / character encoding
 
-TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_1) {
+TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Unspecified) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Server" : @"Apache" };
     NSHTTPURLResponse* response =
@@ -300,7 +300,7 @@ TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_1) {
     ASSERT_OBJCEQ(nil, response.textEncodingName);
 }
 
-TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_2) {
+TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_MIMEOnly) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/html" };
     NSHTTPURLResponse* response =
@@ -309,7 +309,7 @@ TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_2) {
     ASSERT_OBJCEQ(nil, response.textEncodingName);
 }
 
-TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_3) {
+TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Both) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
     NSHTTPURLResponse* response =
@@ -319,7 +319,7 @@ TEST(NSHTTPURLResponse, mimetypeAndCharacterEncoding_3) {
 }
 
 // Archival
-TEST(NSURLResponse, canBeArchived) {
+TEST(NSURLResponse, CanBeArchived) {
     NSURLResponse* expected = [[[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"test"]
                                                 MIMEType:@"txt"
                                                 expectedContentLength:100
@@ -330,7 +330,7 @@ TEST(NSURLResponse, canBeArchived) {
     ASSERT_OBJCEQ(expected, actual);
 }
 
-TEST(NSHTTPURLResponse, canBeArchived) {
+TEST(NSHTTPURLResponse, CanBeArchived) {
     NSURL* url = [NSURL URLWithString:@"https://www.swift.org"];
     auto f = @{ @"Content-Type" : @"text/HTML; charset=ISO-8859-4" };
     NSHTTPURLResponse* expected =

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSURLResponse.mm
@@ -27,7 +27,7 @@
 
 TEST(NSURLResponse, URL) {
     NSURL* url = [NSURL URLWithString:@"a/test/path"];
-    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"txt" expectedContentLength:0 textEncodingName:nil] autorelease];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
     ASSERT_OBJCEQ_MSG(url, res.URL, @"should be the expected url");
 }
 
@@ -71,21 +71,35 @@ TEST(NSURLResponse, TextEncodingName) {
     ASSERT_OBJCEQ(nil, res2.textEncodingName);
 }
 
-TEST(NSURLResponse, SuggestedFilename) {
+// Disabled pending GH#832; we do not respect the incoming MIME type when generating filenames. OS X does.
+OSX_DISABLED_TEST(NSURLResponse, SuggestedFilename) {
     NSURL* url = [NSURL URLWithString:@"a/test/name.extension"];
-    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"txt" expectedContentLength:0 textEncodingName:nil] autorelease];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
     ASSERT_OBJCEQ(@"name.extension", res.suggestedFilename);
 }
 
-TEST(NSURLResponse, SuggestedFilename_2) {
+// Disabled pending GH#832; we do not respect the incoming MIME type when generating filenames. OS X does.
+OSX_DISABLED_TEST(NSURLResponse, SuggestedFilename_QueryParameter) {
     NSURL* url = [NSURL URLWithString:@"a/test/name.extension?foo=bar"];
-    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"txt" expectedContentLength:0 textEncodingName:nil] autorelease];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
     ASSERT_OBJCEQ(@"name.extension", res.suggestedFilename);
 }
 
-TEST(NSURLResponse, SuggestedFilename_3) {
+TEST(NSURLResponse, SuggestedFilename_MatchingMIME) {
+    NSURL* url = [NSURL URLWithString:@"a/test/name.extension.txt"];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
+    ASSERT_OBJCEQ(@"name.extension.txt", res.suggestedFilename);
+}
+
+TEST(NSURLResponse, SuggestedFilename_QueryParameter_MatchingMIME) {
+    NSURL* url = [NSURL URLWithString:@"a/test/name.extension.txt?foo=bar"];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
+    ASSERT_OBJCEQ(@"name.extension.txt", res.suggestedFilename);
+}
+
+TEST(NSURLResponse, SuggestedFilename_NoFilename) {
     NSURL* url = [NSURL URLWithString:@"a://bar"];
-    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"txt" expectedContentLength:0 textEncodingName:nil] autorelease];
+    NSURLResponse* res = [[[NSURLResponse alloc] initWithURL:url MIMEType:@"text/plain" expectedContentLength:0 textEncodingName:nil] autorelease];
     ASSERT_OBJCEQ(@"Unknown", res.suggestedFilename);
 }
 
@@ -262,7 +276,7 @@ TEST(NSHTTPURLResponse, SuggestedFilename_UnusualCharacter) {
     auto f = @{ @"Content-Disposition" : @"attachment; filename=\";.ext\"" };
     NSHTTPURLResponse* response =
         [[[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:f] autorelease];
-    ASSERT_OBJCEQ(@"_.ext", response.suggestedFilename); // Differs from reference platform because ; is an illegal filename character
+    ASSERT_OBJCEQ(@";.ext", response.suggestedFilename);
 }
 
 TEST(NSHTTPURLResponse, SuggestedFilename_MultipleFilenamesInResponse) {
@@ -321,7 +335,7 @@ TEST(NSHTTPURLResponse, MIMETypeAndCharacterEncoding_Both) {
 // Archival
 TEST(NSURLResponse, CanBeArchived) {
     NSURLResponse* expected = [[[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"test"]
-                                                MIMEType:@"txt"
+                                                MIMEType:@"text/plain"
                                                 expectedContentLength:100
                                                 textEncodingName:@"utf8"] autorelease];
 


### PR DESCRIPTION
* For NS*URLResponse, add parallel archival tests that work on OS X but don't use isEqual:. Fixes #780.
* Fix the NS*URLResponse suggested filename tests and regressions.

    `;` is a valid filename character on Windows, and it is valid on OS X.
Fixes #781.

    All our suggested filename tests had invalid MIME types. Now that they
are valid, we've been revealed to be ignoring it. Ref #832.

* Fix the NSURLResponse test names.
* The reference platform takes the _first_ filename from Disposition. Match it.
Ref #781.
