### PR TITLE
Support Kern and ForegroundColorFromContext as well as fix TruncatedL…

### DIFF
--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -51,6 +51,8 @@ static NSMutableAttributedString* _getTruncatedStringFromSourceLine(CTLineRef li
     ret->_leading = _leading;
     ret->_glyphCount = _glyphCount;
     ret->_runs.attach([_runs copy]);
+    ret->_relativeXOffset = _relativeXOffset;
+    ret->_relativeYOffset = _relativeYOffset;
 
     return ret;
 }

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -248,15 +248,11 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
         CGContextSetTextPosition(ctx, curTextPos.x + curRun->_relativeXOffset, curTextPos.y + curRun->_relativeYOffset);
     }
 
-    // TODO::
-    // Fix this once CTFont and UIFont become bridgable classes.
     id fontColor = [curRun->_attributes objectForKey:(id)kCTForegroundColorAttributeName];
     if (fontColor == nil) {
         CFBooleanRef useContextColor =
             static_cast<CFBooleanRef>([curRun->_attributes objectForKey:(id)kCTForegroundColorFromContextAttributeName]);
-        if (useContextColor && CFBooleanGetValue(useContextColor)) {
-            // Leave the context fill color as is
-        } else {
+        if (!useContextColor || !CFBooleanGetValue(useContextColor)) {
             fontColor = [_LazyUIColor blackColor];
             CGContextSetFillColorWithColor(ctx, reinterpret_cast<CGColorRef>(fontColor));
         }

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -252,9 +252,18 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
     // Fix this once CTFont and UIFont become bridgable classes.
     id fontColor = [curRun->_attributes objectForKey:(id)kCTForegroundColorAttributeName];
     if (fontColor == nil) {
-        fontColor = [_LazyUIColor blackColor];
+        CFBooleanRef useContextColor =
+            static_cast<CFBooleanRef>([curRun->_attributes objectForKey:(id)kCTForegroundColorFromContextAttributeName]);
+        if (useContextColor && CFBooleanGetValue(useContextColor)) {
+            // Leave the context fill color as is
+        } else {
+            fontColor = [_LazyUIColor blackColor];
+            CGContextSetFillColorWithColor(ctx, reinterpret_cast<CGColorRef>(fontColor));
+        }
+    } else {
+        CGContextSetFillColorWithColor(ctx, reinterpret_cast<CGColorRef>(fontColor));
     }
-    CGContextSetFillColorWithColor(ctx, reinterpret_cast<CGColorRef>(fontColor));
+
     CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun);
 }
 

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAlignmentTestViewController.m
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAlignmentTestViewController.m
@@ -32,6 +32,7 @@
     UIColor* color = [UIColor blueColor];
 
     CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, color.CGColor);
 
     // Aligns origin for our frame
     CGContextTranslateCTM(context, 0.0f, self.bounds.size.height);
@@ -57,8 +58,8 @@
     // Make dictionary for attributed string with font, color, and alignment
     NSDictionary* attributesDict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)myCFFont,
                                                                               (id)kCTFontAttributeName,
-                                                                              color.CGColor,
-                                                                              (id)kCTForegroundColorAttributeName,
+                                                                              kCFBooleanTrue,
+                                                                              (id)kCTForegroundColorFromContextAttributeName,
                                                                               (__bridge id)paragraphStyle,
                                                                               (id)kCTParagraphStyleAttributeName,
                                                                               nil];

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
@@ -42,6 +42,7 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
     UIColor* color = [UIColor blueColor];
 
     CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, color.CGColor);
 
     // Aligns origin for our frame
     CGContextTranslateCTM(context, 0.0f, self.bounds.size.height);
@@ -69,8 +70,8 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
     // Make dictionary for attributed string with font, color, and alignment
     NSDictionary* attributesDict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)myCFFont,
                                                                               (id)kCTFontAttributeName,
-                                                                              color.CGColor,
-                                                                              (id)kCTForegroundColorAttributeName,
+                                                                              kCFBooleanFalse,
+                                                                              (id)kCTForegroundColorFromContextAttributeName,
                                                                               (__bridge id)paragraphStyle,
                                                                               (id)kCTParagraphStyleAttributeName,
                                                                               nil];

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCLineTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCLineTestViewController.mm
@@ -35,7 +35,7 @@
 
     // Flips y-axis for our frame
     CGContextScaleCTM(context, 1.0f, -1.0f);
-    CGContextSetTextPosition(context, 0.0, 10.0);
+    CGContextSetTextPosition(context, 0.0, 0.0);
     CTLineDraw(_lineRef, context);
     CFRelease(_lineRef);
 }

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -89,3 +89,34 @@ TEST(CoreText, CTParagraphStyle) {
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, 513, sizeof(CGFloat), nullptr);
     ASSERT_TRUE_MSG(!success, "FAILED: An invalid specifier crash should not occur.");
 }
+
+TEST(CoreText, KernAttribute) {
+    const static float c_errorDelta = 0.001f;
+    NSMutableAttributedString* string = [[NSMutableAttributedString alloc] initWithString:@"TESTTESTTEST"];
+    [string autorelease];
+    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:0.0f] } range:NSMakeRange(0, 4)];
+    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:2.0f] } range:NSMakeRange(4, 4)];
+    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:-2.0f] } range:NSMakeRange(8, 4)];
+    CTLineRef line = CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(string));
+    CFAutorelease(line);
+    CFArrayRef runs = CTLineGetGlyphRuns(line);
+    ASSERT_EQ(3, CFArrayGetCount(runs));
+
+    CTRunRef firstRun = static_cast<CTRunRef>(CFArrayGetValueAtIndex(runs, 0));
+    CTRunRef secondRun = static_cast<CTRunRef>(CFArrayGetValueAtIndex(runs, 1));
+    CTRunRef thirdRun = static_cast<CTRunRef>(CFArrayGetValueAtIndex(runs, 2));
+
+    CGSize firstAdvances[4], secondAdvances[4], thirdAdvances[4];
+    CTRunGetAdvances(firstRun, { 0, 0 }, firstAdvances);
+    CTRunGetAdvances(secondRun, { 0, 0 }, secondAdvances);
+    CTRunGetAdvances(thirdRun, { 0, 0 }, thirdAdvances);
+
+    EXPECT_NEAR(secondAdvances[0].width, firstAdvances[0].width + 2.0f, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[1].width, firstAdvances[1].width + 2.0f, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[2].width, firstAdvances[2].width + 2.0f, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[3].width, firstAdvances[3].width + 2.0f, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[0].width, firstAdvances[0].width - 2.0f, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[1].width, firstAdvances[1].width - 2.0f, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[2].width, firstAdvances[2].width - 2.0f, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[3].width, firstAdvances[3].width - 2.0f, c_errorDelta);
+}

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -92,8 +92,7 @@ TEST(CoreText, CTParagraphStyle) {
 
 TEST(CoreText, KernAttribute) {
     const static float c_errorDelta = 0.001f;
-    NSMutableAttributedString* string = [[NSMutableAttributedString alloc] initWithString:@"TESTTESTTEST"];
-    [string autorelease];
+    NSMutableAttributedString* string = [[[NSMutableAttributedString alloc] initWithString:@"TESTTESTTEST"] autorelease];
     [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:0.0f] } range:NSMakeRange(0, 4)];
     [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:2.0f] } range:NSMakeRange(4, 4)];
     [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:-2.0f] } range:NSMakeRange(8, 4)];


### PR DESCRIPTION
…ine test

Fully support kCTKernAttributeName and kCTForegroundColorFromContextAttributeName.  Also fixes CTCatalog truncated line bug where the copied line would be misaligned.

Fixes #1055 and #1056