### PR TITLE
Align NSDateComponents selectors with OSX 

### DIFF
--- a/Frameworks/Foundation/NSDateComponents.mm
+++ b/Frameworks/Foundation/NSDateComponents.mm
@@ -18,7 +18,9 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #include "Foundation/NSDateComponents.h"
 #include "NSDateComponentsInternal.h"
 
-@implementation NSDateComponents
+@implementation NSDateComponents {
+    NSInteger _week;
+}
 
 /**
  @Status Interoperable
@@ -265,6 +267,14 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     [coder encodeInteger:_weekOfMonth forKey:@"NS.weekofmonth"];
     [coder encodeInteger:_weekOfYear forKey:@"NS.weekofyear"];
     [coder encodeInteger:_yearForWeekOfYear forKey:@"NS.yearforweekofyear"];
+}
+
+- (void)setWeek:(NSInteger)v {
+    _week = v;
+}
+
+- (NSInteger)week {
+    return _week;
 }
 
 @end

--- a/include/Foundation/NSDateComponents.h
+++ b/include/Foundation/NSDateComponents.h
@@ -38,7 +38,6 @@ FOUNDATION_EXPORT_CLASS
 @property NSInteger minute;
 @property NSInteger second;
 @property NSInteger nanosecond;
-@property NSInteger week;
 @property NSInteger weekday;
 @property NSInteger weekdayOrdinal;
 @property NSInteger quarter;
@@ -48,4 +47,6 @@ FOUNDATION_EXPORT_CLASS
 @property (getter=isLeapMonth) BOOL leapMonth;
 - (NSInteger)valueForComponent:(NSCalendarUnit)unit;
 - (void)setValue:(NSInteger)value forComponent:(NSCalendarUnit)unit;
+- (NSInteger)week;
+- (void)setWeek:(NSInteger)v;
 @end

--- a/tests/unittests/Foundation/NSDateComponentsTests.m
+++ b/tests/unittests/Foundation/NSDateComponentsTests.m
@@ -75,15 +75,15 @@ TEST(NSDateComponents, IndependentWeekTest) {
     dateComponents.day = 1;
     dateComponents.month = 1;
     dateComponents.year = 1999;
-    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week default value should be LONG_MAX");
+    EXPECT_EQ_MSG([dateComponents week], NSUndefinedDateComponent, "FAILED: week default value should be NSUndefinedDateComponent");
 
     dateComponents.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week value should not change because of calendar");
+    EXPECT_EQ_MSG([dateComponents week], NSUndefinedDateComponent, "FAILED: week value should not change because of calendar");
 
     dateComponents.weekOfMonth = 1;
-    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week value should not depend on weekOfMonth");
+    EXPECT_EQ_MSG([dateComponents week], NSUndefinedDateComponent, "FAILED: week value should not depend on weekOfMonth");
     dateComponents.weekOfYear = 1;
-    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week value should not depend on weekOfYear");
+    EXPECT_EQ_MSG([dateComponents week], NSUndefinedDateComponent, "FAILED: week value should not depend on weekOfYear");
 
     [dateComponents setWeek:1];
     EXPECT_EQ_MSG([dateComponents week], 1, "FAILED: week value should change when assigned");

--- a/tests/unittests/Foundation/NSDateComponentsTests.m
+++ b/tests/unittests/Foundation/NSDateComponentsTests.m
@@ -14,7 +14,7 @@
 //
 //******************************************************************************
 
-#include "gtest-api.h"
+#include "TestFramework.h"
 #import <Foundation/Foundation.h>
 
 TEST(NSDateComponents, ComponentsTimeZoneTest) {
@@ -44,6 +44,7 @@ TEST(NSDateComponents, ComponentsTimeZoneTest) {
     EXPECT_OBJCNE_MSG(cstDateNonMatching, cstDateMatching, "FAILED: dates should differ by one hour");
     EXPECT_OBJCNE_MSG(estDate, cstDateNonMatching, "FAILED: dates should differ by one hour");
     EXPECT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+    [dateComponents release];
 }
 
 TEST(NSDateComponents, CalendarTimeZoneTest) {
@@ -68,6 +69,7 @@ TEST(NSDateComponents, CalendarTimeZoneTest) {
 
     NSTimeInterval secondsBetween = [cstDate timeIntervalSinceDate:estDate];
     EXPECT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+    [dateComponents release];
 }
 
 TEST(NSDateComponents, IndependentWeekTest) {
@@ -87,4 +89,5 @@ TEST(NSDateComponents, IndependentWeekTest) {
 
     [dateComponents setWeek:1];
     EXPECT_EQ_MSG([dateComponents week], 1, "FAILED: week value should change when assigned");
+    [dateComponents release];
 }

--- a/tests/unittests/Foundation/NSDateComponentsTests.m
+++ b/tests/unittests/Foundation/NSDateComponentsTests.m
@@ -40,10 +40,10 @@ TEST(NSDateComponents, ComponentsTimeZoneTest) {
 
     NSTimeInterval secondsBetween = [cstDateNonMatching timeIntervalSinceDate:estDate];
 
-    ASSERT_OBJCEQ_MSG(estDate, cstDateMatching, "FAILED: dates should match");
-    ASSERT_OBJCNE_MSG(cstDateNonMatching, cstDateMatching, "FAILED: dates should differ by one hour");
-    ASSERT_OBJCNE_MSG(estDate, cstDateNonMatching, "FAILED: dates should differ by one hour");
-    ASSERT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+    EXPECT_OBJCEQ_MSG(estDate, cstDateMatching, "FAILED: dates should match");
+    EXPECT_OBJCNE_MSG(cstDateNonMatching, cstDateMatching, "FAILED: dates should differ by one hour");
+    EXPECT_OBJCNE_MSG(estDate, cstDateNonMatching, "FAILED: dates should differ by one hour");
+    EXPECT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
 }
 
 TEST(NSDateComponents, CalendarTimeZoneTest) {
@@ -67,5 +67,24 @@ TEST(NSDateComponents, CalendarTimeZoneTest) {
     NSDate* cstDate = [calendar dateFromComponents:dateComponents];
 
     NSTimeInterval secondsBetween = [cstDate timeIntervalSinceDate:estDate];
-    ASSERT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+    EXPECT_EQ_MSG(secondsBetween, 3600, "FAILED: dates should differ by one hour");
+}
+
+TEST(NSDateComponents, IndependentWeekTest) {
+    NSDateComponents* dateComponents = [[NSDateComponents alloc] init];
+    dateComponents.day = 1;
+    dateComponents.month = 1;
+    dateComponents.year = 1999;
+    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week default value should be LONG_MAX");
+
+    dateComponents.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week value should not change because of calendar");
+
+    dateComponents.weekOfMonth = 1;
+    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week value should not depend on weekOfMonth");
+    dateComponents.weekOfYear = 1;
+    EXPECT_EQ_MSG([dateComponents week], LONG_MAX, "FAILED: week value should not depend on weekOfYear");
+
+    [dateComponents setWeek:1];
+    EXPECT_EQ_MSG([dateComponents week], 1, "FAILED: week value should change when assigned");
 }


### PR DESCRIPTION
NSDateComponents does not have a public "week" property, but it does have deprecated week and setWeek: methods, which do not interact with other values in NSDateComponents.