### PR TITLE
Do not use a recursive MSBuild rule to determine Objective-C residency.

### DIFF
--- a/build/Package/Package.nativeproj
+++ b/build/Package/Package.nativeproj
@@ -47,6 +47,7 @@
       <MSVCFiles Include="..\..\msvc\*.dll" />
       <MSVCFiles Include="..\..\msvc\*.cpp" />
       <MSVCObjCRTFiles Include="..\..\msvc\objcrt\*.cpp" />
+      <MSVCObjCRTFiles Include="..\..\msvc\objcrt\*.h" />
       <SBIncludes Include="..\..\include\**\*" />
       <SBIncludes Include="..\..\deps\prebuilt\include\zlib.h" />
       <SBIncludes Include="..\..\deps\prebuilt\include\zconf.h" />

--- a/msvc/objcrt/objc_2stage_init.cpp
+++ b/msvc/objcrt/objc_2stage_init.cpp
@@ -14,6 +14,8 @@
 //
 //******************************************************************************
 
+#pragma comment(lib, "libobjc2")
+
 // Legacy Loading
 // --------------
 // Each TU containing an Objective-C class emits a user init call to __objc_exec_module with a module.

--- a/msvc/objcrt/objc_2stage_init.h
+++ b/msvc/objcrt/objc_2stage_init.h
@@ -1,0 +1,27 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//****************************************************************************** 
+
+#pragma once
+
+#if defined(__OBJC__)
+#if defined(_M_IX86)
+#pragma comment(linker, "/include:____pin_objc_init")
+#elif defined(_M_ARM)
+#pragma comment(linker, "/include:___pin_objc_init")
+#else
+#error Can't force-include objc_2stage_init initializers.
+#endif
+#endif

--- a/msvc/sbclang.props
+++ b/msvc/sbclang.props
@@ -47,8 +47,6 @@
     <StarboardDefaultLibs Condition="'$(StarboardIncludeDefaultLibs)' == 'true'">Accelerate.lib;Accounts.lib;AddressBook.lib;AddressBookUI.lib;AdSupport.lib;AssetsLibrary.lib;AudioToolbox.lib;AudioUnit.lib;AVFoundation.lib;AVKit.lib;CFNetwork.lib;CloudKit.lib;Contacts.lib;CoreAudio.lib;CoreAudioKit.lib;CoreBluetooth.lib;CoreData.lib;CoreFoundation.lib;CoreGraphics.lib;CoreImage.lib;CoreLocation.lib;CoreMedia.lib;CoreMIDI.lib;CoreMotion.lib;CoreTelephony.lib;CoreText.lib;CoreVideo.lib;EventKit.lib;EventKitUI.lib;Foundation.lib;GameController.lib;GameKit.lib;GameplayKit.lib;GLKit.lib;HealthKit.lib;HomeKit.lib;iAd.lib;ImageIO.lib;LocalAuthentication.lib;MapKit.lib;MediaAccessibility.lib;MediaPlayer.lib;MessageUI.lib;Metal.lib;MobileCoreServices.lib;OpenAL.lib;OpenGLES.lib;QuartzCore.lib;QuickLook.lib;Security.lib;Social.lib;Starboard.lib;StoreKit.lib;SafariServices.lib;SystemConfiguration.lib;Twitter.lib;UIKit.lib;WebKit.lib;libdispatch.lib;objcuwp.lib;RTObjCInterop.lib</StarboardDefaultLibs>
     <StarboardLinkObjCRuntime Condition="'$(StarboardLinkObjCRuntime)' == ''">true</StarboardLinkObjCRuntime>
     <StarboardObjCRuntimeLib>libobjc2.lib</StarboardObjCRuntimeLib>
-    <StarboardObjectiveCPinningSymbolName Condition="'$(Platform)' != 'ARM'">____pin_objc_init</StarboardObjectiveCPinningSymbolName>
-    <StarboardObjectiveCPinningSymbolName Condition="'$(Platform)' == 'ARM'">___pin_objc_init</StarboardObjectiveCPinningSymbolName>
     <IslandwoodDRT Condition="'$(IslandwoodDRT)' == ''">true</IslandwoodDRT>
     <StarboardLinkWholeArchive Condition="'$(StarboardLinkWholeArchive)' == ''">false</StarboardLinkWholeArchive>
     <CopyStarboardLibraries Condition="'$(ConfigurationType)' == 'Application'">true</CopyStarboardLibraries>

--- a/msvc/sbclang.targets
+++ b/msvc/sbclang.targets
@@ -353,6 +353,14 @@
       </ClangCompile>
     </ItemGroup>
 
+    <!-- Figure out whether Objective-C should be pinned -->
+    <ItemGroup>
+      <ClangCompile>
+        <InternalForceIncludes Condition="'%(ClangCompile.CompileAs)' == 'CompileAsObjC' or
+                                          '%(ClangCompile.CompileAs)' == 'CompileAsObjCpp'">$(MSBuildThisFileDirectory)\objcrt\objc_2stage_init.h;%(InternalForceIncludes)</InternalForceIncludes>
+      </ClangCompile>
+    </ItemGroup>
+
   </Target>
 
   <!-- Ensure Link/Lib/ImpLib pick up the object files -->
@@ -365,7 +373,7 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
-    <ComputeLinkInputsTargets>$(ComputeLinkInputsTargets);ComputeClangLinkInputs;ComputeRuntimeInputs;ComputeWholeArchiveLinkInputs;ComputeObjectiveCLinkInputs</ComputeLinkInputsTargets>
+    <ComputeLinkInputsTargets>$(ComputeLinkInputsTargets);ComputeClangLinkInputs;ComputeRuntimeInputs</ComputeLinkInputsTargets>
     <ComputeLibInputsTargets>$(ComputeLibInputsTargets);ComputeClangLibInputs;</ComputeLibInputsTargets>
     <ComputeImpLibInputsTargets>$(ComputeImpLibInputsTargets);ComputeClangImpLibInputs;</ComputeImpLibInputsTargets>
   </PropertyGroup>
@@ -411,10 +419,8 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Sets StarboardRequiresObjectiveCRuntime based on whether this project has either Objective-C sources itself or
-       a reference to a statically-linked library that has Objective-C sources.
-  -->
-  <Target Name="ComputeStarboardRequiresObjectiveCRuntime" DependsOnTargets="ComputeStarboardHasObjCSources;ComputeStarboardReferencesRequiringObjectiveC">
+  <!-- Sets StarboardRequiresObjectiveCRuntime based on whether this project has Objective-C sources non-recursively. -->
+  <Target Name="ComputeStarboardRequiresObjectiveCRuntime" DependsOnTargets="ComputeStarboardHasObjCSources">
     <PropertyGroup Condition="'$(StarboardRequiresObjectiveCRuntime)' == ''">
       <StarboardRequiresObjectiveCRuntime Condition="'@(_StarboardReferencesRequiringObjectiveC)' != ''">true</StarboardRequiresObjectiveCRuntime>
       <StarboardRequiresObjectiveCRuntime Condition="'$(StarboardHasObjCSources)' == 'true'">true</StarboardRequiresObjectiveCRuntime>
@@ -494,14 +500,6 @@
     <ItemGroup Condition="'@(_StarboardReferencesRequiringObjectiveC)'!='' and '$(StarboardLinkWholeArchive)'=='true'">
       <Link>
         <AdditionalOptions>%(Link.AdditionalOptions) "/WHOLEARCHIVE:@(_StarboardReferencesRequiringObjectiveC, '" /WHOLEARCHIVE:"')"</AdditionalOptions>
-      </Link>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="ComputeObjectiveCLinkInputs" DependsOnTargets="ComputeStarboardReferencesRequiringObjectiveC">
-    <ItemGroup Condition="'@(_StarboardReferencesRequiringObjectiveC)'!=''">
-      <Link>
-        <AdditionalOptions>%(Link.AdditionalOptions) /INCLUDE:$(StarboardObjectiveCPinningSymbolName)</AdditionalOptions>
       </Link>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
The recursive rule was causing us some trouble when projects did not include `sbclang.targets`.

This works just as well because any static library with an object containing this directive will spread `___pin_objc_init` in a fairly insidious manner.

Fixes #973.

Verified by:
* x86 debug app launch
* x86 debug UTs
* x86 release app launch
* x86 release UTs
* ARM release app launch
* ARM release UTs