### PR TITLE
Property synthesis issues causing use after release in UIDatePicker.mm

### DIFF
--- a/Frameworks/UIKit/UIDatePicker.mm
+++ b/Frameworks/UIKit/UIDatePicker.mm
@@ -36,7 +36,7 @@ static const int MAX_DATEPICKER_COMPONENTS = 4;
     StrongId<NSMutableArray> _weekdays;
     StrongId<NSDate> _dayStartTime;
     UIDatePickerMode _mode;
-    StrongId<NSDate> __minimumDate, __maximumDate;
+    StrongId<NSDate> _minimumDate, _maximumDate;
     StrongId<UILabel> _hoursLabel, _minutesLabel;
     bool _didSnapTime;
 }
@@ -813,10 +813,24 @@ static void resetPickerPositions(UIDatePicker* self) {
 /**
  @Status Interoperable
 */
+- (NSDate*)minimumDate {
+    return _minimumDate;
+}
+
+/**
+ @Status Interoperable
+*/
 - (void)setMinimumDate:(NSDate*)date {
     _minimumDate = date;
     resetPickerPositions(self);
     [_pickerView _invalidateAllComponents];
+}
+
+/**
+ @Status Interoperable
+*/
+- (NSDate*)maximumDate {
+    return _maximumDate;
 }
 
 /**


### PR DESCRIPTION
There are some use after releases that occur when setting minimumDate/maximumDate in an application due to UIDatePicker.mm using the autosynthesized _minimumDate (_maximumDate) instead of the StrongId __minDate. There's something funny with auto property synthesis at the root of this - just removing one of the double underscores from the ivar results in:

    type of property 'minimumDate' ('NSDate *') does not match type of instance variable '_minimumDate' ('AutoId<NSDate, LifetimeRetain>')

No idea why this works for @property date / _date.

Commit just switches to manual memory management for minimumDate/maximumDate (unless someone knows what's going on with the property synthesis + smart types here).