### PR TITLE
Fix headers to address breaks in the api analyzer tool

### DIFF
--- a/include/AVFoundation/AVAssetWriter.h
+++ b/include/AVFoundation/AVAssetWriter.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/AVFoundation/AVAssetWriterInput.h
+++ b/include/AVFoundation/AVAssetWriterInput.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,7 +17,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundationExport.h>
-#import <Foundation/NSObject.h>
+#import <Foundation/Foundation.h>
 #import <CoreGraphics/CGAffineTransform.h>
 #import <CoreGraphics/CGGeometry.h>
 #import <CoreMedia/CMFormatDescription.h>

--- a/include/AVFoundation/AVCaptureAudioDataOutput.h
+++ b/include/AVFoundation/AVCaptureAudioDataOutput.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,7 +17,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundationExport.h>
-#import <Foundation/NSObject.h>
+#import <Foundation/Foundation.h>
 #import <AVFoundation/AVCaptureOutput.h>
 @protocol AVCaptureAudioDataOutputSampleBufferDelegate;
 

--- a/include/AVFoundation/AVCaptureMetadataOutput.h
+++ b/include/AVFoundation/AVCaptureMetadataOutput.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,7 +17,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundationExport.h>
-#import <Foundation/NSObject.h>
+#import <Foundation/Foundation.h>
 #import <CoreGraphics/CGGeometry.h>
 #import <AVFoundation/AVCaptureOutput.h>
 @protocol AVCaptureMetadataOutputObjectsDelegate;

--- a/include/AVFoundation/AVCaptureVideoDataOutput.h
+++ b/include/AVFoundation/AVCaptureVideoDataOutput.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,7 +17,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundationExport.h>
-#import <Foundation/NSObject.h>
+#import <Foundation/Foundation.h>
 #import <AVFoundation/AVCaptureOutput.h>
 #import <CoreMedia/CMTime.h>
 

--- a/include/AVFoundation/AVFoundationTypes.h
+++ b/include/AVFoundation/AVFoundationTypes.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundationExport.h>
+#import <Foundation/Foundation.h>
 #import <CoreGraphics/CGGeometry.h>
 
 typedef NS_ENUM(NSInteger, AVAudioQuality) { AVAudioQualityMin = 0, AVAudioQualityLow = 0x20, AVAudioQualityMedium = 0x40, AVAudioQualityHigh = 0x60, AVAudioQualityMax = 0x7F };

--- a/include/AVFoundation/AVPlayerItemVideoOutput.h
+++ b/include/AVFoundation/AVPlayerItemVideoOutput.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,7 +17,7 @@
 #pragma once
 
 #import <AVFoundation/AVFoundationExport.h>
-#import <Foundation/NSObject.h>
+#import <Foundation/Foundation.h>
 #import <AVFoundation/AVPlayerItemOutput.h>
 #import <CoreMedia/CMTime.h>
 #import <CoreVideo/CVPixelBuffer.h>

--- a/include/QuickLook/QLPreviewController.h
+++ b/include/QuickLook/QLPreviewController.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/QuickLook/QLPreviewControllerDelegate.h
+++ b/include/QuickLook/QLPreviewControllerDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -16,6 +16,7 @@
 #pragma once
 
 #import <QuickLook/QuickLookExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @class QLPreviewController;

--- a/include/UIKit/NSLayoutAnchor.h
+++ b/include/UIKit/NSLayoutAnchor.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <Foundation/NSObject.h>
+#import <CoreGraphics/CGBase.h>
 
 @class NSLayoutConstraint;
 

--- a/include/UIKit/NSLayoutConstraint.h
+++ b/include/UIKit/NSLayoutConstraint.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <Foundation/NSObject.h>
+#import <CoreGraphics/CGBase.h>
 
 @class NSArray;
 @class NSDictionary;

--- a/include/UIKit/NSLayoutDimension.h
+++ b/include/UIKit/NSLayoutDimension.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -19,6 +19,7 @@
 #import <UIKit/UIKitExport.h>
 #import <Foundation/NSObject.h>
 #import <UIKit/NSLayoutAnchor.h>
+#import <CoreGraphics/CGBase.h>
 
 @class NSLayoutConstraint;
 

--- a/include/UIKit/NSTextStorage.h
+++ b/include/UIKit/NSTextStorage.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <Foundation/NSMutableAttributedString.h>
+#import <CoreGraphics/CGBase.h>
 
 @class NSLayoutManager;
 @protocol NSTextStorageDelegate;

--- a/include/UIKit/UIActivityItemSource.h
+++ b/include/UIKit/UIActivityItemSource.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @class UIActivityViewController;

--- a/include/UIKit/UICollisionBehaviorDelegate.h
+++ b/include/UIKit/UICollisionBehaviorDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @protocol UIDynamicItem;

--- a/include/UIKit/UIContentContainer.h
+++ b/include/UIKit/UIContentContainer.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @protocol UIViewControllerTransitionCoordinator;

--- a/include/UIKit/UICoordinateSpace.h
+++ b/include/UIKit/UICoordinateSpace.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @protocol UICoordinateSpace <NSObject>

--- a/include/UIKit/UIDocumentInteractionControllerDelegate.h
+++ b/include/UIKit/UIDocumentInteractionControllerDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @class UIViewController;

--- a/include/UIKit/UILayoutSupport.h
+++ b/include/UIKit/UILayoutSupport.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <Foundation/NSObject.h>
+#import <CoreGraphics/CGBase.h>
 
 @class NSLayoutYAxisAnchor;
 @class NSLayoutDimension;

--- a/include/UIKit/UITextViewDelegate.h
+++ b/include/UIKit/UITextViewDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <UIKit/UIScrollViewDelegate.h>
+#import <Foundation/Foundation.h>
 
 @class UITextView;
 @class NSString;

--- a/include/UIKit/UIViewControllerPreviewing.h
+++ b/include/UIKit/UIViewControllerPreviewing.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @class UIGestureRecognizer;

--- a/include/UIKit/UIViewControllerPreviewingDelegate.h
+++ b/include/UIKit/UIViewControllerPreviewingDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <Foundation/NSObject.h>
 #import <CoreGraphics/CGGeometry.h>
 
 @class UIViewController;


### PR DESCRIPTION
An earlier fix d9e19bcf88b187e07359dcb2bcad0e0e9ab48f0a removed dependencies on Foundation from CoreGraphics.  Unfortunately, other modules were counting on foundation headers being included by core graphics.  While this passes build, this fails the API analyzer.

This change is to fix the headers so the api analyzer remains happy.
