### PR TITLE
Tweak ci build script to support CI build targeting any source branch.

### DIFF
--- a/.ci-repo.xml
+++ b/.ci-repo.xml
@@ -8,18 +8,12 @@
                 <ID Configuration="Release">72</ID>
                 <ConfigMappings>
                     <Parameter Key="PullRequest">$REMOTEURL $BRANCH</Parameter>
-                </ConfigMappings>
-            </BuildDefinitionSet>
-            <BuildDefinitionSet Name="VSO Any Branch" MatchRemote="*visualstudio*">
-                <ID Configuration="Debug">78</ID>
-                <ID Configuration="Release">79</ID>
-                <ConfigMappings>
                     <SourceBranch>$BRANCH</SourceBranch>
                 </ConfigMappings>
             </BuildDefinitionSet>
-            <BuildDefinitionSet Name="VSO Full"> <!-- No MatchRemote as this one must be specified by BuildFilter -->
-                <ID Configuration="Debug">89</ID>
-                <ID Configuration="Release">90</ID>
+            <BuildDefinitionSet Name="Full"> <!-- No MatchRemote as this one must be specified by BuildFilter -->
+                <ID Configuration="Debug">82</ID>
+                <ID Configuration="Release">83</ID>
                 <ConfigMappings>
                     <SourceBranch>$BRANCH</SourceBranch>
                 </ConfigMappings>

--- a/.ci-repo.xml
+++ b/.ci-repo.xml
@@ -8,14 +8,14 @@
                 <ID Configuration="Release">72</ID>
                 <ConfigMappings>
                     <Parameter Key="PullRequest">$REMOTEURL $BRANCH</Parameter>
-                    <SourceBranch>$BRANCH</SourceBranch>
+                    <SourceBranch>$SOURCEBRANCH</SourceBranch>
                 </ConfigMappings>
             </BuildDefinitionSet>
             <BuildDefinitionSet Name="Full"> <!-- No MatchRemote as this one must be specified by BuildFilter -->
                 <ID Configuration="Debug">82</ID>
                 <ID Configuration="Release">83</ID>
                 <ConfigMappings>
-                    <SourceBranch>$BRANCH</SourceBranch>
+                    <SourceBranch>$SOURCEBRANCH</SourceBranch>
                 </ConfigMappings>
             </BuildDefinitionSet>
         </BuildDefinitions>

--- a/tools/build/Submit-CIBuilds.ps1
+++ b/tools/build/Submit-CIBuilds.ps1
@@ -11,6 +11,7 @@ Param (
     [switch]$Reconfigure,
     [switch]$SkipRemoteCheck,
     [string]$BuildFilter,
+	[string]$SourceBranch='develop',
 
     [string]$AuthUsername,
     [string]$AuthToken
@@ -273,7 +274,7 @@ ForEach($definitionSet in $matchingDefinitions) {
         $parameters[$parameter.Key] = $parameter.InnerText.Replace("`$REMOTEURL", $RemoteURL).Replace("`$BRANCH", $Ref)
     }
     If ($definitionSet.ConfigMappings.SourceBranch) {
-        $requestBody.sourceBranch = $definitionSet.ConfigMappings.SourceBranch.Replace("`$BRANCH", $Ref)
+        $requestBody.sourceBranch = $definitionSet.ConfigMappings.SourceBranch.Replace("`$BRANCH", $SourceBranch)
     }
     $requestBody.parameters = (ConvertTo-JSON -Compress $parameters)
 

--- a/tools/build/Submit-CIBuilds.ps1
+++ b/tools/build/Submit-CIBuilds.ps1
@@ -11,7 +11,7 @@ Param (
     [switch]$Reconfigure,
     [switch]$SkipRemoteCheck,
     [string]$BuildFilter,
-	[string]$SourceBranch='develop',
+    [string]$SourceBranch='develop',
 
     [string]$AuthUsername,
     [string]$AuthToken
@@ -274,7 +274,7 @@ ForEach($definitionSet in $matchingDefinitions) {
         $parameters[$parameter.Key] = $parameter.InnerText.Replace("`$REMOTEURL", $RemoteURL).Replace("`$BRANCH", $Ref)
     }
     If ($definitionSet.ConfigMappings.SourceBranch) {
-        $requestBody.sourceBranch = $definitionSet.ConfigMappings.SourceBranch.Replace("`$BRANCH", $SourceBranch)
+        $requestBody.sourceBranch = $definitionSet.ConfigMappings.SourceBranch.Replace("`$SOURCEBRANCH", $SourceBranch)
     }
     $requestBody.parameters = (ConvertTo-JSON -Compress $parameters)
 


### PR DESCRIPTION
* Removed deprecated build definitions.
* Added support to explicitly specify source branch.
* Note: Source branch could probably be determined from upstream remote,  but it is not very reliable.  Also, explicit parameter allows kicking  off arbitrary builds.

Fix #1089
