### PR TITLE
Implement [NSString sizeWith...] functions using CoreText

### DIFF
--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -592,7 +592,7 @@ static NSDictionary* _getDefaultUITextAttributes() {
 }
 
 // Private helper that converts a UILineBreakMode -> NSParagraphStyle
-// TODO #: NS/CT ParagraphStyle are not properly bridged, and ParagraphStyle is not currently read anywhere
+// TODO #1108: NS/CT ParagraphStyle are not properly bridged, and ParagraphStyle is not currently read anywhere
 static inline NSParagraphStyle* _paragraphStyleWithLineBreakMode(UILineBreakMode lineBreakMode) {
     NSMutableParagraphStyle* ret = [NSMutableParagraphStyle new];
     ret.lineBreakMode = lineBreakMode;

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -579,158 +579,84 @@ static NSDictionary* _getDefaultUITextAttributes() {
     return fontExtent;
 }
 
+// Private helper for sizeWith... functions
+// Returns the bounding box size this string would occupy when drawn as specified
+// All sizeWith... functions in this file funnel to this
+- (CGSize)_sizeWithAttributes:(NSDictionary<NSString*, id>*)attributes constrainedToSize:(CGSize)size {
+    NSAttributedString* attributedSelf = [[[NSAttributedString alloc] initWithString:self attributes:attributes] autorelease];
+
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)attributedSelf);
+    CFAutorelease(framesetter);
+
+    return CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, self.length), nullptr, size, nullptr);
+}
+
+// Private helper that converts a UILineBreakMode -> NSParagraphStyle
+// TODO #: NS/CT ParagraphStyle are not properly bridged, and ParagraphStyle is not currently read anywhere
+static inline NSParagraphStyle* _paragraphStyleWithLineBreakMode(UILineBreakMode lineBreakMode) {
+    NSMutableParagraphStyle* ret = [NSMutableParagraphStyle new];
+    ret.lineBreakMode = lineBreakMode;
+    return ret;
+}
+
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes lineBreakMode is currently not fully supported
 */
 - (CGSize)sizeWithFont:(UIFont*)font constrainedToSize:(CGSize)size lineBreakMode:(UILineBreakMode)lineBreakMode {
-    CGSize ret;
-    std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(self);
-    WORD* str = (WORD*)wideBuffer.c_str();
-
-    CGRect rct;
-    rct.origin.x = 0;
-    rct.origin.y = 0;
-    rct.size = size;
-
-    drawString(font, NULL, str, [self length], rct, lineBreakMode, UITextAlignmentLeft, &ret);
-
-    return ret;
+    return [self _sizeWithAttributes:@{
+        NSFontAttributeName : font,
+        NSParagraphStyleAttributeName : _paragraphStyleWithLineBreakMode(lineBreakMode)
+    }
+                   constrainedToSize:size];
 }
 
 /**
  @Status Interoperable
 */
 - (CGSize)sizeWithFont:(UIFont*)font constrainedToSize:(CGSize)size {
-    CGSize ret;
-    std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(self);
-    WORD* str = (WORD*)wideBuffer.c_str();
-
-    CGRect rct;
-    rct.origin.x = 0;
-    rct.origin.y = 0;
-    rct.size = size;
-
-    drawString(font, NULL, str, [self length], rct, UILineBreakModeWordWrap, UITextAlignmentLeft, &ret);
-
-    return ret;
+    return [self _sizeWithAttributes:@{ NSFontAttributeName : font } constrainedToSize:size];
 }
 
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes lineBreakMode is currently not fully supported
 */
 - (CGSize)sizeWithFont:(UIFont*)font forWidth:(float)width lineBreakMode:(UILineBreakMode)lineBreakMode {
-    CGSize ret;
-    std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(self);
-    WORD* str = (WORD*)wideBuffer.c_str();
-
-    CGRect rct = { 0 };
-    rct.origin.x = 0;
-    rct.origin.y = 0;
-    rct.size.width = width;
-
-    drawString(font, NULL, str, [self length], rct, lineBreakMode, UITextAlignmentLeft, &ret);
-
-    return ret;
-}
-
-- (CGSize)sizeWithFont:(UIFont*)font forWidth:(float)width lineBreakMode:(UILineBreakMode)lineBreakMode lastCharPos:(CGPoint*)lastCharPos {
-    CGSize ret;
-    std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(self);
-    WORD* str = (WORD*)wideBuffer.c_str();
-
-    CGRect rct = { 0 };
-    rct.origin.x = 0;
-    rct.origin.y = 0;
-    rct.size.width = width;
-
-    drawString(font, NULL, str, [self length], rct, lineBreakMode, UITextAlignmentLeft, &ret, lastCharPos);
-
-    return ret;
+    return [self sizeWithFont:font constrainedToSize:{ width, std::numeric_limits<CGFloat>::max() } lineBreakMode:lineBreakMode];
 }
 
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes minFontSize, which is supposed to enable variable font-size scaling, is unsupported
+        However, documentation for this function discourages changing the font size anyway, as it leads to an inconsistent user experience
+        lineBreakMode is currently not fully supported
 */
 - (CGSize)sizeWithFont:(UIFont*)font
            minFontSize:(float)minFontSize
         actualFontSize:(float*)actualFontSize
-              forWidth:(float)forWidth
-         lineBreakMode:(UILineBreakMode)lineBreak {
-    CGSize ret;
-    std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(self);
-    WORD* str = (WORD*)wideBuffer.c_str();
-
-    CGRect rct;
-
-    rct.origin.x = 0;
-    rct.origin.y = 0;
-    rct.size.width = forWidth;
-    rct.size.height = 0;
-
-    drawString(font, NULL, str, [self length], rct, lineBreak, UITextAlignmentLeft, &ret);
+              forWidth:(float)width
+         lineBreakMode:(UILineBreakMode)lineBreakMode {
     if (actualFontSize) {
-        *actualFontSize = 10.0f;
+        *actualFontSize = [font pointSize];
     }
 
-    return ret;
+    return [self sizeWithFont:font forWidth:width lineBreakMode:lineBreakMode];
 }
 
 /**
  @Status Interoperable
 */
 - (CGSize)sizeWithFont:(UIFont*)font {
-    if (font == nil) {
-        font = [UIFont defaultFont];
-    }
-
-    CGSize ret;
-    std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(self);
-    WORD* str = (WORD*)wideBuffer.c_str();
-
-    CGRect rct;
-    rct.origin.x = 0;
-    rct.origin.y = 0;
-    rct.size.width = 0;
-    rct.size.height = 0;
-
-    drawString(font, NULL, str, [self length], rct, UILineBreakModeClip, UITextAlignmentLeft, &ret);
-
-    return ret;
+    return [self sizeWithFont:font constrainedToSize:{ std::numeric_limits<CGFloat>::max(), std::numeric_limits<CGFloat>::max() }];
 }
 
 /**
  @Status Caveat
- @Notes Currently UITextAttributeTextShadowColor and UITextAttributeTextShadowOffset will be ignored.
+ @Notes not all attributes are currently supported
 */
-- (CGSize)sizeWithAttributes:(NSDictionary*)attrs {
-    if (attrs == nil) {
-        attrs = _getDefaultUITextAttributes();
-    }
-
-    UIColor* uiShadowColor = [attrs valueForKey:UITextAttributeTextShadowColor];
-    NSValue* textShadowOffset = [attrs valueForKey:UITextAttributeTextShadowOffset];
-
-    // TODO enable UITextAttributeTextShadowColor and UITextAttributeTextShadowOffset
-    if (uiShadowColor != nil && textShadowOffset != nil) {
-        CGSize offset = textShadowOffset.sizeValue;
-        CGContextSetShadowWithColor(UIGraphicsGetCurrentContext(), offset, 0, [uiShadowColor CGColor]);
-    } else if (textShadowOffset != nil) {
-        CGSize offset = textShadowOffset.sizeValue;
-        CGContextSetShadow(UIGraphicsGetCurrentContext(), offset, 0);
-    }
-
-    UIColor* uiTextColor = [attrs valueForKey:UITextAttributeTextColor];
-    if (uiTextColor != nil) {
-        CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), [uiTextColor CGColor]);
-    }
-
-    UIFont* uiFont = [attrs valueForKey:UITextAttributeFont];
-    if (uiFont != nil) {
-        return [self sizeWithFont:uiFont];
-    }
-
-    // No font was found
-    return { 0, 0 };
+- (CGSize)sizeWithAttributes:(NSDictionary<NSString*, id>*)attrs {
+    return [self _sizeWithAttributes:attrs constrainedToSize:{ std::numeric_limits<CGFloat>::max(), std::numeric_limits<CGFloat>::max() }];
 }
 
 /**

--- a/Frameworks/UIKit/UIFont.mm
+++ b/Frameworks/UIKit/UIFont.mm
@@ -97,12 +97,12 @@ BASE_CLASS_REQUIRED_IMPLS(UIFont, UICTFont, CTFontGetTypeID);
 }
 
 + (UIFont*)defaultFont {
-    static id dFont = [[self systemFontOfSize:10.0f] retain];
+    static id dFont = [[self systemFontOfSize:[self systemFontSize]] retain];
     return dFont;
 }
 
 + (UIFont*)buttonFont {
-    static id dFont = [[self systemFontOfSize:17.0f] retain];
+    static id dFont = [[self systemFontOfSize:[self buttonFontSize]] retain];
     return dFont;
 }
 

--- a/Frameworks/UIKit/UITextView.mm
+++ b/Frameworks/UIKit/UITextView.mm
@@ -40,10 +40,6 @@ NSString* const UITextViewTextDidEndEditingNotification = @"UITextViewTextDidEnd
 extern float keyboardBaseHeight;
 static const float INPUTVIEW_DEFAULT_HEIGHT = 200.f;
 
-@interface NSString (CaretMeasurement)
-- (CGSize)sizeWithFont:(UIFont*)font forWidth:(float)width lineBreakMode:(UILineBreakMode)lineBreakMode lastCharPos:(CGPoint*)lastCharPos;
-@end
-
 @interface UITextView ()
 @property (nonatomic) NSString* _text;
 @end
@@ -756,10 +752,8 @@ static const float INPUTVIEW_DEFAULT_HEIGHT = 200.f;
     rect.size.height -= _marginSize * 2.0f;
 
     CGSize fontExtent = { 0, 0 };
-    CGPoint cursorPos = { 0, 0 };
 
-    fontExtent =
-        [[self _text] sizeWithFont:(id)_font forWidth:rect.size.width lineBreakMode:UILineBreakModeWordWrap lastCharPos:&cursorPos];
+    fontExtent = [[self _text] sizeWithFont:(id)_font forWidth:rect.size.width lineBreakMode:UILineBreakModeWordWrap];
 
     CGRect centerRect;
     centerRect.origin.x = 0;

--- a/include/UIKit/NSString+UIKitAdditions.h
+++ b/include/UIKit/NSString+UIKitAdditions.h
@@ -71,5 +71,5 @@ UIKIT_EXPORT NSString* const UITextAttributeTextShadowOffset;
              options:(NSStringDrawingOptions)options
           attributes:(NSDictionary*)attributes
              context:(NSStringDrawingContext*)context;
-- (CGSize)sizeWithAttributes:(NSDictionary*)attrs;
+- (CGSize)sizeWithAttributes:(NSDictionary<NSString*, id>*)attrs;
 @end

--- a/include/UIKit/UIKitTypes.h
+++ b/include/UIKit/UIKitTypes.h
@@ -17,26 +17,27 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
 
 // This is the home for enums that are shared by more than one interface
 
 enum {
-    NSLineBreakByWordWrapping,
-    NSLineBreakByCharWrapping,
-    NSLineBreakByClipping,
-    NSLineBreakByTruncatingHead,
-    NSLineBreakByTruncatingTail,
-    NSLineBreakByTruncatingMiddle
+    NSLineBreakByWordWrapping = kCTLineBreakByWordWrapping,
+    NSLineBreakByCharWrapping = kCTLineBreakByCharWrapping,
+    NSLineBreakByClipping = kCTLineBreakByClipping,
+    NSLineBreakByTruncatingHead = kCTLineBreakByTruncatingHead,
+    NSLineBreakByTruncatingTail = kCTLineBreakByTruncatingTail,
+    NSLineBreakByTruncatingMiddle = kCTLineBreakByTruncatingMiddle
 };
 typedef NSUInteger NSLineBreakMode;
 
 enum {
-    UILineBreakModeWordWrap = 0,
-    UILineBreakModeCharacterWrap,
-    UILineBreakModeClip,
-    UILineBreakModeHeadTruncation,
-    UILineBreakModeTailTruncation,
-    UILineBreakModeMiddleTruncation,
+    UILineBreakModeWordWrap = NSLineBreakByWordWrapping,
+    UILineBreakModeCharacterWrap = NSLineBreakByCharWrapping,
+    UILineBreakModeClip = NSLineBreakByClipping,
+    UILineBreakModeHeadTruncation = NSLineBreakByTruncatingHead,
+    UILineBreakModeTailTruncation = NSLineBreakByTruncatingTail,
+    UILineBreakModeMiddleTruncation = NSLineBreakByTruncatingMiddle
 };
 typedef NSUInteger UILineBreakMode;
 


### PR DESCRIPTION
These functions began to return {0,0} sizes as a result of CGFont becoming stubbed,
but were incorrect previously as they made a draw call even though they did not have responsibility for drawing.

- Fixes visual issues in CTCatalog
  - Back button was incorrect width
  - Most text labels were not correctly displaying
- Remove an unused WinObjC-only function in NSString+UIKitAdditions
- Ensure that UIKit line break mode constants align with CoreText's
- Misc fix to change some UIFont default fonts to use UIFont default sizes

Fixes #1014