### PR TITLE
[Win32] Foundation.UnitTests project doesn't cause a dep rebuild on Foundation.dll

### DIFF
--- a/msvc/sbclang.targets
+++ b/msvc/sbclang.targets
@@ -486,6 +486,7 @@
     <ItemGroup Condition="'@(_StarboardReferencesRequiringObjectiveC)'!='' and '$(StarboardLinkWholeArchive)'=='true'">
       <Link>
         <AdditionalOptions>%(Link.AdditionalOptions) "/WHOLEARCHIVE:@(_StarboardReferencesRequiringObjectiveC, '" /WHOLEARCHIVE:"')"</AdditionalOptions>
+        <LinkIncremental>false</LinkIncremental>
       </Link>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This causes library changes to not be picked up by the unit test build.