### PR TITLE
Fixing a bug with the memory of the elements for a CGPath

### DIFF
--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -493,6 +493,12 @@ void CGPathAddPath(CGMutablePathRef path, const CGAffineTransform* m, CGPathRef 
             }
         }
     }
+
+    // we need to re init the elements to setup the pointers propertly
+    for (int i = 0; i < path->_count; i++) {
+        CGPathElementInternal* element = &path->_elements[i];
+        element->init();
+    }
 }
 
 /**


### PR DESCRIPTION
- When we hit the bounds of the elements and call resize we need to reinitialize the elements pointers.

Fix:  993