### PR TITLE
Fix a handful of issues in /WHOLEARCHIVE support.

### DIFF
--- a/Frameworks/Starboard/pthread.cpp
+++ b/Frameworks/Starboard/pthread.cpp
@@ -24,7 +24,6 @@
 #include <cmath>
 #include <map>
 #include <mutex>
-#include <concrt.h>
 #include "StubReturn.h"
 
 #include "pthread.h"

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -27,6 +27,12 @@
     <SBResourceCopy Include="$(MSBuildThisFileDirectory)\..\..\..\tests\ContainerCRTDeps\$(ProcessorArchitecture)\msvcp140_app.dll">
       <FileType>Document</FileType>
     </SBResourceCopy>
+    <SBResourceCopy Include="$(MSBuildThisFileDirectory)\..\..\..\tests\ContainerCRTDeps\$(ProcessorArchitecture)\vccorlib140.dll">
+      <FileType>Document</FileType>
+    </SBResourceCopy>
+    <SBResourceCopy Include="$(MSBuildThisFileDirectory)\..\..\..\tests\ContainerCRTDeps\$(ProcessorArchitecture)\vccorlib140d.dll">
+      <FileType>Document</FileType>
+    </SBResourceCopy>
     <SBResourceCopy Include="$(MSBuildThisFileDirectory)\..\..\..\tests\ContainerCRTDeps\$(ProcessorArchitecture)\vccorlib140d_app.dll">
       <FileType>Document</FileType>
     </SBResourceCopy>

--- a/build/Tests/UnitTests/Accelerate/Accelerate.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Accelerate/Accelerate.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/Accounts/Accounts.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Accounts/Accounts.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/AddressBook/AddressBook.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/AddressBook/AddressBook.UnitTests.vcxproj
@@ -63,6 +63,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/AudioToolbox/AudioToolbox.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/AudioToolbox/AudioToolbox.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/ClangModules/ClangModules.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/ClangModules/ClangModules.UnitTests.vcxproj
@@ -61,6 +61,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/CoreData/CoreData.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreData/CoreData.UnitTests.vcxproj
@@ -63,6 +63,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/CoreFoundation/CoreFoundation.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreFoundation/CoreFoundation.UnitTests.vcxproj
@@ -62,6 +62,7 @@
     <StarboardIncludeDefaultLibs>false</StarboardIncludeDefaultLibs>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
@@ -66,6 +66,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/CoreImage/CoreImage.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreImage/CoreImage.UnitTests.vcxproj
@@ -72,6 +72,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/CoreLocation/CoreLocation.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreLocation/CoreLocation.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
@@ -69,6 +69,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/Foundation.WindowsOnly/Foundation.WindowsOnly.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Foundation.WindowsOnly/Foundation.WindowsOnly.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/GLKit/GLKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/GLKit/GLKit.UnitTests.vcxproj
@@ -78,6 +78,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/ImageIO/ImageIO.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/ImageIO/ImageIO.UnitTests.vcxproj
@@ -69,6 +69,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/MobileCoreServices/MobileCoreServices.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/MobileCoreServices/MobileCoreServices.UnitTests.vcxproj
@@ -63,6 +63,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/QuartzCore/QuartzCore.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/QuartzCore/QuartzCore.UnitTests.vcxproj
@@ -66,6 +66,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/Security/Security.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Security/Security.UnitTests.vcxproj
@@ -63,6 +63,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/Starboard/Starboard.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Starboard/Starboard.UnitTests.vcxproj
@@ -60,6 +60,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
@@ -78,6 +78,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/build/Tests/UnitTests/WOCStdLib/WOCStdLib.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/WOCStdLib/WOCStdLib.UnitTests.vcxproj
@@ -57,6 +57,7 @@
     <IslandwoodDRT>false</IslandwoodDRT>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(RootNamespace)\</OutDir>
   </PropertyGroup>
+  <Import Project="$(StarboardBasePath)\msvc\ut-build-early.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/deps/3rdparty/cassowary-0.60/cassowary-0.60-Windows.vcxproj
+++ b/deps/3rdparty/cassowary-0.60/cassowary-0.60-Windows.vcxproj
@@ -98,6 +98,7 @@
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/deps/prebuilt/Universal Windows/ARM/cassowary-0.60-Debug.lib
+++ b/deps/prebuilt/Universal Windows/ARM/cassowary-0.60-Debug.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2380e10b0aebd2904bd9911716547ce8233a3b11aca394b17386e841d0c759ac
-size 2661486
+oid sha256:ceff77591ca39bb4a430f56a50aca913fe6ce18ac9c3df65ec4b7f9db4ddd723
+size 2698144

--- a/deps/prebuilt/Universal Windows/x86/cassowary-0.60-Debug.lib
+++ b/deps/prebuilt/Universal Windows/x86/cassowary-0.60-Debug.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b184a8a28e6bd234a83c8e8cc4aa48f463e80c7496e9a6c49ec27208737d761b
-size 2549686
+oid sha256:9f799f9aa8fa141da383f0ea87c89fe511b2efd004f06b11ee3045bb0bc649d6
+size 2518532

--- a/msvc/sbclang.props
+++ b/msvc/sbclang.props
@@ -63,6 +63,7 @@
 
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(StarboardSdkRoot)\include\VCInclude</AdditionalIncludeDirectories>
+      <DebugInformationFormat Condition="'%(ClCompile.DebugInformationFormat)'=='EditAndContinue'">ProgramDatabase</DebugInformationFormat>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/msvc/sbclang.targets
+++ b/msvc/sbclang.targets
@@ -394,13 +394,23 @@
 
   </Target>
 
-  <!-- Sets StarboardHasObjCSources based on whether any files in this project are being built as Objective-C -->
+  <!-- Sets StarboardHasObjCSources based on whether any non-excluded files in this project are being built as Objective-C -->
   <Target Name="ComputeStarboardHasObjCSources" DependsOnTargets="ComputeClangOptions">
-    <PropertyGroup Condition="'$(StarboardHasObjCSources)' == ''">
+    <ItemGroup>
+      <ClangCompileNonExcluded Include="@(ClangCompile)" Condition="'%(ClangCompile.ExcludedFromBuild)' != 'true'">
+        <CompileAs>%(ClangCompile.CompileAs)</CompileAs>
+      </ClangCompileNonExcluded>
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StarboardHasObjCSources)' == '' And '@(ClangCompileNonExcluded)' != ''">
       <!-- ComputeClangOptions fills CompileAs based on file extension in the absence of other information. -->
-      <StarboardHasObjCSources Condition="'@(ClangCompile->WithMetadataValue('CompileAs', 'CompileAsObjC'))' != ''">true</StarboardHasObjCSources>
-      <StarboardHasObjCSources Condition="'@(ClangCompile->WithMetadataValue('CompileAs', 'CompileAsObjCpp'))' != ''">true</StarboardHasObjCSources>
+      <StarboardHasObjCSources Condition="@(ClangCompileNonExcluded->AnyHaveMetadataValue('CompileAs', 'CompileAsObjC'))">true</StarboardHasObjCSources>
+      <StarboardHasObjCSources Condition="@(ClangCompileNonExcluded->AnyHaveMetadataValue('CompileAs', 'CompileAsObjCpp'))">true</StarboardHasObjCSources>
     </PropertyGroup>
+
+    <ItemGroup>
+      <ClangCompileNonExcluded Remove="@(ClangCompileNonExcluded)"/>
+    </ItemGroup>
   </Target>
 
   <!-- Sets StarboardRequiresObjectiveCRuntime based on whether this project has either Objective-C sources itself or

--- a/msvc/sbclang.targets
+++ b/msvc/sbclang.targets
@@ -483,6 +483,10 @@
        and 2-stage loading.
   -->
   <Target Name="ComputeWholeArchiveLinkInputs" DependsOnTargets="ComputeStarboardReferencesRequiringObjectiveC">
+    <PropertyGroup Condition="'@(_StarboardReferencesRequiringObjectiveC)'!='' and '$(StarboardLinkWholeArchive)'=='true'">
+      <!-- The linker shipped with VS 2015 Updates 2 and 3 will not properly consume a /WHOLEARCHIVE during incremental linking. -->
+      <LinkIncremental>false</LinkIncremental>
+    </PropertyGroup>
     <ItemGroup Condition="'@(_StarboardReferencesRequiringObjectiveC)'!='' and '$(StarboardLinkWholeArchive)'=='true'">
       <Link>
         <AdditionalOptions>%(Link.AdditionalOptions) "/WHOLEARCHIVE:@(_StarboardReferencesRequiringObjectiveC, '" /WHOLEARCHIVE:"')"</AdditionalOptions>

--- a/msvc/sdk-build.props
+++ b/msvc/sdk-build.props
@@ -71,7 +71,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc/sdk-build.props
+++ b/msvc/sdk-build.props
@@ -71,6 +71,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc/ut-build-early.props
+++ b/msvc/ut-build-early.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Starboard OneCore Overrides">
+    <_SB_Local_VCInstallDir Condition="'$(_SB_Local_VCInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\Setup\VC@ProductDir)</_SB_Local_VCInstallDir>
+    <_SB_Local_VCInstallDir Condition="'$(_SB_Local_VCInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\Setup\VC@ProductDir)</_SB_Local_VCInstallDir>
+    <_SB_Local_VCInstallDir Condition="'$(_SB_Local_VCInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VSWinExpress\14.0\Setup\VC@ProductDir)</_SB_Local_VCInstallDir>
+    <_SB_Local_VCInstallDir Condition="'$(_SB_Local_VCInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VSWinExpress\14.0\Setup\VC@ProductDir)</_SB_Local_VCInstallDir>
+
+    <!-- We want to link the ARM unit test binaries against the store libraries without turning on WindowsAppContainer.
+         Therefore, we have to override the VC ARM library path early - before Microsoft.Cpp.Common.props is included.
+    -->
+    <StarboardUnitTestAPISet Condition="'$(StarboardUnitTestAPISet)'==''">onecore</StarboardUnitTestAPISet>
+    <VC_LibraryPath_VC_ARM>$(_SB_Local_VCInstallDir)lib\$(StarboardUnitTestAPISet)\ARM;</VC_LibraryPath_VC_ARM>
+  </PropertyGroup>
+</Project>
+

--- a/tests/ContainerCRTDeps/ARM/vccorlib140.dll
+++ b/tests/ContainerCRTDeps/ARM/vccorlib140.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bbc799e795abc9efd7037f512dbd9950e3aaf9508a84ed600f53523ba6bd3bc
+size 328064

--- a/tests/ContainerCRTDeps/ARM/vccorlib140d.dll
+++ b/tests/ContainerCRTDeps/ARM/vccorlib140d.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb843628ce1248c986dd0c8f2ddfdaf7caadc42b0cf7be01f6a6e8566462bb6
+size 878168

--- a/tests/ContainerCRTDeps/x86/vccorlib140.dll
+++ b/tests/ContainerCRTDeps/x86/vccorlib140.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cd13772dd046e9e8a36343c96e6c145ce9072dc51de05aeae4a770cf4b1c33
+size 271176

--- a/tests/ContainerCRTDeps/x86/vccorlib140d.dll
+++ b/tests/ContainerCRTDeps/x86/vccorlib140d.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70121acfe928eaf4b17c5e311bd23278f949b6705e16124c1d07ac73673e75a6
+size 779600


### PR DESCRIPTION
* There was a breakage in the ARM unit tests due to a missing dependency pulled in through /WHOLEARCHIVE.
  * That dependency is now included in the test CRT dependency set.
* The library path for our ARM unit tests was being set incorrectly.
  * In setting it correctly, we found that Starboard had a dependency on the concurrency runtime, which we cannot link. That dependency was found to be in error.
* Linking a project with both `/INCREMENTAL` and `/WHOLEARCHIVE` can lead to incomplete object merging.
* We would occasionally emit `/WHOLEARCHIVE` and `___pin_objc_init` for referenced libraries containing only **excluded** Objective-C files.

Local tests:
* Passed ARM Unit Tests (Debug/Release).
* Passed ARM application validation.
* Passed x86 Unit Tests (Debug/Release)

Remote tests:
* Currently running a full soak (ARM+x86) test.