### PR TITLE
Remove spurious define of TARGET_IPHONE_SIMULATOR.  

### DIFF
--- a/include/StarboardAdditionalDefines.h
+++ b/include/StarboardAdditionalDefines.h
@@ -17,10 +17,6 @@
 #ifndef __STARBOARD_ADDITIONAL_DEFINES
 #define __STARBOARD_ADDITIONAL_DEFINES
 
-#ifndef TARGET_IPHONE_SIMULATOR
-#define TARGET_IPHONE_SIMULATOR 1 //  Temporary for Cocos2D compat, for now
-#endif
-
 enum { noErr = 0 };
 
 typedef unsigned int uint;


### PR DESCRIPTION
This was originally added according to comments for cocos2d compat.  Looking at the sources, this isnt required anymore.  Worse, it interferes with suspend/resume handling on apps where due to a workaround in the TARGET_IPHONE_SIMULATOR codepath, we are trying to resume a track while suspending, resulting in the track not playing on resume.

We no longer pretend to be TARGET_IPHONE, so there is no need to pretend to be the simulator either.