### PR TITLE
UIBezierPath CGPath should have NS_RETURNS_INNER_POINTER

### DIFF
--- a/include/UIKit/UIBezierPath.h
+++ b/include/UIKit/UIBezierPath.h
@@ -71,7 +71,7 @@ UIKIT_EXPORT_CLASS
 - (void)removeAllPoints STUB_METHOD;
 - (void)appendPath:(UIBezierPath*)bezierPath;
 
-@property (nonatomic) CGPathRef CGPath;
+@property (nonatomic) CGPathRef CGPath NS_RETURNS_INNER_POINTER CF_RETURNS_NOT_RETAINED;
 @property (nonatomic, readonly) CGPoint currentPoint;
 
 @property (nonatomic) CGFloat lineWidth;


### PR DESCRIPTION
I've hit a crash attempting to use the FSCalendar library.

Here: https://github.com/WenchaoD/FSCalendar/blob/712cdb5974f89bf3ce56c51872c3c4a116581477/FSCalendar/FSCalendarCell.m#L243

the FSCalendar library grabs a CGPathRef from an autoreleased object. There's apparently an optimization with ARC to avoid the autorelease pool - but here the early deallocation of the object results in a crash when the CGPathRef is accessed a few lines down.

Adding NS_RETURNS_INNER_POINTER prevents the early deallocation avoiding the crash (also added CF_RETURNS_NOT_RETAINED for good measure).

Aside:

The reference platform prefers to put these attribute macros on a separate declaration of the getter right below the property. Either way works but putting them on the property seems cleaner (though admittedly this may be inappropriately applying the attribute to the setter as well - doesn't result in any warning). Note: there may also be problems with other APIs marked NS_RETURNS_INNER_POINTER on the ref platform (don't encounter them in our app).