### PR TITLE
Start the runloop asynchronously rather than synchronously during activation

### DIFF
--- a/Frameworks/Foundation/MainDispatcher.mm
+++ b/Frameworks/Foundation/MainDispatcher.mm
@@ -107,7 +107,7 @@ extern "C" void ScheduleMainRunLoopAsync() {
         ScheduleMainRunLoop();
         return S_OK;
     });
-    _ensureDispatcher();
+    _EnsureDispatcher();
     ComPtr<IAsyncAction> asyncAction;
     s_dispatcher->RunAsync(CoreDispatcherPriority_Normal, dispatchCallback.Get(), &asyncAction);
 }
@@ -132,8 +132,6 @@ int MainRunLoopTimedMultipleWait(EbrEvent* events, int numEvents, double timeout
                           });
             return 0;
         }
-
-        _EnsureDispatcher();
 
         if (timeout == 0) {
             // Optimization to not schedule a wait on a threadpool when the timeout value passed was 0.

--- a/Frameworks/Foundation/MainDispatcher.mm
+++ b/Frameworks/Foundation/MainDispatcher.mm
@@ -133,7 +133,7 @@ int MainRunLoopTimedMultipleWait(EbrEvent* events, int numEvents, double timeout
             return 0;
         }
 
-        _ensureDispatcher();
+        _EnsureDispatcher();
 
         if (timeout == 0) {
             // Optimization to not schedule a wait on a threadpool when the timeout value passed was 0.

--- a/Frameworks/Foundation/MainDispatcher.mm
+++ b/Frameworks/Foundation/MainDispatcher.mm
@@ -87,17 +87,17 @@ void _DispatchMainRunLoopOnUIThread(int signaledEvent) {
 /**
 * Private method to create the dispatcher
 */
-void _ensureDispatcher() {
+void _EnsureDispatcher() {
     if (s_dispatcher == nullptr) {
         ComPtr<ICoreWindowStatic> coreWindowStatic;
         ComPtr<ICoreWindow> coreWindow;
 
-        THROW_IF_FAILED(
-            GetActivationFactory(Wrappers::HStringReference(RuntimeClass_Windows_UI_Core_CoreWindow).Get(), &coreWindowStatic));
+        THROW_IF_FAILED(GetActivationFactory(Wrappers::HStringReference(RuntimeClass_Windows_UI_Core_CoreWindow).Get(), &coreWindowStatic));
         THROW_IF_FAILED(coreWindowStatic->GetForCurrentThread(&coreWindow));
         THROW_IF_FAILED(coreWindow->get_Dispatcher(&s_dispatcher));
     }
 }
+
 /**
  * Method that schedules the main runloop asynchronously on the UI thread.
  * Note: This method always schedules the work asynchronously on the UI thread to let the caller stack unwind.
@@ -134,7 +134,7 @@ int MainRunLoopTimedMultipleWait(EbrEvent* events, int numEvents, double timeout
         }
 
         _ensureDispatcher();
-        
+
         if (timeout == 0) {
             // Optimization to not schedule a wait on a threadpool when the timeout value passed was 0.
             _DispatchMainRunLoopOnUIThread(-1);

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
@@ -147,6 +147,12 @@ int ApplicationMainStart(const char* principalName,
     [displayMode _updateDisplaySettings];
 
     UIApplicationMainInit(principalClassName, delegateClassName, defaultOrientation, (int)activationType, activationArgument);
+
+    // The main runloop has to be started asynchronously, so we return as soon as possible from application activate.
+    // The apps can (and do) handle application launch delegate from the first tine NSRunloop run is called, and that can
+    // take a REALLY long time to complete, causing PLM to terminate us.  We were getting lucky in some cases and the app would launch.
+    // This will also fix the number of sporadic launch test failures that we have seen in the labs.
+
     ScheduleMainRunLoopAsync();
 
     return 0;

--- a/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationMain.mm
@@ -147,7 +147,7 @@ int ApplicationMainStart(const char* principalName,
     [displayMode _updateDisplaySettings];
 
     UIApplicationMainInit(principalClassName, delegateClassName, defaultOrientation, (int)activationType, activationArgument);
-    ScheduleMainRunLoop();
+    ScheduleMainRunLoopAsync();
 
     return 0;
 }

--- a/Frameworks/include/MainDispatcher.h
+++ b/Frameworks/include/MainDispatcher.h
@@ -16,4 +16,5 @@
 #pragma once
 
 extern "C" void ScheduleMainRunLoop();
+extern "C" void ScheduleMainRunLoopAsync();
 extern "C" void SetupMainRunLoopTimedMultipleWaiter();

--- a/build/Foundation/dll/Foundation.def
+++ b/build/Foundation/dll/Foundation.def
@@ -873,4 +873,5 @@ LIBRARY Foundation
 
         ; MainDispatcher
         ScheduleMainRunLoop
+        ScheduleMainRunLoopAsync
         SetupMainRunLoopTimedMultipleWaiter


### PR DESCRIPTION
Our activation code is starting runloop synchornously in the main thread.

This turned out to be bad for some apps.  This change is to do an aysnc task that sets up the runloop.