### PR TITLE
Fixing a crash when calling CGContextAddPath with a NULL path

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -452,7 +452,11 @@ void CGContextFillEllipseInRect(CGContextRef ctx, CGRect rct) {
  @Status Interoperable
 */
 void CGContextAddPath(CGContextRef ctx, CGPathRef path) {
-    ctx->Backing()->CGContextAddPath(path);
+    // The Apple SDK docs imply that passing a NULL path is valid.
+    // So avoid calling into the backing if NULL.
+    if (path) {
+        ctx->Backing()->CGContextAddPath(path);
+    }
 }
 
 /**


### PR DESCRIPTION
The Apple docs for CGContextAddPath imply that passing a NULL path does nothing and is a valid API call.

Fix #966