### PR TITLE
Improve the performance of -[NSObject valueForKeyPath:].

### DIFF
--- a/Frameworks/include/type_encoding_cases.h
+++ b/Frameworks/include/type_encoding_cases.h
@@ -1,35 +1,58 @@
-/** 
- * type_encoding_cases.h -  expects the APPLY_TYPE macro to be defined.  This
- * macro is invoked once for every type and its Objective-C name.  Use this
- * file when implementing things like the -unsignedIntValue family of methods.
- * For this case, the macro will be invoked with unsigned int as the type and
- * unsignedInt as the name.
- */
-#ifndef APPLY_TYPE
-#error Define APPLY_TYPE(type, name, capitalizedName, encodingChar) before including this file
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#pragma once
+
+// Each OBJC_APPLY_*_TYPE_ENCODINGS macro expects a single argument: the name
+// of a macro to apply for every type encoding. That macro should take the form
+// #define name(ctype, objectiveCName, CapitalizedObjectiveCName, typeEncodingCharacter)
+
+#if defined(_Bool)
+#define OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO) \
+	_APPLY_TYPE_MACRO(_Bool, bool, Bool, 'B')
+#else
+#define OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO) // Nothing
 #endif
-APPLY_TYPE(double, double, Double, 'd')
-APPLY_TYPE(float, float, Float, 'f')
-APPLY_TYPE(signed char, char, Char, 'c')
-APPLY_TYPE(int, int, Int, 'i')
-APPLY_TYPE(short, short, Short, 's')
-APPLY_TYPE(long, long, Long, 'l')
-APPLY_TYPE(long long, longLong, LongLong, 'q')
-//APPLY_TYPE(__int128, int128, Int128, 't')
-APPLY_TYPE(unsigned char, unsignedChar, UnsignedChar, 'C')
-APPLY_TYPE(unsigned short, unsignedShort, UnsignedShort, 'S')
-APPLY_TYPE(unsigned int, unsignedInt, UnsignedInt, 'I')
-APPLY_TYPE(unsigned long, unsignedLong, UnsignedLong, 'L')
-APPLY_TYPE(unsigned long long, unsignedLongLong, UnsignedLongLong, 'Q')
+
+#define OBJC_APPLY_NUMERIC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+	_APPLY_TYPE_MACRO(double, double, Double, 'd') \
+	_APPLY_TYPE_MACRO(float, float, Float, 'f') \
+	_APPLY_TYPE_MACRO(signed char, char, Char, 'c') \
+	_APPLY_TYPE_MACRO(int, int, Int, 'i') \
+	_APPLY_TYPE_MACRO(short, short, Short, 's') \
+	_APPLY_TYPE_MACRO(long, long, Long, 'l') \
+	_APPLY_TYPE_MACRO(long long, longLong, LongLong, 'q') \
+	_APPLY_TYPE_MACRO(unsigned char, unsignedChar, UnsignedChar, 'C') \
+	_APPLY_TYPE_MACRO(unsigned short, unsignedShort, UnsignedShort, 'S') \
+	_APPLY_TYPE_MACRO(unsigned int, unsignedInt, UnsignedInt, 'I') \
+	_APPLY_TYPE_MACRO(unsigned long, unsignedLong, UnsignedLong, 'L') \
+	_APPLY_TYPE_MACRO(unsigned long long, unsignedLongLong, UnsignedLongLong, 'Q') \
+	OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO)
+
+//APPLY_TYPE(__int128, int128, Int128, 't') \
 //APPLY_TYPE(unsigned __int128, unsignedInt128, UnsignedInt128, 'T')
-#ifdef NON_INTEGER_TYPES
-#undef NON_INTEGER_TYPES
-APPLY_TYPE(_Bool, bool, Bool, 'B')
-#ifndef SKIP_ID
-APPLY_TYPE(id, object, Object, '@')
-#endif
-APPLY_TYPE(Class, class, Class, '#')
-APPLY_TYPE(SEL, selector, Selector, ':')
-APPLY_TYPE(char*, cString, CString, '*')
-#endif
-#undef APPLY_TYPE
+
+#define OBJC_APPLY_OBJECTIVEC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+	_APPLY_TYPE_MACRO(id, object, Object, '@') \
+	_APPLY_TYPE_MACRO(Class, class, Class, '#') \
+	_APPLY_TYPE_MACRO(SEL, selector, Selector, ':')
+#define OBJC_APPLY_POINTER_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+	_APPLY_TYPE_MACRO(char*, cString, CString, '*')
+
+#define OBJC_APPLY_ALL_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+	OBJC_APPLY_NUMERIC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+	OBJC_APPLY_OBJECTIVEC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+	OBJC_APPLY_POINTER_TYPE_ENCODINGS(_APPLY_TYPE_MACRO)

--- a/Frameworks/include/type_encoding_cases.h
+++ b/Frameworks/include/type_encoding_cases.h
@@ -22,37 +22,37 @@
 
 #if defined(_Bool)
 #define OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO) \
-	_APPLY_TYPE_MACRO(_Bool, bool, Bool, 'B')
+    _APPLY_TYPE_MACRO(_Bool, bool, Bool, 'B')
 #else
 #define OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO) // Nothing
 #endif
 
 #define OBJC_APPLY_NUMERIC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
-	_APPLY_TYPE_MACRO(double, double, Double, 'd') \
-	_APPLY_TYPE_MACRO(float, float, Float, 'f') \
-	_APPLY_TYPE_MACRO(signed char, char, Char, 'c') \
-	_APPLY_TYPE_MACRO(int, int, Int, 'i') \
-	_APPLY_TYPE_MACRO(short, short, Short, 's') \
-	_APPLY_TYPE_MACRO(long, long, Long, 'l') \
-	_APPLY_TYPE_MACRO(long long, longLong, LongLong, 'q') \
-	_APPLY_TYPE_MACRO(unsigned char, unsignedChar, UnsignedChar, 'C') \
-	_APPLY_TYPE_MACRO(unsigned short, unsignedShort, UnsignedShort, 'S') \
-	_APPLY_TYPE_MACRO(unsigned int, unsignedInt, UnsignedInt, 'I') \
-	_APPLY_TYPE_MACRO(unsigned long, unsignedLong, UnsignedLong, 'L') \
-	_APPLY_TYPE_MACRO(unsigned long long, unsignedLongLong, UnsignedLongLong, 'Q') \
-	OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO)
+    _APPLY_TYPE_MACRO(double, double, Double, 'd') \
+    _APPLY_TYPE_MACRO(float, float, Float, 'f') \
+    _APPLY_TYPE_MACRO(signed char, char, Char, 'c') \
+    _APPLY_TYPE_MACRO(int, int, Int, 'i') \
+    _APPLY_TYPE_MACRO(short, short, Short, 's') \
+    _APPLY_TYPE_MACRO(long, long, Long, 'l') \
+    _APPLY_TYPE_MACRO(long long, longLong, LongLong, 'q') \
+    _APPLY_TYPE_MACRO(unsigned char, unsignedChar, UnsignedChar, 'C') \
+    _APPLY_TYPE_MACRO(unsigned short, unsignedShort, UnsignedShort, 'S') \
+    _APPLY_TYPE_MACRO(unsigned int, unsignedInt, UnsignedInt, 'I') \
+    _APPLY_TYPE_MACRO(unsigned long, unsignedLong, UnsignedLong, 'L') \
+    _APPLY_TYPE_MACRO(unsigned long long, unsignedLongLong, UnsignedLongLong, 'Q') \
+    OBJC_APPLY_BOOL_TYPE_ENCODING(_APPLY_TYPE_MACRO)
 
 //APPLY_TYPE(__int128, int128, Int128, 't') \
 //APPLY_TYPE(unsigned __int128, unsignedInt128, UnsignedInt128, 'T')
 
 #define OBJC_APPLY_OBJECTIVEC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
-	_APPLY_TYPE_MACRO(id, object, Object, '@') \
-	_APPLY_TYPE_MACRO(Class, class, Class, '#') \
-	_APPLY_TYPE_MACRO(SEL, selector, Selector, ':')
+    _APPLY_TYPE_MACRO(id, object, Object, '@') \
+    _APPLY_TYPE_MACRO(Class, class, Class, '#') \
+    _APPLY_TYPE_MACRO(SEL, selector, Selector, ':')
 #define OBJC_APPLY_POINTER_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
-	_APPLY_TYPE_MACRO(char*, cString, CString, '*')
+    _APPLY_TYPE_MACRO(char*, cString, CString, '*')
 
 #define OBJC_APPLY_ALL_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
-	OBJC_APPLY_NUMERIC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
-	OBJC_APPLY_OBJECTIVEC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
-	OBJC_APPLY_POINTER_TYPE_ENCODINGS(_APPLY_TYPE_MACRO)
+    OBJC_APPLY_NUMERIC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+    OBJC_APPLY_OBJECTIVEC_TYPE_ENCODINGS(_APPLY_TYPE_MACRO) \
+    OBJC_APPLY_POINTER_TYPE_ENCODINGS(_APPLY_TYPE_MACRO)


### PR DESCRIPTION
This replaces `_NSKVCSplitKeypath`, a key-splitting workhorse used in KVC and KVO, with a significantly more svelte version.

The old version:
* Used `dataUsingEncoding:` to take a full copy of the buffer at every step.
* Used ICU to find `.`

The new version:
* Trusts that CFString is capable of finding strings itself.

### Average per-invocation times.

```
  Old  |  New   | Workload
--------------------------
4208ns | 2762ns | "A.B.C.D" (2MM hits)
4985ns |  293ns | empty strings
4568ns | 1415ns | real-world profiling in application (56,000 hits @ string lengths 0-65)
```

Because both `valueForKey:` and `valueForKeyPath:` can be overridden by NSObject subclasses, full string copies of keypath components must be taken at every depth. This provides for a nearly-negligible performance impact (~799ns p/i in the average case.)

This pull request also fixes a regression in `valueForKey:` that caused the NSInvocation codepath to be triggered when the returned value would otherwise truly be `nil`.

#904.