### PR TITLE
[UIKit] [Gestures] Add support for cancelsTouchesInView = NO, add Gestures tab to WOCCatalog

### DIFF
--- a/Frameworks/UIKit/UIGestureRecognizer.mm
+++ b/Frameworks/UIKit/UIGestureRecognizer.mm
@@ -231,7 +231,7 @@ static void commonInit(UIGestureRecognizer* self) {
     UNIMPLEMENTED();
 }
 
-+ (BOOL)_fireGestures:(id)gestures {
++ (BOOL)_fireGestures:(id)gestures shouldCancelTouches:(BOOL&)shouldCancelTouches {
     bool didRecognize = false;
 
     for (UIGestureRecognizer* curgesture in gestures) {
@@ -240,6 +240,7 @@ static void commonInit(UIGestureRecognizer* self) {
         if (state == UIGestureRecognizerStateRecognized || state == UIGestureRecognizerStateBegan ||
             state == UIGestureRecognizerStateChanged || state == UIGestureRecognizerStateEnded) {
             [curgesture _fire];
+            shouldCancelTouches |= curgesture.cancelsTouchesInView;
             didRecognize = true;
         }
     }

--- a/Frameworks/UIKit/UILabel.mm
+++ b/Frameworks/UIKit/UILabel.mm
@@ -192,7 +192,6 @@
     _lineBreakMode = UILineBreakModeTailTruncation;
     [self setFont:[UIFont fontWithName:@"Helvetica" size:[UIFont labelFontSize]]];
     _textColor = [UIColor blackColor];
-    [self setBackgroundColor:[UIColor whiteColor]];
     _shadowColor = _textColor;
     _minimumFontSize = 8.0f;
     _numberOfLines = 1;

--- a/Frameworks/UIKit/UILongPressGestureRecognizer.mm
+++ b/Frameworks/UIKit/UILongPressGestureRecognizer.mm
@@ -251,6 +251,26 @@ static TrackedTouch* findTouch(UITouch* touch, std::vector<TrackedTouch>& touche
     [self reset];
 }
 
+/**
+ @Status Interoperable
+*/
+- (CGPoint)locationInView:(UIView*)view {
+    if (_trackedTouches.size() > 0) {
+        CGPoint averagePoint = { 0, 0 };
+        for (size_t i = 0; i < _trackedTouches.size(); i++) {
+            CGPoint touchLocation = [_trackedTouches[i].touch locationInView:view];
+            averagePoint.x += touchLocation.x;
+            averagePoint.y += touchLocation.y;
+        }
+        averagePoint.x /= _trackedTouches.size();
+        averagePoint.y /= _trackedTouches.size();
+        return averagePoint;
+    }
+
+    CGPoint ret = { 0, 0 };
+    return ret;
+}
+
 - (void)_commonInit {
     self->minimumPressDuration = 0.5f;
     self->numberOfTapsRequired = 0;

--- a/Frameworks/UIKit/UILongPressGestureRecognizer.mm
+++ b/Frameworks/UIKit/UILongPressGestureRecognizer.mm
@@ -257,8 +257,8 @@ static TrackedTouch* findTouch(UITouch* touch, std::vector<TrackedTouch>& touche
 - (CGPoint)locationInView:(UIView*)view {
     if (_trackedTouches.size() > 0) {
         CGPoint averagePoint = { 0, 0 };
-        for (size_t i = 0; i < _trackedTouches.size(); i++) {
-            CGPoint touchLocation = [_trackedTouches[i].touch locationInView:view];
+        for (TrackedTouch& trackedTouch : _trackedTouches) {
+            CGPoint touchLocation = [trackedTouch.touch locationInView:view];
             averagePoint.x += touchLocation.x;
             averagePoint.y += touchLocation.y;
         }
@@ -267,8 +267,7 @@ static TrackedTouch* findTouch(UITouch* touch, std::vector<TrackedTouch>& touche
         return averagePoint;
     }
 
-    CGPoint ret = { 0, 0 };
-    return ret;
+    return { 0, 0 };
 }
 
 - (void)_commonInit {

--- a/Frameworks/UIKit/UIPanGestureRecognizer.mm
+++ b/Frameworks/UIKit/UIPanGestureRecognizer.mm
@@ -504,7 +504,7 @@ static CGPoint pointFromView(const CGPoint& pt, UIView* viewAddr) {
     }
 }
 
-+ (BOOL)_fireGestures:(id)gestures {
++ (BOOL)_fireGestures:(id)gestures shouldCancelTouches:(BOOL&)shouldCancelTouches {
     bool didRecognize = false;
     int count = [gestures count];
 
@@ -530,6 +530,7 @@ static CGPoint pointFromView(const CGPoint& pt, UIView* viewAddr) {
                     curgesture->_state = UIGestureRecognizerStateChanged;
                 }
                 [curgesture _fire];
+                shouldCancelTouches |= curgesture.cancelsTouchesInView;
                 didRecognize = true;
             }
         }

--- a/Frameworks/UIKit/UISwipeGestureRecognizer.mm
+++ b/Frameworks/UIKit/UISwipeGestureRecognizer.mm
@@ -160,13 +160,20 @@ static void commonInit(UISwipeGestureRecognizer* self) {
  @Status Interoperable
 */
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
- // Intended no-op
+    _startPos = { 0, 0 };
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
-- (CGPoint)locationInView:(UIView*)viewAddr {
-    return StubReturn();
+- (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
+    _startPos = { 0, 0 };
+}
+
+/**
+ @Status Interoperable
+*/
+- (CGPoint)locationInView:(UIView*)view {
+    return [[self view] convertPoint:_startPos toView:view];
 }
 @end

--- a/Frameworks/UIKit/UITapGestureRecognizer.mm
+++ b/Frameworks/UIKit/UITapGestureRecognizer.mm
@@ -256,12 +256,12 @@ static void resetSavedTouches(UITapGestureRecognizer* self) {
     }
 
     id allTouches = [event allTouches];
-    unsigned count = [touches count];
 
-    if (count > _numberOfTouchesRequired || EbrGetMediaTime() - _tapTime > 0.75f) {
-        TraceVerbose(TAG, L"too many touches, numberOfTouchesRequired=%d, count=%d", _numberOfTouchesRequired, count);
+    // We may have to revisit this logic, since the UITouch tap count should drive it.
+    if (_maxTouches > _numberOfTouchesRequired || EbrGetMediaTime() - _tapTime > 0.75f) {
+        TraceVerbose(TAG, L"too many touches, numberOfTouchesRequired=%d, _maxTouches=%d", _numberOfTouchesRequired, _maxTouches);
         _state = UIGestureRecognizerStateFailed;
-    } else if (count == _numberOfTouchesRequired) {
+    } else if (_maxTouches == _numberOfTouchesRequired) {
         bool success = true;
 
         // get max numberofTapsRequired in current Tap gesture list.

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -135,7 +135,7 @@ BOOL g_resetAllTrackingGestures = TRUE;
         g_currentlyTrackingGesturesList = [NSMutableArray new];
     }
 
-    bool handled = false;
+    BOOL shouldCancelTouches = false;
 
     UIView* views[128];
     int viewDepth = 0;
@@ -214,9 +214,8 @@ BOOL g_resetAllTrackingGestures = TRUE;
     for (int i = 0; i < s_numGestureTypes; i++) {
         id curgestureClass = s_gesturesPriority[i];
         id gestures = [g_curGesturesDict objectForKey:curgestureClass];
-        if ([curgestureClass _fireGestures:gestures]) {
-            handled = true;
-            if (handled && DEBUG_GESTURES) {
+        if ([curgestureClass _fireGestures:gestures shouldCancelTouches:shouldCancelTouches]) {
+            if (DEBUG_GESTURES) {
                 TraceVerbose(TAG, L"Gesture (%hs) handled.", object_getClassName(curgestureClass));
             }
         }
@@ -244,7 +243,7 @@ BOOL g_resetAllTrackingGestures = TRUE;
     [g_curGesturesDict release];
     g_curGesturesDict = nil;
 
-    return handled;
+    return shouldCancelTouches;
 }
 // TODO: This block of code will likely change when we incorporate WinRT GestureRecognizers
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -487,7 +487,6 @@ static std::string _printViewHeirarchy(UIView* leafView) {
                 }
 
                 // Use this sole touch for the event we send to the view
-                // TODO: This is how it worked before; is that the expected behavior?
                 touchesForEvent = [NSMutableSet setWithObject:touchPoint.touch];
                 break;
 
@@ -521,7 +520,6 @@ static std::string _printViewHeirarchy(UIView* leafView) {
                 [touchPoint.touch->_view->priv->currentTouches removeObject:touchPoint.touch];
 
                 // Use this sole touch for the event we send to the view
-                // TODO: This is how it worked before; is that the expected behavior?
                 touchesForEvent = [NSMutableSet setWithObject:touchPoint.touch];
                 break;
 

--- a/Frameworks/include/UIGestureRecognizerInternal.h
+++ b/Frameworks/include/UIGestureRecognizerInternal.h
@@ -67,7 +67,7 @@ typedef NS_ENUM(NSUInteger, _UIPanGestureStage) {
 - (void)_setView:(UIView*)view;
 - (void)_cancelIfActive;
 - (void)_fire;
-+ (BOOL)_fireGestures:(id)gestures;
++ (BOOL)_fireGestures:(id)gestures shouldCancelTouches:(BOOL&)shouldCancelTouches;
 + (void)_failActiveExcept:(UIGestureRecognizer*)gesture;
 - (void)_addEventConnection:(UIRuntimeEventConnection*)connection;
 @end

--- a/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj
+++ b/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj
@@ -205,6 +205,7 @@
     <ClInclude Include="..\..\WOCCatalog\FoundationsViewController.h" />
     <ClInclude Include="..\..\WOCCatalog\GLKitExampleController.h" />
     <ClInclude Include="..\..\WOCCatalog\GeocodingViewController.h" />
+    <ClInclude Include="..\..\WOCCatalog\GesturesViewController.h" />
     <ClInclude Include="..\..\WOCCatalog\ImagesViewController.h" />
     <ClInclude Include="..\..\WOCCatalog\MainViewController.h" />
     <ClInclude Include="..\..\WOCCatalog\MenuTableViewController.h" />
@@ -244,6 +245,7 @@
     <ClangCompile Include="..\..\WOCCatalog\FoundationsViewController.m" />
     <ClangCompile Include="..\..\WOCCatalog\GLKitExampleController.mm" />
     <ClangCompile Include="..\..\WOCCatalog\GeocodingViewController.m" />
+    <ClangCompile Include="..\..\WOCCatalog\GesturesViewController.m" />
     <ClangCompile Include="..\..\WOCCatalog\ImagesViewController.m" />
     <ClangCompile Include="..\..\WOCCatalog\MainViewController.m" />
     <ClangCompile Include="..\..\WOCCatalog\MenuTableViewController.m" />

--- a/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj.filters
+++ b/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/WOCCatalog.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClInclude Include="..\..\WOCCatalog\GeocodingViewController.h">
       <Filter>WOCCatalog</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\WOCCatalog\GesturesViewController.h">
+      <Filter>WOCCatalog</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\WOCCatalog\ImagesViewController.h">
       <Filter>WOCCatalog</Filter>
     </ClInclude>
@@ -216,6 +219,9 @@
     <ClangCompile Include="..\..\WOCCatalog\GeocodingViewController.m">
       <Filter>WOCCatalog</Filter>
     </ClangCompile>
+    <ClangCompile Include="..\..\WOCCatalog\GesturesViewController.m">
+      <Filter>WOCCatalog</Filter>
+    </ClangCompile>    
     <ClangCompile Include="..\..\WOCCatalog\ImagesViewController.m">
       <Filter>WOCCatalog</Filter>
     </ClangCompile>

--- a/samples/WOCCatalog/WOCCatalog.xcodeproj/project.pbxproj
+++ b/samples/WOCCatalog/WOCCatalog.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		7BCEEE4C1B70220300C31CF5 /* OpenGLES11Controller.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BCEEE481B70220300C31CF5 /* OpenGLES11Controller.m */; };
 		7BCEEE4D1B70220300C31CF5 /* OpenGLES20Controller.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BCEEE4A1B70220300C31CF5 /* OpenGLES20Controller.m */; };
 		7BCEEE4F1B70225500C31CF5 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BCEEE4E1B70225500C31CF5 /* OpenGLES.framework */; };
+		7BFC0CC81DB17E2C00797C13 /* GesturesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BFC0CC71DB17E2C00797C13 /* GesturesViewController.m */; };
 		8252DB791CA9EDDE00A202B6 /* PopoverViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8252DB781CA9EDDE00A202B6 /* PopoverViewController.m */; };
 		8430AAC91BE7F2E500927545 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8430AAC81BE7F2E500927545 /* GLKit.framework */; };
 		AF8072C61C86238E00512FB6 /* URLDownloadCell.mm in Sources */ = {isa = PBXBuildFile; fileRef = AF8072C41C86238E00512FB6 /* URLDownloadCell.mm */; };
@@ -171,6 +172,8 @@
 		7BCEEE491B70220300C31CF5 /* OpenGLES20Controller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenGLES20Controller.h; sourceTree = "<group>"; };
 		7BCEEE4A1B70220300C31CF5 /* OpenGLES20Controller.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpenGLES20Controller.m; sourceTree = "<group>"; };
 		7BCEEE4E1B70225500C31CF5 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		7BFC0CC71DB17E2C00797C13 /* GesturesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GesturesViewController.m; sourceTree = "<group>"; };
+		7BFC0CC91DB17E5000797C13 /* GesturesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GesturesViewController.h; sourceTree = "<group>"; };
 		8252DB771CA9EDDE00A202B6 /* PopoverViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PopoverViewController.h; sourceTree = "<group>"; };
 		8252DB781CA9EDDE00A202B6 /* PopoverViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PopoverViewController.m; sourceTree = "<group>"; };
 		8430AAC81BE7F2E500927545 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
@@ -326,6 +329,8 @@
 				7B2A18571BB5FF020004E097 /* AutoLayoutViewController.h */,
 				7B2A18591BB5FF9B0004E097 /* AutoLayoutViewController.m */,
 				4ED640241B717E530092921E /* SingleImageViewController.h */,
+				7BFC0CC71DB17E2C00797C13 /* GesturesViewController.m */,
+				7BFC0CC91DB17E5000797C13 /* GesturesViewController.h */,
 				4EE861581B5996BF00682BDB /* Supporting Files */,
 				7B42BCF31B90ECFE00D45782 /* BezierViewController.h */,
 				7B42BCF41B90ECFE00D45782 /* BezierViewController.m */,
@@ -550,6 +555,7 @@
 				4EE861D01B5997A500682BDB /* AppDelegate.m in Sources */,
 				4EE861D51B5997A500682BDB /* SearchBarViewController.m in Sources */,
 				4EE861FA1B5997E400682BDB /* ImagesViewController.m in Sources */,
+				7BFC0CC81DB17E2C00797C13 /* GesturesViewController.m in Sources */,
 				F01C225B1C1A54450007FF0B /* TaskInfoViewController.m in Sources */,
 				E789B2E01CC59D3C0044F169 /* ShadowViewController.m in Sources */,
 				4EE861D91B5997A500682BDB /* ToolbarsViewController.m in Sources */,

--- a/samples/WOCCatalog/WOCCatalog/GesturesViewController.h
+++ b/samples/WOCCatalog/WOCCatalog/GesturesViewController.h
@@ -1,0 +1,21 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <UIKit/UIKit.h>
+
+@interface GesturesViewController : UIViewController
+
+@end

--- a/samples/WOCCatalog/WOCCatalog/GesturesViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/GesturesViewController.m
@@ -202,7 +202,7 @@ static float splashStrokeWidth = 5.0f;
 }
 
 -(void)_doTap:(UITapGestureRecognizer*)sender {
-    if (sender.state == UIGestureRecognizerStateBegan) {
+    if (sender.state == UIGestureRecognizerStateRecognized) {
         [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self.view atPoint:[sender locationInView:self.view] endSize:8 color:[UIColor redColor]];
     }
 }

--- a/samples/WOCCatalog/WOCCatalog/GesturesViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/GesturesViewController.m
@@ -1,0 +1,248 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "GesturesViewController.h"
+
+static float segmentStrokeWidth = 4.0f;
+static float splashStrokeWidth = 5.0f;
+
+@interface FadeAwayPathView : UIView
+@property (nonatomic, assign) CGPathRef path;
+@property (nonatomic, retain) UIColor* color;
+@end
+
+@implementation FadeAwayPathView
+
+-(void)drawRect:(CGRect)rect {
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextClearRect(context, self.bounds);
+    CGContextSetLineCap(context, kCGLineCapRound);
+    CGContextSetLineWidth(context, segmentStrokeWidth);
+    CGContextSetStrokeColorWithColor(context, [self.color CGColor]);
+    CGContextBeginPath(context);
+    CGContextAddPath(context, self.path);
+    CGContextStrokePath(context);
+}
+
+-(instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        self.backgroundColor = [UIColor clearColor];
+        self.color = [UIColor grayColor];
+    }
+    
+    return self;
+}
+
+-(void)showInView:(UIView*)view endSize:(float)size duration:(NSTimeInterval)duration {
+    [view addSubview:self];
+    
+    [UIView animateWithDuration:duration animations:^() {
+        self.transform = CGAffineTransformMakeScale(size, size);
+        self.alpha = 0.0f;
+    } completion:^(BOOL finished) {
+        [self removeFromSuperview];
+        CGPathRelease(self.path);
+        self.path = nil;
+    }];
+}
+
+@end
+
+@interface SplashView : FadeAwayPathView
+
+@end
+
+@implementation SplashView
+
+-(void)showInView:(UIView*)view atPoint:(CGPoint)point endSize:(float)size color:(UIColor*)color  {
+    self.frame = CGRectMake(point.x - self.frame.size.width / 2, point.y - self.frame.size.height / 2, self.frame.size.width, self.frame.size.height);
+    
+    self.path = CGPathCreateWithEllipseInRect(CGRectInset(self.bounds, splashStrokeWidth, splashStrokeWidth), NULL);
+    self.color = color;
+    
+    [super showInView:view endSize:size duration:0.5f];
+}
+
+@end
+
+@interface SegmentView : FadeAwayPathView
+
+@end
+
+@implementation SegmentView {
+    CGMutablePathRef _segment;
+}
+
+-(void)showInView:(UIView*)view atPoint:(CGPoint)point toPoint:(CGPoint)toPoint color:(UIColor*)color {
+    CGRect drawRect = { MIN(point.x, toPoint.x), MIN(point.y, toPoint.y), ABS(toPoint.x - point.x), ABS(toPoint.y - point.y) };
+    
+    if (CGSizeEqualToSize(drawRect.size, CGSizeZero)) {
+        return;
+    }
+    
+    CGRect insetRect = CGRectInset(drawRect, -segmentStrokeWidth/2.0f, -segmentStrokeWidth/2.0f);
+    self.frame = insetRect;
+   
+    CGMutablePathRef segment = CGPathCreateMutable();
+    CGPathMoveToPoint(segment, NULL, point.x - insetRect.origin.x, point.y - insetRect.origin.y);
+    CGPathAddLineToPoint(segment, NULL, toPoint.x - insetRect.origin.x, toPoint.y - insetRect.origin.y);
+    self.path = segment;
+    self.color = color;
+    
+    [super showInView:view endSize:1.0f duration:1.0f];
+}
+
+@end
+
+@interface GestureDiagnosticView : UIView
+
+@end
+
+@implementation GestureDiagnosticView
+
+-(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    for (UITouch* touch in touches) {
+        [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self atPoint:[touch locationInView:self] endSize:8 color:[UIColor blueColor]];
+    }
+}
+
+-(void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    for (UITouch* touch in touches) {
+        [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self atPoint:[touch locationInView:self] endSize:0.25 color:[UIColor blueColor]];
+    }
+}
+
+-(void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    for (UITouch* touch in touches) {
+        CGPoint currentPoint = [touch locationInView:self];
+        CGPoint lastPoint = [touch previousLocationInView:self];
+        [[[SegmentView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self atPoint:lastPoint   toPoint:currentPoint color:[UIColor blueColor]];
+    }
+}
+
+-(void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    for (UITouch* touch in touches) {
+        [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self atPoint:[touch locationInView:self] endSize:0.25 color:[UIColor blueColor]];
+    }
+}
+
+@end
+
+@implementation GesturesViewController {
+    UILabel* _stateLabel;
+    CGPoint _lastPanPoint;
+}
+
+-(void)_doTap:(UITapGestureRecognizer*)sender {
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self.view atPoint:[sender locationInView:self.view] endSize:8 color:[UIColor redColor]];
+    }
+}
+
+-(void)_doPan:(UIPanGestureRecognizer*)sender {
+    switch (sender.state) {
+        case UIGestureRecognizerStateBegan:
+            _lastPanPoint = [sender locationInView:self.view];
+            [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self.view atPoint:_lastPanPoint endSize:8 color:[UIColor redColor]];
+            break;
+        case UIGestureRecognizerStateChanged: {
+            CGPoint currentPoint = [sender locationInView:self.view];
+            [[[SegmentView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self.view atPoint:_lastPanPoint toPoint:currentPoint color:[UIColor redColor]];
+            _lastPanPoint = currentPoint;
+            break;
+        }
+        case UIGestureRecognizerStateEnded:
+            [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self.view atPoint:[sender locationInView:self.view] endSize:0.25 color:[UIColor redColor]];
+        default:
+            break;
+    }
+}
+
+-(void)_doLongPress:(UILongPressGestureRecognizer*)sender {
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        [[[SplashView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)] showInView:self.view atPoint:[sender locationInView:self.view] endSize:8 color:[UIColor redColor]];
+    }
+}
+
+-(void)loadView {
+    self.view = [[GestureDiagnosticView alloc] initWithFrame:[UIScreen mainScreen].applicationFrame];
+    self.view.backgroundColor = [UIColor whiteColor];
+}
+
+-(void)viewDidLoad {
+    UIView* sizingView = [[UIView alloc] init];
+    
+    UILabel* instructionLabel = [[UILabel alloc] init];
+    _stateLabel = [[UILabel alloc] init];
+    
+    instructionLabel.text = @"Tap, Pan or Long-Press";
+    instructionLabel.font = [UIFont systemFontOfSize:[UIFont labelFontSize] * 1.25f];
+    instructionLabel.textColor = [UIColor blackColor];
+    [instructionLabel sizeToFit];
+    
+    _stateLabel.text = @"Tap and Long-Press require 2 fingers, Pan requires 2-4. Gestures do not cancel touches. Blue shows raw multitouch sequence. Red shows gesture responses.";
+    _stateLabel.font = [UIFont systemFontOfSize:[UIFont labelFontSize] * 0.75f];
+    _stateLabel.textColor = [UIColor darkGrayColor];
+    [_stateLabel sizeToFit];
+    
+    // Autosize to center in the frame.
+    sizingView.frame = CGRectMake(self.view.bounds.size.width / 2 - 150,
+                                self.view.bounds.size.height / 2 - 20,
+                                  300, 200);
+    
+    CGRect instructionFrame = instructionLabel.frame;
+    instructionFrame.origin.y = 0;
+    instructionFrame.origin.x = 0;
+    instructionFrame.size.width = sizingView.frame.size.width;
+    instructionLabel.frame = instructionFrame;
+    instructionLabel.textAlignment = NSTextAlignmentCenter;
+    
+    CGRect stateFrame = _stateLabel.frame;
+    stateFrame.origin.y = instructionFrame.size.height;
+    stateFrame.origin.x = sizingView.frame.size.width / 2 - 120;
+    stateFrame.size.width = 240;
+    stateFrame.size.height = 100;
+    _stateLabel.frame = stateFrame;
+    _stateLabel.numberOfLines = 0;
+    _stateLabel.textAlignment = NSTextAlignmentCenter;
+    
+    sizingView.autoresizingMask =
+        UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin |
+        UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    
+    [self.view addSubview:sizingView];
+    [sizingView addSubview:instructionLabel];
+    [sizingView addSubview:_stateLabel];
+    
+    UILongPressGestureRecognizer* longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(_doLongPress:)];
+    UITapGestureRecognizer* tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(_doTap:)];
+    UIPanGestureRecognizer* pan = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(_doPan:)];
+    
+    longPress.numberOfTouchesRequired = 2;
+    tap.numberOfTouchesRequired = 2;
+    
+    pan.minimumNumberOfTouches = 2;
+    pan.maximumNumberOfTouches = 4;
+    
+    longPress.cancelsTouchesInView = pan.cancelsTouchesInView = tap.cancelsTouchesInView = NO;
+    
+    [self.view addGestureRecognizer:longPress];
+    [self.view addGestureRecognizer:tap];
+    [self.view addGestureRecognizer:pan];
+}
+
+@end

--- a/samples/WOCCatalog/WOCCatalog/MainViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/MainViewController.m
@@ -45,6 +45,7 @@
 #import "AudioToolboxViewController.h"
 #import "GeocodingViewController.h"
 #import "CoreLocationViewController.h"
+#import "GesturesViewController.h"
 
 #ifdef WINOBJC
 #import "XamlViewController.h"
@@ -78,6 +79,9 @@
     // Controls
     [self addMenuItemViewController:[[ControlsViewController alloc] init] andTitle:@"Controls"];
 
+    // Gestures
+    [self addMenuItemViewController:[[GesturesViewController alloc] init] andTitle:@"Gestures"];
+    
     // Buttons
     [self addMenuItemViewController:[[ButtonsViewController alloc] init] andTitle:@"ButtonsViewController"];
 


### PR DESCRIPTION
Changes of note:

- touchesMoved now only gets called with one touch at a time
- hitTesting only happens on UITouchPhaseBegan
- UITapGestureRecognizer now works on maxTouches, since we never expect more than one UITouch at once
- WOCCatalog/Gestures tab draws to a backing CGImage every time 128 line segments are created. Seems performant enough, but we log a lot of CGLines in the process, slowing everything down. (May remove in a later PR)
- UILabel's background remains clear.

Testing:

Created new WOCCatalog tab, which sets all gesture recognizers' cancelsTouchesInView to NO, and displays trails for all touches and gestures. The rest is ad hoc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1168)
<!-- Reviewable:end -->
