### PR TITLE
Fix NSCalendar tests that fail on OSX

### DIFF
--- a/Frameworks/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/Frameworks/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -744,14 +744,14 @@ static CFRange __CFCalendarGetRangeOfUnit2(CFCalendarRef calendar, CFCalendarUni
             }
         break;
     // WINOBJC: Add cases for weekOf units. ICU will handle them below.
-    case kCFCalendarUnitWeekOfYear:
     case kCFCalendarUnitWeekOfMonth:
-    // WINOBJC: Asking for the range of WeekOfMonth in Year always returns 6.
+        // WINOBJC: Asking for the range of WeekOfMonth in Year always returns 6.
         if (biggerUnit == kCFCalendarUnitYear) {
             range.location = 1;
             range.length = 6;
             break;
         }
+    case kCFCalendarUnitWeekOfYear:
     case kCFCalendarUnitWeek:
             switch (biggerUnit) {
             case kCFCalendarUnitMonth:

--- a/Frameworks/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/Frameworks/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -746,6 +746,12 @@ static CFRange __CFCalendarGetRangeOfUnit2(CFCalendarRef calendar, CFCalendarUni
     // WINOBJC: Add cases for weekOf units. ICU will handle them below.
     case kCFCalendarUnitWeekOfYear:
     case kCFCalendarUnitWeekOfMonth:
+    // WINOBJC: Asking for the range of WeekOfMonth in Year always returns 6.
+        if (biggerUnit == kCFCalendarUnitYear) {
+            range.location = 1;
+            range.length = 6;
+            break;
+        }
     case kCFCalendarUnitWeek:
             switch (biggerUnit) {
             case kCFCalendarUnitMonth:
@@ -961,6 +967,13 @@ Boolean _CFCalendarAddComponentsV(CFCalendarRef calendar, /* inout */ CFAbsolute
     ucal_setMillis(calendar->_cal, udate, &status);
     char ch = *componentDesc;
     while (ch) {
+        // WINOBJC: ICU function ucal_add does not accept Nanoseconds. Skip this component as it causes failure.
+        if (ch == '#') {
+            vector++;
+            componentDesc++;
+            ch = *componentDesc;
+            continue;
+        }
         UCalendarDateFields field = __CFCalendarGetICUFieldCodeFromChar(ch);
             int amount = *vector;
         if (options & kCFCalendarComponentsWrap) {

--- a/Frameworks/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/Frameworks/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -744,14 +744,8 @@ static CFRange __CFCalendarGetRangeOfUnit2(CFCalendarRef calendar, CFCalendarUni
             }
         break;
     // WINOBJC: Add cases for weekOf units. ICU will handle them below.
-    case kCFCalendarUnitWeekOfMonth:
-        // WINOBJC: Asking for the range of WeekOfMonth in Year always returns 6.
-        if (biggerUnit == kCFCalendarUnitYear) {
-            range.location = 1;
-            range.length = 6;
-            break;
-        }
     case kCFCalendarUnitWeekOfYear:
+    case kCFCalendarUnitWeekOfMonth:
     case kCFCalendarUnitWeek:
             switch (biggerUnit) {
             case kCFCalendarUnitMonth:
@@ -782,6 +776,7 @@ static CFRange __CFCalendarGetRangeOfUnit2(CFCalendarRef calendar, CFCalendarUni
     }
     return range;
 
+    // TODO 8463791 : rangeOfUnit can return incorrect results
     calculate:;
     ucal_clear(calendar->_cal);
     UCalendarDateFields smallField = __CFCalendarGetICUFieldCode(smallerUnit);

--- a/tests/frameworks/include/TestFramework.h
+++ b/tests/frameworks/include/TestFramework.h
@@ -121,6 +121,39 @@
                             }())
 #endif
 
+// Macros to disable tests only for the WIN32 platform. This is for ensuring our tests match the reference platform's behavior
+// even if our tests do not. Another use case is validating tests and assumptions before our own implementation.
+#if TARGET_OS_WIN32
+
+#define WIN32_DISABLED_TEST(category, testName) DISABLED_TEST(category, testName)
+#define WIN32_DISABLED_TEST_F(category, testName) DISABLED_TEST_F(category, testName)
+#define WIN32_DISABLED_INSTANTIATE_TEST_CASE_P(instantiationName, testClass, values, disabledValues) \
+    DISABLED_INSTANTIATE_TEST_CASE_P(instantiationName, testClass, values, disabledValues)
+
+#else
+
+#define WIN32_DISABLED_TEST(category, testName) TEST(category, testName)
+#define WIN32_DISABLED_TEST_F(category, testName) TEST_F(category, testName)
+#define WIN32_DISABLED_INSTANTIATE_TEST_CASE_P(instantiationName, testClass, values, disabledValues)                \
+    INSTANTIATE_TEST_CASE_P(instantiationName,                                                                      \
+                            testClass,                                                                              \
+                            []() {                                                                                  \
+                                ::testing::internal::ParamGenerator<testClass::ParamType> values1 = values;         \
+                                ::testing::internal::ParamGenerator<testClass::ParamType> values2 = disabledValues; \
+                                std::vector<testClass::ParamType> combined;                                         \
+                                for (const auto& item : values1) {                                                  \
+                                    combined.push_back(item);                                                       \
+                                }                                                                                   \
+                                                                                                                    \
+                                for (const auto& item : values2) {                                                  \
+                                    combined.push_back(item);                                                       \
+                                }                                                                                   \
+                                                                                                                    \
+                                return ::testing::ValuesIn(combined);                                               \
+                                                                                                                    \
+                            }())
+#endif
+
 // OSX defines for compatibility
 #ifndef boolean
 #define boolean Boolean

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -492,10 +492,6 @@ TEST(NSCalendar, NSRangeValidation) {
     range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitMonth forDate:expectedDate];
     ASSERT_EQ(range.location, 1);
     ASSERT_EQ(range.length, 5);
-
-    range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:expectedDate];
-    ASSERT_EQ(range.location, 1);
-    ASSERT_EQ(range.length, 6);
 }
 
 ARM_DISABLED_TEST(NSCalendar, BadMatchingOptions) {
@@ -530,4 +526,18 @@ OSX_DISABLED_TEST(NSCalendar, NanoSecondComparison) {
     NSDate* date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:.9];
     ASSERT_EQ([calendar compareDate:date1 toDate:date2 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedAscending);
     ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
+}
+
+DISABLED_TEST(NSCalendar, rangeOfWeekOfMonthTest) {
+    // TODO 8463791 : rangeOfUnit can return incorrect results
+    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    NSDate* expectedDate = [calendar dateWithEra:1 year:2016 month:7 day:1 hour:0 minute:0 second:0 nanosecond:0];
+
+    NSRange range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:expectedDate];
+    EXPECT_EQ(range.location, 1);
+    EXPECT_EQ(range.length, 6);
+
+    range = [calendar rangeOfUnit:NSCalendarUnitWeekOfYear inUnit:NSCalendarUnitMonth forDate:expectedDate];
+    EXPECT_EQ(range.location, 27);
+    EXPECT_EQ(range.length, 6);
 }

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -46,9 +46,10 @@ TEST(NSCalendar, GetDates) {
 
     // Find all leap days going backwards
     dateCount = 0;
+
     [calendar enumerateDatesStartingAfterDate:[NSDate dateWithTimeIntervalSinceReferenceDate:0]
                            matchingComponents:leapYearComponents
-                                      options:NSCalendarSearchBackwards
+                                      options:NSCalendarSearchBackwards | NSCalendarMatchStrictly
                                    usingBlock:^(NSDate* date, BOOL exactMatch, BOOL* stop) {
                                        NSString* result = [dateFormatter stringFromDate:date];
                                        ASSERT_OBJCEQ([result substringWithRange:NSMakeRange(0, 6)], @"Feb 29");
@@ -236,10 +237,6 @@ TEST(NSCalendar, CompareDates) {
     ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
 
     date1 = [NSDate dateWithTimeIntervalSinceReferenceDate:.1];
-    date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:.9];
-    ASSERT_EQ([calendar compareDate:date1 toDate:date2 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedAscending);
-    ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
-
     date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:.1];
     ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedSame);
 
@@ -338,12 +335,6 @@ TEST(NSCalendar, PreserveSmallerUnitsMatching) {
 
     ASSERT_OBJCEQ(expectedDate, actualDate);
 
-    components.day = 29;
-    actualDate = [calendar nextDateAfterDate:date matchingComponents:components options:NSCalendarMatchNextTimePreservingSmallerUnits];
-    expectedDate = [calendar dateWithEra:1 year:2012 month:2 day:29 hour:3 minute:4 second:5 nanosecond:0];
-
-    ASSERT_OBJCEQ(expectedDate, actualDate);
-
     date = [calendar dateWithEra:1 year:1999 month:5 day:1 hour:0 minute:0 second:0 nanosecond:0];
     components.day = 1;
     components.month = 5;
@@ -400,12 +391,12 @@ TEST(NSCalendar, weekOfUnitMatching) {
 
     date = [calendar dateWithEra:1 year:2000 month:1 day:1 hour:0 minute:0 second:0 nanosecond:0];
     actualDate = [calendar nextDateAfterDate:date matchingComponents:components options:NSCalendarMatchStrictly];
-    expectedDate = [calendar dateWithEra:1 year:2000 month:2 day:5 hour:0 minute:0 second:0 nanosecond:0];
+    expectedDate = [calendar dateWithEra:1 year:2000 month:1 day:30 hour:0 minute:0 second:0 nanosecond:0];
 
     ASSERT_OBJCEQ(expectedDate, actualDate);
 
     actualDate = [calendar nextDateAfterDate:expectedDate matchingComponents:components options:NSCalendarMatchStrictly];
-    expectedDate = [calendar dateWithEra:1 year:2001 month:2 day:10 hour:0 minute:0 second:0 nanosecond:0];
+    expectedDate = [calendar dateWithEra:1 year:2001 month:2 day:4 hour:0 minute:0 second:0 nanosecond:0];
 
     ASSERT_OBJCEQ(expectedDate, actualDate);
 
@@ -481,15 +472,69 @@ TEST(NSCalendar, NSRangeValidation) {
     NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     NSDate* expectedDate = [calendar dateWithEra:1 year:2010 month:3 day:31 hour:0 minute:0 second:0 nanosecond:0];
 
-    NSRange range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:expectedDate];
-    ASSERT_EQ(range.location, 1);
-    ASSERT_EQ(range.length, 5);
-
-    range = [calendar rangeOfUnit:NSCalendarUnitWeekOfYear inUnit:NSCalendarUnitMonth forDate:expectedDate];
+    NSRange range = [calendar rangeOfUnit:NSCalendarUnitWeekOfYear inUnit:NSCalendarUnitMonth forDate:expectedDate];
     ASSERT_EQ(range.location, 10);
     ASSERT_EQ(range.length, 5);
 
     range = [calendar rangeOfUnit:NSCalendarUnitHour inUnit:NSCalendarUnitWeekOfMonth forDate:expectedDate];
     ASSERT_EQ(range.location, 0);
     ASSERT_EQ(range.length, 24);
+}
+
+TEST(NSCalendar, BadMatchingOptions) {
+    @try {
+        NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+
+        // January 1st 2010
+        NSDate* constantDate = [calendar dateWithEra:1 year:2010 month:1 day:1 hour:0 minute:0 second:0 nanosecond:0];
+        // January 2nd 2010
+        NSDate* expectedNextDay = [calendar dateWithEra:1 year:2010 month:1 day:2 hour:0 minute:0 second:0 nanosecond:0];
+
+        NSDateComponents* comps = [[NSDateComponents alloc] init];
+        comps.day = 2;
+
+        // No matching options
+        NSDate* date = [calendar nextDateAfterDate:constantDate matchingComponents:comps options:0];
+
+        ASSERT_TRUE_MSG(false, "Should not have gotten here. nextDateAfterDate should throw an INVALID_ARG exception");
+    } @catch (NSException* e) {
+        ASSERT_OBJCEQ(e.name, @"NSInvalidArgumentException");
+    }
+}
+
+OSX_DISABLED_TEST(NSCalendar, DisabledCalendarTests) {
+    // Nanosecond comparison is disabled on OSX as the behavior does not match the documentation. Nanosecond comparison will
+    // always return NSOrderedSame if the two dates are within the same second of each other. Thus, even though the two
+    // nanosecond values below are different, OSX will return that this comparison to the granularity of Nanoseconds will
+    // is the same.
+
+    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    NSDate* date1 = [NSDate dateWithTimeIntervalSinceReferenceDate:.1];
+    NSDate* date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:.9];
+    ASSERT_EQ([calendar compareDate:date1 toDate:date2 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedAscending);
+    ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
+
+    // Retrieving the range of a WeekOfMonth unit should return the number of weeks within the month for that date.
+    // The behavior on OSX however, is that the returned range is always 6 weeks regardless of the actual number of
+    // weeks in the given month.
+
+    NSDate* date = [calendar dateWithEra:1 year:2010 month:3 day:31 hour:3 minute:4 second:5 nanosecond:0];
+    NSRange range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:date];
+    ASSERT_EQ(range.location, 1);
+    ASSERT_EQ(range.length, 5);
+
+    // NSCalendarMatchNextTimePreservingSmallerUnits as a matching option does not reflect the documentation accurately.
+    // When matching a date, this option should preserve all smaller values when finding the next date. The behavior on OSX
+    // has instead stripped the date of these smaller values. The date matched from OSX is 2/29/2012 00:00:00 when it should be
+    // 2/29/2012 03:04:05. Thus, this test is disabled.
+
+    NSDateComponents* components = [[[NSDateComponents alloc] init] autorelease];
+    components.day = 29;
+
+    date = [calendar dateWithEra:1 year:2012 month:2 day:20 hour:3 minute:4 second:5 nanosecond:0];
+    NSDate* actualDate =
+        [calendar nextDateAfterDate:date matchingComponents:components options:NSCalendarMatchNextTimePreservingSmallerUnits];
+    NSDate* expectedDate = [calendar dateWithEra:1 year:2012 month:2 day:29 hour:3 minute:4 second:5 nanosecond:0];
+
+    ASSERT_OBJCEQ(expectedDate, actualDate);
 }

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -494,25 +494,19 @@ TEST(NSCalendar, NSRangeValidation) {
     ASSERT_EQ(range.length, 5);
 }
 
-ARM_DISABLED_TEST(NSCalendar, BadMatchingOptions) {
-    @try {
-        NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+TEST(NSCalendar, BadMatchingOptions) {
+    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
 
-        // January 1st 2010
-        NSDate* constantDate = [calendar dateWithEra:1 year:2010 month:1 day:1 hour:0 minute:0 second:0 nanosecond:0];
-        // January 2nd 2010
-        NSDate* expectedNextDay = [calendar dateWithEra:1 year:2010 month:1 day:2 hour:0 minute:0 second:0 nanosecond:0];
+    // January 1st 2010
+    NSDate* constantDate = [calendar dateWithEra:1 year:2010 month:1 day:1 hour:0 minute:0 second:0 nanosecond:0];
+    // January 2nd 2010
+    NSDate* expectedNextDay = [calendar dateWithEra:1 year:2010 month:1 day:2 hour:0 minute:0 second:0 nanosecond:0];
 
-        NSDateComponents* comps = [[NSDateComponents alloc] init];
-        comps.day = 2;
+    NSDateComponents* comps = [[NSDateComponents alloc] init];
+    comps.day = 2;
 
-        // No matching options
-        NSDate* date = [calendar nextDateAfterDate:constantDate matchingComponents:comps options:0];
-
-        ASSERT_TRUE_MSG(false, "Should not have gotten here. nextDateAfterDate should throw an INVALID_ARG exception");
-    } @catch (NSException* e) {
-        ASSERT_OBJCEQ(e.name, @"NSInvalidArgumentException");
-    }
+    // No matching options should throw.
+    EXPECT_ANY_THROW(NSDate* date = [calendar nextDateAfterDate:constantDate matchingComponents:comps options:0]);
 }
 
 OSX_DISABLED_TEST(NSCalendar, NanoSecondComparison) {
@@ -528,7 +522,7 @@ OSX_DISABLED_TEST(NSCalendar, NanoSecondComparison) {
     ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
 }
 
-DISABLED_TEST(NSCalendar, rangeOfWeekOfMonthTest) {
+WIN32_DISABLED_TEST(NSCalendar, RangeOfWeekOfMonthTest) {
     // TODO 8463791 : rangeOfUnit can return incorrect results
     NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     NSDate* expectedDate = [calendar dateWithEra:1 year:2016 month:7 day:1 hour:0 minute:0 second:0 nanosecond:0];

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -348,6 +348,15 @@ TEST(NSCalendar, PreserveSmallerUnitsMatching) {
     expectedDate = [calendar dateWithEra:1 year:2001 month:5 day:1 hour:0 minute:0 second:0 nanosecond:0];
 
     ASSERT_OBJCEQ(expectedDate, actualDate);
+
+    components = [[[NSDateComponents alloc] init] autorelease];
+    components.day = 29;
+
+    date = [calendar dateWithEra:1 year:2012 month:2 day:20 hour:3 minute:4 second:5 nanosecond:0];
+    actualDate = [calendar nextDateAfterDate:date matchingComponents:components options:NSCalendarMatchNextTimePreservingSmallerUnits];
+    expectedDate = [calendar dateWithEra:1 year:2012 month:2 day:29 hour:0 minute:0 second:0 nanosecond:0];
+
+    ASSERT_OBJCEQ(expectedDate, actualDate);
 }
 
 TEST(NSCalendar, weekOfUnitMatching) {
@@ -479,9 +488,17 @@ TEST(NSCalendar, NSRangeValidation) {
     range = [calendar rangeOfUnit:NSCalendarUnitHour inUnit:NSCalendarUnitWeekOfMonth forDate:expectedDate];
     ASSERT_EQ(range.location, 0);
     ASSERT_EQ(range.length, 24);
+
+    range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitMonth forDate:expectedDate];
+    ASSERT_EQ(range.location, 1);
+    ASSERT_EQ(range.length, 5);
+
+    range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:expectedDate];
+    ASSERT_EQ(range.location, 1);
+    ASSERT_EQ(range.length, 6);
 }
 
-TEST(NSCalendar, BadMatchingOptions) {
+ARM_DISABLED_TEST(NSCalendar, BadMatchingOptions) {
     @try {
         NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
 
@@ -513,34 +530,4 @@ OSX_DISABLED_TEST(NSCalendar, NanoSecondComparison) {
     NSDate* date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:.9];
     ASSERT_EQ([calendar compareDate:date1 toDate:date2 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedAscending);
     ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
-}
-
-OSX_DISABLED_TEST(NSCalendar, RangeOfWeekOfMonth) {
-    // Retrieving the range of a WeekOfMonth unit should return the number of weeks within the month for that date.
-    // The behavior on OSX however, is that the returned range is always 6 weeks regardless of the actual number of
-    // weeks in the given month.
-
-    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
-    NSDate* date = [calendar dateWithEra:1 year:2010 month:3 day:31 hour:3 minute:4 second:5 nanosecond:0];
-    NSRange range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:date];
-    ASSERT_EQ(range.location, 1);
-    ASSERT_EQ(range.length, 5);
-}
-
-OSX_DISABLED_TEST(NSCalendar, NSCalendarMatchNextTimePreservingSmallerUnitsLeapDay) {
-    // NSCalendarMatchNextTimePreservingSmallerUnits as a matching option does not reflect the documentation accurately.
-    // When matching a date, this option should preserve all smaller values when finding the next date. The behavior on OSX
-    // has instead stripped the date of these smaller values. The date matched from OSX is 2/29/2012 00:00:00 when it should be
-    // 2/29/2012 03:04:05. Thus, this test is disabled.
-
-    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
-    NSDateComponents* components = [[[NSDateComponents alloc] init] autorelease];
-    components.day = 29;
-
-    NSDate* startingDate = [calendar dateWithEra:1 year:2012 month:2 day:20 hour:3 minute:4 second:5 nanosecond:0];
-    NSDate* actualDate =
-        [calendar nextDateAfterDate:startingDate matchingComponents:components options:NSCalendarMatchNextTimePreservingSmallerUnits];
-    NSDate* expectedDate = [calendar dateWithEra:1 year:2012 month:2 day:29 hour:3 minute:4 second:5 nanosecond:0];
-
-    ASSERT_OBJCEQ(expectedDate, actualDate);
 }

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -502,7 +502,7 @@ TEST(NSCalendar, BadMatchingOptions) {
     }
 }
 
-OSX_DISABLED_TEST(NSCalendar, DisabledCalendarTests) {
+OSX_DISABLED_TEST(NSCalendar, NanoSecondComparison) {
     // Nanosecond comparison is disabled on OSX as the behavior does not match the documentation. Nanosecond comparison will
     // always return NSOrderedSame if the two dates are within the same second of each other. Thus, even though the two
     // nanosecond values below are different, OSX will return that this comparison to the granularity of Nanoseconds will
@@ -513,27 +513,33 @@ OSX_DISABLED_TEST(NSCalendar, DisabledCalendarTests) {
     NSDate* date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:.9];
     ASSERT_EQ([calendar compareDate:date1 toDate:date2 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedAscending);
     ASSERT_EQ([calendar compareDate:date2 toDate:date1 toUnitGranularity:NSCalendarUnitNanosecond], NSOrderedDescending);
+}
 
+OSX_DISABLED_TEST(NSCalendar, RangeOfWeekOfMonth) {
     // Retrieving the range of a WeekOfMonth unit should return the number of weeks within the month for that date.
     // The behavior on OSX however, is that the returned range is always 6 weeks regardless of the actual number of
     // weeks in the given month.
 
+    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     NSDate* date = [calendar dateWithEra:1 year:2010 month:3 day:31 hour:3 minute:4 second:5 nanosecond:0];
     NSRange range = [calendar rangeOfUnit:NSCalendarUnitWeekOfMonth inUnit:NSCalendarUnitYear forDate:date];
     ASSERT_EQ(range.location, 1);
     ASSERT_EQ(range.length, 5);
+}
 
+OSX_DISABLED_TEST(NSCalendar, NSCalendarMatchNextTimePreservingSmallerUnitsLeapDay) {
     // NSCalendarMatchNextTimePreservingSmallerUnits as a matching option does not reflect the documentation accurately.
     // When matching a date, this option should preserve all smaller values when finding the next date. The behavior on OSX
     // has instead stripped the date of these smaller values. The date matched from OSX is 2/29/2012 00:00:00 when it should be
     // 2/29/2012 03:04:05. Thus, this test is disabled.
 
+    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents* components = [[[NSDateComponents alloc] init] autorelease];
     components.day = 29;
 
-    date = [calendar dateWithEra:1 year:2012 month:2 day:20 hour:3 minute:4 second:5 nanosecond:0];
+    NSDate* startingDate = [calendar dateWithEra:1 year:2012 month:2 day:20 hour:3 minute:4 second:5 nanosecond:0];
     NSDate* actualDate =
-        [calendar nextDateAfterDate:date matchingComponents:components options:NSCalendarMatchNextTimePreservingSmallerUnits];
+        [calendar nextDateAfterDate:startingDate matchingComponents:components options:NSCalendarMatchNextTimePreservingSmallerUnits];
     NSDate* expectedDate = [calendar dateWithEra:1 year:2012 month:2 day:29 hour:3 minute:4 second:5 nanosecond:0];
 
     ASSERT_OBJCEQ(expectedDate, actualDate);


### PR DESCRIPTION
Fixes #744

NSCalendar Tests have some failures as well as some unexpected behavior.
Some of the tests actually produce the correct results as described in the
documentation despite OSX actually producing incorrect results. These are
when the nanoseconds of two dates are compared using a calendar, when using
a matching flag that preserves smaller units when matching a leap date such as
February 29th, as well as the range of weeks in months always returning 6
despite not every month having 6 weeks.

These tests have been disabled for OSX.