### PR TITLE
Enable multiple fonts and paragraph alignment in coretext

### DIFF
--- a/Frameworks/CoreText/DWriteWrapper.mm
+++ b/Frameworks/CoreText/DWriteWrapper.mm
@@ -187,7 +187,6 @@ static ComPtr<IDWriteTextFormat> __CreateDWriteTextFormat(_CTTypesetter* ts, CFR
     // Note here we only look at attribute value at first index of the specified range as we can get a default faont size to use here.
     // Per string range attribute handling will be done in _CreateDWriteTextLayout.
 
-    // TODO: #1001 attribs can be nil here?
     NSDictionary* attribs = [ts->_attributedString attributesAtIndex:range.location effectiveRange:NULL];
 
     CGFloat fontSize = kCTFontSystemFontSize;
@@ -282,7 +281,6 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(_CTTypesetter* ts, CFR
                                                    longestEffectiveRange:&attributeRange
                                                                  inRange:{ i, [ts->_attributedString length] - i }];
 
-        const DWRITE_TEXT_RANGE dwriteRange = { attributeRange.location, attributeRange.length };
         CTFontRef font = static_cast<CTFontRef>([attribs objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
         if (font != nil) {
             CGFloat fontSize = CTFontGetSize(font);
@@ -294,6 +292,7 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(_CTTypesetter* ts, CFR
             std::vector<wchar_t> familyName(CFStringGetLength(fontFamilyName) + 1);
             CFStringGetCharacters(fontFamilyName, CFRangeMake(0, familyName.size()), reinterpret_cast<UniChar*>(familyName.data()));
 
+            const DWRITE_TEXT_RANGE dwriteRange = { attributeRange.location, attributeRange.length };
             THROW_IF_FAILED(textLayout->SetFontSize(fontSize, dwriteRange));
             THROW_IF_FAILED(textLayout->SetFontWeight(weight, dwriteRange));
             THROW_IF_FAILED(textLayout->SetFontStretch(stretch, dwriteRange));

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAlignmentTestViewController.m
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAlignmentTestViewController.m
@@ -93,6 +93,7 @@
     CTAlignmentTestView* _leftView;
     CTAlignmentTestView* _centerView;
     CTAlignmentTestView* _rightView;
+    CTAlignmentTestView* _justifiedView;
     UITextField* _textField;
     UISlider* _fontSizeSlider;
     UIPickerView* _fontPicker;
@@ -181,6 +182,16 @@
         [[_textField.text stringByReplacingOccurrencesOfString:@"\\n" withString:@"\n"] stringByReplacingOccurrencesOfString:@"\\t"
                                                                                                                   withString:@"\t"];
     [self.view addSubview:_rightView];
+
+    // Create justified text
+    _justifiedView = [[CTAlignmentTestView alloc] initWithFrame:CGRectMake(20, 620, 400, 200)];
+    _justifiedView.backgroundColor = [UIColor whiteColor];
+    _justifiedView.alignment = kCTJustifiedTextAlignment;
+    _justifiedView.font = _font;
+    _justifiedView.text =
+        [[_textField.text stringByReplacingOccurrencesOfString:@"\\n" withString:@"\n"] stringByReplacingOccurrencesOfString:@"\\t"
+                                                                                                                  withString:@"\t"];
+    [self.view addSubview:_justifiedView];
 }
 
 // Update texts to new font/size
@@ -188,6 +199,7 @@
     [_leftView removeFromSuperview];
     [_centerView removeFromSuperview];
     [_rightView removeFromSuperview];
+    [_justifiedView removeFromSuperview];
     [self drawTests];
 }
 

--- a/tests/unittests/CoreText/CTFrameTests.mm
+++ b/tests/unittests/CoreText/CTFrameTests.mm
@@ -25,7 +25,7 @@ static constexpr double c_errorDelta = 0.0005;
 static constexpr float c_arbitraryFloat = 314159.2717;
 
 static NSAttributedString* getAttributedString(NSString* str) {
-    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Times New Roman" size:40];
+    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Segoe UI" size:40];
     UIFont* font = [UIFont fontWithDescriptor:fontDescriptor size:40];
 
     NSRange wholeRange = NSMakeRange(0, str.length);

--- a/tests/unittests/CoreText/CTLineTests.mm
+++ b/tests/unittests/CoreText/CTLineTests.mm
@@ -19,7 +19,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 
 NSMutableAttributedString* getAttributedString(NSString* str) {
-    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Times New Roman" size:40];
+    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Segoe UI" size:40];
     UIFont* font = [UIFont fontWithDescriptor:fontDescriptor size:40];
 
     NSRange wholeRange = NSMakeRange(0, str.length);
@@ -166,24 +166,23 @@ TEST(CTLine, CreateTruncatedLineNoTruncationToken) {
     CFRelease(startTruncated);
 
     CTLineRef endTruncated = CTLineCreateTruncatedLine(line, 40.0, kCTLineTruncationEnd, NULL);
-    EXPECT_EQ(3, CTLineGetGlyphCount(endTruncated));
+    EXPECT_EQ(2, CTLineGetGlyphCount(endTruncated));
 
-    // Truncated should be ABC in one run
+    // Truncated should be AB in one run
     const CGGlyph* endTruncatedGlyphs =
         CTRunGetGlyphsPtr(static_cast<CTRunRef>(CFArrayGetValueAtIndex(CTLineGetGlyphRuns(endTruncated), 0)));
     EXPECT_EQ(*originalGlyphs, *endTruncatedGlyphs);
-    EXPECT_EQ(*(originalGlyphs + 2), *(endTruncatedGlyphs + 2));
+    EXPECT_EQ(*(originalGlyphs + 1), *(endTruncatedGlyphs + 1));
     CFRelease(endTruncated);
 
     CTLineRef middleTruncated = CTLineCreateTruncatedLine(line, 40.0, kCTLineTruncationMiddle, NULL);
-    EXPECT_EQ(3, CTLineGetGlyphCount(middleTruncated));
+    EXPECT_EQ(2, CTLineGetGlyphCount(middleTruncated));
 
-    // Truncated should be AEF in one run
+    // Truncated should be AF in one run
     const CGGlyph* middleTruncatedGlyphs =
         CTRunGetGlyphsPtr(static_cast<CTRunRef>(CFArrayGetValueAtIndex(CTLineGetGlyphRuns(middleTruncated), 0)));
     EXPECT_EQ(*originalGlyphs, *middleTruncatedGlyphs);
-    EXPECT_EQ(*(originalGlyphs + 4), *(middleTruncatedGlyphs + 1));
-    EXPECT_EQ(*(originalGlyphs + 5), *(middleTruncatedGlyphs + 2));
+    EXPECT_EQ(*(originalGlyphs + 5), *(middleTruncatedGlyphs + 1));
     CFRelease(middleTruncated);
     CFRelease(line);
 }

--- a/tests/unittests/CoreText/CTRunTests.mm
+++ b/tests/unittests/CoreText/CTRunTests.mm
@@ -27,7 +27,7 @@ static constexpr double c_errorDelta = 0.0005;
 static constexpr float c_arbitraryFloat = 114138.2292;
 
 NSMutableAttributedString* getString(NSString* str) {
-    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Times New Roman" size:40];
+    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Segoe UI" size:40];
     UIFont* font = [UIFont fontWithDescriptor:fontDescriptor size:40];
 
     NSRange wholeRange = NSMakeRange(0, str.length);
@@ -154,8 +154,8 @@ TEST_P(TypographicBounds, VerifyBounds) {
     EXPECT_NEAR_MSG(width, ::testing::get<1>(GetParam()), c_errorDelta, "Failed: Typographic width is incorrect");
 }
 
-const double widthExpected = 14.1094;
-const double reducedWidthExpected = 7.0547;
+const double widthExpected = 13.3477;
+const double reducedWidthExpected = 6.6738;
 
 INSTANTIATE_TEST_CASE_P(CTRun,
                         TypographicBounds,
@@ -175,7 +175,7 @@ TEST(CTRun, GetAttributes) {
     UIFont* font = (UIFont*)CFDictionaryGetValue(dictionary, NSFontAttributeName);
     ASSERT_TRUE_MSG([font isKindOfClass:[UIFont class]], "Failed: Wrong object type in dictionary");
     NSString* fontName = ((UIFont*)font).fontName;
-    ASSERT_OBJCEQ_MSG(fontName, @"Times New Roman", "Failed: Wrong data in dictionary");
+    ASSERT_OBJCEQ_MSG(fontName, @"Segoe UI", "Failed: Wrong data in dictionary");
 
     UIColor* color = (UIColor*)CFDictionaryGetValue(dictionary, NSForegroundColorAttributeName);
     ASSERT_TRUE_MSG([color isKindOfClass:[UIColor class]], "Failed: Wrong object type in dictionary");

--- a/tests/unittests/CoreText/CTTypesetterTests.mm
+++ b/tests/unittests/CoreText/CTTypesetterTests.mm
@@ -20,7 +20,7 @@
 #import <CoreFoundation/CoreFoundation.h>
 
 static NSAttributedString* getMultilineAttributedString() {
-    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Times New Roman" size:40];
+    UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Segoe UI" size:40];
     UIFont* font = [UIFont fontWithDescriptor:fontDescriptor size:40];
 
     NSRange wholeRange = NSMakeRange(0, 20);


### PR DESCRIPTION
Fixes regression which defaulted to left-aligned text, and adds support for selecting different fonts and changing writing direction

Fixes #1013 