### PR TITLE
Fix Foundation.UnitTests errors under AppVerifier

### DIFF
--- a/Frameworks/Foundation/NSCondition.mm
+++ b/Frameworks/Foundation/NSCondition.mm
@@ -132,15 +132,9 @@ struct _mach_timeval {
             return YES;
 
         case ETIMEDOUT:
-            if ((rc = pthread_mutex_unlock(&_mutex)) != 0) {
-                [NSException raise:NSInvalidArgumentException format:@"failed to unlock %@ (errno: %d)", self, rc];
-            }
             return NO;
 
         default:
-            if ((rc = pthread_mutex_unlock(&_mutex)) != 0) {
-                [NSException raise:NSInvalidArgumentException format:@"failed to unlock %@ (errno: %d)", self, rc];
-            }
             [NSException raise:NSInvalidArgumentException format:@"failed to lock %@ before date %@ (errno: %d)", self, date, rc];
             return NO;
     }

--- a/tests/unittests/Foundation/NSFileManagerTests.mm
+++ b/tests/unittests/Foundation/NSFileManagerTests.mm
@@ -111,7 +111,7 @@ TEST(NSFileManager, EnumateDirectoryUsingURL) {
     // OSX wchar_t's are twice as wide
     LOG_INFO("Change current dir to:%@",
 #if TARGET_OS_WIN32
-             [NSString stringWithCharacters:(const unichar*)currentDir length:_MAX_PATH]);
+             [NSString stringWithCharacters:(const unichar*)currentDir length:ret]);
 #else
              [NSString stringWithBytes:currentDir length:sizeof(wchar_t) * ret encoding:WCHAR_ENCODING]);
 #endif

--- a/tests/unittests/Foundation/NSObject_CancelPreviousPerformRequests.m
+++ b/tests/unittests/Foundation/NSObject_CancelPreviousPerformRequests.m
@@ -47,23 +47,33 @@
 - (void)incrementFoo {
     @synchronized(self) {
         self.foo += 1;
+        [_fooCondition lock];
         [_fooCondition broadcast];
+        [_fooCondition unlock];
     }
 }
 
 - (void)incrementBar:(NSNumber*)amount {
     @synchronized(self) {
         self.bar += [amount intValue];
+        [_barCondition lock];
         [_barCondition broadcast];
+        [_barCondition unlock];
     }
 }
 
 - (BOOL)waitOnFooForInterval:(NSTimeInterval)interval {
-    return [_fooCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
+    [_fooCondition lock];
+    BOOL ret = [_fooCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
+    [_fooCondition unlock];
+    return ret;
 }
 
 - (BOOL)waitOnBarForInterval:(NSTimeInterval)interval {
-    return [_barCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
+    [_barCondition lock];
+    BOOL ret = [_barCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
+    [_barCondition unlock];
+    return ret;
 }
 @end
 

--- a/tests/unittests/Foundation/NSTimerTests.mm
+++ b/tests/unittests/Foundation/NSTimerTests.mm
@@ -56,7 +56,9 @@ TEST(NSTimer, Init) {
     _called = YES;
     _count++;
     if (_count >= _maxCalls) {
+        [_calledCondition lock];
         [_calledCondition broadcast];
+        [_calledCondition unlock];
     }
 }
 
@@ -65,7 +67,9 @@ TEST(NSTimer, Init) {
     _count++;
     _dummyVal = dummyVal;
     if (_count >= _maxCalls) {
+        [_calledCondition lock];
         [_calledCondition broadcast];
+        [_calledCondition unlock];
     }
 }
 
@@ -81,7 +85,10 @@ TEST(NSTimer, Init) {
 }
 
 - (BOOL)waitOnCalledConditionForInterval:(NSTimeInterval)interval {
-    return [_calledCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
+    [_calledCondition lock];
+    BOOL ret = [_calledCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:interval]];
+    [_calledCondition unlock];
+    return ret;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
The following errors only repro'd under AppVerifier:
 - Fix an instance of NSString initialization in unit tests where too large a length was being passed,
   causing an AV by accessing uninitialized memory.
 - NSCondition functions signal, broadcast, wait, and waitUntilDate:
   are documented to require the NSCondition be locked before being called
    - Fixed instances in Foundation.UnitTests where an NSCondition was not being locked before use,
      causing a mutex overrelease upon dealloc
    - Removed NSCondition unlocking its own mutexes in waitUntilDate: -
      users are expected to lock/unlock the condition themselves

This change does not impact pass/fail on OSX

Fixes #670