### PR TITLE
NSBundle tests fail on OSX (WinObjC implementation details?)

### DIFF
--- a/Frameworks/Logging/LoggingNative.cpp
+++ b/Frameworks/Logging/LoggingNative.cpp
@@ -33,10 +33,10 @@ std::mutex s_isRegisteredMutex;
 
 // TODO: WIL logging hook
 // This is where we store the WIL hook
-//namespace wil {
-//namespace details {
+// namespace wil {
+// namespace details {
 //
-//void(__stdcall* g_pfnLoggingCallback)(wil::FailureInfo const& failure) WI_NOEXCEPT;
+// void(__stdcall* g_pfnLoggingCallback)(wil::FailureInfo const& failure) WI_NOEXCEPT;
 //
 //}
 //}
@@ -77,7 +77,7 @@ void TraceCritical(const wchar_t* tag, const wchar_t* format, ...) {
 }
 
 // TODO: WIL logging hook
-//void __stdcall _wilLoggingCallback(wil::FailureInfo const& failure) {
+// void __stdcall _wilLoggingCallback(wil::FailureInfo const& failure) {
 //    wchar_t debugString[2048];
 //    wil::GetFailureLogString(debugString, _countof(debugString), failure);
 //    TraceVerbose(L"WIL", debugString);
@@ -90,7 +90,7 @@ void TraceRegister() {
     }
 
     // TODO: WIL logging hook
-    //if (wil::details::g_pfnLoggingCallback == nullptr) {
+    // if (wil::details::g_pfnLoggingCallback == nullptr) {
     //    wil::details::g_pfnLoggingCallback = &_wilLoggingCallback;
     //}
 }
@@ -102,7 +102,7 @@ void TraceUnregister() {
     }
 
     // TODO: WIL logging hook
-    //if (wil::details::g_pfnLoggingCallback == &_wilLoggingCallback) {
+    // if (wil::details::g_pfnLoggingCallback == &_wilLoggingCallback) {
     //    wil::details::g_pfnLoggingCallback = nullptr;
     //}
 }

--- a/tests/frameworks/OSXShims/src/LoggingNative.mm
+++ b/tests/frameworks/OSXShims/src/LoggingNative.mm
@@ -15,12 +15,36 @@
 //******************************************************************************
 
 #import <LoggingNative.h>
+#import <Starboard/SmartTypes.h>
 #import <Foundation/NSString.h>
 
 #import <cstdarg>
 
+// NOTE: this function is assumed to only run in Little Endian environments like OSX
+static NSStringEncoding _getWcharEncoding() {
+    switch (sizeof(wchar_t)) {
+        case 2:
+            return NSUTF16LittleEndianStringEncoding;
+        case 4:
+            return NSUTF32LittleEndianStringEncoding;
+        default:
+            assert(false);
+    }
+}
+
+static NSStringEncoding getWcharEncoding() {
+    static NSStringEncoding encoding = _getWcharEncoding();
+    return encoding;
+}
+
 void TraceVerbose(const wchar_t* tag, const wchar_t* format, ...) {
-    NSString* formatString = [NSString stringWithFormat:@"[%ls] %ls", tag, format];
+    StrongId<NSString> nsTag;
+    nsTag.attach([[NSString alloc] initWithBytes:tag length:sizeof(wchar_t) * wcslen(tag) encoding:getWcharEncoding()]);
+
+    StrongId<NSString> nsFormat;
+    nsFormat.attach([[NSString alloc] initWithBytes:format length:sizeof(wchar_t) * wcslen(format) encoding:getWcharEncoding()]);
+
+    NSString* formatString = [NSString stringWithFormat:@"[%@] %@", static_cast<NSString*>(nsTag), static_cast<NSString*>(nsFormat)];
     va_list varArgs;
     va_start(varArgs, format);
     NSLogv(formatString, varArgs);
@@ -28,7 +52,13 @@ void TraceVerbose(const wchar_t* tag, const wchar_t* format, ...) {
 }
 
 void TraceInfo(const wchar_t* tag, const wchar_t* format, ...) {
-    NSString* formatString = [NSString stringWithFormat:@"[%ls] %ls", tag, format];
+    StrongId<NSString> nsTag;
+    nsTag.attach([[NSString alloc] initWithBytes:tag length:sizeof(wchar_t) * wcslen(tag) encoding:getWcharEncoding()]);
+
+    StrongId<NSString> nsFormat;
+    nsFormat.attach([[NSString alloc] initWithBytes:format length:sizeof(wchar_t) * wcslen(format) encoding:getWcharEncoding()]);
+
+    NSString* formatString = [NSString stringWithFormat:@"[%@] %@", static_cast<NSString*>(nsTag), static_cast<NSString*>(nsFormat)];
     va_list varArgs;
     va_start(varArgs, format);
     NSLogv(formatString, varArgs);
@@ -36,7 +66,13 @@ void TraceInfo(const wchar_t* tag, const wchar_t* format, ...) {
 }
 
 void TraceWarning(const wchar_t* tag, const wchar_t* format, ...) {
-    NSString* formatString = [NSString stringWithFormat:@"[%ls] %ls", tag, format];
+    StrongId<NSString> nsTag;
+    nsTag.attach([[NSString alloc] initWithBytes:tag length:sizeof(wchar_t) * wcslen(tag) encoding:getWcharEncoding()]);
+
+    StrongId<NSString> nsFormat;
+    nsFormat.attach([[NSString alloc] initWithBytes:format length:sizeof(wchar_t) * wcslen(format) encoding:getWcharEncoding()]);
+
+    NSString* formatString = [NSString stringWithFormat:@"[%@] %@", static_cast<NSString*>(nsTag), static_cast<NSString*>(nsFormat)];
     va_list varArgs;
     va_start(varArgs, format);
     NSLogv(formatString, varArgs);
@@ -44,7 +80,13 @@ void TraceWarning(const wchar_t* tag, const wchar_t* format, ...) {
 }
 
 void TraceError(const wchar_t* tag, const wchar_t* format, ...) {
-    NSString* formatString = [NSString stringWithFormat:@"[%ls] %ls", tag, format];
+    StrongId<NSString> nsTag;
+    nsTag.attach([[NSString alloc] initWithBytes:tag length:sizeof(wchar_t) * wcslen(tag) encoding:getWcharEncoding()]);
+
+    StrongId<NSString> nsFormat;
+    nsFormat.attach([[NSString alloc] initWithBytes:format length:sizeof(wchar_t) * wcslen(format) encoding:getWcharEncoding()]);
+
+    NSString* formatString = [NSString stringWithFormat:@"[%@] %@", static_cast<NSString*>(nsTag), static_cast<NSString*>(nsFormat)];
     va_list varArgs;
     va_start(varArgs, format);
     NSLogv(formatString, varArgs);
@@ -52,7 +94,13 @@ void TraceError(const wchar_t* tag, const wchar_t* format, ...) {
 }
 
 void TraceCritical(const wchar_t* tag, const wchar_t* format, ...) {
-    NSString* formatString = [NSString stringWithFormat:@"[%ls] %ls", tag, format];
+    StrongId<NSString> nsTag;
+    nsTag.attach([[NSString alloc] initWithBytes:tag length:sizeof(wchar_t) * wcslen(tag) encoding:getWcharEncoding()]);
+
+    StrongId<NSString> nsFormat;
+    nsFormat.attach([[NSString alloc] initWithBytes:format length:sizeof(wchar_t) * wcslen(format) encoding:getWcharEncoding()]);
+
+    NSString* formatString = [NSString stringWithFormat:@"[%@] %@", static_cast<NSString*>(nsTag), static_cast<NSString*>(nsFormat)];
     va_list varArgs;
     va_start(varArgs, format);
     NSLogv(formatString, varArgs);

--- a/tests/unittests/Foundation/NSBundleTests.mm
+++ b/tests/unittests/Foundation/NSBundleTests.mm
@@ -31,6 +31,13 @@ TEST(NSBundle, NSBundle_SanityTest) {
     ASSERT_EQ_MSG(nil, [NSBundle bundleWithPath:nil], @"Bundle with nil path somehow not nil");
 }
 
+// Add a new class that will definitely be part of the mainBundle for this UT executable.
+@interface Waffle : NSObject
+@property (nonatomic, assign) float bacon;
+@end
+@implementation Waffle
+@end
+
 TEST(NSBundle, ClassNamed) {
-    ASSERT_OBJCEQ([NSString class], [[NSBundle mainBundle] classNamed:@"NSString"]);
+    ASSERT_OBJCEQ([Waffle class], [[NSBundle mainBundle] classNamed:@"Waffle"]);
 }


### PR DESCRIPTION
Looks like we were testing for something WinObjC-exclusive? If so, should move to WindowsOnly tests:

[ RUN      ] NSBundle.ClassNamed
Foundation/NSBundleTests.mm:35: Failure
Value of: [[NSBundle mainBundle] classNamed:@"NSString"]
  Actual: NULL
Expected: [NSString class]
Which is: NSString
[  FAILED  ] NSBundle.ClassNamed (1 ms)

[ RUN      ] NSBundle.Localizations
Foundation/ReferenceFoundation/TestNSBundle.mm:89: Failure
Value of: bundle.localizations
  Actual: (
)
Expected: @[ @"en" ]
Which is: (
    en
)
[  FAILED  ] NSBundle.Localizations (0 ms)