### PR TITLE
Add reading of contentHorizontalAlignment/contentVerticalAlignment UIControl properties from xib3/storyboard files

### DIFF
--- a/tools/vsimporter/xib2nib/UIControl.cpp
+++ b/tools/vsimporter/xib2nib/UIControl.cpp
@@ -18,8 +18,8 @@
 
 UIControl::UIControl()
 {
-    _contentVerticalAlignment = 1;
-    _contentHorizontalAlignment = 1;
+    _contentVerticalAlignment = UIControlContentVerticalAlignmentTop;
+    _contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
 }
 
 void UIControl::InitFromXIB(XIBObject *obj)
@@ -35,6 +35,37 @@ void UIControl::InitFromXIB(XIBObject *obj)
 void UIControl::InitFromStory(XIBObject *obj)
 {
     UIView::InitFromStory(obj);
+
+    const char* horizontalAlign = getAttrAndHandle("contentHorizontalAlignment");
+    if (horizontalAlign) {
+        if (strcmp(horizontalAlign, "center") == 0) {
+            _contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
+        } else if (strcmp(horizontalAlign, "left") == 0) {
+            _contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+        } else if (strcmp(horizontalAlign, "right") == 0) {
+            _contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+        } else if (strcmp(horizontalAlign, "fill") == 0) {
+            _contentHorizontalAlignment = UIControlContentHorizontalAlignmentFill;
+        } else {
+            printf("Unknown contentHorizontalAlignment value: %s\n", horizontalAlign);
+        }
+    }
+
+    const char* verticalAlign = getAttrAndHandle("contentVerticalAlignment");
+    if (verticalAlign) {
+        if (strcmp(verticalAlign, "center") == 0) {
+            _contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
+        } else if (strcmp(verticalAlign, "top") == 0) {
+            _contentVerticalAlignment = UIControlContentVerticalAlignmentTop;
+        } else if (strcmp(verticalAlign, "bottom") == 0) {
+            _contentVerticalAlignment = UIControlContentVerticalAlignmentBottom;
+        } else if (strcmp(verticalAlign, "fill") == 0) {
+            _contentVerticalAlignment = UIControlContentVerticalAlignmentFill;
+        } else {
+            printf("Unknown contentVerticalAlignment value: %s\n", verticalAlign);
+        }
+    }
+
     _outputClassName = "UIControl";
 }
 
@@ -42,6 +73,6 @@ void UIControl::ConvertStaticMappings(NIBWriter *writer, XIBObject *obj)
 {
     UIView::ConvertStaticMappings(writer, obj);
 
-    if ( _contentVerticalAlignment != 1 ) AddInt(writer, "UIContentVerticalAlignment", _contentVerticalAlignment);
-    if ( _contentHorizontalAlignment != 1 ) AddInt(writer, "UIContentHorizontalAlignment", _contentHorizontalAlignment);
+    if (_contentVerticalAlignment != UIControlContentVerticalAlignmentTop) AddInt(writer, "UIContentVerticalAlignment", _contentVerticalAlignment);
+    if (_contentHorizontalAlignment != UIControlContentHorizontalAlignmentLeft) AddInt(writer, "UIContentHorizontalAlignment", _contentHorizontalAlignment);
 }

--- a/tools/vsimporter/xib2nib/UIControl.h
+++ b/tools/vsimporter/xib2nib/UIControl.h
@@ -42,6 +42,20 @@ enum {
    UIControlEventAllEvents           = 0xFFFFFFFF
 };
 
+typedef enum {
+    UIControlContentHorizontalAlignmentCenter = 0,
+    UIControlContentHorizontalAlignmentLeft = 1,
+    UIControlContentHorizontalAlignmentRight = 2,
+    UIControlContentHorizontalAlignmentFill = 3,
+} UIControlContentHorizontalAlignment;
+
+typedef enum {
+    UIControlContentVerticalAlignmentCenter = 0,
+    UIControlContentVerticalAlignmentTop = 1,
+    UIControlContentVerticalAlignmentBottom = 2,
+    UIControlContentVerticalAlignmentFill = 3,
+} UIControlContentVerticalAlignment;
+
 class UIControl :
     public UIView
 {


### PR DESCRIPTION
This is related to issue #589. Note that commit 40d4d765b611c16245f8d4008266eb118fdc35a8 fixes most of the issues with UITextField vertical alignment (after that commit, UITextField properly handles _contentVerticalAlignment).