### PR TITLE
Fix URLByAppendingPathComponent for empty strings

### DIFF
--- a/Frameworks/Foundation/NSURL.mm
+++ b/Frameworks/Foundation/NSURL.mm
@@ -603,6 +603,15 @@ BASE_CLASS_REQUIRED_IMPLS(NSURL, NSURLPrototype, CFURLGetTypeID);
  @Status Interoperable
 */
 - (NSURL*)URLByAppendingPathComponent:(NSString*)pathComponent {
+    if (pathComponent.length == 0) {
+        // When given an empty path component, we just append a slash if there isn't already one
+        if ([[self relativeString] hasSuffix:_NSGetSlashStr()]) {
+            return [self copy];
+        } else {
+            return [self URLByAppendingPathComponent:_NSGetSlashStr() isDirectory:NO];
+        }
+    }
+
     // Ensure exactly one slash exists between the original URL and pathComponent
     NSString* originalURL = _ensureLastPathSeparator([self relativeString]);
     if ([pathComponent hasPrefix:_NSGetSlashStr()]) {

--- a/tests/unittests/Foundation/NSURLTests.m
+++ b/tests/unittests/Foundation/NSURLTests.m
@@ -176,12 +176,23 @@ TEST(NSURL, StandardizedURL) {
 TEST(NSURL, URLByAppendingPathComponent) {
     NSURL* fileURL = [NSURL fileURLWithPath:@"."];
     NSURL* newFileURL = [fileURL URLByAppendingPathComponent:@"Hello.txt"];
-    ASSERT_TRUE_MSG([newFileURL isFileURL], "The passed URL should be a file URL type");
+    ASSERT_TRUE([newFileURL isFileURL]);
 
     NSString* fileURLString = [fileURL absoluteString];
     NSString* newFileURLString = [newFileURL absoluteString];
     fileURLString = [fileURLString stringByAppendingString:@"Hello.txt"];
-    ASSERT_OBJCEQ_MSG(fileURLString, newFileURLString, "File URLs do not match!");
+    ASSERT_OBJCEQ(fileURLString, newFileURLString);
+
+    // Appending "" should just add a slash
+    newFileURL = [newFileURL URLByAppendingPathComponent:@""];
+    fileURLString = [fileURLString stringByAppendingString:@"/"];
+    newFileURLString = [newFileURL absoluteString];
+    ASSERT_OBJCEQ(fileURLString, newFileURLString);
+
+    // But only once
+    newFileURL = [newFileURL URLByAppendingPathComponent:@""];
+    newFileURLString = [newFileURL absoluteString];
+    ASSERT_OBJCEQ(fileURLString, newFileURLString);
 }
 
 TEST(NSURL, URLByAppendingPathExtension) {


### PR DESCRIPTION
To match the reference platform, URLByAppendingPathComponent with an empty path component will append a slash if the URL does not end with one, or return a copy if it does

Fixes #880