### PR TITLE
Revert NSMutableCharacterSet test changes.

### DIFF
--- a/Frameworks/Foundation/NSCharacterSet.mm
+++ b/Frameworks/Foundation/NSCharacterSet.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/Frameworks/Foundation/NSCharacterSet.mm
+++ b/Frameworks/Foundation/NSCharacterSet.mm
@@ -193,16 +193,14 @@ BASE_CLASS_REQUIRED_IMPLS(NSCharacterSet, NSMutableCharacterSetPrototype, CFChar
 /**
  @Status Interoperable
 */
-+ (instancetype)characterSetWithBitmapRepresentation:(NSData*)data {
-    THROW_NS_IF_NULL(E_INVALIDARG, data);
++ (instancetype)characterSetWithBitmapRepresentation:(NSData* _Nonnull)data {
     return [static_cast<NSCharacterSet*>(CFCharacterSetCreateWithBitmapRepresentation(nullptr, static_cast<CFDataRef>(data))) autorelease];
 }
 
 /**
  @Status Interoperable
 */
-+ (instancetype)characterSetWithContentsOfFile:(NSString*)path {
-    THROW_NS_IF_NULL(E_INVALIDARG, path);
++ (instancetype)characterSetWithContentsOfFile:(NSString* _Nonnull)path {
     return [NSCharacterSet characterSetWithBitmapRepresentation:[NSData dataWithContentsOfFile:path]];
 }
 

--- a/tests/unittests/Foundation/NSCharacterSetTests.m
+++ b/tests/unittests/Foundation/NSCharacterSetTests.m
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/unittests/Foundation/NSCharacterSetTests.m
+++ b/tests/unittests/Foundation/NSCharacterSetTests.m
@@ -219,22 +219,7 @@ TEST(NSCharacterSet, Polymorphic_Creators) {
 
     set = [NSMutableCharacterSet characterSetWithRange:NSMakeRange(0, 32)];
     EXPECT_TRUE([set isKindOfClass:[NSMutableCharacterSet class]]);
-}
 
-ARM_DISABLED_TEST(NSCharacterSet, ExceptionTests) {
-    NSMutableCharacterSet* set;
-    @try {
-        set = [NSMutableCharacterSet characterSetWithBitmapRepresentation:nil];
-        FAIL();
-    } @catch (NSException* e) {
-        ASSERT_OBJCEQ(e.name, @"NSInvalidArgumentException");
-    }
-
-    @
-    try {
-        set = [NSMutableCharacterSet characterSetWithContentsOfFile:nil];
-        FAIL();
-    } @catch (NSException* e) {
-        ASSERT_OBJCEQ(e.name, @"NSInvalidArgumentException");
-    }
+    set = [NSMutableCharacterSet characterSetWithBitmapRepresentation:nil];
+    EXPECT_TRUE([set isKindOfClass:[NSMutableCharacterSet class]]);
 }


### PR DESCRIPTION
There was a misunderstanding that the expected nonnull argument to
two factory methods in NSCharacterSet should be enforced by
throwing an exception. This is not correct. 

One test case has still been removed. set = [NSMutableCharacterSet characterSetWithContentsOfFile:nil]; is not a valid statement as searching for a nil file will throw an exception.

Fix #897