### PR TITLE
Fix build break in Foundation.UnitTests on OSX

### DIFF
--- a/tests/unittests/Foundation/Makefile
+++ b/tests/unittests/Foundation/Makefile
@@ -32,6 +32,7 @@ CFLAGS += -x objective-c++
 CFLAGS += $(INC_PARAMS)
 CFLAGS += -DTARGET_OS_MAC
 CFLAGS += -DWINOBJCRT_IMPEXP=
+CFLAGS += -DLOGGING_IMPEXP=
 CFLAGS += -mmacosx-version-min=$(OSX_VERSION_MIN)
 
 LDFLAGS := -framework Foundation -mmacosx-version-min=$(OSX_VERSION_MIN)


### PR DESCRIPTION
A recent merge to GitHub develop took a change that introduced __declspec to LoggingNative, which is unavailable on OSX.
Edited the makefile so that LOGGING_IMPEXP is predefined to empty.

Fixes #894