### PR TITLE
Fully implement CTRunDraw and CTRunGetTypographicBounds

### DIFF
--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -298,30 +298,11 @@ double CTLineGetTypographicBounds(CTLineRef lineRef, CGFloat* ascent, CGFloat* d
     // Created with impossible values -FLT_MAX which signify they need to be populated
     if (line->_ascent == -FLT_MAX || line->_descent == -FLT_MAX || line->_leading == -FLT_MAX) {
         for (_CTRun* run in static_cast<id<NSFastEnumeration>>(line->_runs)) {
-            DWRITE_GLYPH_METRICS glyphMetrics[run->_dwriteGlyphRun.glyphCount];
-            THROW_IF_FAILED(run->_dwriteGlyphRun.fontFace->GetDesignGlyphMetrics(run->_dwriteGlyphRun.glyphIndices,
-                                                                                 run->_dwriteGlyphRun.glyphCount,
-                                                                                 glyphMetrics,
-                                                                                 run->_dwriteGlyphRun.isSideways));
-
-            CTFontRef font = static_cast<CTFontRef>([run->_attributes objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
-            CGFloat pointSize = kCTFontSystemFontSize;
-            if (font) {
-                pointSize = CTFontGetSize(font);
-            }
-
-            DWRITE_FONT_METRICS fontMetrics;
-            run->_dwriteGlyphRun.fontFace->GetMetrics(&fontMetrics);
-
-            // Need scaling factor to convert from design units to pointSize
-            CGFloat scalingFactor = pointSize / fontMetrics.designUnitsPerEm;
-
-            for (size_t i = 0; i < run->_dwriteGlyphRun.glyphCount; ++i) {
-                line->_ascent = std::max(line->_ascent, glyphMetrics[i].verticalOriginY * scalingFactor);
-                line->_descent = std::max(line->_descent, glyphMetrics[i].bottomSideBearing * scalingFactor);
-            }
-
-            line->_leading = std::max(line->_leading, fontMetrics.lineGap * scalingFactor);
+            CGFloat newAscent, newDescent, newLeading;
+            CTRunGetTypographicBounds(static_cast<CTRunRef>(run), { 0, 0 }, &newAscent, &newDescent, &newLeading);
+            line->_ascent = std::max(line->_ascent, newAscent);
+            line->_descent = std::max(line->_descent, newDescent);
+            line->_leading = std::max(line->_leading, newLeading);
         }
     }
 

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -59,7 +59,7 @@ static NSMutableAttributedString* _getTruncatedStringFromSourceLine(CTLineRef li
 @end
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 CTLineRef CTLineCreateWithAttributedString(CFAttributedStringRef string) {
     return string ? static_cast<CTLineRef>(_DWriteGetLine(string)) : nil;

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -69,6 +69,20 @@ static IWLazyClassLookup _LazyUIColor("UIColor");
 
 @end
 
+// Helper method to produce a DWRITE_GLYPH_RUN for drawing
+// Shares memory with the original, so should NOT be deleted
+// Expects range parameter to be verified to work with glyph run
+DWRITE_GLYPH_RUN __GetGlyphRunForDrawingInRange(const DWRITE_GLYPH_RUN& run, const CFRange& range) {
+    return DWRITE_GLYPH_RUN{ run.fontFace,
+                             run.fontEmSize,
+                             range.length,
+                             run.glyphIndices ? run.glyphIndices + range.location : nullptr,
+                             run.glyphAdvances ? run.glyphAdvances + range.location : nullptr,
+                             run.glyphOffsets ? run.glyphOffsets + range.location : nullptr,
+                             run.isSideways,
+                             run.bidiLevel };
+}
+
 /**
 @Status Interoperable
 */
@@ -182,12 +196,8 @@ CFRange CTRunGetStringRange(CTRunRef run) {
  @Status Interoperable
 */
 double CTRunGetTypographicBounds(CTRunRef run, CFRange range, CGFloat* ascent, CGFloat* descent, CGFloat* leading) {
-    if (run == nullptr) {
+    if (run == nullptr || range.length < 0L) {
         return 0;
-    }
-
-    if (range.length < 0) {
-        THROW_NS_HR(E_INVALIDARG);
     }
 
     _CTRun* curRun = static_cast<_CTRun*>(run);
@@ -201,31 +211,50 @@ double CTRunGetTypographicBounds(CTRunRef run, CFRange range, CGFloat* ascent, C
         range.location = 0;
     }
 
-    if ((range.location + range.length) > (curRun->_range.location + curRun->_range.length)) {
+    if ((range.location + range.length) > (curRun->_range.location + curRun->_range.length) || range.length <= 0) {
         return 0;
     }
 
-    UIFont* font = [curRun->_attributes objectForKey:(id)kCTFontAttributeName];
+    CTFontRef font = static_cast<CTFontRef>([curRun->_attributes objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
+    CGFloat pointSize = kCTFontSystemFontSize;
+    if (font) {
+        pointSize = CTFontGetSize(font);
+    }
+
+    DWRITE_FONT_METRICS fontMetrics;
+    curRun->_dwriteGlyphRun.fontFace->GetMetrics(&fontMetrics);
+
+    // Need scaling factor to convert from design units to pointSize
+    CGFloat scalingFactor = pointSize / fontMetrics.designUnitsPerEm;
+
+    DWRITE_GLYPH_METRICS glyphMetrics[range.length];
+    THROW_IF_FAILED(curRun->_dwriteGlyphRun.fontFace->GetDesignGlyphMetrics(curRun->_dwriteGlyphRun.glyphIndices + range.location,
+                                                                            range.length,
+                                                                            glyphMetrics,
+                                                                            curRun->_dwriteGlyphRun.isSideways));
+
+    double width = 0;
+    CGFloat newAscent = -FLT_MAX;
+    CGFloat newDescent = -FLT_MAX;
+    for (size_t i = range.location; i < range.location + range.length; ++i) {
+        newAscent = std::max(newAscent, glyphMetrics[i].verticalOriginY * scalingFactor);
+        newDescent = std::max(newDescent, glyphMetrics[i].bottomSideBearing * scalingFactor);
+        width += curRun->_dwriteGlyphRun.glyphAdvances[i];
+    }
+
     if (ascent) {
-        *ascent = [font ascender];
+        *ascent = newAscent;
     }
 
     if (descent) {
-        *descent = [font descender];
+        *descent = newDescent;
     }
 
     if (leading) {
-        *leading = [font leading];
+        *leading = fontMetrics.lineGap * scalingFactor;
     }
 
-    if (range.length < 0) {
-        return 0;
-    }
-
-    // Calculate the typographic width for the specified range
-    return std::accumulate(curRun->_dwriteGlyphRun.glyphAdvances + range.location,
-                           curRun->_dwriteGlyphRun.glyphAdvances + range.location + range.length,
-                           0.0);
+    return width;
 }
 
 /**
@@ -238,11 +267,12 @@ CGRect CTRunGetImageBounds(CTRunRef run, CGContextRef context, CFRange range) {
 }
 
 void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition) {
-    if (!run) {
+    _CTRun* curRun = static_cast<_CTRun*>(run);
+    if (!curRun || textRange.length < 0L || textRange.location < 0L ||
+        textRange.location + textRange.length > curRun->_dwriteGlyphRun.glyphCount) {
         return;
     }
 
-    _CTRun* curRun = (_CTRun*)run;
     if (adjustTextPosition) {
         CGPoint curTextPos = CGContextGetTextPosition(ctx);
         CGContextSetTextPosition(ctx, curTextPos.x + curRun->_relativeXOffset, curTextPos.y + curRun->_relativeYOffset);
@@ -260,12 +290,23 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
         CGContextSetFillColorWithColor(ctx, reinterpret_cast<CGColorRef>(fontColor));
     }
 
-    CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun);
+    if (textRange.location == 0L && (textRange.length == 0L || textRange.length == curRun->_dwriteGlyphRun.glyphCount)) {
+        // Print the whole glyph run
+        CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun);
+    } else {
+        if (textRange.length == 0L) {
+            textRange.length = curRun->_dwriteGlyphRun.glyphCount - textRange.location;
+        }
+
+        // Only print glyphs in range
+        DWRITE_GLYPH_RUN runInRange = __GetGlyphRunForDrawingInRange(curRun->_dwriteGlyphRun, textRange);
+        CGContextDrawGlyphRun(ctx, &runInRange);
+    }
 }
 
 /**
- @Status Caveat
- @Notes textRange parameter not supported
+ @Status Interoperable
+ @Notes
 */
 void CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange) {
     _CTRunDraw(run, ctx, textRange, true);

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -216,10 +216,7 @@ double CTRunGetTypographicBounds(CTRunRef run, CFRange range, CGFloat* ascent, C
     }
 
     CTFontRef font = static_cast<CTFontRef>([curRun->_attributes objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
-    CGFloat pointSize = kCTFontSystemFontSize;
-    if (font) {
-        pointSize = CTFontGetSize(font);
-    }
+    CGFloat pointSize = font ? CTFontGetSize(font) : kCTFontSystemFontSize;
 
     DWRITE_FONT_METRICS fontMetrics;
     curRun->_dwriteGlyphRun.fontFace->GetMetrics(&fontMetrics);

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -29,9 +29,8 @@
 // Helper method for validating range and copying internal data to given outData
 template <typename T>
 void _boundedCopy(CFRange range, CFIndex size, const T inData[], T outData[]) {
-    if (inData && outData && range.location < size && range.length >= 0L) {
-        range.location = std::max(range.location, 0L);
-        if (range.length == 0L || range.location + range.length >= size) {
+    if (inData && outData && range.location >= 0L && range.length >= 0L && range.location + range.length < size) {
+        if (range.length == 0L) {
             range.length = size - range.location;
         }
 

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -29,7 +29,7 @@
 // Helper method for validating range and copying internal data to given outData
 template <typename T>
 void _boundedCopy(CFRange range, CFIndex size, const T inData[], T outData[]) {
-    if (inData && outData && range.location >= 0L && range.length >= 0L && range.location + range.length < size) {
+    if (inData && outData && range.location >= 0L && range.length >= 0L && range.location + range.length <= size) {
         if (range.length == 0L) {
             range.length = size - range.location;
         }

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
@@ -17,6 +17,9 @@
 
 #import "CTCRunTestViewController.h"
 
+static const NSString* c_text = @"XCTRunX";
+static const CFRange c_visibleRange = CFRangeMake(1, 5);
+
 @interface CTRunTestView : UIView {
 }
 
@@ -64,9 +67,8 @@
                                                                               (id)kCTParagraphStyleAttributeName,
                                                                               nil];
 
-    NSString* text = @"XCTRunX";
     CFAttributedStringRef attrString =
-        CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)text, (__bridge CFDictionaryRef)attributesDict);
+        CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)c_text, (__bridge CFDictionaryRef)attributesDict);
     CFAutorelease(attrString);
 
     CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(attrString);
@@ -83,7 +85,7 @@
 
     // Flips y-axis for our frame
     CGContextSetTextPosition(context, 0.0, 10.0);
-    CTRunDraw(run, context, CFRangeMake(1, 5));
+    CTRunDraw(run, context, c_visibleRange);
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
@@ -169,7 +171,7 @@
     }
 
     CGPoint points[5];
-    CTRunGetPositions(run, CFRangeMake(1, 5), points);
+    CTRunGetPositions(run, c_visibleRange, points);
     const CGPoint* pointPtr = CTRunGetPositionsPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetPositions - {x, y}:", @"CTRunGetPositionsPtr - {x, y}", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -179,7 +181,7 @@
     }
 
     CGSize advances[5];
-    CTRunGetAdvances(run, CFRangeMake(1, 5), advances);
+    CTRunGetAdvances(run, c_visibleRange, advances);
     const CGSize* advancePtr = CTRunGetAdvancesPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetAdvances - {width, height}:", @"CTRunGetAdvancesPtr {width, height}", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -189,7 +191,7 @@
     }
 
     CGGlyph glyphs[5];
-    CTRunGetGlyphs(run, CFRangeMake(1, 5), glyphs);
+    CTRunGetGlyphs(run, c_visibleRange, glyphs);
     const CGGlyph* glyphPtr = CTRunGetGlyphsPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetGlyphs:", @"CTRunGetGlyphsPtr:", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -199,7 +201,7 @@
     }
 
     CFIndex indices[5];
-    CTRunGetStringIndices(run, CFRangeMake(1, 5), indices);
+    CTRunGetStringIndices(run, c_visibleRange, indices);
     const CFIndex* indicesPtr = CTRunGetStringIndicesPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetStringIndices:", @"CTRunGetStringIndicesPtr:", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -209,7 +211,7 @@
     }
 
     CGFloat ascent, descent, leading;
-    double totalWidth = CTRunGetTypographicBounds(run, CFRangeMake(1, 5), &ascent, &descent, &leading);
+    double totalWidth = CTRunGetTypographicBounds(run, c_visibleRange, &ascent, &descent, &leading);
     [_testCells
         addObject:createTextCell(@"CTRunGetTypographicBounds",
                                  [NSString

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
@@ -64,7 +64,7 @@
                                                                               (id)kCTParagraphStyleAttributeName,
                                                                               nil];
 
-    NSString* text = @"CTRun";
+    NSString* text = @"XCTRunX";
     CFAttributedStringRef attrString =
         CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)text, (__bridge CFDictionaryRef)attributesDict);
     CFAutorelease(attrString);
@@ -83,7 +83,7 @@
 
     // Flips y-axis for our frame
     CGContextSetTextPosition(context, 0.0, 10.0);
-    CTRunDraw(run, context, CFRangeMake(0, 0));
+    CTRunDraw(run, context, CFRangeMake(1, 5));
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
@@ -169,7 +169,7 @@
     }
 
     CGPoint points[5];
-    CTRunGetPositions(run, CFRangeMake(0, 0), points);
+    CTRunGetPositions(run, CFRangeMake(1, 5), points);
     const CGPoint* pointPtr = CTRunGetPositionsPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetPositions - {x, y}:", @"CTRunGetPositionsPtr - {x, y}", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -179,7 +179,7 @@
     }
 
     CGSize advances[5];
-    CTRunGetAdvances(run, CFRangeMake(0, 0), advances);
+    CTRunGetAdvances(run, CFRangeMake(1, 5), advances);
     const CGSize* advancePtr = CTRunGetAdvancesPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetAdvances - {width, height}:", @"CTRunGetAdvancesPtr {width, height}", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -189,7 +189,7 @@
     }
 
     CGGlyph glyphs[5];
-    CTRunGetGlyphs(run, CFRangeMake(0, 0), glyphs);
+    CTRunGetGlyphs(run, CFRangeMake(1, 5), glyphs);
     const CGGlyph* glyphPtr = CTRunGetGlyphsPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetGlyphs:", @"CTRunGetGlyphsPtr:", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -199,7 +199,7 @@
     }
 
     CFIndex indices[5];
-    CTRunGetStringIndices(run, CFRangeMake(0, 0), indices);
+    CTRunGetStringIndices(run, CFRangeMake(1, 5), indices);
     const CFIndex* indicesPtr = CTRunGetStringIndicesPtr(run);
     [_testCells addObject:createTextCell(@"CTRunGetStringIndices:", @"CTRunGetStringIndicesPtr:", width / 2)];
     for (CFIndex i = 0; i < 5; ++i) {
@@ -209,7 +209,7 @@
     }
 
     CGFloat ascent, descent, leading;
-    double totalWidth = CTRunGetTypographicBounds(run, CFRangeMake(0, 0), &ascent, &descent, &leading);
+    double totalWidth = CTRunGetTypographicBounds(run, CFRangeMake(1, 5), &ascent, &descent, &leading);
     [_testCells
         addObject:createTextCell(@"CTRunGetTypographicBounds",
                                  [NSString

--- a/tests/unittests/CoreText/CTFrameTests.mm
+++ b/tests/unittests/CoreText/CTFrameTests.mm
@@ -146,16 +146,8 @@ TEST(CTFrame, GetLineOrigins) {
 
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(-110, 0), origins.data());
-    EXPECT_NEAR(0.0f, origins[0].x, c_errorDelta);
-    EXPECT_NEAR(43.1641f, origins[0].y, c_errorDelta);
-    EXPECT_NEAR(0.0f, origins[1].x, c_errorDelta);
-    EXPECT_NEAR(96.3672f, origins[1].y, c_errorDelta);
-    EXPECT_NEAR(0.0f, origins[2].x, c_errorDelta);
-    EXPECT_NEAR(149.5703f, origins[2].y, c_errorDelta);
-    EXPECT_NEAR(0.0f, origins[3].x, c_errorDelta);
-    EXPECT_NEAR(202.7734f, origins[3].y, c_errorDelta);
-    EXPECT_EQ(c_arbitraryFloat, origins[4].x);
-    EXPECT_EQ(c_arbitraryFloat, origins[4].y);
+    EXPECT_EQ(c_arbitraryFloat, origins[0].x);
+    EXPECT_EQ(c_arbitraryFloat, origins[0].y);
 
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 0), origins.data());
@@ -172,16 +164,8 @@ TEST(CTFrame, GetLineOrigins) {
 
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 525600), origins.data());
-    EXPECT_NEAR(0.0f, origins[0].x, c_errorDelta);
-    EXPECT_NEAR(43.1641f, origins[0].y, c_errorDelta);
-    EXPECT_NEAR(0.0f, origins[1].x, c_errorDelta);
-    EXPECT_NEAR(96.3672f, origins[1].y, c_errorDelta);
-    EXPECT_NEAR(0.0f, origins[2].x, c_errorDelta);
-    EXPECT_NEAR(149.5703f, origins[2].y, c_errorDelta);
-    EXPECT_NEAR(0.0f, origins[3].x, c_errorDelta);
-    EXPECT_NEAR(202.7734f, origins[3].y, c_errorDelta);
-    EXPECT_EQ(c_arbitraryFloat, origins[4].x);
-    EXPECT_EQ(c_arbitraryFloat, origins[4].y);
+    EXPECT_EQ(c_arbitraryFloat, origins[0].x);
+    EXPECT_EQ(c_arbitraryFloat, origins[0].y);
 
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(1, 2), origins.data());

--- a/tests/unittests/CoreText/CTFrameTests.mm
+++ b/tests/unittests/CoreText/CTFrameTests.mm
@@ -134,16 +134,20 @@ TEST(CTFrame, GetLineOrigins) {
     CFAutorelease(framesetter);
     CFAutorelease(frame);
 
+    // Location greater than available lines, does nothing
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(110, 0), origins.data());
     EXPECT_EQ(c_arbitraryFloat, origins[0].x);
     EXPECT_EQ(c_arbitraryFloat, origins[0].y);
 
+    // Length negative, does nothing
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(0, -110), origins.data());
     EXPECT_EQ(c_arbitraryFloat, origins[0].x);
     EXPECT_EQ(c_arbitraryFloat, origins[0].y);
 
+    // Location negative, does nothing
+    std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(-110, 0), origins.data());
     EXPECT_EQ(c_arbitraryFloat, origins[0].x);
@@ -162,6 +166,7 @@ TEST(CTFrame, GetLineOrigins) {
     EXPECT_EQ(c_arbitraryFloat, origins[4].x);
     EXPECT_EQ(c_arbitraryFloat, origins[4].y);
 
+    // Length greater than available lines, does nothing
     std::fill(origins.begin(), origins.end(), CGPoint{ c_arbitraryFloat, c_arbitraryFloat });
     CTFrameGetLineOrigins(frame, CFRangeMake(0, 525600), origins.data());
     EXPECT_EQ(c_arbitraryFloat, origins[0].x);

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -92,10 +92,11 @@ TEST(CoreText, CTParagraphStyle) {
 
 TEST(CoreText, KernAttribute) {
     const static float c_errorDelta = 0.001f;
+    const static float c_diff = 2.0f;
     NSMutableAttributedString* string = [[[NSMutableAttributedString alloc] initWithString:@"TESTTESTTEST"] autorelease];
     [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:0.0f] } range:NSMakeRange(0, 4)];
-    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:2.0f] } range:NSMakeRange(4, 4)];
-    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:-2.0f] } range:NSMakeRange(8, 4)];
+    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:c_diff] } range:NSMakeRange(4, 4)];
+    [string setAttributes:@{ static_cast<NSString*>(kCTKernAttributeName) : [NSNumber numberWithFloat:-c_diff] } range:NSMakeRange(8, 4)];
     CTLineRef line = CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(string));
     CFAutorelease(line);
     CFArrayRef runs = CTLineGetGlyphRuns(line);
@@ -110,12 +111,12 @@ TEST(CoreText, KernAttribute) {
     CTRunGetAdvances(secondRun, { 0, 0 }, secondAdvances);
     CTRunGetAdvances(thirdRun, { 0, 0 }, thirdAdvances);
 
-    EXPECT_NEAR(secondAdvances[0].width, firstAdvances[0].width + 2.0f, c_errorDelta);
-    EXPECT_NEAR(secondAdvances[1].width, firstAdvances[1].width + 2.0f, c_errorDelta);
-    EXPECT_NEAR(secondAdvances[2].width, firstAdvances[2].width + 2.0f, c_errorDelta);
-    EXPECT_NEAR(secondAdvances[3].width, firstAdvances[3].width + 2.0f, c_errorDelta);
-    EXPECT_NEAR(thirdAdvances[0].width, firstAdvances[0].width - 2.0f, c_errorDelta);
-    EXPECT_NEAR(thirdAdvances[1].width, firstAdvances[1].width - 2.0f, c_errorDelta);
-    EXPECT_NEAR(thirdAdvances[2].width, firstAdvances[2].width - 2.0f, c_errorDelta);
-    EXPECT_NEAR(thirdAdvances[3].width, firstAdvances[3].width - 2.0f, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[0].width, firstAdvances[0].width + c_diff, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[1].width, firstAdvances[1].width + c_diff, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[2].width, firstAdvances[2].width + c_diff, c_errorDelta);
+    EXPECT_NEAR(secondAdvances[3].width, firstAdvances[3].width + c_diff, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[0].width, firstAdvances[0].width - c_diff, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[1].width, firstAdvances[1].width - c_diff, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[2].width, firstAdvances[2].width - c_diff, c_errorDelta);
+    EXPECT_NEAR(thirdAdvances[3].width, firstAdvances[3].width - c_diff, c_errorDelta);
 }

--- a/tests/unittests/CoreText/CTRunTests.mm
+++ b/tests/unittests/CoreText/CTRunTests.mm
@@ -197,6 +197,7 @@ TEST(CTRun, GetAdvances) {
     EXPECT_EQ(c_arbitraryFloat, advances[5].height);
     EXPECT_EQ(c_arbitraryFloat, advances[5].width);
 
+    // Length greater than available advances, does nothing
     std::fill(advances.begin(), advances.end(), CGSizeMake(c_arbitraryFloat, c_arbitraryFloat));
     CTRunGetAdvances(run, CFRangeMake(0, 5000), advances.data());
     EXPECT_EQ(c_arbitraryFloat, advances[0].height);
@@ -278,6 +279,7 @@ TEST(CTRun, GetPositions) {
     EXPECT_EQ(c_arbitraryFloat, positions[6].x);
     EXPECT_EQ(c_arbitraryFloat, positions[6].y);
 
+    // Location larger than available positions, does nothing
     std::fill(positions.begin(), positions.end(), CGPointMake(c_arbitraryFloat, c_arbitraryFloat));
     CTRunGetPositions(run, CFRangeMake(10, 0), positions.data());
     EXPECT_EQ(c_arbitraryFloat, positions[0].x);
@@ -285,10 +287,13 @@ TEST(CTRun, GetPositions) {
     EXPECT_EQ(c_arbitraryFloat, positions[6].x);
     EXPECT_EQ(c_arbitraryFloat, positions[6].y);
 
+    // Length larger than available positions, does nothing
     std::fill(positions.begin(), positions.end(), CGPointMake(c_arbitraryFloat, c_arbitraryFloat));
     CTRunGetPositions(run, CFRangeMake(0, 5000), positions.data());
     EXPECT_NEAR(c_arbitraryFloat, positions[0].x, c_errorDelta);
     EXPECT_NEAR(c_arbitraryFloat, positions[0].y, c_errorDelta);
+    EXPECT_NEAR(c_arbitraryFloat, positions[6].x, c_errorDelta);
+    EXPECT_NEAR(c_arbitraryFloat, positions[6].y, c_errorDelta);
 
     std::fill(positions.begin(), positions.end(), CGPointMake(c_arbitraryFloat, c_arbitraryFloat));
     CTRunGetPositions(run, CFRangeMake(1, 2), positions.data());


### PR DESCRIPTION
CTRunDraw now handles the range parameter and CTRunGetTypographicBounds gets the bounds for the text in given range rather than for the font.  Also rewrites CTLineGetTypographicBounds using CTRunGetTypographicBounds and small cleanups.

Fixes #963