### PR TITLE
Fix [NSString stringByAddingPercentEscapesUsingEncoding:] not working.

### DIFF
--- a/Frameworks/CoreFoundation/URL.subproj/CFURL.c
+++ b/Frameworks/CoreFoundation/URL.subproj/CFURL.c
@@ -1333,7 +1333,7 @@ static Boolean _stringContainsCharacter(CFStringRef string, UniChar ch) {
 CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapes(CFAllocatorRef allocator, CFStringRef originalString, CFStringRef charactersToLeaveUnescaped, CFStringRef legalURLCharactersToBeEscaped, CFStringEncoding encoding) {
     CFCharacterSetRef allowedCharacterSet = CFCharacterSetCreateWithCharactersInString(allocator, charactersToLeaveUnescaped);
     CFCharacterSetRef legalEscapedCharacterSet = CFCharacterSetCreateWithCharactersInString(allocator, legalURLCharactersToBeEscaped);
-    CFStringRef escapedString = CFURLCreateStringByAddingPercentEscapesWithCharacterSets(allocator, originalString, CFCharacterSetCreateWithCharactersInString(allocator, charactersToLeaveUnescaped), CFCharacterSetCreateWithCharactersInString(allocator, legalURLCharactersToBeEscaped), encoding);
+    CFStringRef escapedString = CFURLCreateStringByAddingPercentEscapesWithCharacterSets(allocator, originalString, allowedCharacterSet, legalEscapedCharacterSet, encoding);
     CFRelease(allowedCharacterSet);
     CFRelease(legalEscapedCharacterSet);
 

--- a/Frameworks/CoreFoundation/URL.subproj/CFURL.c
+++ b/Frameworks/CoreFoundation/URL.subproj/CFURL.c
@@ -1348,7 +1348,7 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
     if (length == 0) return (CFStringRef)CFStringCreateCopy(allocator, originalString);
     CFStringInitInlineBuffer(originalString, &buf, CFRangeMake(0, length));
 
-    for (idx = 0; idx < length; idx++) {
+    for (idx = 0; idx < length; idx ++) {
         UniChar ch = __CFStringGetCharacterFromInlineBufferQuick(&buf, idx);
         Boolean shouldReplace = (isURLLegalCharacter(ch) == false);
         if (shouldReplace) {
@@ -1358,13 +1358,13 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
         } else if (legalURLCharactersToBeEscaped && CFCharacterSetIsCharacterMember(legalURLCharactersToBeEscaped, ch)) {
             shouldReplace = true;
         }
-
+        
         if (shouldReplace) {
             enum {
                 kMaxBytesPerUniChar = 8,    // 8 bytes is the maximum a single UniChar can require in any current encodings; future encodings could require more
                 kMaxPercentEncodedUniChars = kMaxBytesPerUniChar * 3
             };
-
+            
             static const UInt8 hexchars[] = "0123456789ABCDEF";
             uint8_t bytes[kMaxBytesPerUniChar];
             uint8_t *bytePtr = bytes;
@@ -1373,22 +1373,22 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
             CFIndex byteLength;
 
             // Perform the replacement
-            if (!newString) {
+            if ( !newString ) {
                 newString = CFStringCreateMutableCopy(CFGetAllocator(originalString), 0, originalString);
-                CFStringDelete(newString, CFRangeMake(idx, length - idx));
+                CFStringDelete(newString, CFRangeMake(idx, length-idx));
             }
             // make sure charBuffer has enough room
-            if (charBufferIndex >= (kCharBufferMax - kMaxPercentEncodedUniChars)) {
+            if ( charBufferIndex >= (kCharBufferMax - kMaxPercentEncodedUniChars) ) {
                 // make room
                 CFStringAppendCharacters(newString, charBuffer, charBufferIndex);
                 charBufferIndex = 0;
             }
-
+            
             // convert the UniChar to bytes
-            if (CFStringEncodingUnicodeToBytes(encoding, 0, &ch, 1, NULL, bytePtr, 8, &byteLength) == kCFStringEncodingConversionSuccess) {
+            if ( CFStringEncodingUnicodeToBytes(encoding, 0, &ch, 1, NULL, bytePtr, 8, &byteLength) == kCFStringEncodingConversionSuccess ) {
                 // percent-encode the bytes
                 endPtr = bytePtr + byteLength;
-                for (currByte = bytePtr; currByte < endPtr; currByte++) {
+                for ( currByte = bytePtr; currByte < endPtr; currByte++ ) {
                     charBuffer[charBufferIndex++] = '%';
                     charBuffer[charBufferIndex++] = hexchars[*currByte >> 4];
                     charBuffer[charBufferIndex++] = hexchars[*currByte & 0x0f];
@@ -1396,7 +1396,7 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
             }
             else {
                 // FIXME: once CFString supports finding glyph boundaries walk by glyph boundaries instead of by unichars
-                if (encoding == kCFStringEncodingUTF8 && CFCharacterSetIsSurrogateHighCharacter(ch) && idx + 1 < length && CFCharacterSetIsSurrogateLowCharacter(__CFStringGetCharacterFromInlineBufferQuick(&buf, idx + 1))) {
+                if ( encoding == kCFStringEncodingUTF8 && CFCharacterSetIsSurrogateHighCharacter(ch) && idx + 1 < length && CFCharacterSetIsSurrogateLowCharacter(__CFStringGetCharacterFromInlineBufferQuick(&buf, idx + 1)) ) {
                     UniChar surrogate[2];
                     uint8_t *currByte;
 
@@ -1411,8 +1411,7 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
                             charBuffer[charBufferIndex++] = hexchars[*currByte & 0x0f];
                         }
                         idx++; // We consumed 2 characters, not 1
-                    }
-                    else {
+                    } else {
                         // surrogate pair conversion failed
                         break;
                     }
@@ -1422,10 +1421,9 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
                     break;
                 }
             }
-        }
-        else if (newString) {
+        } else if ( newString ) {
             charBuffer[charBufferIndex++] = ch;
-            if (charBufferIndex == kCharBufferMax) {
+            if ( charBufferIndex == kCharBufferMax ) {
                 CFStringAppendCharacters(newString, charBuffer, charBufferIndex);
                 charBufferIndex = 0;
             }
@@ -1435,14 +1433,12 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
         // Ran into an encoding failure
         if (newString) CFRelease(newString);
         return NULL;
-    }
-    else if (newString) {
-        if (charBufferIndex != 0) {
+    } else if ( newString ) {
+        if ( charBufferIndex != 0 ) {
             CFStringAppendCharacters(newString, charBuffer, charBufferIndex);
         }
         return newString;
-    }
-    else {
+    } else {
         return (CFStringRef)CFStringCreateCopy(CFGetAllocator(originalString), originalString);
     }
 }

--- a/Frameworks/CoreFoundation/URL.subproj/CFURL.c
+++ b/Frameworks/CoreFoundation/URL.subproj/CFURL.c
@@ -1404,7 +1404,7 @@ CF_EXPORT CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(C
             }
             else {
                 // FIXME: once CFString supports finding glyph boundaries walk by glyph boundaries instead of by unichars
-                if ( encoding == kCFStringEncodingUTF8 && CFCharacterSetIsSurrogateHighCharacter(ch) && idx+1 < length && CFCharacterSetIsSurrogateLowCharacter(__CFStringGetCharacterFromInlineBufferQuick(&buf, idx + 1)) ) {
+                if ( encoding == kCFStringEncodingUTF8 && CFCharacterSetIsSurrogateHighCharacter(ch) && idx + 1 < length && CFCharacterSetIsSurrogateLowCharacter(__CFStringGetCharacterFromInlineBufferQuick(&buf, idx+1)) ) {
                     UniChar surrogate[2];
                     uint8_t *currByte;
                     

--- a/Frameworks/CoreFoundation/URL.subproj/CFURL.h
+++ b/Frameworks/CoreFoundation/URL.subproj/CFURL.h
@@ -406,6 +406,9 @@ CFStringRef CFURLCreateStringByReplacingPercentEscapesUsingEncoding(CFAllocatorR
 CF_EXPORT
 CFStringRef CFURLCreateStringByAddingPercentEscapes(CFAllocatorRef allocator, CFStringRef originalString, CFStringRef charactersToLeaveUnescaped, CFStringRef legalURLCharactersToBeEscaped, CFStringEncoding encoding) CF_DEPRECATED(10_0, 10_11, 2_0, 9_0, "Use [NSString stringByAddingPercentEncodingWithAllowedCharacters:] instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent (since each URL component or subcomponent has different rules for what characters are valid).");
 
+// WINOBJC : An additional method for using character sets has been added for efficiency.
+CF_EXPORT
+CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(CFAllocatorRef allocator, CFStringRef originalString, CFCharacterSetRef charactersToLeaveUnescaped, CFCharacterSetRef legalURLCharactersToBeEscaped, CFStringEncoding encoding) CF_DEPRECATED(10_0, 10_11, 2_0, 9_0, "Use [NSString stringByAddingPercentEncodingWithAllowedCharacters:] instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent (since each URL component or subcomponent has different rules for what characters are valid).");
 
 #if (TARGET_OS_MAC || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE) || CF_BUILDING_CF || NSBUILDINGFOUNDATION
 CF_IMPLICIT_BRIDGING_DISABLED

--- a/Frameworks/CoreFoundation/URL.subproj/CFURL.h
+++ b/Frameworks/CoreFoundation/URL.subproj/CFURL.h
@@ -406,7 +406,7 @@ CFStringRef CFURLCreateStringByReplacingPercentEscapesUsingEncoding(CFAllocatorR
 CF_EXPORT
 CFStringRef CFURLCreateStringByAddingPercentEscapes(CFAllocatorRef allocator, CFStringRef originalString, CFStringRef charactersToLeaveUnescaped, CFStringRef legalURLCharactersToBeEscaped, CFStringEncoding encoding) CF_DEPRECATED(10_0, 10_11, 2_0, 9_0, "Use [NSString stringByAddingPercentEncodingWithAllowedCharacters:] instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent (since each URL component or subcomponent has different rules for what characters are valid).");
 
-// WINOBJC : An additional method for using character sets has been added for efficiency.
+// WINOBJC : Added a method for using character sets instead of strings.
 CF_EXPORT
 CFStringRef CFURLCreateStringByAddingPercentEscapesWithCharacterSets(CFAllocatorRef allocator, CFStringRef originalString, CFCharacterSetRef charactersToLeaveUnescaped, CFCharacterSetRef legalURLCharactersToBeEscaped, CFStringEncoding encoding) CF_DEPRECATED(10_0, 10_11, 2_0, 9_0, "Use [NSString stringByAddingPercentEncodingWithAllowedCharacters:] instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent (since each URL component or subcomponent has different rules for what characters are valid).");
 

--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -1454,8 +1454,7 @@ const int s_oneByte = 16;
 /**
  @Status Interoperable
  @Notes This API was deprecated in favor of stringByAddingPercentEncodingWithAllowedCharacters. APIs to decode anything other than
- UTF8StringEncoding is unsupported
-        both here and on the reference platform.
+ UTF8StringEncoding is unsupported both here and on the reference platform.
 */
 - (NSString*)stringByAddingPercentEscapesUsingEncoding:(NSStringEncoding)encoding {
     // Allowed characters in this escape api.

--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -1451,7 +1451,7 @@ BOOL _isALineSeparatorTypeCharacter(unichar ch) {
 /**
  @Status Interoperable
  @Notes This API was deprecated in favor of stringByAddingPercentEncodingWithAllowedCharacters. APIs to decode anything other than
- UTF8StringEncoding is unsupported both here and on the reference platform.
+ UTF8StringEncoding are unsupported both here and on the reference platform.
 */
 - (NSString*)stringByAddingPercentEscapesUsingEncoding:(NSStringEncoding)encoding {
     // Allowed characters in this escape api.

--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -1448,36 +1448,25 @@ BOOL _isALineSeparatorTypeCharacter(unichar ch) {
     return mutableCopy;
 }
 
+NSString* s_percentEncodedFormat = @"%%%s%X";
+const int s_oneByte = 16;
+
 /**
  @Status Interoperable
+ @Notes This API was deprecated in favor of stringByAddingPercentEncodingWithAllowedCharacters. APIs to decode anything other than
+ UTF8StringEncoding is unsupported
+        both here and on the reference platform.
 */
 - (NSString*)stringByAddingPercentEscapesUsingEncoding:(NSStringEncoding)encoding {
-    NSUInteger i, length = [self length], resultLength = 0;
-    std::unique_ptr<unichar[], decltype(&IwFree)> unicode(static_cast<unichar*>(IwMalloc(length * 2)), IwFree);
-    std::unique_ptr<unichar[], decltype(&IwFree)> result(static_cast<unichar*>(IwMalloc(length * 3 * 2)), IwFree);
-    const char* hex = "0123456789ABCDEF";
+    // Allowed characters in this escape api.
+    NSCharacterSet* set = [NSCharacterSet URLFragmentAllowedCharacterSet];
 
-    [self getCharacters:unicode.get()];
-
-    for (i = 0; i < length; i++) {
-        unichar code = unicode[i];
-
-        if ((code <= 0x20) || (code == 0x22) || (code == 0x23) || (code == 0x25) || (code == 0x3C) || (code == 0x3E) || (code == 0x5B) ||
-            (code == 0x5C) || (code == 0x5D) || (code == 0x5E) || (code == 0x60) || (code == 0x7B) || (code == 0x7C) || (code == 0x7D)) {
-            result[resultLength++] = '%';
-            result[resultLength++] = hex[(code >> 4) & 0xF];
-            result[resultLength++] = hex[code & 0xF];
-        } else {
-            result[resultLength++] = code;
-        }
-    }
-
-    if (length == resultLength) {
-        return self;
-    }
-
-    NSString* ret = [NSString stringWithCharacters:result.get() length:resultLength];
-    return ret;
+    return [static_cast<NSString*>(
+        CFURLCreateStringByAddingPercentEscapesWithCharacterSets(kCFAllocatorDefault,
+                                                                 static_cast<CFStringRef>(self),
+                                                                 static_cast<CFCharacterSetRef>(set),
+                                                                 nullptr,
+                                                                 CFStringConvertNSStringEncodingToEncoding(encoding))) autorelease];
 }
 
 /**

--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -1448,9 +1448,6 @@ BOOL _isALineSeparatorTypeCharacter(unichar ch) {
     return mutableCopy;
 }
 
-NSString* s_percentEncodedFormat = @"%%%s%X";
-const int s_oneByte = 16;
-
 /**
  @Status Interoperable
  @Notes This API was deprecated in favor of stringByAddingPercentEncodingWithAllowedCharacters. APIs to decode anything other than

--- a/build/CoreFoundation/dll/CoreFoundation.def
+++ b/build/CoreFoundation/dll/CoreFoundation.def
@@ -1141,6 +1141,7 @@ LIBRARY CoreFoundation
         CFURLIsFileReferenceURL
         CFURLCreateData
         CFURLCreateStringByAddingPercentEscapes
+        CFURLCreateStringByAddingPercentEscapesWithCharacterSets
         CFURLCreateStringByReplacingPercentEscapes
         CFURLCreateStringByReplacingPercentEscapesUsingEncoding
         CFURLGetFileSystemRepresentation

--- a/tests/unittests/EntryPoint.cpp
+++ b/tests/unittests/EntryPoint.cpp
@@ -24,6 +24,7 @@ using namespace Microsoft::WRL::Wrappers;
 
 int main(int argc, char** argv) {
 #ifdef WIN32
+    SetConsoleOutputCP(CP_UTF8);
     // Initialize the windows runtime, with uninitialized upon destructor invocation.
     RoInitializeWrapper initialize(RO_INIT_MULTITHREADED);
     if (FAILED(initialize)) {

--- a/tests/unittests/EntryPoint.cpp
+++ b/tests/unittests/EntryPoint.cpp
@@ -24,7 +24,6 @@ using namespace Microsoft::WRL::Wrappers;
 
 int main(int argc, char** argv) {
 #ifdef WIN32
-    SetConsoleOutputCP(CP_UTF8);
     // Initialize the windows runtime, with uninitialized upon destructor invocation.
     RoInitializeWrapper initialize(RO_INIT_MULTITHREADED);
     if (FAILED(initialize)) {

--- a/tests/unittests/Foundation/NSStringTests.m
+++ b/tests/unittests/Foundation/NSStringTests.m
@@ -609,6 +609,38 @@ TEST(NSString, StringsFormatPropertyList) {
     ASSERT_OBJCEQ(@"value2", propertyList[@"key2"]);
 }
 
+TEST(NSString, StringByAddingPercentEscapesUsingEncodingTest) {
+    NSString* originalString = @"abcdefghijklmnopqrstuvwxyz : !@#$%^&*()_+1234567890-=`~\\|]}[{'\";:.>,</?";
+    NSString* expectedEscapedString =
+        @"abcdefghijklmnopqrstuvwxyz%20:%20!@%23$%25%5E&*()_+1234567890-=%60~%5C%7C%5D%7D%5B%7B'%22;:.%3E,%3C/?";
+
+    NSString* escapedString = [originalString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+
+    EXPECT_OBJCEQ(expectedEscapedString, escapedString);
+    EXPECT_OBJCEQ(originalString, escapedString.stringByRemovingPercentEncoding);
+    EXPECT_OBJCEQ(originalString, [escapedString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]);
+
+    originalString = @"claesström";
+    expectedEscapedString = @"claesstr%C3%B6m";
+
+    escapedString = [originalString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+
+    EXPECT_OBJCEQ(expectedEscapedString, escapedString);
+    EXPECT_OBJCEQ(originalString, escapedString.stringByRemovingPercentEncoding);
+    EXPECT_OBJCEQ(originalString, [escapedString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]);
+
+    // Removing percent encoding is unsupported on the reference platform for anything other than UTF8 which is why the reference platform
+    // has deprecated this API.
+    // This test is to ensure the percent encoding matches the reference platform's behavior.
+    originalString = @"abcdefghijklmnopqrstuvwxyz : !@#$%^&*()_+1234567890-=`~\\|]}[{'\";:.>,</?";
+    expectedEscapedString = @"abcdefghijklmnopqrstuvwxyz%FF%FE%20%00:%FF%FE%20%00!@%FF%FE%23%00$%FF%FE%25%00%FF%FE%5E%00&*()_+1234567890-=%"
+                            @"FF%FE%60%00~%FF%FE%5C%00%FF%FE%7C%00%FF%FE%5D%00%FF%FE%7D%00%FF%FE%5B%00%FF%FE%7B%00'%FF%FE%22%00;:.%FF%FE%"
+                            @"3E%00,%FF%FE%3C%00/?";
+
+    escapedString = [originalString stringByAddingPercentEscapesUsingEncoding:NSUnicodeStringEncoding];
+
+    EXPECT_OBJCEQ(expectedEscapedString, escapedString);
+}
 TEST(NSString, LastPathComponent) {
     NSString* string = @"";
     EXPECT_OBJCEQ(@"", string.lastPathComponent);

--- a/tests/unittests/Foundation/NSStringTests.m
+++ b/tests/unittests/Foundation/NSStringTests.m
@@ -629,8 +629,7 @@ TEST(NSString, StringByAddingPercentEscapesUsingEncodingTest) {
     EXPECT_OBJCEQ(originalString, escapedString.stringByRemovingPercentEncoding);
     EXPECT_OBJCEQ(originalString, [escapedString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding]);
 
-    // Removing percent encoding is unsupported on the reference platform for anything other than UTF8 which is why the reference platform
-    // has deprecated this API.
+    // Removing percent encoding is unsupported on the reference platform for anything other than UTF8.
     // This test is to ensure the percent encoding matches the reference platform's behavior.
     originalString = @"abcdefghijklmnopqrstuvwxyz : !@#$%^&*()_+1234567890-=`~\\|]}[{'\";:.>,</?";
     expectedEscapedString = @"abcdefghijklmnopqrstuvwxyz%FF%FE%20%00:%FF%FE%20%00!@%FF%FE%23%00$%FF%FE%25%00%FF%FE%5E%00&*()_+1234567890-=%"


### PR DESCRIPTION
This deprecated API was working incorrectly. A fix has been added
using modified Core Foundation percent encoding APIs. New tests
have been added.

Fix #943