### PR TITLE
Do not roam NSUserDefaults (or CFPreferences)

### DIFF
--- a/Frameworks/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFPlatform.c
@@ -495,7 +495,7 @@ CF_INLINE CFIndex strlen_UniChar(const UniChar* p) {
  * or if the bundle name cannot be obtained:
  *     <nFolder_path>\Apple Computer\
  * where nFolder_path is obtained by calling SHGetFolderPath with nFolder
- * (CSIDL_LOCAL_APPDATA).
+ * (for example, with CSIDL_APPDATA or CSIDL_LOCAL_APPDATA).
  *
  * The CFMutableStringRef result must be released by the caller.
  *
@@ -505,8 +505,7 @@ CF_EXPORT CFMutableStringRef _CFCreateApplicationRepositoryPath(CFAllocatorRef a
     CFMutableStringRef result = NULL;
     CFStringRef str = NULL;
 
-    // In Reference platform, CFPreferences does not roam, so ignore nFolder
-
+    //WinOBJC- In Reference platform, CFPreferences does not roam, so ignore nFolder
     Wrappers::HString path = GetAppDataPath(true);
     if (path.IsValid()) {
         unsigned int rawLength;

--- a/Frameworks/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFPlatform.c
@@ -505,7 +505,7 @@ CF_EXPORT CFMutableStringRef _CFCreateApplicationRepositoryPath(CFAllocatorRef a
     CFMutableStringRef result = NULL;
     CFStringRef str = NULL;
 
-    //WinOBJC- In Reference platform, CFPreferences does not roam, so ignore nFolder
+    // WINOBJC: In Reference platform, CFPreferences does not roam, so ignore nFolder
     Wrappers::HString path = GetAppDataPath(true);
     if (path.IsValid()) {
         unsigned int rawLength;

--- a/Frameworks/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFPlatform.c
@@ -495,7 +495,7 @@ CF_INLINE CFIndex strlen_UniChar(const UniChar* p) {
  * or if the bundle name cannot be obtained:
  *     <nFolder_path>\Apple Computer\
  * where nFolder_path is obtained by calling SHGetFolderPath with nFolder
- * (for example, with CSIDL_APPDATA or CSIDL_LOCAL_APPDATA).
+ * (CSIDL_LOCAL_APPDATA).
  *
  * The CFMutableStringRef result must be released by the caller.
  *
@@ -505,8 +505,9 @@ CF_EXPORT CFMutableStringRef _CFCreateApplicationRepositoryPath(CFAllocatorRef a
     CFMutableStringRef result = NULL;
     CFStringRef str = NULL;
 
-    // WINOBJC: make sure that nFolder is CSIDL_APPDATA or CSIDL_LOCAL_APPDATA and return the app data folder for the app.
-    Wrappers::HString path = GetAppDataPath(nFolder == CSIDL_LOCAL_APPDATA);
+    // In Reference platform, CFPreferences does not roam, so ignore nFolder
+
+    Wrappers::HString path = GetAppDataPath(true);
     if (path.IsValid()) {
         unsigned int rawLength;
         const wchar_t* rawPath = WindowsGetStringRawBuffer(path.Get(), &rawLength);


### PR DESCRIPTION
    Save NSUserDefaults to local app data, not roaming app data.
    App preferences writes with kCFPreferencesAnyHost, which means we cannot
    use the host parameter to differentiate roaming vs local.
    
    The correct way to roam would be through ubiquitous store (which would
    have to be covered separately based on need).
    
    Fix #1167