### PR TITLE
Add __deprecated_msg macro

### DIFF
--- a/include/AvailabilityMacros.h
+++ b/include/AvailabilityMacros.h
@@ -18,6 +18,7 @@
 #define __AVAILABILITYMACROS_H_
 
 #define UNAVAILABLE_ATTRIBUTE __attribute__((unavailable))
-#define DEPRECATED_MSG_ATTRIBUTE(s) __attribute__((deprecated(s)))
+#define __deprecated_msg(s) __attribute__((deprecated(s)))
+#define DEPRECATED_MSG_ATTRIBUTE(s) __deprecated_msg(s)
 
 #endif


### PR DESCRIPTION
Adding the __deprecated_msg macro, which exists on the reference platform.