### PR TITLE
AddressBook Framework -- Mutable MultiValue Support

### DIFF
--- a/Frameworks/AddressBook/ABMultiValueInternal.h
+++ b/Frameworks/AddressBook/ABMultiValueInternal.h
@@ -41,4 +41,15 @@
 - (CFIndex)getFirstIndexOfValue:(CFTypeRef)value;
 - (CFIndex)getIndexForIdentifier:(ABMultiValueIdentifier)identifier;
 
+// The following methods parallel those found in ABMutableMultiValue.mm.
+- (_ABMultiValue*)createMutableCopy;
+- (bool)addValue:(CFTypeRef)value andLabel:(CFStringRef)label outIdentifier:(ABMultiValueIdentifier*)outIdentifier;
+- (bool)replaceValue:(CFTypeRef)value atIndex:(CFIndex)index;
+- (bool)replaceLabel:(CFStringRef)label atIndex:(CFIndex)index;
+- (bool)insertValue:(CFTypeRef)value
+           andLabel:(CFStringRef)label
+            atIndex:(CFIndex)index
+      outIdentifier:(ABMultiValueIdentifier*)outIdentifier;
+- (bool)removeValueAndLabelAtIndex:(CFIndex)index;
+
 @end

--- a/Frameworks/AddressBook/ABMultiValueInternal.h
+++ b/Frameworks/AddressBook/ABMultiValueInternal.h
@@ -19,7 +19,7 @@
 #import <AddressBook/ABMultiValue.h>
 #import <Foundation/Foundation.h>
 
-@interface _ABMultiValue : NSObject
+@interface _ABMultiValue : NSObject <NSMutableCopying>
 
 - (id)initWithPropertyType:(ABPropertyType)propertyType;
 
@@ -42,7 +42,7 @@
 - (CFIndex)getIndexForIdentifier:(ABMultiValueIdentifier)identifier;
 
 // The following methods parallel those found in ABMutableMultiValue.mm.
-- (_ABMultiValue*)createMutableCopy;
+- (id)mutableCopyWithZone:(NSZone*)zone;
 - (bool)addValue:(CFTypeRef)value andLabel:(CFStringRef)label outIdentifier:(ABMultiValueIdentifier*)outIdentifier;
 - (bool)replaceValue:(CFTypeRef)value atIndex:(CFIndex)index;
 - (bool)replaceLabel:(CFStringRef)label atIndex:(CFIndex)index;

--- a/Frameworks/AddressBook/ABMultiValueInternal.mm
+++ b/Frameworks/AddressBook/ABMultiValueInternal.mm
@@ -159,7 +159,7 @@
     return index;
 }
 
-- (_ABMultiValue*)createMutableCopy {
+- (id)mutableCopyWithZone:(NSZone*)zone {
     _ABMultiValue* copy = [[_ABMultiValue alloc] initWithPropertyType:[self getPropertyType]];
     for (__ABMultiValuePair* pair in self->_list) {
         [copy appendPairWithLabel:pair.label andValue:pair.value];
@@ -169,6 +169,10 @@
 }
 
 - (bool)addValue:(CFTypeRef)value andLabel:(CFStringRef)label outIdentifier:(ABMultiValueIdentifier*)outIdentifier {
+    if (![self isMutable]) {
+        return false;
+    }
+
     bool result = [self appendPairWithLabel:(__bridge NSString*)label andValue:(__bridge id)value];
     if (result && outIdentifier) {
         *outIdentifier = [self getIdentifierAtIndex:([self getCount] - 1)];

--- a/Frameworks/AddressBook/ABMultiValueInternal.mm
+++ b/Frameworks/AddressBook/ABMultiValueInternal.mm
@@ -209,7 +209,7 @@
                       atIndex:index];
 
     // Increment the next usable identifier to ensure that each label/value pair has a unique identifier.
-    self->_nextIdentifier++;
+    (self->_nextIdentifier)++;
     if (outIdentifier) {
         *outIdentifier = [self getIdentifierAtIndex:index];
     }

--- a/Frameworks/AddressBook/ABMultiValueInternal.mm
+++ b/Frameworks/AddressBook/ABMultiValueInternal.mm
@@ -159,4 +159,71 @@
     return index;
 }
 
+- (_ABMultiValue*)createMutableCopy {
+    _ABMultiValue* copy = [[_ABMultiValue alloc] initWithPropertyType:[self getPropertyType]];
+    for (__ABMultiValuePair* pair in self->_list) {
+        [copy appendPairWithLabel:pair.label andValue:pair.value];
+    }
+
+    return copy;
+}
+
+- (bool)addValue:(CFTypeRef)value andLabel:(CFStringRef)label outIdentifier:(ABMultiValueIdentifier*)outIdentifier {
+    bool result = [self appendPairWithLabel:(__bridge NSString*)label andValue:(__bridge id)value];
+    if (result && outIdentifier) {
+        *outIdentifier = [self getIdentifierAtIndex:([self getCount] - 1)];
+    }
+
+    return result;
+}
+
+- (bool)replaceValue:(CFTypeRef)value atIndex:(CFIndex)index {
+    if (![self isMutable] || [self->_list count] <= index || index < 0) {
+        return false;
+    }
+
+    static_cast<__ABMultiValuePair*>(self->_list[index]).value = (__bridge id)value;
+    return true;
+}
+
+- (bool)replaceLabel:(CFStringRef)label atIndex:(CFIndex)index {
+    if (![self isMutable] || [self->_list count] <= index || index < 0) {
+        return false;
+    }
+
+    static_cast<__ABMultiValuePair*>(self->_list[index]).label = (__bridge NSString*)label;
+    return true;
+}
+
+- (bool)insertValue:(CFTypeRef)value
+           andLabel:(CFStringRef)label
+            atIndex:(CFIndex)index
+      outIdentifier:(ABMultiValueIdentifier*)outIdentifier {
+    if (![self isMutable] || [self->_list count] <= index || index < 0) {
+        return false;
+    }
+
+    [self->_list insertObject:[[__ABMultiValuePair alloc] initWithLabel:(__bridge NSString*)label
+                                                                  value:(__bridge id)value
+                                                             identifier:self->_nextIdentifier]
+                      atIndex:index];
+
+    // Increment the next usable identifier to ensure that each label/value pair has a unique identifier.
+    self->_nextIdentifier++;
+    if (outIdentifier) {
+        *outIdentifier = [self getIdentifierAtIndex:index];
+    }
+
+    return true;
+}
+
+- (bool)removeValueAndLabelAtIndex:(CFIndex)index {
+    if (![self isMutable] || [self->_list count] <= index || index < 0) {
+        return false;
+    }
+
+    [self->_list removeObjectAtIndex:index];
+    return true;
+}
+
 @end

--- a/Frameworks/AddressBook/ABMutableMultiValue.mm
+++ b/Frameworks/AddressBook/ABMutableMultiValue.mm
@@ -46,9 +46,7 @@ bool ABMultiValueAddValueAndLabel(ABMutableMultiValueRef multiValue,
                                   CFTypeRef value,
                                   CFStringRef label,
                                   ABMultiValueIdentifier* outIdentifier) {
-    if (multiValue == nullptr) {
-        return false;
-    }
+    RETURN_FALSE_IF(multiValue == nullptr);
 
     return [(__bridge _ABMultiValue*)multiValue addValue:value andLabel:label outIdentifier:outIdentifier];
 }
@@ -58,9 +56,7 @@ bool ABMultiValueAddValueAndLabel(ABMutableMultiValueRef multiValue,
  @Notes
 */
 bool ABMultiValueReplaceValueAtIndex(ABMutableMultiValueRef multiValue, CFTypeRef value, CFIndex index) {
-    if (multiValue == nullptr) {
-        return false;
-    }
+    RETURN_FALSE_IF(multiValue == nullptr);
 
     return [(__bridge _ABMultiValue*)multiValue replaceValue:value atIndex:index];
 }
@@ -70,9 +66,7 @@ bool ABMultiValueReplaceValueAtIndex(ABMutableMultiValueRef multiValue, CFTypeRe
  @Notes
 */
 bool ABMultiValueReplaceLabelAtIndex(ABMutableMultiValueRef multiValue, CFStringRef label, CFIndex index) {
-    if (multiValue == nullptr) {
-        return false;
-    }
+    RETURN_FALSE_IF(multiValue == nullptr);
 
     return [(__bridge _ABMultiValue*)multiValue replaceLabel:label atIndex:index];
 }
@@ -83,9 +77,7 @@ bool ABMultiValueReplaceLabelAtIndex(ABMutableMultiValueRef multiValue, CFString
 */
 bool ABMultiValueInsertValueAndLabelAtIndex(
     ABMutableMultiValueRef multiValue, CFTypeRef value, CFStringRef label, CFIndex index, ABMultiValueIdentifier* outIdentifier) {
-    if (multiValue == nullptr) {
-        return false;
-    }
+    RETURN_FALSE_IF(multiValue == nullptr);
 
     return [(__bridge _ABMultiValue*)multiValue insertValue:value andLabel:label atIndex:index outIdentifier:outIdentifier];
 }
@@ -95,9 +87,7 @@ bool ABMultiValueInsertValueAndLabelAtIndex(
  @Notes
 */
 bool ABMultiValueRemoveValueAndLabelAtIndex(ABMutableMultiValueRef multiValue, CFIndex index) {
-    if (multiValue == nullptr) {
-        return false;
-    }
+    RETURN_FALSE_IF(multiValue == nullptr);
 
     return [(__bridge _ABMultiValue*)multiValue removeValueAndLabelAtIndex:index];
 }

--- a/Frameworks/AddressBook/ABMutableMultiValue.mm
+++ b/Frameworks/AddressBook/ABMutableMultiValue.mm
@@ -35,7 +35,7 @@ ABMutableMultiValueRef ABMultiValueCreateMutable(ABPropertyType type) {
 ABMutableMultiValueRef ABMultiValueCreateMutableCopy(ABMultiValueRef multiValue) {
     RETURN_NULL_IF(multiValue == nullptr);
 
-    return (__bridge_retained ABMutableMultiValueRef)[(__bridge _ABMultiValue*)multiValue createMutableCopy];
+    return (__bridge_retained ABMutableMultiValueRef)[(__bridge _ABMultiValue*)multiValue mutableCopy];
 }
 
 /**

--- a/Frameworks/AddressBook/ABMutableMultiValue.mm
+++ b/Frameworks/AddressBook/ABMutableMultiValue.mm
@@ -18,70 +18,86 @@
 
 #import <StubReturn.h>
 #import "AssertARCEnabled.h"
+#import "ABMultiValueInternal.h"
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 ABMutableMultiValueRef ABMultiValueCreateMutable(ABPropertyType type) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return (__bridge_retained ABMutableMultiValueRef)[[_ABMultiValue alloc] initWithPropertyType:type];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 ABMutableMultiValueRef ABMultiValueCreateMutableCopy(ABMultiValueRef multiValue) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    RETURN_NULL_IF(multiValue == nullptr);
+
+    return (__bridge_retained ABMutableMultiValueRef)[(__bridge _ABMultiValue*)multiValue createMutableCopy];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool ABMultiValueAddValueAndLabel(ABMutableMultiValueRef multiValue,
                                   CFTypeRef value,
                                   CFStringRef label,
                                   ABMultiValueIdentifier* outIdentifier) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (multiValue == nullptr) {
+        return false;
+    }
+
+    return [(__bridge _ABMultiValue*)multiValue addValue:value andLabel:label outIdentifier:outIdentifier];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool ABMultiValueReplaceValueAtIndex(ABMutableMultiValueRef multiValue, CFTypeRef value, CFIndex index) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (multiValue == nullptr) {
+        return false;
+    }
+
+    return [(__bridge _ABMultiValue*)multiValue replaceValue:value atIndex:index];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool ABMultiValueReplaceLabelAtIndex(ABMutableMultiValueRef multiValue, CFStringRef label, CFIndex index) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (multiValue == nullptr) {
+        return false;
+    }
+
+    return [(__bridge _ABMultiValue*)multiValue replaceLabel:label atIndex:index];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool ABMultiValueInsertValueAndLabelAtIndex(
     ABMutableMultiValueRef multiValue, CFTypeRef value, CFStringRef label, CFIndex index, ABMultiValueIdentifier* outIdentifier) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (multiValue == nullptr) {
+        return false;
+    }
+
+    return [(__bridge _ABMultiValue*)multiValue insertValue:value andLabel:label atIndex:index outIdentifier:outIdentifier];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool ABMultiValueRemoveValueAndLabelAtIndex(ABMutableMultiValueRef multiValue, CFIndex index) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (multiValue == nullptr) {
+        return false;
+    }
+
+    return [(__bridge _ABMultiValue*)multiValue removeValueAndLabelAtIndex:index];
 }

--- a/build/Tests/UnitTests/AddressBook/AddressBook.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/AddressBook/AddressBook.UnitTests.vcxproj
@@ -239,6 +239,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\AddressBook\AuthorizationTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\AddressBook\BasicQueryTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\AddressBook\MultiValueTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\AddressBook\MutableMultiValueTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\Frameworks\AddressBook\NSDate+AddressBookAdditions.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/include/AddressBook/ABMutableMultiValue.h
+++ b/include/AddressBook/ABMutableMultiValue.h
@@ -22,19 +22,16 @@
 #import <CoreFoundation/CFString.h>
 
 typedef CFTypeRef ABMutableMultiValueRef;
-ADDRESSBOOK_EXPORT ABMutableMultiValueRef ABMultiValueCreateMutable(ABPropertyType type) STUB_METHOD;
-ADDRESSBOOK_EXPORT ABMutableMultiValueRef ABMultiValueCreateMutableCopy(ABMultiValueRef multiValue) STUB_METHOD;
+ADDRESSBOOK_EXPORT ABMutableMultiValueRef ABMultiValueCreateMutable(ABPropertyType type);
+ADDRESSBOOK_EXPORT ABMutableMultiValueRef ABMultiValueCreateMutableCopy(ABMultiValueRef multiValue);
 ADDRESSBOOK_EXPORT bool ABMultiValueAddValueAndLabel(ABMutableMultiValueRef multiValue,
                                                      CFTypeRef value,
                                                      CFStringRef label,
-                                                     ABMultiValueIdentifier* outIdentifier) STUB_METHOD;
+                                                     ABMultiValueIdentifier* outIdentifier);
 
-ADDRESSBOOK_EXPORT bool ABMultiValueReplaceValueAtIndex(ABMutableMultiValueRef multiValue, CFTypeRef value, CFIndex index) STUB_METHOD;
-ADDRESSBOOK_EXPORT bool ABMultiValueReplaceLabelAtIndex(ABMutableMultiValueRef multiValue, CFStringRef label, CFIndex index) STUB_METHOD;
-ADDRESSBOOK_EXPORT bool ABMultiValueInsertValueAndLabelAtIndex(ABMutableMultiValueRef multiValue,
-                                                               CFTypeRef value,
-                                                               CFStringRef label,
-                                                               CFIndex index,
-                                                               ABMultiValueIdentifier* outIdentifier) STUB_METHOD;
+ADDRESSBOOK_EXPORT bool ABMultiValueReplaceValueAtIndex(ABMutableMultiValueRef multiValue, CFTypeRef value, CFIndex index);
+ADDRESSBOOK_EXPORT bool ABMultiValueReplaceLabelAtIndex(ABMutableMultiValueRef multiValue, CFStringRef label, CFIndex index);
+ADDRESSBOOK_EXPORT bool ABMultiValueInsertValueAndLabelAtIndex(
+    ABMutableMultiValueRef multiValue, CFTypeRef value, CFStringRef label, CFIndex index, ABMultiValueIdentifier* outIdentifier);
 
-ADDRESSBOOK_EXPORT bool ABMultiValueRemoveValueAndLabelAtIndex(ABMutableMultiValueRef multiValue, CFIndex index) STUB_METHOD;
+ADDRESSBOOK_EXPORT bool ABMultiValueRemoveValueAndLabelAtIndex(ABMutableMultiValueRef multiValue, CFIndex index);

--- a/tests/unittests/AddressBook/MutableMultiValueTests.mm
+++ b/tests/unittests/AddressBook/MutableMultiValueTests.mm
@@ -78,28 +78,28 @@ TEST(MutableMultiValue, AddAndReplaceTest) {
     ABMultiValueIdentifier identifier2 = -1;
     ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"0000000000", kABHomeLabel, &identifier1),
                     "FAILED: Error adding first value/label pair!\n");
-    ASSERT_EQ_MSG(1, ABMultiValueGetCount(multiValue), "FAILED: Count of multivalue should be 1!\n");
+    ASSERT_EQ(1, ABMultiValueGetCount(multiValue));
 
     ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"1111111111", kABPersonPhoneMobileLabel, &identifier2),
                     "FAILED: Error adding second value/label pair!\n");
-    ASSERT_EQ_MSG(2, ABMultiValueGetCount(multiValue), "FAILED: Count of multivalue should be 2!\n");
+    ASSERT_EQ(2, ABMultiValueGetCount(multiValue));
 
     ASSERT_NE_MSG(identifier1, identifier2, "FAILED: Identifiers should be unique!\n");
 
     CFStringRef value1 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
-    EXPECT_OBJCEQ_MSG((__bridge NSString*)value1, @"0000000000", "FAILED: Values should be the same!\n");
+    EXPECT_OBJCEQ((__bridge NSString*)value1, @"0000000000");
     CFRelease(value1);
 
     CFStringRef label1 = ABMultiValueCopyLabelAtIndex(multiValue, 0);
-    EXPECT_OBJCEQ_MSG((__bridge NSString*)label1, (__bridge NSString*)kABHomeLabel, "FAILED: Labels should be the same!\n");
+    EXPECT_OBJCEQ((__bridge NSString*)label1, (__bridge NSString*)kABHomeLabel);
     CFRelease(label1);
 
     CFStringRef value2 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
-    EXPECT_OBJCEQ_MSG((__bridge NSString*)value2, @"1111111111", "FAILED: Values should be the same!\n");
+    EXPECT_OBJCEQ((__bridge NSString*)value2, @"1111111111");
     CFRelease(value2);
 
     CFStringRef label2 = ABMultiValueCopyLabelAtIndex(multiValue, 1);
-    EXPECT_OBJCEQ_MSG((__bridge NSString*)label2, (__bridge NSString*)kABPersonPhoneMobileLabel, "FAILED: Labels should be the same!\n");
+    EXPECT_OBJCEQ((__bridge NSString*)label2, (__bridge NSString*)kABPersonPhoneMobileLabel);
     CFRelease(label2);
 
     // Tests for replacing values.

--- a/tests/unittests/AddressBook/MutableMultiValueTests.mm
+++ b/tests/unittests/AddressBook/MutableMultiValueTests.mm
@@ -1,0 +1,154 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <TestFramework.h>
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+
+#import "UWP/WindowsApplicationModelContacts.h"
+#import <AddressBook/ABAddressBook.h>
+#import <AddressBook/ABRecord.h>
+#import <AddressBook/ABPerson.h>
+#import <AddressBook/ABMultiValue.h>
+#import <AddressBook/ABMutableMultiValue.h>
+#import "ABContactInternal.h"
+
+void addPhone(WACContact* contact, WACContactPhoneKind kind, NSString* number) {
+    WACContactPhone* phone = [WACContactPhone make];
+    phone.number = number;
+    phone.kind = kind;
+
+    [contact.phones addObject:phone];
+    [phone release];
+}
+
+ABMultiValueRef createMultiValue() {
+    WACContact* contact = [WACContact make];
+    addPhone(contact, WACContactPhoneKindHome, @"0000000000");
+    addPhone(contact, WACContactPhoneKindMobile, @"1111111111");
+    ABRecordRef record = (__bridge_retained ABRecordRef)[[_ABContact alloc] initWithContact:contact];
+    [contact release];
+    ABMultiValueRef multiValue = (ABMultiValueRef)ABRecordCopyValue(record, kABPersonPhoneProperty);
+    CFRelease(record);
+    return multiValue;
+}
+
+TEST(AddressBook, MutableMultiValueCreateTest) {
+    ABMultiValueRef multiValue = createMultiValue();
+    ABMutableMultiValueRef mutableMultiValue = ABMultiValueCreateMutableCopy(multiValue);
+    ASSERT_EQ_MSG(ABMultiValueGetCount(multiValue),
+                  ABMultiValueGetCount(mutableMultiValue),
+                  "FAILED: The mutable multi value should have the same count!\n");
+    for (int i = 0; i < ABMultiValueGetCount(mutableMultiValue); i++) {
+        CFStringRef value = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, i);
+        CFStringRef valueCopy = (CFStringRef)ABMultiValueCopyValueAtIndex(mutableMultiValue, i);
+        ASSERT_OBJCEQ_MSG((__bridge NSString*)value, (__bridge NSString*)valueCopy, "FAILED: Values should be the same!\n");
+        CFRelease(value);
+        CFRelease(valueCopy);
+
+        CFStringRef label = ABMultiValueCopyLabelAtIndex(multiValue, i);
+        CFStringRef labelCopy = ABMultiValueCopyLabelAtIndex(mutableMultiValue, i);
+        ASSERT_OBJCEQ_MSG((__bridge NSString*)label, (__bridge NSString*)labelCopy, "FAILED: Labels should be the same!\n");
+        CFRelease(label);
+        CFRelease(labelCopy);
+    }
+    CFRelease(mutableMultiValue);
+    CFRelease(multiValue);
+}
+
+TEST(AddressBook, MutableMultiValueAddAndReplaceTest) {
+    // Tests for adding label/value pairs.
+    ABMutableMultiValueRef multiValue = ABMultiValueCreateMutable(kABStringPropertyType);
+    ASSERT_EQ_MSG(0, ABMultiValueGetCount(multiValue), "FAILED: Count of multivalue should be 0!\n");
+    ABMultiValueIdentifier identifier1 = -1;
+    ABMultiValueIdentifier identifier2 = -1;
+    ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"0000000000", kABHomeLabel, &identifier1),
+                    "FAILED: Error adding first value/label pair!\n");
+    ASSERT_EQ_MSG(1, ABMultiValueGetCount(multiValue), "FAILED: Count of multivalue should be 1!\n");
+
+    ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"1111111111", kABPersonPhoneMobileLabel, &identifier2),
+                    "FAILED: Error adding second value/label pair!\n");
+    ASSERT_EQ_MSG(2, ABMultiValueGetCount(multiValue), "FAILED: Count of multivalue should be 2!\n");
+
+    ASSERT_NE_MSG(identifier1, identifier2, "FAILED: Identifiers should be unique!\n");
+
+    CFStringRef value1 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value1, @"0000000000", "FAILED: Values should be the same!\n");
+    CFRelease(value1);
+
+    CFStringRef label1 = ABMultiValueCopyLabelAtIndex(multiValue, 0);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)label1, (__bridge NSString*)kABHomeLabel, "FAILED: Labels should be the same!\n");
+    CFRelease(label1);
+
+    CFStringRef value2 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value2, @"1111111111", "FAILED: Values should be the same!\n");
+    CFRelease(value2);
+
+    CFStringRef label2 = ABMultiValueCopyLabelAtIndex(multiValue, 1);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)label2, (__bridge NSString*)kABPersonPhoneMobileLabel, "FAILED: Labels should be the same!\n");
+    CFRelease(label2);
+
+    // Tests for replacing values.
+    ASSERT_TRUE_MSG(ABMultiValueReplaceValueAtIndex(multiValue, @"2222222222", 0), "FAILED: Error replacing value!\n");
+    CFStringRef value = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value, @"2222222222", "FAILED: Replaced value didn't match!\n");
+    CFRelease(value);
+
+    // Tests for replacing labels.
+    ASSERT_TRUE_MSG(ABMultiValueReplaceLabelAtIndex(multiValue, (__bridge CFStringRef) @"fake label", 1),
+                    "FAILED: Error replacing label!\n");
+    CFStringRef label = ABMultiValueCopyLabelAtIndex(multiValue, 1);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)label, @"fake label", "FAILED: Replaced label didn't match!\n");
+    CFRelease(label);
+}
+
+TEST(AddressBook, MutableMultiValueInsertAndRemoveTest) {
+    ABMutableMultiValueRef multiValue = ABMultiValueCreateMutable(kABStringPropertyType);
+    ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"0000000000", kABHomeLabel, nullptr),
+                    "FAILED: Error adding first value/label pair!\n");
+    ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"1111111111", kABPersonPhoneMobileLabel, nullptr),
+                    "FAILED: Error adding second value/label pair!\n");
+
+    // Test inserting at index.
+    ASSERT_TRUE_MSG(ABMultiValueInsertValueAndLabelAtIndex(multiValue, @"2222222222", kABWorkLabel, 1, nullptr),
+                    "FAILED: Error inserting at index 1!\n");
+    ASSERT_EQ_MSG(3, ABMultiValueGetCount(multiValue), "FAILED: Incorrect count after inserting at index!\n");
+
+    CFStringRef value0 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value0, @"0000000000", "FAILED: Values should be the same!\n");
+    CFRelease(value0);
+
+    CFStringRef value1 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value1, @"2222222222", "FAILED: Values should be the same!\n");
+    CFRelease(value1);
+
+    CFStringRef value2 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 2);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value2, @"1111111111", "FAILED: Values should be the same!\n");
+    CFRelease(value2);
+
+    // Test removing at index.
+    ASSERT_TRUE_MSG(ABMultiValueRemoveValueAndLabelAtIndex(multiValue, 0), "FAILED: Error removing at index 0!\n");
+    ASSERT_EQ_MSG(2, ABMultiValueGetCount(multiValue), "FAILED: Incorrect count after removing at index!\n");
+
+    CFStringRef value0PostDelete = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value0PostDelete, @"2222222222", "FAILED: Values should be the same!\n");
+    CFRelease(value0PostDelete);
+
+    CFStringRef value1PostDelete = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
+    ASSERT_OBJCEQ_MSG((__bridge NSString*)value1PostDelete, @"1111111111", "FAILED: Values should be the same!\n");
+    CFRelease(value1PostDelete);
+}

--- a/tests/unittests/AddressBook/MutableMultiValueTests.mm
+++ b/tests/unittests/AddressBook/MutableMultiValueTests.mm
@@ -19,7 +19,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 #import <Foundation/Foundation.h>
 
-#import "UWP/WindowsApplicationModelContacts.h"
+#import <UWP/WindowsApplicationModelContacts.h>
 #import <AddressBook/ABAddressBook.h>
 #import <AddressBook/ABRecord.h>
 #import <AddressBook/ABPerson.h>

--- a/tests/unittests/AddressBook/MutableMultiValueTests.mm
+++ b/tests/unittests/AddressBook/MutableMultiValueTests.mm
@@ -56,13 +56,13 @@ TEST(MutableMultiValue, CreateTest) {
     for (int i = 0; i < ABMultiValueGetCount(mutableMultiValue); i++) {
         CFStringRef value = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, i);
         CFStringRef valueCopy = (CFStringRef)ABMultiValueCopyValueAtIndex(mutableMultiValue, i);
-        EXPECT_OBJCEQ_MSG((__bridge NSString*)value, (__bridge NSString*)valueCopy, "FAILED: Values should be the same!\n");
+        EXPECT_OBJCEQ((__bridge NSString*)value, (__bridge NSString*)valueCopy);
         CFRelease(value);
         CFRelease(valueCopy);
 
         CFStringRef label = ABMultiValueCopyLabelAtIndex(multiValue, i);
         CFStringRef labelCopy = ABMultiValueCopyLabelAtIndex(mutableMultiValue, i);
-        EXPECT_OBJCEQ_MSG((__bridge NSString*)label, (__bridge NSString*)labelCopy, "FAILED: Labels should be the same!\n");
+        EXPECT_OBJCEQ((__bridge NSString*)label, (__bridge NSString*)labelCopy);
         CFRelease(label);
         CFRelease(labelCopy);
     }
@@ -129,15 +129,15 @@ TEST(MutableMultiValue, InsertAndRemoveTest) {
     ASSERT_EQ_MSG(3, ABMultiValueGetCount(multiValue), "FAILED: Incorrect count after inserting at index!\n");
 
     CFStringRef value0 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value0, @"0000000000", "FAILED: Values should be the same!\n");
+    ASSERT_OBJCEQ((__bridge NSString*)value0, @"0000000000");
     CFRelease(value0);
 
     CFStringRef value1 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value1, @"2222222222", "FAILED: Values should be the same!\n");
+    ASSERT_OBJCEQ((__bridge NSString*)value1, @"2222222222");
     CFRelease(value1);
 
     CFStringRef value2 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 2);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value2, @"1111111111", "FAILED: Values should be the same!\n");
+    ASSERT_OBJCEQ((__bridge NSString*)value2, @"1111111111");
     CFRelease(value2);
 
     // Test removing at index.
@@ -145,10 +145,10 @@ TEST(MutableMultiValue, InsertAndRemoveTest) {
     ASSERT_EQ_MSG(2, ABMultiValueGetCount(multiValue), "FAILED: Incorrect count after removing at index!\n");
 
     CFStringRef value0PostDelete = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value0PostDelete, @"2222222222", "FAILED: Values should be the same!\n");
+    ASSERT_OBJCEQ((__bridge NSString*)value0PostDelete, @"2222222222");
     CFRelease(value0PostDelete);
 
     CFStringRef value1PostDelete = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value1PostDelete, @"1111111111", "FAILED: Values should be the same!\n");
+    ASSERT_OBJCEQ((__bridge NSString*)value1PostDelete, @"1111111111");
     CFRelease(value1PostDelete);
 }

--- a/tests/unittests/AddressBook/MutableMultiValueTests.mm
+++ b/tests/unittests/AddressBook/MutableMultiValueTests.mm
@@ -47,7 +47,7 @@ ABMultiValueRef createMultiValue() {
     return multiValue;
 }
 
-TEST(AddressBook, MutableMultiValueCreateTest) {
+TEST(MutableMultiValue, CreateTest) {
     ABMultiValueRef multiValue = createMultiValue();
     ABMutableMultiValueRef mutableMultiValue = ABMultiValueCreateMutableCopy(multiValue);
     ASSERT_EQ_MSG(ABMultiValueGetCount(multiValue),
@@ -56,13 +56,13 @@ TEST(AddressBook, MutableMultiValueCreateTest) {
     for (int i = 0; i < ABMultiValueGetCount(mutableMultiValue); i++) {
         CFStringRef value = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, i);
         CFStringRef valueCopy = (CFStringRef)ABMultiValueCopyValueAtIndex(mutableMultiValue, i);
-        ASSERT_OBJCEQ_MSG((__bridge NSString*)value, (__bridge NSString*)valueCopy, "FAILED: Values should be the same!\n");
+        EXPECT_OBJCEQ_MSG((__bridge NSString*)value, (__bridge NSString*)valueCopy, "FAILED: Values should be the same!\n");
         CFRelease(value);
         CFRelease(valueCopy);
 
         CFStringRef label = ABMultiValueCopyLabelAtIndex(multiValue, i);
         CFStringRef labelCopy = ABMultiValueCopyLabelAtIndex(mutableMultiValue, i);
-        ASSERT_OBJCEQ_MSG((__bridge NSString*)label, (__bridge NSString*)labelCopy, "FAILED: Labels should be the same!\n");
+        EXPECT_OBJCEQ_MSG((__bridge NSString*)label, (__bridge NSString*)labelCopy, "FAILED: Labels should be the same!\n");
         CFRelease(label);
         CFRelease(labelCopy);
     }
@@ -70,7 +70,7 @@ TEST(AddressBook, MutableMultiValueCreateTest) {
     CFRelease(multiValue);
 }
 
-TEST(AddressBook, MutableMultiValueAddAndReplaceTest) {
+TEST(MutableMultiValue, AddAndReplaceTest) {
     // Tests for adding label/value pairs.
     ABMutableMultiValueRef multiValue = ABMultiValueCreateMutable(kABStringPropertyType);
     ASSERT_EQ_MSG(0, ABMultiValueGetCount(multiValue), "FAILED: Count of multivalue should be 0!\n");
@@ -87,19 +87,19 @@ TEST(AddressBook, MutableMultiValueAddAndReplaceTest) {
     ASSERT_NE_MSG(identifier1, identifier2, "FAILED: Identifiers should be unique!\n");
 
     CFStringRef value1 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 0);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value1, @"0000000000", "FAILED: Values should be the same!\n");
+    EXPECT_OBJCEQ_MSG((__bridge NSString*)value1, @"0000000000", "FAILED: Values should be the same!\n");
     CFRelease(value1);
 
     CFStringRef label1 = ABMultiValueCopyLabelAtIndex(multiValue, 0);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)label1, (__bridge NSString*)kABHomeLabel, "FAILED: Labels should be the same!\n");
+    EXPECT_OBJCEQ_MSG((__bridge NSString*)label1, (__bridge NSString*)kABHomeLabel, "FAILED: Labels should be the same!\n");
     CFRelease(label1);
 
     CFStringRef value2 = (CFStringRef)ABMultiValueCopyValueAtIndex(multiValue, 1);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)value2, @"1111111111", "FAILED: Values should be the same!\n");
+    EXPECT_OBJCEQ_MSG((__bridge NSString*)value2, @"1111111111", "FAILED: Values should be the same!\n");
     CFRelease(value2);
 
     CFStringRef label2 = ABMultiValueCopyLabelAtIndex(multiValue, 1);
-    ASSERT_OBJCEQ_MSG((__bridge NSString*)label2, (__bridge NSString*)kABPersonPhoneMobileLabel, "FAILED: Labels should be the same!\n");
+    EXPECT_OBJCEQ_MSG((__bridge NSString*)label2, (__bridge NSString*)kABPersonPhoneMobileLabel, "FAILED: Labels should be the same!\n");
     CFRelease(label2);
 
     // Tests for replacing values.
@@ -116,7 +116,7 @@ TEST(AddressBook, MutableMultiValueAddAndReplaceTest) {
     CFRelease(label);
 }
 
-TEST(AddressBook, MutableMultiValueInsertAndRemoveTest) {
+TEST(MutableMultiValue, InsertAndRemoveTest) {
     ABMutableMultiValueRef multiValue = ABMultiValueCreateMutable(kABStringPropertyType);
     ASSERT_TRUE_MSG(ABMultiValueAddValueAndLabel(multiValue, @"0000000000", kABHomeLabel, nullptr),
                     "FAILED: Error adding first value/label pair!\n");


### PR DESCRIPTION
Fixes #682
Adds support for mutable multi-values,
giving functionality to add new value/label
pairs, as well as removing or modifying
existing ones.