### PR TITLE
NSString/StringsFormatPropertyList tests fail on OSX

### DIFF
--- a/tests/unittests/Foundation/NSStringTests.m
+++ b/tests/unittests/Foundation/NSStringTests.m
@@ -596,11 +596,8 @@ TEST(NSString, Exceptions) {
     EXPECT_ANY_THROW([(NSMutableString*)immutableFormattedString replaceCharactersInRange:range withString:@"boom"]);
 }
 
-class StringsFormatPropertyList : public ::testing::TestWithParam<const wchar_t*> {};
-
-TEST_P(StringsFormatPropertyList, CanDeserialize) {
-    const wchar_t* data = GetParam();
-    NSString* string = [NSString stringWithCharacters:(const unichar*)data length:wcslen(data)];
+TEST(NSString, StringsFormatPropertyList) {
+    NSString* string = @"key1=value1;\n\"key2\"=\"value2\";";
 
     ASSERT_OBJCNE(nil, string);
 
@@ -611,9 +608,3 @@ TEST_P(StringsFormatPropertyList, CanDeserialize) {
     ASSERT_OBJCEQ(@"value1", propertyList[@"key1"]);
     ASSERT_OBJCEQ(@"value2", propertyList[@"key2"]);
 }
-
-INSTANTIATE_TEST_CASE_P(NSString,
-                        StringsFormatPropertyList,
-                        ::testing::Values(L"\uFEFFkey1=value1;\n\"key2\"=\"value2\";", // BOM
-                                          L"key1=value1;\n\"key2\"=\"value2\";" // No BOM
-                                          ));


### PR DESCRIPTION
[----------] 2 tests from NSString/StringsFormatPropertyList
[ RUN      ] NSString/StringsFormatPropertyList.CanDeserialize/0
unknown file: Failure
Unknown C++ exception thrown in the test body.
[  FAILED  ] NSString/StringsFormatPropertyList.CanDeserialize/0, where GetParam() = L"\xFEFFkey1=value1;\n\"key2\"=\"value2\";" (0 ms)
[ RUN      ] NSString/StringsFormatPropertyList.CanDeserialize/1
Foundation/NSStringTests.m:611: Failure
Value of: propertyList[@"key1"]
  Actual: NULL
Expected: @"value1"
Which is: value1
[  FAILED  ] NSString/StringsFormatPropertyList.CanDeserialize/1, where GetParam() = L"key1=value1;\n\"key2\"=\"value2\";" (0 ms)
[----------] 2 tests from NSString/StringsFormatPropertyList (1 ms total)