### PR TITLE
Fix regular expression test on long running operations.

### DIFF
--- a/tests/unittests/Foundation/NSRegularExpressionTests.m
+++ b/tests/unittests/Foundation/NSRegularExpressionTests.m
@@ -296,7 +296,14 @@ void testOption(
                          usingBlock:^void(NSTextCheckingResult* textResult, NSMatchingFlags flags, BOOL* stop) {
                              count++;
                          }];
-    ASSERT_EQ(count, expected);
+
+    // NSMatchingReportProgress can match longer than expected based on the running time. This should call the block no fewer than the
+    // expected number of times.
+    if (NSMatchingReportProgress & options) {
+        ASSERT_GE(count, expected);
+    } else {
+        ASSERT_EQ(count, expected);
+    }
 }
 
 void testOption(StrongId<NSRegularExpression> regex, StrongId<NSString> testString, NSMatchingOptions options, int expected) {


### PR DESCRIPTION
Regular expression matching can potentially take longer to run.
On a matching option of type NSMatchingReportProgress, this will
call the block passed in to be called more times than expected.
Modify this test case so that the test calls the block at least
an expected number of times.

Fix #766