### PR TITLE
Fix bad merge

### DIFF
--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
@@ -78,6 +78,7 @@
     </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UISliderTests.mm">
       <Filter>Tests</Filter>
+    </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIApplicationTests.mm">
       <Filter>Tests</Filter>
     </ClangCompile>


### PR DESCRIPTION
There was a bad merge to the functional tests filters project that caused the project to be not usable from solution explorer.