### PR TITLE
Create file for NSData write tests and NSFileHandle WritingAtPath test

### DIFF
--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -352,6 +352,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
         return TRUE;
     } else {
         TraceVerbose(TAG, L"NSData couldn't open %hs for write (with options)", fname);
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:4 userInfo:@{ NSFilePathErrorKey : filename }];
         return FALSE;
     }
 }

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -348,13 +348,14 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
     if (fpOut) {
         EbrFwrite([self bytes], 1, [self length], fpOut);
         EbrFclose(fpOut);
-
-        return TRUE;
-    } else {
-        TraceVerbose(TAG, L"NSData couldn't open %hs for write (with options)", fname);
-        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:4 userInfo:@{ NSFilePathErrorKey : filename }];
-        return FALSE;
+        return YES;
     }
+
+    TraceVerbose(TAG, L"NSData couldn't open %hs for write (with options)", fname);
+    if (error) {
+        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSFilePathErrorKey : filename }];
+    }
+    return NO;
 }
 
 /**

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -183,18 +183,49 @@ TEST(NSData, Base64EncodeDecodeWrappers) {
                       base64EncodedDataWithOptions:NSDataBase64Encoding76CharacterLineLength]);
 }
 
+TEST(NSData, WriteToFile) {
+    // first, write the test string to NSURL which represents as a file
+    // ensure it succeeds
+    const char bytes[] = "Hello world";
+    StrongId<NSData> expectedData = [NSData dataWithBytes:bytes length:std::extent<decltype(bytes)>::value];
+
+    // Create the file or trying to write will fail
+    StrongId<NSString> filePath = @"./Helloworld.txt";
+    ASSERT_TRUE([[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:nil]);
+
+    NSError* error = nil;
+    EXPECT_TRUE_MSG([expectedData writeToFile:@"./Helloworld.txt" options:0 error:&error], "NSDataWriteToURL should succeed");
+    EXPECT_EQ(nil, error);
+
+    // second, read the file content back, compare with original content
+    // ensure they are equal
+    StrongId<NSData> actualData = [NSData dataWithContentsOfFile:filePath];
+    EXPECT_OBJCEQ_MSG(expectedData, actualData, "Data should be equal");
+
+    [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
+}
+
 TEST(NSData, WriteToURL) {
     // first, write the test string to NSURL which represents as a file
     // ensure it succeeds
     const char bytes[] = "Hello world";
     StrongId<NSData> expectedData = [NSData dataWithBytes:bytes length:std::extent<decltype(bytes)>::value];
-    StrongId<NSURL> fileURL = [NSURL fileURLWithPath:@"./Library/Helloworld.txt"];
-    ASSERT_TRUE_MSG([expectedData writeToURL:fileURL options:0 error:nullptr], "NSDataWriteToURL should succeed");
+
+    // Create the file or trying to write will fail
+    StrongId<NSString> filePath = @"./Helloworld.txt";
+    ASSERT_TRUE([[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:nil]);
+
+    StrongId<NSURL> fileURL = [NSURL fileURLWithPath:filePath];
+    NSError* error = nil;
+    EXPECT_TRUE_MSG([expectedData writeToURL:fileURL options:0 error:&error], "NSDataWriteToURL should succeed");
+    EXPECT_EQ(nil, error);
 
     // second, read the file content back, compare with original content
     // ensure they are equal
     StrongId<NSData> actualData = [NSData dataWithContentsOfFile:[fileURL path]];
-    ASSERT_OBJCEQ_MSG(expectedData, actualData, "Data should be equal");
+    EXPECT_OBJCEQ_MSG(expectedData, actualData, "Data should be equal");
+
+    [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
 }
 
 TEST(NSData, MutableDataBasicTests) {

--- a/tests/unittests/Foundation/NSFileHandleTests.mm
+++ b/tests/unittests/Foundation/NSFileHandleTests.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/unittests/Foundation/NSFileHandleTests.mm
+++ b/tests/unittests/Foundation/NSFileHandleTests.mm
@@ -29,10 +29,10 @@ TEST(NSFileHandle, ReadFile) {
     NSString* fullPath = getPathToFile(fileName);
     NSFileHandle* fh = [NSFileHandle fileHandleForReadingAtPath:fullPath];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     NSData* fileData = [fh readDataToEndOfFile];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the entire file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the entire file failed.");
 
     NSString* str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, content, "FAILED: Unable to read the file content.");
@@ -46,7 +46,7 @@ TEST(NSFileHandle, UpdateAndSeeks) {
     NSString* fullPath = getPathToFile(fileName);
     NSFileHandle* fh = [NSFileHandle fileHandleForUpdatingAtPath:fullPath];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     unsigned long long cursor = [fh seekToEndOfFile];
 
@@ -68,7 +68,7 @@ TEST(NSFileHandle, Offsets) {
     NSFileHandle* fh = [NSFileHandle fileHandleForReadingAtPath:getPathToFile(fileName)];
     SCOPE_CLOSE_HANDLE(fh);
 
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     ASSERT_EQ([fh offsetInFile], 0);
 
@@ -94,10 +94,10 @@ TEST(NSFileHandle, WriteToNonExistentFileAndRead) {
 
     NSFileHandle* fh = [NSFileHandle fileHandleForReadingAtPath:getPathToFile(fileName)];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     NSData* fileData = [fh readDataToEndOfFile];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the entire file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the entire file failed.");
 
     NSString* str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, testStr, "FAILED: Unable to read the file content.");
@@ -112,7 +112,7 @@ TEST(NSFileHandle, TruncateFileAtOffset) {
 
     NSFileHandle* fh = [NSFileHandle fileHandleForUpdatingAtPath:getPathToFile(fileName)];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     unsigned long long endCursor = [fh seekToEndOfFile];
 
@@ -125,7 +125,7 @@ TEST(NSFileHandle, TruncateFileAtOffset) {
     fh = [NSFileHandle fileHandleForReadingAtPath:getPathToFile(fileName)];
     SCOPE_CLOSE_HANDLE(fh);
     NSData* fileData = [fh readDataToEndOfFile];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the entire file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the entire file failed.");
 
     NSString* str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     NSString* finalData = [NSString stringWithFormat:@"%@%@", testString, content];
@@ -145,7 +145,7 @@ TEST(NSFileHandle, TruncateFileAtOffset) {
     fh = [NSFileHandle fileHandleForReadingAtPath:getPathToFile(fileName)];
     SCOPE_CLOSE_HANDLE(fh);
     fileData = [fh readDataToEndOfFile];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the entire file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the entire file failed.");
 
     str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, testString, "FAILED: Unable to read the file content.");
@@ -156,7 +156,7 @@ TEST(NSFileHandle, TruncateFileAtOffset) {
 TEST(NSFileHandle, FileHandleWithNullDevice) {
     NSFileHandle* fh = [NSFileHandle fileHandleWithNullDevice];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     // no-op
     [fh writeData:nil];
@@ -181,24 +181,24 @@ TEST(NSFileHandle, ReadDataOfLength) {
     NSFileHandle* fh = [NSFileHandle fileHandleForReadingAtPath:fullPath];
     SCOPE_CLOSE_HANDLE(fh);
 
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     NSData* fileData = [fh readDataOfLength:9];
-    ASSERT_TRUE(fileData != nil);
+    ASSERT_NE(fileData, nil);
 
     NSString* str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, @"The Quick", "FAILED: Unable to read the file content.");
 
     // Try to read more than the max bytes.
     fileData = [fh readDataOfLength:30];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the file failed.");
 
     str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, @" Brown Fox.", "FAILED: Unable to read the file content.");
 
     // Try to read again.
     fileData = [fh readDataOfLength:30000];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the file failed.");
     ASSERT_OBJCEQ(fileData, [NSData data]);
 }
 
@@ -211,7 +211,7 @@ TEST(NSFileHandle, UpdatingURL) {
 
     NSFileHandle* fh = [NSFileHandle fileHandleForUpdatingURL:[NSURL fileURLWithPath:fullPath] error:&error];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     unsigned long long cursor = [fh seekToEndOfFile];
 
@@ -235,10 +235,10 @@ TEST(NSFileHandle, ReadingFromURL) {
     NSError* error;
     NSFileHandle* fh = [NSFileHandle fileHandleForReadingFromURL:[NSURL fileURLWithPath:fullPath] error:&error];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     NSData* fileData = [fh readDataToEndOfFile];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the entire file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the entire file failed.");
 
     NSString* str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, @"The Quick Brown Fox.", "FAILED: Unable to read the file content.");
@@ -247,14 +247,14 @@ TEST(NSFileHandle, ReadingFromURL) {
 TEST(NSFileHandle, WritingAtPath) {
     NSString* fileName = @"FileToDeleteWritingAtPath.txt";
     NSString* testStr = @"The Brown Fox.!";
-
+    createFileWithContentAndVerify(fileName, @"");
     NSString* fullPath = getPathToFile(fileName);
     NSError* error;
 
     SCOPE_DELETE_FILE(fileName);
     NSFileHandle* fh = [NSFileHandle fileHandleForWritingToURL:[NSURL fileURLWithPath:fullPath] error:&error];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     NSData* data = [testStr dataUsingEncoding:NSUTF8StringEncoding];
     [fh writeData:data];
@@ -266,10 +266,10 @@ TEST(NSFileHandle, WritingAtPath) {
 
     fh = [NSFileHandle fileHandleForReadingAtPath:getPathToFile(fileName)];
     SCOPE_CLOSE_HANDLE(fh);
-    ASSERT_TRUE(fh != nil);
+    ASSERT_NE(fh, nil);
 
     NSData* fileData = [fh readDataToEndOfFile];
-    ASSERT_TRUE_MSG(fileData != nil, "FAILED: reading the entire file failed.");
+    ASSERT_NE_MSG(fileData, nil, "FAILED: reading the entire file failed.");
 
     NSString* str = [[[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding] autorelease];
     ASSERT_OBJCEQ_MSG(str, testStr, "FAILED: Unable to read the file content.");
@@ -279,6 +279,6 @@ TEST(NSFileHandle, ReadingNonExistentFile) {
     NSString* fullPath = getPathToFile(@"nonexisting.txt");
     NSError* error;
     NSFileHandle* fh = [NSFileHandle fileHandleForReadingFromURL:[NSURL fileURLWithPath:fullPath] error:&error];
-    ASSERT_TRUE(fh == nil);
-    ASSERT_TRUE(error != nil);
+    ASSERT_EQ(fh, nil);
+    ASSERT_NE(error, nil);
 }


### PR DESCRIPTION
Our platform is more forgiving when writing to files, creating them when they do not exist rather than failing, so these tests were failing on the reference platform because the files were not created beforehand.

Fixes #899 