### PR TITLE
Add an ObjC class to act as the parent of all CF types.

### DIFF
--- a/Frameworks/CoreFoundation/Base.subproj/CFInternal.h
+++ b/Frameworks/CoreFoundation/Base.subproj/CFInternal.h
@@ -367,6 +367,7 @@ CF_PRIVATE Boolean __CFProcessIsRestricted();
 // CF_EXPORT void * __CFConstantStringClassReferencePtrPtr;
 // CF_EXPORT void *__CFConstantStringClassReferencePtr[];
 extern "C" Class _OBJC_CLASS__NSCFString;
+extern "C" Class _OBJC_CLASS__NSCFType;
 
 // WINOBJC: Compilation can't find these class names
 // Needed for class checks against cfisa, _CFRuntimeBridgeTypeToClass
@@ -691,6 +692,7 @@ extern void _CFRuntimeSetInstanceTypeIDAndIsa(CFTypeRef cf, CFTypeID newTypeID);
 #define CF_IS_OBJC(typeID, obj) ( \
     (!obj) || \
     ((((CFRuntimeBase*)(obj))->_cfisa != 0) && \
+    (((CFRuntimeBase*)(obj))->_cfisa != (uintptr_t)(&_OBJC_CLASS__NSCFType)) && \
     (((CFRuntimeBase*)(obj))->_cfisa != (uintptr_t)(&_OBJC_CLASS__NSCFString)) && \
     (__CFISAForTypeID(typeID) != ((CFRuntimeBase*)(obj))->_cfisa) && \
     (![(id)(((CFRuntimeBase*)(obj)))->_cfisa isSubclassOfClass:(Class)__CFISAForTypeID(typeID)])))
@@ -711,7 +713,8 @@ CF_INLINE bool __CF_IsBridgedObject(CFTypeRef obj) {
         return false;
     }
 
-    if ((object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFString)) || 
+    if ((object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFType)) || 
+        (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFString)) || 
         (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFNumber)) || 
         (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFBoolean))) {
         return true;
@@ -734,6 +737,7 @@ CF_INLINE bool __CF_IsBridgedObject(CFTypeRef obj) {
 CF_INLINE bool __CF_IsCFObject(CFTypeRef obj) {
     CFRuntimeBase* object = (CFRuntimeBase*)obj;
     if ((object->_cfisa == 0) || 
+        (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFType)) ||
         (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFString)) ||
         (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFNumber)) ||
         (object->_cfisa == (uintptr_t)(&_OBJC_CLASS__NSCFBoolean)) ||

--- a/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1129,6 +1129,7 @@ void __CFInitialize(void) {
         memset(__CFRuntimeObjCClassTable, 0, sizeof(__CFRuntimeObjCClassTable));
 
 #if WINOBJC
+        // WINOBJC: Under the WinObjC runtime, all CFTypeRefs are _NSCFTypes or a toll-free bridged type
         for (CFIndex idx = 1; idx < __CFRuntimeClassTableSize; ++idx) {
             __CFRuntimeObjCClassTable[idx] = (uintptr_t)&_OBJC_CLASS__NSCFType;
         }

--- a/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
@@ -291,9 +291,19 @@ void _CFRuntimeUnregisterClassWithTypeID(CFTypeID typeID) {
 CF_PRIVATE uint8_t __CFZombieEnabled = 0;
 CF_PRIVATE uint8_t __CFDeallocateZombies = 0;
 
-extern void __CFZombifyNSObject(void);  // from NSObject.m
+// WINOBJC: Since NSObject lives in Foundation, we have to invert the dependency here;
+// like in libobjc2, Foundation will set a callback to fire on object deallocation when
+// zombies are turned on.
+// extern void __CFZombifyNSObject(void);  // from NSObject.m
+void (*__CFZombifyNSObjectHook)(id);
 
 void _CFEnableZombies(void) {
+    __CFZombieEnabled = 1;
+}
+
+// WINOBJC: Zombies can be disabled.
+void _CFDisableZombies(void) {
+    __CFZombieEnabled = 0;
 }
 
 #endif /* DEBUG */
@@ -1851,6 +1861,12 @@ static void _CFRelease(CFTypeRef CF_RELEASES_ARGUMENT cf) {
             usesSystemDefaultAllocator = _CFAllocatorIsSystemDefault(allocator);
     }
 
+    // WinObjC: Resurrect zombie support; it looks like this was removed from the original codebase.
+#if defined(DEBUG) || defined(ENABLE_ZOMBIES)
+    if (__CFZombieEnabled && __CFZombifyNSObjectHook) {
+        __CFZombifyNSObjectHook((id)cf);
+    } else
+#endif
     {
         CFAllocatorDeallocate(allocator, (uint8_t *)cf - (usesSystemDefaultAllocator ? 0 : sizeof(CFAllocatorRef)));
     }

--- a/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1118,6 +1118,11 @@ void __CFInitialize(void) {
         memset(__CFRuntimeClassTable, 0, sizeof(__CFRuntimeClassTable));
         memset(__CFRuntimeObjCClassTable, 0, sizeof(__CFRuntimeObjCClassTable));
 
+#if WINOBJC
+        for (CFIndex idx = 1; idx < __CFRuntimeClassTableSize; ++idx) {
+            __CFRuntimeObjCClassTable[idx] = (uintptr_t)&_OBJC_CLASS__NSCFType;
+        }
+#endif
         
 #if DEPLOYMENT_RUNTIME_SWIFT
 

--- a/Frameworks/CoreFoundationAdditions/_NSCFType.mm
+++ b/Frameworks/CoreFoundationAdditions/_NSCFType.mm
@@ -1,0 +1,55 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <CoreFoundation/CFBase.h>
+#include "CFFoundationInternal.h"
+#include "CFInternal.h"
+
+@interface _NSCFType: _NSCFTemporaryRootObject
+@end
+@implementation _NSCFType
+
+- (instancetype)retain {
+    CFRetain(static_cast<CFTypeRef>(self));
+    return self;
+}
+
+- (oneway void)release {
+    CFRelease(static_cast<CFTypeRef>(self));
+}
+
+- (id)autorelease {
+    return (id)(CFAutorelease(static_cast<CFTypeRef>(self)));
+}
+
+- (NSUInteger)retainCount {
+    return CFGetRetainCount(static_cast<CFTypeRef>(self));
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
+- (void)dealloc {
+    /* No-op for bridged classes. This is because the CF system is responsible for the allocation and dealloc of the backing memory. */
+    /* This is all handled via the CFRelease calls. */
+    /* When its CF ref count drops to 0 the CF version of dealloc is invoked */
+    /* so by the time the NSObject dealloc is called, there is nothing left to do. */
+}
+
++ (instancetype)allocWithZone:(NSZone*)zone {
+    return nil;
+}
+#pragma clang diagnostic pop
+@end

--- a/Frameworks/Foundation/NSObject.mm
+++ b/Frameworks/Foundation/NSObject.mm
@@ -632,6 +632,8 @@ static IMP _NSIMPForward(id object, SEL selector) {
  @Status Interoperable
 */
 + (void)load {
+    class_setSuperclass(objc_getClass("_NSCFType"), self);
+
     objc_proxy_lookup = _NSForwardingDestination;
     __objc_msg_forward2 = _NSIMPForward;
     __objc_msg_forward3 = _NSSlotForward;

--- a/Frameworks/Foundation/NSObject.mm
+++ b/Frameworks/Foundation/NSObject.mm
@@ -38,6 +38,7 @@
 #import <mutex>
 
 #import "ForFoundationOnly.h"
+#import "CFFoundationInternal.h"
 #import "NSInvocationInternal.h"
 
 static void _NSObjCEnumerationMutation(id object) {
@@ -707,11 +708,36 @@ __attribute__((objc_root_class)) @interface NSZombie {
 }
 @end
 
-    @implementation NSZombie
-    /**
-     @Status Interoperable
-    */
-    - (void)doesNotRecognizeSelector : (SEL)selector {
+static void _dealloc_zombify(id self, SEL _cmd); // forward declaration
+
+static void _NSCFZombifyHook(id object) {
+    _dealloc_zombify(object, nullptr);
+}
+
+@implementation NSZombie
++ (void)load {
+    __CFZombifyNSObjectHook = _NSCFZombifyHook;
+}
+
+// This implementation is required by CF, but NSZombie is a root class and does not inherit
+// NSObject's version.
++ (BOOL)isSubclassOfClass:(Class)classRef {
+    Class curClass = self;
+
+    while (curClass != nil) {
+        if (curClass == classRef) {
+            return YES;
+        }
+
+        curClass = class_getSuperclass(curClass);
+    }
+
+    return NO;
+}
+/**
+ @Status Interoperable
+*/
+- (void)doesNotRecognizeSelector: (SEL)selector {
     // NSZombie subclasses store the original class as a class variable. Retrieve it here.
     Class oldIsa = reinterpret_cast<Class*>(object_getIndexedIvars(isa))[0];
     THROW_NS_HR_MSG(HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE),
@@ -722,8 +748,8 @@ __attribute__((objc_root_class)) @interface NSZombie {
 }
 @end
 
-    static void
-    _dealloc_dispose(id self, SEL _cmd) {
+static void
+_dealloc_dispose(id self, SEL _cmd) {
     object_dispose(self);
 }
 
@@ -758,6 +784,12 @@ void WinObjC_SetZombiesEnabled(BOOL enabled) {
     Method dealloc = class_getInstanceMethod([NSObject class], @selector(dealloc));
     if (dealloc) {
         method_setImplementation(dealloc, targetDeallocIMP);
+    }
+
+    if (enabled) {
+        _CFEnableZombies();
+    } else {
+        _CFDisableZombies();
     }
 }
 #pragma endregion

--- a/Frameworks/include/CFFoundationInternal.h
+++ b/Frameworks/include/CFFoundationInternal.h
@@ -65,5 +65,10 @@ CF_EXTERN_C_END
 #define IS_SLASH(C) ((C) == '/')
 #endif
 
+// From CFRuntime.c, for object zombification.
+CF_EXPORT void (*__CFZombifyNSObjectHook)(id);
+CF_EXPORT void _CFEnableZombies(void);
+CF_EXPORT void _CFDisableZombies(void);
+
 // Expose current directory functionality from CFURL
 CF_EXPORT CFURLRef _CFURLCreateCurrentDirectoryURL(CFAllocatorRef allocator) CF_RETURNS_RETAINED;

--- a/build/CoreFoundation/dll/CoreFoundation.def
+++ b/build/CoreFoundation/dll/CoreFoundation.def
@@ -35,6 +35,9 @@ LIBRARY CoreFoundation
         _CFGetSlashStr
         _CFProcessPath
         _CFURLCreateCurrentDirectoryURL
+        _CFEnableZombies
+        _CFDisableZombies
+        __CFZombifyNSObjectHook CONSTANT
         _NS_chdir
 
         ; Base Utilities.mm

--- a/build/CoreFoundationAdditions/lib/CoreFoundationAdditionsLib.vcxproj
+++ b/build/CoreFoundationAdditions/lib/CoreFoundationAdditionsLib.vcxproj
@@ -22,6 +22,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreFoundationAdditions\_NSCFNumber.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreFoundationAdditions\_NSCFTemporaryRootObject.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreFoundationAdditions\_NSCFString.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreFoundationAdditions\_NSCFType.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreFoundationAdditions\_CFLocaleInternal.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreFoundationAdditions\CFStringTokenizer.mm" />
   </ItemGroup>

--- a/tests/unittests/Foundation/CoreFoundationTests.m
+++ b/tests/unittests/Foundation/CoreFoundationTests.m
@@ -18,6 +18,7 @@
 #include <windows.h>
 
 #import <CoreFoundation/CoreFoundation.h>
+#import <CoreFoundation/CFTree.h>
 #import <mach/mach_time.h>
 
 static uint64_t walltime(const struct mach_timebase_info& timebase, uint64_t value) {
@@ -55,4 +56,20 @@ TEST(CoreFoundation, mach_absolute_time) {
     // does in fact move forward when expected.
     EXPECT_GT(measurement3, measurement2);
     EXPECT_GT(measurement2, measurement1);
+}
+
+TEST(CFType, UnknownTypeInObjCContainer) {
+    // This test requires a non-bridged public CF type. CFTreeRef will suffice.
+    CFTreeContext treeContext{};
+    CFTypeRef tree = static_cast<CFTypeRef>(CFTreeCreate(kCFAllocatorDefault, &treeContext));
+
+    NSArray* array = nil;
+
+    // The ',' in this method call upsets EXPECT_NO_THROW(...), so we need to hide it behind a lambda.
+    auto create = [&tree](){
+        return [[NSArray alloc] initWithObjects:static_cast<id>(tree), nil];
+    };
+    EXPECT_NO_THROW(array = create());
+    EXPECT_NO_THROW(CFRelease(tree));
+    EXPECT_NO_THROW([array release]);
 }

--- a/tests/unittests/Foundation/WindowsOnly/NSObjectInternalTests.mm
+++ b/tests/unittests/Foundation/WindowsOnly/NSObjectInternalTests.mm
@@ -29,3 +29,15 @@ TEST(NSObject, NSZombie) { // This test will fail with an AV if zombies do not w
 
     WinObjC_SetZombiesEnabled(NO);
 }
+
+TEST(NSCFObject, NSZombie) {
+    WinObjC_SetZombiesEnabled(YES);
+
+    NSString* string = [[NSMutableString alloc] initWithString:@"Hello"];
+    [string release];
+    EXPECT_ANY_THROW([string self]);
+
+    EXPECT_ANY_THROW(CFStringGetLength(static_cast<CFStringRef>(string)));
+
+    WinObjC_SetZombiesEnabled(NO);
+}


### PR DESCRIPTION
This pull request intends to both complete #719 and fix the crash behind #649 (#649 is both a compliance bug _and_ a crash bug.).

True Objective-C memory management for CoreFoundation (as seen [here](https://github.com/DHowett-MSFT/WinObjC/compare/201609-nscftype?expand=1)) is infeasible right now. We have too few fiddly bitfields and subclasses to determine with any accuracy whether an object was statically-allocated or heap-allocated, and we almost certainly don't want to manipulate the nonexistent reference count on non-heap-allocated objects.

Herein, therefore, we try to solve two of the major Objective-C <-> CF bridging compliance issues:
* Not every CF type has an Objective-C parallel (and as such cannot live in an Objective-C collection.)
* CF objects cannot be zombified.
