### PR TITLE
Fix surface format for RGBA surfaces

### DIFF
--- a/Frameworks/include/CGSurfaceInfoInternal.h
+++ b/Frameworks/include/CGSurfaceInfoInternal.h
@@ -88,10 +88,12 @@ static inline __CGSurfaceFormat _CGImageGetFormat(unsigned int bitsPerComponent,
                         fmt = _ColorARGB;
                     }
                     break;
-                case kCGImageAlphaNoneSkipLast:
                 case kCGImageAlphaLast:
                 case kCGImageAlphaPremultipliedLast:
                     fmt = _ColorRGBA;
+                    break;
+                case kCGImageAlphaNoneSkipLast:
+                    fmt = _ColorXBGR;
                     break;
                 default:
                     UNIMPLEMENTED_WITH_MSG("Unknown pixel format, assuming ARGB");

--- a/Frameworks/include/CGSurfaceInfoInternal.h
+++ b/Frameworks/include/CGSurfaceInfoInternal.h
@@ -91,8 +91,10 @@ static inline __CGSurfaceFormat _CGImageGetFormat(unsigned int bitsPerComponent,
                 case kCGImageAlphaNoneSkipLast:
                 case kCGImageAlphaLast:
                 case kCGImageAlphaPremultipliedLast:
+                    fmt = _ColorRGBA;
+                    break;
                 default:
-                    UNIMPLEMENTED_WITH_MSG("RGBX and RGBA pixelformats unsupported");
+                    UNIMPLEMENTED_WITH_MSG("Unknown pixel format, assuming ARGB");
                     fmt = _ColorARGB;
                     break;
             }

--- a/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj
+++ b/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj
@@ -233,7 +233,7 @@
     <SBResourceCopy Include="..\..\WOCCatalog\Images\segment_search.png" />
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo1.jpg" />
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo7.gif" />
-    <SBResourceCopy Include="..\..\WOCCatalog\Images\photo2.jpg" />
+    <SBResourceCopy Include="..\..\WOCCatalog\Images\photo2.png" />
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo3.jpg" />
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo5.jpg" />
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo6.jpg" />

--- a/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj.filters
+++ b/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj.filters
@@ -198,10 +198,13 @@
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo1.jpg">
       <Filter>Images</Filter>
     </SBResourceCopy>
+    <SBResourceCopy Include="..\..\WOCCatalog\Images\photo2.png">
+      <Filter>Images</Filter>
+    </SBResourceCopy>
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo7.gif">
       <Filter>Images</Filter>
     </SBResourceCopy>
-    <SBResourceCopy Include="..\..\WOCCatalog\Images\photo2.jpg">
+    <SBResourceCopy Include="..\..\WOCCatalog\Images\photo2.png">
       <Filter>Images</Filter>
     </SBResourceCopy>
     <SBResourceCopy Include="..\..\WOCCatalog\Images\photo3.jpg">

--- a/samples/WOCCatalog/WOCCatalog.xcodeproj/project.pbxproj
+++ b/samples/WOCCatalog/WOCCatalog.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		4EE861DD1B5997A500682BDB /* XamlViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4EE861CE1B5997A500682BDB /* XamlViewController.m */; };
 		4EE861EB1B5997AD00682BDB /* blueButton.png in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861DE1B5997AD00682BDB /* blueButton.png */; };
 		4EE861EC1B5997AD00682BDB /* photo1.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861DF1B5997AD00682BDB /* photo1.jpg */; };
-		4EE861ED1B5997AD00682BDB /* photo2.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861E01B5997AD00682BDB /* photo2.jpg */; };
+		4EE861ED1B5997AD00682BDB /* photo2.png in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861E01B5997AD00682BDB /* photo2.png */; };
 		4EE861EE1B5997AD00682BDB /* photo3.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861E11B5997AD00682BDB /* photo3.jpg */; };
 		4EE861EF1B5997AD00682BDB /* photo4.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861E21B5997AD00682BDB /* photo4.jpg */; };
 		4EE861F01B5997AD00682BDB /* photo5.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4EE861E31B5997AD00682BDB /* photo5.jpg */; };
@@ -133,7 +133,7 @@
 		4EE861CE1B5997A500682BDB /* XamlViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XamlViewController.m; sourceTree = "<group>"; };
 		4EE861DE1B5997AD00682BDB /* blueButton.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = blueButton.png; path = WOCCatalog/Images/blueButton.png; sourceTree = "<group>"; };
 		4EE861DF1B5997AD00682BDB /* photo1.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = photo1.jpg; path = WOCCatalog/Images/photo1.jpg; sourceTree = "<group>"; };
-		4EE861E01B5997AD00682BDB /* photo2.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = photo2.jpg; path = WOCCatalog/Images/photo2.jpg; sourceTree = "<group>"; };
+		4EE861E01B5997AD00682BDB /* photo2.png */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = photo2.png; path = WOCCatalog/Images/photo2.png; sourceTree = "<group>"; };
 		4EE861E11B5997AD00682BDB /* photo3.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = photo3.jpg; path = WOCCatalog/Images/photo3.jpg; sourceTree = "<group>"; };
 		4EE861E21B5997AD00682BDB /* photo4.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = photo4.jpg; path = WOCCatalog/Images/photo4.jpg; sourceTree = "<group>"; };
 		4EE861E31B5997AD00682BDB /* photo5.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = photo5.jpg; path = WOCCatalog/Images/photo5.jpg; sourceTree = "<group>"; };
@@ -375,7 +375,7 @@
 				D2AC20331C69733600D54717 /* photo9.jpg */,
 				4EE861DE1B5997AD00682BDB /* blueButton.png */,
 				4EE861DF1B5997AD00682BDB /* photo1.jpg */,
-				4EE861E01B5997AD00682BDB /* photo2.jpg */,
+				4EE861E01B5997AD00682BDB /* photo2.png */,
 				4EE861E11B5997AD00682BDB /* photo3.jpg */,
 				4EE861E21B5997AD00682BDB /* photo4.jpg */,
 				4EE861E31B5997AD00682BDB /* photo5.jpg */,
@@ -489,7 +489,7 @@
 				4EE861EC1B5997AD00682BDB /* photo1.jpg in Resources */,
 				4EE861F21B5997AD00682BDB /* photo7.gif in Resources */,
 				77E93C4A1D21D87C009F27A2 /* test.wav in Resources */,
-				4EE861ED1B5997AD00682BDB /* photo2.jpg in Resources */,
+				4EE861ED1B5997AD00682BDB /* photo2.png in Resources */,
 				4EE861EE1B5997AD00682BDB /* photo3.jpg in Resources */,
 				4EE861F01B5997AD00682BDB /* photo5.jpg in Resources */,
 				4EE861F11B5997AD00682BDB /* photo6.jpg in Resources */,

--- a/samples/WOCCatalog/WOCCatalog/AccelerateViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/AccelerateViewController.m
@@ -441,7 +441,7 @@ static const double meanDivisor = 100;
         [self.collectionView registerClass:[SelectorCell class] forCellWithReuseIdentifier:@"photoCell"];
 
         images = [NSArray arrayWithObjects:[[UIImage imageNamed:@"photo1.jpg"] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal],
-                                           [UIImage imageNamed:@"photo2.jpg"],
+                                           [UIImage imageNamed:@"photo2.png"],
                                            [UIImage imageNamed:@"photo3.jpg"],
                                            [UIImage imageNamed:@"photo4.jpg"],
                                            [UIImage imageNamed:@"photo5.jpg"],

--- a/samples/WOCCatalog/WOCCatalog/Images/photo2.png
+++ b/samples/WOCCatalog/WOCCatalog/Images/photo2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35862fa5f6a147eb616c2f50daa5757509d64d42f9e1a5fc2ba762f948a21b39
+size 1533934

--- a/samples/WOCCatalog/WOCCatalog/ImagesViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/ImagesViewController.m
@@ -27,7 +27,7 @@
 
     CGContextSetInterpolationQuality(context, quality);
     CGAffineTransform flipVertical = CGAffineTransformMake(1, 0, 0, -1, 0, rect.size.height);
-    CGContextConcatCTM(context, flipVertical);  
+    CGContextConcatCTM(context, flipVertical);
     CGContextDrawImage(context, rect, imageRef);
     CGImageRef scaledImageRef = CGBitmapContextCreateImage(context);
     UIImage* scaledImage = [UIImage imageWithCGImage:scaledImageRef];
@@ -42,44 +42,35 @@
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor blackColor];
     CGRect rect = CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height);
-    UIImageView* imagesView = [[UIImageView alloc] initWithFrame: rect];
+    UIImageView* imagesView = [[UIImageView alloc] initWithFrame:rect];
     UIImage* photo = [UIImage imageNamed:@"photo9.jpg"];
-    UIImage* scaledPhotoHighInterpolation = [ImagesViewController scaleImage:
-                                                photo.CGImage
-                                                scaledRect:rect
-                                                quality:kCGInterpolationHigh];
-    UIImage* scaledPhotoNoInterpolation = [ImagesViewController scaleImage:
-                                                photo.CGImage 
-                                                scaledRect:rect
-                                                quality:kCGInterpolationNone];
+    UIImage* scaledPhotoHighInterpolation = [ImagesViewController scaleImage:photo.CGImage scaledRect:rect quality:kCGInterpolationHigh];
+    UIImage* scaledPhotoNoInterpolation = [ImagesViewController scaleImage:photo.CGImage scaledRect:rect quality:kCGInterpolationNone];
 
     CIContext* context = [CIContext contextWithOptions:nil];
-    photo = [UIImage imageNamed:@"photo2.jpg"];
+    photo = [UIImage imageNamed:@"photo2.png"];
     CIImage* ciImage = [CIImage imageWithCGImage:photo.CGImage];
     CGImageRef cgImage = [context createCGImage:ciImage fromRect:CGRectMake(300, 600, 200, 200)];
 
-    imagesView.animationImages = [NSArray arrayWithObjects:
-                            scaledPhotoHighInterpolation,
-                            scaledPhotoNoInterpolation,
-                            [UIImage imageNamed:@"photo1.jpg"],
-                            [UIImage imageNamed:@"photo2.jpg"],
-                            [UIImage imageWithCGImage:cgImage],
-                            [UIImage imageNamed:@"photo3.jpg"],
-                            [UIImage imageNamed:@"photo4.jpg"],
-                            [UIImage imageNamed:@"photo5.jpg"],
-                            [UIImage imageNamed:@"photo6.jpg"],
-                            [UIImage imageNamed:@"photo7.gif"],
-                            [UIImage imageNamed:@"photo8.tif"],
-                            nil];
+    imagesView.animationImages = [NSArray arrayWithObjects:scaledPhotoHighInterpolation,
+                                                           scaledPhotoNoInterpolation,
+                                                           [UIImage imageNamed:@"photo1.jpg"],
+                                                           [UIImage imageNamed:@"photo2.png"],
+                                                           [UIImage imageWithCGImage:cgImage],
+                                                           [UIImage imageNamed:@"photo3.jpg"],
+                                                           [UIImage imageNamed:@"photo4.jpg"],
+                                                           [UIImage imageNamed:@"photo5.jpg"],
+                                                           [UIImage imageNamed:@"photo6.jpg"],
+                                                           [UIImage imageNamed:@"photo7.gif"],
+                                                           [UIImage imageNamed:@"photo8.tif"],
+                                                           nil];
 
     imagesView.animationDuration = 10.0;
 
     [imagesView setContentMode:UIViewContentModeScaleAspectFit];
     [imagesView startAnimating];
     imagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    [[self view] addSubview: imagesView];
+    [[self view] addSubview:imagesView];
 }
 
 @end
-
-

--- a/samples/WOCCatalog/WOCCatalog/PhotogridViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/PhotogridViewController.m
@@ -42,7 +42,8 @@
 
 - (id)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
-        self.imageView = [[UIImageView alloc] initWithFrame:CGRectInset(CGRectMake(0, 0, CGRectGetWidth(frame), CGRectGetHeight(frame)), 5, 5)];
+        self.imageView =
+            [[UIImageView alloc] initWithFrame:CGRectInset(CGRectMake(0, 0, CGRectGetWidth(frame), CGRectGetHeight(frame)), 5, 5)];
 
         self.imageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
         self.imageView.layer.masksToBounds = YES;
@@ -76,7 +77,7 @@
     }
 
     images = [NSArray arrayWithObjects:[[UIImage imageNamed:@"photo1.jpg"] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal],
-                                       [UIImage imageNamed:@"photo2.jpg"],
+                                       [UIImage imageNamed:@"photo2.png"],
                                        [UIImage imageNamed:@"photo3.jpg"],
                                        [UIImage imageNamed:@"photo4.jpg"],
                                        [UIImage imageNamed:@"photo5.jpg"],


### PR DESCRIPTION
The correct surface format for Big Endian + Alpha Last is _ColorRGBA. We were incorrectly setting it to ARGB, resulting in apps that use this combination to get blue and red swapped and broke some validation apps.

To uncover future regressions, also modified one of the images to be PNG in WOCCatalog.  We still need additional validation through OpenGL samples.  Opened Issue #859 to track this.

Fixes #847