### PR TITLE
Fix for loading images on non-retina devices

### DIFF
--- a/Frameworks/UIKit/UIImage.mm
+++ b/Frameworks/UIKit/UIImage.mm
@@ -382,7 +382,7 @@ static bool loadTIFF(UIImage* dest, void* bytes, int length) {
 
         if (EbrAccess(pathStr, 0) == -1) {
             id pathFind =
-                [bundle pathForResource:[NSString stringWithCString:newStr] ofType:nil inDirectory:nil forLocalization:@"English"];
+                [bundle pathForResource:[NSString stringWithCString:newStr] ofType:@"png" inDirectory:nil forLocalization:@"English"];
 
             if (pathFind != nil) {
                 path = (char*)[pathFind UTF8String];
@@ -403,7 +403,7 @@ static bool loadTIFF(UIImage* dest, void* bytes, int length) {
         pathStr = IwStrDup(path);
 
         if (EbrAccess(pathStr, 0) == -1) {
-            NSString* pathFind = [bundle pathForResource:pathAddr ofType:nil inDirectory:nil forLocalization:@"English"];
+            NSString* pathFind = [bundle pathForResource:pathAddr ofType:@"png" inDirectory:nil forLocalization:@"English"];
 
             if (pathFind != nil) {
                 path = [pathFind UTF8String];


### PR DESCRIPTION
- no longer passing in nil, but adding a png image extension for the non retina cases

Fix: 1003

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1004)

<!-- Reviewable:end -->
