### PR TITLE
Add missing base classes for some stubbed interfaces. Fix #901.

### DIFF
--- a/Frameworks/CoreBluetooth/CBCentral.mm
+++ b/Frameworks/CoreBluetooth/CBCentral.mm
@@ -25,7 +25,7 @@
 */
 - (id)copyWithZone:(NSZone*)zone {
     UNIMPLEMENTED();
-    return [self retain];
+    return self;
 }
 
 @end

--- a/Frameworks/CoreBluetooth/CBCentral.mm
+++ b/Frameworks/CoreBluetooth/CBCentral.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -19,4 +19,13 @@
 #import "AssertARCEnabled.h"
 
 @implementation CBCentral
+
+/**
+ @Status Stub
+*/
+- (id)copyWithZone:(NSZone*)zone {
+    UNIMPLEMENTED();
+    return [self retain];
+}
+
 @end

--- a/Frameworks/EventKit/EKStructuredLocation.mm
+++ b/Frameworks/EventKit/EKStructuredLocation.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -25,6 +25,14 @@
 + (EKStructuredLocation*)locationWithTitle:(NSString*)title {
     UNIMPLEMENTED();
     return StubReturn();
+}
+
+/**
+ @Status Stub
+*/
+- (id)copyWithZone:(NSZone*)zone {
+    UNIMPLEMENTED();
+    return [self retain];
 }
 
 @end

--- a/Frameworks/MapKit/MKDistanceFormatter.mm
+++ b/Frameworks/MapKit/MKDistanceFormatter.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -34,6 +34,29 @@
 - (CLLocationDistance)distanceFromString:(NSString*)distance {
     UNIMPLEMENTED();
     return StubReturn();
+}
+
+/**
+ @Status Stub
+*/
+- (id)copyWithZone:(NSZone*)zone {
+    UNIMPLEMENTED();
+    return [self retain];
+}
+
+/**
+ @Status Stub
+*/
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+*/
+- (void)encodeWithCoder:(NSCoder*)encoder {
+    UNIMPLEMENTED();
 }
 
 @end

--- a/Frameworks/MessageUI/MFMailComposeViewController.mm
+++ b/Frameworks/MessageUI/MFMailComposeViewController.mm
@@ -77,4 +77,102 @@ NSString* const MFMailComposeErrorDomain = @"MFMailComposeErrorDomain";
     UNIMPLEMENTED();
 }
 
+/**
+ @Status Stub
+*/
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+*/
+- (void)encodeWithCoder:(NSCoder*)encoder {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)willTransitionToTraitCollection:(UITraitCollection*)newCollection
+              withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (CGSize)sizeForChildContentContainer:(id<UIContentContainer>)container withParentContainerSize:(CGSize)parentSize {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)systemLayoutFittingSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (void)setNeedsFocusUpdate {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (void)updateFocusIfNeeded {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext*)context {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext*)context withAnimationCoordinator:(UIFocusAnimationCoordinator*)coordinator {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UITraitEnvironment.h
+*/
+- (void)traitCollectionDidChange:(UITraitCollection*)previousTraitCollection {
+    UNIMPLEMENTED();
+}
+
 @end

--- a/Frameworks/MessageUI/MFMailComposeViewController.mm
+++ b/Frameworks/MessageUI/MFMailComposeViewController.mm
@@ -14,7 +14,8 @@
 //
 //******************************************************************************
 
-#include "ErrorHandling.h"
+#import "ErrorHandling.h"
+#import <StubReturn.h>
 #import <MessageUI/MFMailComposeViewController.h>
 
 NSString* const MFMailComposeErrorDomain = @"MFMailComposeErrorDomain";

--- a/Frameworks/MessageUI/MFMessageComposeViewController.mm
+++ b/Frameworks/MessageUI/MFMessageComposeViewController.mm
@@ -84,4 +84,102 @@ NSString* const MFMessageComposeViewControllerAttachmentAlternateFilename = @"MF
     UNIMPLEMENTED();
 }
 
+/**
+ @Status Stub
+*/
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+*/
+- (void)encodeWithCoder:(NSCoder*)encoder {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)willTransitionToTraitCollection:(UITraitCollection*)newCollection
+              withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (CGSize)sizeForChildContentContainer:(id<UIContentContainer>)container withParentContainerSize:(CGSize)parentSize {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)preferredContentSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIContentContainer.h
+*/
+- (void)systemLayoutFittingSizeDidChangeForChildContentContainer:(id<UIContentContainer>)container {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (void)setNeedsFocusUpdate {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (void)updateFocusIfNeeded {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext*)context {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UIFocusEnvironment.h
+*/
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext*)context withAnimationCoordinator:(UIFocusAnimationCoordinator*)coordinator {
+    UNIMPLEMENTED();
+}
+
+/**
+ @Status Stub
+ @Notes Conform to UITraitEnvironment.h
+*/
+- (void)traitCollectionDidChange:(UITraitCollection*)previousTraitCollection {
+    UNIMPLEMENTED();
+}
+
 @end

--- a/Frameworks/MessageUI/MFMessageComposeViewController.mm
+++ b/Frameworks/MessageUI/MFMessageComposeViewController.mm
@@ -14,7 +14,8 @@
 //
 //******************************************************************************
 
-#include "ErrorHandling.h"
+#import "ErrorHandling.h"
+#import <StubReturn.h>
 #import <MessageUI/MFMessageComposeViewController.h>
 
 NSString* const MFMessageComposeViewControllerTextMessageAvailabilityKey = @"MFMessageComposeViewControllerTextMessageAvailabilityKey";

--- a/include/CoreBluetooth/CBATTRequest.h
+++ b/include/CoreBluetooth/CBATTRequest.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -24,7 +24,7 @@
 @class NSData;
 
 COREBLUETOOTH_EXPORT_CLASS
-@interface CBATTRequest
+@interface CBATTRequest : NSObject <NSObject>
 @property (readonly, retain, nonatomic) CBCentral* central STUB_PROPERTY;
 @property (readonly, retain, nonatomic) CBCharacteristic* characteristic STUB_PROPERTY;
 @property (readwrite, copy) NSData* value STUB_PROPERTY;

--- a/include/CoreBluetooth/CBCentral.h
+++ b/include/CoreBluetooth/CBCentral.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -24,7 +24,7 @@
 @class NSUUID;
 
 COREBLUETOOTH_EXPORT_CLASS
-@interface CBCentral
+@interface CBCentral : NSObject <NSObject>
 @property (readonly, nonatomic) CFUUIDRef UUID STUB_PROPERTY;
 @property (readonly, nonatomic) NSUUID* identifier STUB_PROPERTY;
 @property (readonly, nonatomic) NSUInteger maximumUpdateValueLength STUB_PROPERTY;

--- a/include/CoreBluetooth/CBCentral.h
+++ b/include/CoreBluetooth/CBCentral.h
@@ -24,7 +24,7 @@
 @class NSUUID;
 
 COREBLUETOOTH_EXPORT_CLASS
-@interface CBCentral : NSObject <NSObject>
+@interface CBCentral : NSObject <NSObject, NSCopying>
 @property (readonly, nonatomic) CFUUIDRef UUID STUB_PROPERTY;
 @property (readonly, nonatomic) NSUUID* identifier STUB_PROPERTY;
 @property (readonly, nonatomic) NSUInteger maximumUpdateValueLength STUB_PROPERTY;

--- a/include/CoreBluetooth/CBMutableCharacteristic.h
+++ b/include/CoreBluetooth/CBMutableCharacteristic.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 
 #import <CoreBluetooth/CoreBluetoothExport.h>
 #import <CoreBluetooth/CBCharacteristic.h>
+#import <Foundation/NSObject.h>
 
 @class CBUUID;
 @class NSData;
@@ -30,7 +31,7 @@ typedef enum {
 } CBAttributePermissions;
 
 COREBLUETOOTH_EXPORT_CLASS
-@interface CBMutableCharacteristic
+@interface CBMutableCharacteristic : NSObject <NSObject>
 - (id)initWithType:(CBUUID*)UUID
         properties:(CBCharacteristicProperties)properties
              value:(NSData*)value

--- a/include/CoreBluetooth/CBMutableDescriptor.h
+++ b/include/CoreBluetooth/CBMutableDescriptor.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -16,10 +16,10 @@
 #pragma once
 
 #import <CoreBluetooth/CoreBluetoothExport.h>
-
+#import <Foundation/NSObject.h>
 @class CBUUID;
 
 COREBLUETOOTH_EXPORT_CLASS
-@interface CBMutableDescriptor
+@interface CBMutableDescriptor : NSObject <NSObject>
 - (id)initWithType:(CBUUID*)UUID value:(id)value STUB_METHOD;
 @end

--- a/include/CoreBluetooth/CBPeripheralManager.h
+++ b/include/CoreBluetooth/CBPeripheralManager.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,7 +17,7 @@
 
 #import <CoreBluetooth/CoreBluetoothExport.h>
 #import <CoreBluetooth/CBConstants.h>
-
+#import <Foundation/NSObject.h>
 #import <dispatch/dispatch.h>
 #import <objc/runtime.h>
 
@@ -56,7 +56,7 @@ COREBLUETOOTH_EXPORT NSString* const CBPeripheralManagerOptionShowPowerAlertKey;
 COREBLUETOOTH_EXPORT NSString* const CBPeripheralManagerOptionRestoreIdentifierKey;
 COREBLUETOOTH_EXPORT_CLASS
 
-@interface CBPeripheralManager
+@interface CBPeripheralManager : NSObject <NSObject>
 - (id)initWithDelegate:(id<CBPeripheralManagerDelegate>)delegate queue:(dispatch_queue_t)queue STUB_METHOD;
 - (id)initWithDelegate:(id<CBPeripheralManagerDelegate>)delegate queue:(dispatch_queue_t)queue options:(NSDictionary*)options STUB_METHOD;
 @property (nonatomic, weak) id<CBPeripheralManagerDelegate> delegate STUB_PROPERTY;

--- a/include/CoreTelephony/CTCallCenter.h
+++ b/include/CoreTelephony/CTCallCenter.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreTelephony/CTSubscriber.h
+++ b/include/CoreTelephony/CTSubscriber.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,12 +17,13 @@
 #pragma once
 
 #import <CoreTelephony/CoreTelephonyExport.h>
+#import <Foundation/NSObject.h>
 
 @class NSString;
 @class NSData;
 
 CORETELEPHONY_EXPORT NSString* const CTSubscriberTokenRefreshed;
 CORETELEPHONY_EXPORT_CLASS
-@interface CTSubscriber
+@interface CTSubscriber : NSObject <NSObject>
 @property (readonly, retain, nonatomic) NSData* carrierToken STUB_PROPERTY;
 @end

--- a/include/EventKit/EKStructuredLocation.h
+++ b/include/EventKit/EKStructuredLocation.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -16,12 +16,13 @@
 #pragma once
 
 #import <EventKit/EventKitExport.h>
+#import <Foundation/NSObject.h>
 
 @class NSString;
 @class CLLocation;
 
 EVENTKIT_EXPORT_CLASS
-@interface EKStructuredLocation
+@interface EKStructuredLocation : NSObject <NSObject>
 + (EKStructuredLocation*)locationWithTitle:(NSString*)title STUB_METHOD;
 @property (retain, nonatomic) NSString* title STUB_PROPERTY;
 @property (retain, nonatomic) CLLocation* geoLocation STUB_PROPERTY;

--- a/include/EventKit/EKStructuredLocation.h
+++ b/include/EventKit/EKStructuredLocation.h
@@ -22,7 +22,7 @@
 @class CLLocation;
 
 EVENTKIT_EXPORT_CLASS
-@interface EKStructuredLocation : NSObject <NSObject>
+@interface EKStructuredLocation : NSObject <NSObject, NSCopying>
 + (EKStructuredLocation*)locationWithTitle:(NSString*)title STUB_METHOD;
 @property (retain, nonatomic) NSString* title STUB_PROPERTY;
 @property (retain, nonatomic) CLLocation* geoLocation STUB_PROPERTY;

--- a/include/MapKit/MKDirectionsResponse.h
+++ b/include/MapKit/MKDirectionsResponse.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -16,12 +16,13 @@
 #pragma once
 
 #import <MapKit/MapKitExport.h>
+#import <Foundation/NSObject.h>
 
 @class MKMapItem;
 @class NSArray;
 
 MAPKIT_EXPORT_CLASS
-@interface MKDirectionsResponse
+@interface MKDirectionsResponse : NSObject <NSObject>
 @property (readonly, nonatomic) MKMapItem* source STUB_PROPERTY;
 @property (readonly, nonatomic) MKMapItem* destination STUB_PROPERTY;
 @property (readonly, nonatomic) NSArray* routes STUB_PROPERTY;

--- a/include/MapKit/MKDistanceFormatter.h
+++ b/include/MapKit/MKDistanceFormatter.h
@@ -36,7 +36,7 @@ typedef enum {
 } MKDistanceFormatterUnitStyle;
 
 MAPKIT_EXPORT_CLASS
-@interface MKDistanceFormatter : NSObject <NSObject>
+@interface MKDistanceFormatter : NSObject <NSObject, NSCopying, NSCoding>
 - (NSString*)stringFromDistance:(CLLocationDistance)distance STUB_METHOD;
 - (CLLocationDistance)distanceFromString:(NSString*)distance STUB_METHOD;
 @property (copy, nonatomic) NSLocale* locale STUB_PROPERTY;

--- a/include/MapKit/MKDistanceFormatter.h
+++ b/include/MapKit/MKDistanceFormatter.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 
 #import <MapKit/MapKitExport.h>
 #import <CoreLocation/CLLocation.h>
+#import <Foundation/NSObject.h>
 
 @class NSString;
 @class NSLocale;
@@ -35,7 +36,7 @@ typedef enum {
 } MKDistanceFormatterUnitStyle;
 
 MAPKIT_EXPORT_CLASS
-@interface MKDistanceFormatter
+@interface MKDistanceFormatter : NSObject <NSObject>
 - (NSString*)stringFromDistance:(CLLocationDistance)distance STUB_METHOD;
 - (CLLocationDistance)distanceFromString:(NSString*)distance STUB_METHOD;
 @property (copy, nonatomic) NSLocale* locale STUB_PROPERTY;

--- a/include/MapKit/MKMapSnapshotter.h
+++ b/include/MapKit/MKMapSnapshotter.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -16,6 +16,7 @@
 #pragma once
 
 #import <MapKit/MapKitExport.h>
+#import <Foundation/NSObject.h>
 #import <objc/runtime.h>
 #import <objc/toydispatch.h>
 

--- a/include/MapKit/MKMapSnapshotter.h
+++ b/include/MapKit/MKMapSnapshotter.h
@@ -26,7 +26,7 @@
 typedef void (^MKMapSnapshotCompletionHandler)(MKMapSnapshot* snapshot, NSError* error);
 
 MAPKIT_EXPORT_CLASS
-@interface MKMapSnapshotter
+@interface MKMapSnapshotter : NSObject <NSObject>
 - (instancetype)initWithOptions:(MKMapSnapshotOptions*)options STUB_METHOD;
 - (void)startWithCompletionHandler:(MKMapSnapshotCompletionHandler)completionHandler STUB_METHOD;
 - (void)startWithQueue:(dispatch_queue_t)queue completionHandler:(MKMapSnapshotCompletionHandler)completionHandler STUB_METHOD;

--- a/include/MessageUI/MFMailComposeViewController.h
+++ b/include/MessageUI/MFMailComposeViewController.h
@@ -19,11 +19,16 @@
 #import <MessageUI/MessageUIExport.h>
 #import <MessageUI/MFMailComposeViewControllerDelegate.h>
 #import <UIKit/UINavigationController.h>
+#import <UIKit/UIAppearanceContainer.h>
+#import <UIKit/UIContentContainer.h>
+#import <UIKit/UIFocusEnvironment.h>
+#import <UIKit/UITraitEnvironment.h>
 
 MESSAGEUI_EXPORT NSString* const MFMailComposeErrorDomain;
 
 MESSAGEUI_EXPORT_CLASS
-@interface MFMailComposeViewController : UINavigationController <NSCoding, UIAppearanceContainer>
+@interface MFMailComposeViewController
+    : UINavigationController <NSCoding, NSObject, UIAppearanceContainer, UIContentContainer, UIFocusEnvironment, UITraitEnvironment>
 
 + (BOOL)canSendMail;
 

--- a/include/MessageUI/MFMailComposeViewController.h
+++ b/include/MessageUI/MFMailComposeViewController.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,11 +18,12 @@
 #import <Foundation/Foundation.h>
 #import <MessageUI/MessageUIExport.h>
 #import <MessageUI/MFMailComposeViewControllerDelegate.h>
+#import <UIKit/UINavigationController.h>
 
 MESSAGEUI_EXPORT NSString* const MFMailComposeErrorDomain;
 
 MESSAGEUI_EXPORT_CLASS
-@interface MFMailComposeViewController
+@interface MFMailComposeViewController : UINavigationController <NSCoding, UIAppearanceContainer>
 
 + (BOOL)canSendMail;
 

--- a/include/MessageUI/MFMessageComposeViewController.h
+++ b/include/MessageUI/MFMessageComposeViewController.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,10 @@
 #import <MessageUI/MessageUIExport.h>
 #import <MessageUI/MFMessageComposeViewControllerDelegate.h>
 #import <UIKit/UINavigationController.h>
+#import <UIKit/UIAppearanceContainer.h>
+#import <UIKit/UIContentContainer.h>
+#import <UIKit/UIFocusEnvironment.h>
+#import <UIKit/UITraitEnvironment.h>
 
 @class NSString;
 @class NSArray;
@@ -29,7 +33,8 @@ MESSAGEUI_EXPORT NSString* const MFMessageComposeViewControllerAttachmentURL;
 MESSAGEUI_EXPORT NSString* const MFMessageComposeViewControllerAttachmentAlternateFilename;
 
 MESSAGEUI_EXPORT_CLASS
-@interface MFMessageComposeViewController : UINavigationController <NSCoding, UIAppearanceContainer>
+@interface MFMessageComposeViewController
+    : UINavigationController <NSCoding, NSObject, UIAppearanceContainer, UIContentContainer, UIFocusEnvironment, UITraitEnvironment>
 
 + (BOOL)canSendText;
 + (BOOL)canSendAttachments;


### PR DESCRIPTION
During our stubbing exercise, some interfaces didn't get any parent, so you can't really compile using them..