### PR TITLE
Code Review: Fix convertPoint issue in UIScrollview and ensure two delegates are fired properly when decelerating. 

### DIFF
--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -2562,7 +2562,7 @@ inline id _createRtProxy(Class cls, IInspectable* iface) {
 }
 
 inline WXUIElement* _getBackingXamlElementForCALayer(CALayer* layer) {
-    Microsoft::WRL::ComPtr<IInspectable> fromNode(GetCACompositor()->GetXamlLayoutElement([layer _presentationNode]));
+    Microsoft::WRL::ComPtr<IInspectable> fromNode(GetCACompositor()->GetXamlContentElement([layer _presentationNode]));
     return _createRtProxy([WXUIElement class], fromNode.Get());
 }
 
@@ -2586,6 +2586,10 @@ inline WXUIElement* _getBackingXamlElementForCALayer(CALayer* layer) {
         WFPoint* pointInFromLayer = [WXPointHelper fromCoordinates:point.x y:point.y];
         WFPoint* pointInToLayer = [transform transformPoint:pointInFromLayer];
         ret = { pointInToLayer.x, pointInToLayer.y };
+    }
+
+    if (DEBUG_VERBOSE) {
+        TraceVerbose(TAG, L"convertPoint: {%f, %f} to {%f, %f}",  point.x, point.y, ret.x, ret.y);
     }
 
     return ret;

--- a/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
+++ b/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
@@ -1295,6 +1295,13 @@ public:
         return inspectableNode;
     }
 
+    virtual Microsoft::WRL::ComPtr<IInspectable> GetXamlContentElement(DisplayNode* displayNode) override {
+        Microsoft::WRL::ComPtr<IUnknown> xamlNode(static_cast<IUnknown*>(displayNode->_contentElement));
+        Microsoft::WRL::ComPtr<IInspectable> inspectableNode;
+        xamlNode.As(&inspectableNode);
+        return inspectableNode;
+    }
+
     std::shared_ptr<DisplayTransaction> CreateDisplayTransaction() override {
         return std::make_shared<DisplayTransaction>();
     }

--- a/Frameworks/UIKit/UIScrollView.mm
+++ b/Frameworks/UIKit/UIScrollView.mm
@@ -319,8 +319,6 @@ const float UIScrollViewDecelerationRateFast = StubConstant();
                             strongSelf->_decelerating = YES;
 
                             if (strongSelf->_pagingEnabled) {
-                                strongSelf->_decelerating = NO;
-
                                 // cancel the direct manipulation before we do manual animating to page boundary
                                 [strongSelf->_scrollViewer cancelDirectManipulations];
 

--- a/Frameworks/include/CACompositor.h
+++ b/Frameworks/include/CACompositor.h
@@ -38,6 +38,7 @@ public:
 
     virtual DisplayNode* CreateDisplayNode() = 0;
     virtual Microsoft::WRL::ComPtr<IInspectable> GetXamlLayoutElement(DisplayNode*) = 0;
+    virtual Microsoft::WRL::ComPtr<IInspectable> GetXamlContentElement(DisplayNode* displayNode) = 0;
     virtual std::shared_ptr<DisplayTransaction> CreateDisplayTransaction() = 0;
     virtual void QueueDisplayTransaction(const std::shared_ptr<DisplayTransaction>& transaction,
                                          const std::shared_ptr<DisplayTransaction>& onTransaction) = 0;

--- a/tests/unittests/UIKit/NullCompositor.h
+++ b/tests/unittests/UIKit/NullCompositor.h
@@ -29,6 +29,9 @@ public:
     Microsoft::WRL::ComPtr<IInspectable> GetXamlLayoutElement(DisplayNode*) override {
         return Microsoft::WRL::ComPtr<IInspectable>();
     }
+    Microsoft::WRL::ComPtr<IInspectable> GetXamlContentElement(DisplayNode*) override {
+        return Microsoft::WRL::ComPtr<IInspectable>();
+    }
     std::shared_ptr<DisplayTransaction> CreateDisplayTransaction() override {
         return nullptr;
     }


### PR DESCRIPTION
Fix bug 9024055 - The selected glyph is not the one displayed 
     when getting back the xaml element during convertPoint from one layer to the other, we should look for contentElement.  In much earlier refactoring to support UIScrollview/Scrollviewer. We differentiate the layoutElement and ContentElement within Scrollviewer. For most other controls, , LayoutElement is the same as ContentElement. Thus convertPoint isn't a problem. But for a UIScrollviewer whose layout element isn't the same as content element. We should use its content Element during point conversion. Because conentElement (canvas) is the one who origin is transformed by xaml scrollviewer, which really reflect the right position on touch happens on UIScrollview.

fix bug 8776065 -Tab bar vs Content page caused by corresponding delegates not being called 

     The issue here is that we mistakenly flagging decelerating flag from YES to NO,  which shut off two delegates that we need to fire.   

                     if (strongSelf->_decelerating) {
                         // when final viewchanged fires, the scrollview comes at halt, if previously it is decelerating
                         // flag decelerating to NO and invoke delegate that scrollViewDidEndDecelerating
                         strongSelf->_decelerating = NO;
                         if ([strongSelf.delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) {
     ..
                             [strongSelf.delegate scrollViewDidEndDecelerating:strongSelf];
                         }

                         // scrolling stopped, reset flags
                         if ([strongSelf.delegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]) {
     ...

                             [strongSelf.delegate scrollViewDidEndScrollingAnimation:strongSelf];

                         }