### PR TITLE
Consolidate uses of Ebr file functions.

### DIFF
--- a/Frameworks/AudioToolbox/CAFDecoder.h
+++ b/Frameworks/AudioToolbox/CAFDecoder.h
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <vector>
-#include "Platform/EbrPlatform.h"
+#include <Foundation/NSInputStream.h>
 
 uint32_t int32Swap(uint32_t val);
 uint64_t int64Swap(uint64_t val);
@@ -129,28 +129,25 @@ private:
         kAudioCodecProduceOutputPacketSuccessHasMore
     } Result;
 
-    int GetUsedInputBufferByteSize(EbrFile* fpIn);
-    Byte* GetBytes(EbrFile* fpIn, int len);
+    Byte* GetBytes(NSInputStream* stream, int len);
 
     typedef std::vector<ChannelState> ChannelStateList;
 
-    UInt32 ProduceOutputPackets(EbrFile* fpIn,
-                                ChannelStateList& mChannelStateList,
-                                void* outOutputData,
-                                UInt32& ioOutputDataByteSize,
-                                UInt32& ioNumberPackets,
-                                OutputDescription& mOutputFormat,
-                                CAFAudioDescription& mInputFormat);
-    EbrFile* fpIn;
+    void ProduceOutputPackets(NSInputStream* stream,
+                              ChannelStateList& mChannelStateList,
+                              void* outOutputData,
+                              UInt32& ioOutputDataByteSize,
+                              OutputDescription& mOutputFormat,
+                              CAFAudioDescription& mInputFormat);
     CAFAudioDescription cafDesc;
     CAFPacketTableHeader cafPacketTbl;
 
+    
+    ChannelStateList channelStates;
+
 public:
     OutputDescription OutputFormat;
-    ChannelStateList channelStates;
-    int dataStart;
 
-    bool InitForRead(EbrFile* in);
-    int ReadBuf(int16_t* samplesOut, uint32_t& ioOutputDataByteSize);
-    void Reset();
+    bool InitForRead(NSInputStream* stream);
+    int ReadBuf(NSInputStream* stream, int16_t* samplesOut, uint32_t& ioOutputDataByteSize);
 };

--- a/Frameworks/AudioToolbox/CAFDecoder.mm
+++ b/Frameworks/AudioToolbox/CAFDecoder.mm
@@ -184,45 +184,27 @@ double dSwap(double val) {
     return ret;
 }
 
-enum {
-    kAudioCodecProduceOutputPacketSuccess,
-    kAudioCodecProduceOutputPacketNeedsMoreInputData,
-    kAudioCodecProduceOutputPacketSuccessHasMore
-} Result;
-
-int CAFDecoder::GetUsedInputBufferByteSize(EbrFile* fpIn) {
-    int cur = EbrFtell(fpIn);
-    EbrFseek(fpIn, 0, SEEK_END);
-    int left = EbrFtell(fpIn) - cur;
-    EbrFseek(fpIn, cur, SEEK_SET);
-
-    return left;
-}
-
-Byte* CAFDecoder::GetBytes(EbrFile* fpIn, int len) {
+Byte* CAFDecoder::GetBytes(NSInputStream* stream, int len) {
     Byte* ret = (Byte*)IwMalloc(len);
-
-    EbrFread(ret, 1, len, fpIn);
-
+    [stream read:ret maxLength:len];
     return ret;
 }
 
-UInt32 CAFDecoder::ProduceOutputPackets(EbrFile* fpIn,
-                                        ChannelStateList& mChannelStateList,
-                                        void* outOutputData,
-                                        UInt32& ioOutputDataByteSize,
-                                        UInt32& ioNumberPackets,
-                                        OutputDescription& mOutputFormat,
-                                        CAFAudioDescription& mInputFormat) {
-    if (isPcm) {
-        int read = EbrFread(outOutputData, cafDesc.mBytesPerPacket, ioOutputDataByteSize / cafDesc.mBytesPerPacket, fpIn);
-        ioNumberPackets = read;
-        ioOutputDataByteSize = ioNumberPackets * cafDesc.mBytesPerPacket;
-        return 0;
-    }
+void CAFDecoder::ProduceOutputPackets(NSInputStream* stream,
+                                      ChannelStateList& mChannelStateList,
+                                      void* outOutputData,
+                                      UInt32& ioOutputDataByteSize,
+                                      OutputDescription& mOutputFormat,
+                                      CAFAudioDescription& mInputFormat) {
+    UInt32 ioNumberPackets = 1;
 
-    //  setup the return value, by assuming that everything is going to work
-    UInt32 theAnswer = kAudioCodecProduceOutputPacketSuccess;
+    if (isPcm) {
+        NSInteger result =
+            [stream read:(uint8_t*)&outOutputData maxLength:(cafDesc.mBytesPerPacket * (ioOutputDataByteSize / cafDesc.mBytesPerPacket))];
+        ioNumberPackets = (result / cafDesc.mBytesPerPacket);
+        ioOutputDataByteSize = result;
+        return;
+    }
 
     //  Note that the decoder doesn't suffer from the same problem the encoder
     //  does with not having enough data for a packet, since the encoded data
@@ -231,21 +213,16 @@ UInt32 CAFDecoder::ProduceOutputPackets(EbrFile* fpIn,
     //  clamp the number of packets to produce based on what is available in the
     //  input buffer
     UInt32 inputPacketSize = mInputFormat.mBytesPerPacket;
-    UInt32 numberOfInputPackets = GetUsedInputBufferByteSize(fpIn) / inputPacketSize;
+    UInt32 numberOfInputPackets = 1;
     if (ioNumberPackets < numberOfInputPackets) {
         numberOfInputPackets = ioNumberPackets;
     } else if (ioNumberPackets > numberOfInputPackets) {
         ioNumberPackets = numberOfInputPackets;
-
-        //  this also means we need more input to satisfy the request so set the
-        //  return value
-        theAnswer = kAudioCodecProduceOutputPacketNeedsMoreInputData;
     }
 
     // We only produce 1 at a time
     if (ioNumberPackets > 1 && numberOfInputPackets > 1) {
         numberOfInputPackets = ioNumberPackets = 1;
-        theAnswer = kAudioCodecProduceOutputPacketSuccessHasMore;
     }
 
     UInt32 inputByteSize = numberOfInputPackets * inputPacketSize;
@@ -255,23 +232,16 @@ UInt32 CAFDecoder::ProduceOutputPackets(EbrFile* fpIn,
         //  encoded data
         //  it is an error to ask for more output than you pass in buffer space for
         UInt32 theOutputByteSize = ioNumberPackets * mInputFormat.mFramesPerPacket * mOutputFormat.mBytesPerFrame;
-        // ThrowIf(ioOutputDataByteSize < theOutputByteSize,
-        // static_cast<OSStatus>(kAudioCodecNotEnoughBufferSpaceError),
-        // "ACAppleIMA4Decoder::ProduceOutputPackets: not
-        // enough space in the output buffer");
 
         //  set the return value
         ioOutputDataByteSize = theOutputByteSize;
 
         //  decode the input data for each channel
-        Byte* theInputData = GetBytes(fpIn, inputByteSize);
+        Byte* theInputData = GetBytes(stream, inputByteSize);
         SInt16* theOutputData = reinterpret_cast<SInt16*>(outOutputData);
 
         ChannelStateList::iterator theIterator = mChannelStateList.begin();
         for (int theChannelIndex = 0; theChannelIndex < mOutputFormat.mChannelsPerFrame; ++theChannelIndex) {
-            // TraceVerbose(TAG, L"->DecodeChannel %d %d %d %08X %08X",
-            // mOutputFormat.mChannelsPerFrame, theChannelIndex,
-            // ioNumberPackets, theInputData, theOutputData);
             DecodeChannelSInt16(*theIterator,
                                 mOutputFormat.mChannelsPerFrame,
                                 theChannelIndex,
@@ -282,44 +252,33 @@ UInt32 CAFDecoder::ProduceOutputPackets(EbrFile* fpIn,
         }
 
         IwFree(theInputData);
-
-        // ConsumeInputData(inputByteSize);
     } else {
         //  set the return value since we're not actually doing any work
         ioOutputDataByteSize = 0;
     }
 
-    /*
-    if((theAnswer == kAudioCodecProduceOutputPacketSuccess) &&
-    (GetUsedInputBufferByteSize() >= inputPacketSize))
-    {
-    //  we satisfied the request, and there's at least one more full packet of
-    data we can decode
-    //  so set the return value
-    theAnswer = kAudioCodecProduceOutputPacketSuccessHasMore;
-    }
-    */
-
-    return theAnswer;
+    return;
 }
 
-bool CAFDecoder::InitForRead(EbrFile* in) {
-    fpIn = in;
+bool CAFDecoder::InitForRead(NSInputStream* inStream) {
     CAFFileHeader header;
-    EbrFread(&header, 1, sizeof(CAFFileHeader), fpIn);
+    [inStream read:(uint8_t*)&header maxLength:sizeof(CAFFileHeader)];
     bool stop = false;
     isPcm = false;
 
-    while (!EbrFeof(fpIn) && !stop) {
+    while ([inStream hasBytesAvailable] && !stop) {
         CAFChunkHeader chunkHeader;
-        EbrFread(&chunkHeader, 1, sizeof(CAFChunkHeader), fpIn);
+        [inStream read:(uint8_t*)&chunkHeader maxLength:sizeof(CAFChunkHeader)];
         chunkHeader.mChunkType = int32Swap(chunkHeader.mChunkType);
         chunkHeader.mChunkSize = int64Swap(chunkHeader.mChunkSize);
 
-        int64_t chunkEnd = EbrFtell(fpIn) + chunkHeader.mChunkSize;
+        int64_t bytesLeftUntilChunkEnd = chunkHeader.mChunkSize;
+        std::vector<uint8_t> bytesToSkip;
+        uint8_t editCount[4];
+
         switch (chunkHeader.mChunkType) {
             case CAF_StreamDescriptionChunkID:
-                EbrFread(&cafDesc, 1, sizeof(CAFAudioDescription), fpIn);
+                bytesLeftUntilChunkEnd -= [inStream read:(uint8_t*)&cafDesc maxLength:sizeof(CAFAudioDescription)];
                 cafDesc.mSampleRate = dSwap(cafDesc.mSampleRate);
 
                 cafDesc.mFormatID = int32Swap(cafDesc.mFormatID);
@@ -347,7 +306,7 @@ bool CAFDecoder::InitForRead(EbrFile* in) {
                 break;
 
             case CAF_PacketTableChunkID:
-                EbrFread(&cafPacketTbl, 1, sizeof(cafPacketTbl), fpIn);
+                bytesLeftUntilChunkEnd -= [inStream read:(uint8_t*)&cafPacketTbl maxLength:sizeof(cafPacketTbl)];
 
                 cafPacketTbl.mNumberPackets = int64Swap(cafPacketTbl.mNumberPackets);
                 cafPacketTbl.mNumberValidFrames = int64Swap(cafPacketTbl.mNumberValidFrames);
@@ -357,8 +316,7 @@ bool CAFDecoder::InitForRead(EbrFile* in) {
 
             case CAF_AudioDataChunkID:
                 //  Skip edit count
-                EbrFseek(fpIn, 4, SEEK_CUR);
-                dataStart = EbrFtell(fpIn);
+                bytesLeftUntilChunkEnd -= [inStream read:(uint8_t*)editCount maxLength:_countof(editCount)];
                 stop = true;
 
                 OutputFormat.mBytesPerFrame = 2 * cafDesc.mChannelsPerFrame;
@@ -373,29 +331,22 @@ bool CAFDecoder::InitForRead(EbrFile* in) {
                 break;
 
             default:
-                EbrFseek(fpIn, (long)chunkHeader.mChunkSize, SEEK_CUR);
+                bytesToSkip.reserve(chunkHeader.mChunkSize);
+                bytesLeftUntilChunkEnd -= [inStream read:(uint8_t*)&bytesToSkip[0] maxLength:chunkHeader.mChunkSize];
                 break;
         }
 
-        if (!stop)
-            EbrFseek(fpIn, (long)chunkEnd, SEEK_SET);
+        if (!stop) {
+            if (bytesLeftUntilChunkEnd > 0) {
+                [inStream read:(uint8_t*)&bytesToSkip[0] maxLength:bytesLeftUntilChunkEnd];
+            }
+        }
     }
 
     return true;
 }
 
-int CAFDecoder::ReadBuf(int16_t* out, uint32_t& ioOutputDataByteSize) {
-    UInt32 ioNumberPackets = 1;
-
-    ProduceOutputPackets(fpIn, channelStates, out, ioOutputDataByteSize, ioNumberPackets, OutputFormat, cafDesc);
+int CAFDecoder::ReadBuf(NSInputStream* inputStream, int16_t* out, uint32_t& ioOutputDataByteSize) {
+    ProduceOutputPackets(inputStream, channelStates, out, ioOutputDataByteSize, OutputFormat, cafDesc);
     return ioOutputDataByteSize;
-}
-
-void CAFDecoder::Reset() {
-    EbrFseek(fpIn, dataStart, SEEK_SET);
-
-    channelStates.clear();
-    for (int i = 0; i < OutputFormat.mChannelsPerFrame; i++) {
-        channelStates.push_back(ChannelState());
-    }
 }

--- a/Frameworks/AudioToolbox/ExtendedAudioFile.mm
+++ b/Frameworks/AudioToolbox/ExtendedAudioFile.mm
@@ -15,7 +15,6 @@
 //******************************************************************************
 
 #include "Starboard.h"
-#include "Platform/EbrPlatform.h"
 #include "Etc.h"
 
 #import "stb_vorbis.h"

--- a/Frameworks/CoreGraphics/CGDiscardableImage.mm
+++ b/Frameworks/CoreGraphics/CGDiscardableImage.mm
@@ -202,18 +202,20 @@ void CGDiscardableImageBacking::GetPixel(int x, int y, float& r, float& g, float
     _forward->GetPixel(x, y, r, g, b, a);
 }
 
-ImageDataStreamFile::ImageDataStreamFile(EbrFile* in) {
-    fpIn = in;
+ImageDataStreamFile::ImageDataStreamFile(NSInputStream* inStream) : _inputStream(inStream) {
+    if (NSStreamStatusOpen != [_inputStream streamStatus]) {
+        [_inputStream open];
+    }
 }
 
 ImageDataStreamFile::~ImageDataStreamFile() {
-    EbrFclose(fpIn);
+    if (NSStreamStatusOpen == [_inputStream streamStatus]) {
+        [_inputStream close];
+    }
 }
 
 int ImageDataStreamFile::readData(void* in, int len) {
-    int ret = EbrFread(in, 1, len, fpIn);
-
-    return ret;
+    return [_inputStream read:(uint8_t*)in maxLength:len];
 }
 
 ImageDataStreamMemory::ImageDataStreamMemory(const void* in, int len) {

--- a/Frameworks/CoreGraphics/CGJPEGDecoderImage.mm
+++ b/Frameworks/CoreGraphics/CGJPEGDecoderImage.mm
@@ -297,18 +297,11 @@ CGImageBacking* CGJPEGImageBacking::ConstructBacking() {
 }
 
 void CGJPEGImageBacking::Decode(void* imgDest, int stride) {
-    EbrFile* fpIn;
-
     ImageDataStream* reader;
 
     if (_fileName) {
-        fpIn = EbrFopen(_fileName, "rb");
-        if (!fpIn) {
-            assert(0);
-            return;
-        }
-
-        reader = new ImageDataStreamFile(fpIn);
+        NSInputStream* inputStream = [NSInputStream inputStreamWithFileAtPath:[NSString stringWithUTF8String:_fileName]];
+        reader = new ImageDataStreamFile(inputStream);
     } else {
         reader = new ImageDataStreamMemory((char*)[_data bytes], [_data length]);
     }

--- a/Frameworks/CoreGraphics/CGPNGDecoderImage.mm
+++ b/Frameworks/CoreGraphics/CGPNGDecoderImage.mm
@@ -192,17 +192,10 @@ CGImageBacking* CGPNGImageBacking::ConstructBacking() {
 }
 
 void CGPNGImageBacking::Decode(void* imgDest, int stride) {
-    EbrFile* fpIn;
-
     ImageDataStream* reader;
 
     if (_fileName) {
-        fpIn = EbrFopen(_fileName, "rb");
-        if (!fpIn) {
-            assert(0);
-        }
-
-        reader = new ImageDataStreamFile(fpIn);
+        reader = new ImageDataStreamFile([NSInputStream inputStreamWithFileAtPath:[NSString stringWithUTF8String:_fileName]]);
     } else {
         reader = new ImageDataStreamMemory((char*)[(NSData*)_data bytes], [(NSData*)_data length]);
     }

--- a/Frameworks/Foundation/NSCFData.mm
+++ b/Frameworks/Foundation/NSCFData.mm
@@ -39,6 +39,23 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFData)
         (CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, reinterpret_cast<const byte*>(bytes), length, deallocator))));
 }
 
+/**
+ @Status Caveat
+ @Notes options parameter not supported
+*/
+- (_Nullable instancetype)initWithContentsOfFile:(NSString*)filename options:(NSDataReadingOptions)options error:(NSError**)error {
+    CFDataRef tempData;
+    SInt32 cfError{};
+    
+    if (CFURLCreateDataAndPropertiesFromResource(nullptr, static_cast<CFURLRef>([NSURL fileURLWithPath:filename]), &tempData, nullptr, nullptr, &cfError)) {
+        return reinterpret_cast<NSDataPrototype*>(static_cast<NSData*>(tempData));
+    } else if (error != nullptr) {
+        *error = [NSError errorWithDomain:@"NSData" code:cfError userInfo:nil];
+    }
+
+    return nil;
+}
+
 @end
 #pragma endregion
 

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -25,6 +25,8 @@
 #import "Foundation/NSString.h"
 #import "Foundation/NSMutableArray.h"
 #import "Foundation/NSValue.h"
+#import "Foundation/NSInputStream.h"
+#import "Foundation/NSOutputStream.h"
 #import <CoreFoundation/CFData.h>
 #include <COMIncludes.h>
 #import "ErrorHandling.h"
@@ -303,23 +305,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
  @Notes atomically parameter not supported
 */
 - (BOOL)writeToFile:(NSString*)filename atomically:(BOOL)atomically {
-    char* fname = (char*)[filename UTF8String];
-
-    TraceVerbose(TAG, L"NSData writing %hs (%d bytes)", fname, [self length]);
-    if (!fname) {
-        TraceVerbose(TAG, L"Filename is null!");
-        return FALSE;
-    }
-    EbrFile* fpOut = EbrFopen((const char*)fname, "wb");
-    if (fpOut) {
-        EbrFwrite([self bytes], 1, [self length], fpOut);
-        EbrFclose(fpOut);
-
-        return TRUE;
-    } else {
-        TraceVerbose(TAG, L"NSData couldn't open %hs for write", fname);
-        return FALSE;
-    }
+    return [self writeToURL:[NSURL fileURLWithPath:filename] atomically:atomically];
 }
 
 /**
@@ -327,11 +313,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
  @Notes Only file:// URLs supported. atomically parameter not supported.
 */
 - (BOOL)writeToURL:(NSURL*)url atomically:(BOOL)atomically {
-    if (![url isFileURL]) {
-        TraceVerbose(TAG, L"-[NSData::writeToURL]: Only file: URLs are supported. (%hs)", [[url absoluteString] UTF8String]);
-        return NO;
-    }
-    return [self writeToFile:[url path] atomically:atomically];
+    return [self writeToURL:url options:(atomically ? NSDataWritingAtomic : 0) error:nil];
 }
 
 /**
@@ -339,21 +321,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
  @Notes options parameter not supported
 */
 - (BOOL)writeToFile:(NSString*)filename options:(NSDataWritingOptions)options error:(NSError**)error {
-    char* fname = (char*)[filename UTF8String];
-
-    TraceVerbose(TAG, L"NSData writing %hs (%d bytes)", fname, [self length]);
-    EbrFile* fpOut = EbrFopen((const char*)fname, "wb");
-    if (fpOut) {
-        EbrFwrite([self bytes], 1, [self length], fpOut);
-        EbrFclose(fpOut);
-        return YES;
-    }
-
-    TraceVerbose(TAG, L"NSData couldn't open %hs for write (with options)", fname);
-    if (error) {
-        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileNoSuchFileError userInfo:@{ NSFilePathErrorKey : filename }];
-    }
-    return NO;
+    return [self writeToURL:[NSURL fileURLWithPath:filename] options:options error:error];
 }
 
 /**
@@ -361,11 +329,35 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
  @Notes options parameter not supported
 */
 - (BOOL)writeToURL:(NSURL*)url options:(NSDataWritingOptions)options error:(NSError**)errorp {
-    if (![url isFileURL]) {
-        TraceVerbose(TAG, L"-[NSData::writeToURL]: Only file: URLs are supported. (%hs)", [[url absoluteString] UTF8String]);
+    if (!url) {
+        if (errorp) {
+            *errorp = [NSError errorWithDomain:@"NSData" code:100 userInfo:nil];
+        }
         return NO;
     }
-    return [self writeToFile:[url path] options:options error:errorp];
+
+    NSOutputStream* outputStream =
+        [NSOutputStream outputStreamWithURL:url append:(0 != (options & NSDataWritingWithoutOverwriting)) ? YES : NO];
+    [outputStream open];
+
+    if (NSStreamStatusOpen != outputStream.streamStatus) {
+        if (errorp) {
+            *errorp = [NSError errorWithDomain:@"NSData" code:100 userInfo:nil];
+        }
+        return NO;
+    }
+    auto numBytes = [self length];
+    auto result = [outputStream write:(const unsigned char*)[self bytes] maxLength:numBytes];
+    [outputStream close];
+
+    if (result != numBytes) {
+        if (errorp) {
+            *errorp = [NSError errorWithDomain:@"NSData" code:100 userInfo:nil];
+        }
+        return NO;
+    }
+
+    return YES;
 }
 
 /**
@@ -396,34 +388,11 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
         return nil;
     }
 
-    char* fname = (char*)[filename UTF8String];
+    NSInputStream* inputStream = [NSInputStream inputStreamWithFileAtPath:filename];
+    [inputStream open];
 
-    TraceVerbose(TAG, L"NSData extended-opening %hs", fname);
-    EbrFile* fpIn = EbrFopen(fname, "rb");
-    if (fpIn) {
-        auto closeFile = wil::ScopeExit([&]() { EbrFclose(fpIn); });
-
-        EbrFseek(fpIn, 0, SEEK_END);
-        size_t length = EbrFtell(fpIn);
-        EbrFseek(fpIn, 0, SEEK_SET);
-
-        if (length) {
-            // The created NSData takes ownership of freeing this
-            woc::unique_iw<uint8_t> copiedBytes(static_cast<uint8_t*>(IwMalloc(length)));
-            if (!copiedBytes.get()) {
-                if (error) {
-                    *error = [NSError errorWithDomain:@"NSData" code:100 userInfo:nil];
-                }
-                [self release];
-                return nil;
-            }
-
-            size_t fileLength = EbrFread(copiedBytes.get(), 1, length, fpIn);
-            self = [self initWithBytesNoCopy:copiedBytes.release() length:fileLength];
-        }
-
-    } else {
-        TraceVerbose(TAG, L"NSData couldn't open %hs for read (extended)", fname);
+    if (NSStreamStatusOpen != inputStream.streamStatus) {
+        TraceVerbose(TAG, L"NSData couldn't open %hs for read (extended)", filename);
         if (error) {
             *error = [NSError errorWithDomain:@"NSData" code:100 userInfo:nil];
         }
@@ -431,7 +400,17 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
         return nil;
     }
 
-    return self;
+    auto closeFile = wil::ScopeExit([&]() { [inputStream close]; });
+
+    uint8_t byteBuffer[4096] = {};
+    NSMutableData* tempData = [NSMutableData data];
+
+    while ([inputStream hasBytesAvailable]) {
+        auto result = [inputStream read:byteBuffer maxLength:_countof(byteBuffer)];
+        [tempData appendBytes:byteBuffer length:result];
+    }
+
+    return [self initWithData:tempData];
 }
 
 /**

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -392,6 +392,10 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
     SInt32 cfError{};
 
     if (CFURLCreateDataAndPropertiesFromResource(nullptr, static_cast<CFURLRef>([NSURL fileURLWithPath:filename]), &tempData, nullptr, nullptr, &cfError)) {
+        // An astute reader may be wondering why initWithData should be called when tempData is already a fully realized NSData with the information we want.
+        // In order to comply with Toll Free bridging and class clustering, *instancetype* always needs to be returned here which may not be the case for a 
+        // derived class (say NSMutableData). This init call forwards to a designated initializer internally so the derived implementor need not think about
+        // it if they don't want. Note that the default NSData implementation, NSCFData, does not make an extra copy since a CFDataRef is a NSCFData.
         return [self initWithData:static_cast<NSData*>(tempData)];
     } else if (error != nullptr) {
         *error = [NSError errorWithDomain:@"NSData" code:cfError userInfo:nil];

--- a/Frameworks/Foundation/NSFileHandle.mm
+++ b/Frameworks/Foundation/NSFileHandle.mm
@@ -348,7 +348,7 @@ typedef NS_ENUM(NSUInteger, _NSFileOpenMode) { _NSFileOpenModeRead, _NSFileOpenM
  @Status Interoperable
 */
 - (void)synchronizeFile {
-    if (EbrFflush(EbrFileFromFd(_fileDescriptor)) != 0) {
+    if (EbrFflush(_fileDescriptor) != 0) {
         [NSException raise:NSFileHandleOperationException format:@"Unable to synchronize file."];
     }
 }

--- a/Frameworks/Foundation/NSURLProtocol_file.h
+++ b/Frameworks/Foundation/NSURLProtocol_file.h
@@ -16,12 +16,7 @@
 
 #include "Foundation/NSURLProtocol.h"
 
-@interface NSURLProtocol_file : NSURLProtocol {
-@public
-    id _modes;
-    id _path;
-    EbrFile* fpIn;
-}
+@interface NSURLProtocol_file : NSURLProtocol
 - (id)initWithRequest:(id)request cachedResponse:(id)response client:(id)client;
 - (id)startLoading;
 - (id)stopLoading;

--- a/Frameworks/Foundation/NSURLProtocol_file.mm
+++ b/Frameworks/Foundation/NSURLProtocol_file.mm
@@ -1,37 +1,43 @@
-/* Copyright (c) 2006-2007 Christopher J. W. Lloyd
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
-Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2006-2007 Christopher J. W. Lloyd
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
 
 #import "Starboard.h"
-#import "Foundation/NSMutableString.h"
-#import "Foundation/NSURLProtocol.h"
-#import "Foundation/NSMutableArray.h"
-#import "Foundation/NSNumber.h"
-#import "Foundation/NSMutableData.h"
-#import "Foundation/NSMutableDictionary.h"
-#import "Foundation/NSRunLoop.h"
-#import "Foundation/NSTimer.h"
-#import "Foundation/NSStream.h"
-#import "Foundation/NSError.h"
-#import "Foundation/NSHTTPURLResponse.h"
+#import <Foundation/NSMutableString.h>
+#import <Foundation/NSURLProtocol.h>
+#import <Foundation/NSMutableArray.h>
+#import <Foundation/NSNumber.h>
+#import <Foundation/NSMutableData.h>
+#import <Foundation/NSMutableDictionary.h>
+#import <Foundation/NSRunLoop.h>
+#import <Foundation/NSTimer.h>
+#import <Foundation/NSStream.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSHTTPURLResponse.h>
 #import "NSURLProtocol_file.h"
 #import "NSURLProtocolInternal.h"
 #import "LoggingNative.h"
 
 static const wchar_t* TAG = L"NSURLProtocol_file";
 
-@implementation NSURLProtocol_file
+@implementation NSURLProtocol_file {
+@private
+    StrongId<NSString> _path;
+}
+
 + (void)load {
     [NSURLProtocol registerClass:self];
 }
@@ -46,28 +52,19 @@ static const wchar_t* TAG = L"NSURLProtocol_file";
 }
 
 - (id)initWithRequest:(id)request cachedResponse:(id)response client:(id)client {
-    [super initWithRequest:request cachedResponse:response client:client];
+    if (self = [super initWithRequest:request cachedResponse:response client:client]) {
+        id url = [_request URL];
+        TraceVerbose(TAG, L"Loading %hs", [[url absoluteString] UTF8String]);
 
-    _modes = [[NSMutableArray arrayWithObject:@"kCFRunLoopDefaultMode"] retain];
-
-    id url = [_request URL];
-    TraceVerbose(TAG, L"Loading %hs", [[url absoluteString] UTF8String]);
-
-    _path = [[url path] copy];
-    // id host = [NSHost hostWithName:hostName];
+        _path.attach([[url path] copy]);
+    }
 
     return self;
 }
 
 - (id)startLoading {
-    const char* pFilePath = [_path UTF8String];
-
-    fpIn = EbrFopen(pFilePath, "rb");
-    if (!fpIn) {
-        TraceVerbose(TAG, L"Couldn't open %hs", pFilePath);
-    } else {
-        TraceVerbose(TAG, L"Opened %hs", pFilePath);
-    }
+    // TODO 1162: An NSInputStream should be initialized here and run loop events should be used to schedule
+    // the file operations.
     return self;
 }
 
@@ -85,25 +82,7 @@ static const wchar_t* TAG = L"NSURLProtocol_file";
 }
 
 - (id)_doFileLoad {
-    id url = [_request URL];
-
-    if (fpIn == NULL) {
-        TraceVerbose(TAG, L"doFileLoad: fpIn = NULL! self=%x", self);
-        id error = [NSError errorWithDomain:@"Couldn't open file" code:100 userInfo:nil];
-        [_client URLProtocol:self didFailWithError:error];
-        return self;
-    }
-
-    EbrFseek(fpIn, 0, SEEK_END);
-    int len = EbrFtell(fpIn);
-    EbrFseek(fpIn, 0, SEEK_SET);
-
-    char* pData = (char*)IwMalloc(len);
-    len = EbrFread(pData, 1, len, fpIn);
-    id dataReceived = [NSData dataWithBytes:pData length:len];
-    IwFree(pData);
-
-    EbrFclose(fpIn);
+    NSData* dataReceived = [NSData dataWithContentsOfFile:_path];
 
     [_client URLProtocol:self didReceiveResponse:nil cacheStoragePolicy:NSURLCacheStorageAllowed];
     [_client URLProtocol:self didLoadData:dataReceived];

--- a/Frameworks/Starboard/PlatformSupport.cpp
+++ b/Frameworks/Starboard/PlatformSupport.cpp
@@ -653,7 +653,7 @@ int EbrIOFile::Flush() {
 }
 
 int EbrFflush(int fd) {
-    return return _openFiles[fd]->Flush();
+    return _openFiles[fd]->Flush();
 }
 
 int EbrIOFile::Setpos(__int64* pos) {

--- a/Frameworks/Starboard/PlatformSupport.cpp
+++ b/Frameworks/Starboard/PlatformSupport.cpp
@@ -31,6 +31,7 @@
 #include "pevents.h"
 #include "PathMapper.h"
 #include "LoggingNative.h"
+#include "PlatformSupportInternal.h"
 
 static const wchar_t* TAG = L"PlatformSupport";
 
@@ -651,8 +652,8 @@ int EbrIOFile::Flush() {
     return fflush(fp);
 }
 
-int EbrFflush(EbrFile* fp) {
-    return fp->Flush();
+int EbrFflush(int fd) {
+    return return _openFiles[fd]->Flush();
 }
 
 int EbrIOFile::Setpos(__int64* pos) {

--- a/Frameworks/Starboard/PlatformSupportInternal.h
+++ b/Frameworks/Starboard/PlatformSupportInternal.h
@@ -1,0 +1,91 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+enum EbrFileType { EbrFileTypeUnknown, EbrFileTypeIO, EbrFileTypeSocket, EbrFileTypeVirtual, EbrFileTypeZipAsset };
+
+class EbrFile {
+public:
+    int idx;
+    EbrFileType type;
+
+    EbrFile();
+    virtual ~EbrFile();
+
+    virtual int Close();
+    virtual size_t Read(void* dest, size_t elem, size_t count);
+    virtual size_t Write(const void* dest, size_t elem, size_t count);
+    virtual int Seek(long offset, int origin);
+    virtual int Seek64(__int64 offset, int origin);
+    virtual size_t Tell();
+    virtual int Eof();
+    virtual int Putc(int c);
+    virtual int Rewind();
+    virtual int Error();
+    virtual int Getc();
+    virtual int Ungetc(int val);
+    virtual char* Gets(char* dest, size_t size);
+    virtual int Puts(const char* str);
+    virtual void Clearerr();
+    virtual int Flush();
+    virtual int Setpos(__int64* pos);
+    virtual int Getpos(__int64* pos);
+
+    virtual int HostFd();
+    virtual int Stat(struct stat* ret);
+    virtual int Stat64i32(struct _stat64i32* ret);
+    virtual int Read(void* dest, size_t count);
+    virtual int Write(const void* src, size_t count);
+    virtual int Lseek(__int64 pos, int whence);
+    virtual int Truncate(off_t size);
+    virtual int Truncate64(__int64 size);
+    virtual int Dup();
+
+    virtual void* Mmap(void* addr, size_t size, uint32_t prot, uint32_t flags, uint32_t offset);
+    virtual int Munmap(void* addr, size_t size);
+
+    virtual intptr_t GetOSFHandle();
+};
+
+EbrFile* EbrAllocFile(EbrFile* ioInterface);
+void EbrFreeFile(EbrFile* pFile);
+EbrFile* EbrFileFromFd(int fd);
+EbrFileType EbrFileGetType(EbrFile* pFile);
+
+EbrFile* EbrFmake(FILE* fp);
+EbrFile* EbrFopen(const char* filename, const char* mode);
+EbrFile* EbrFdopen(int handle, const char* mode);
+int EbrFclose(EbrFile* file);
+size_t EbrFread(void* dest, size_t elem, size_t count, EbrFile* file);
+size_t EbrFwrite(const void* dest, size_t elem, size_t count, EbrFile* file);
+int EbrFseek(EbrFile* fp, long offset, int origin);
+int EbrFseek64(EbrFile* fp, __int64 offset, int origin);
+size_t EbrFtell(EbrFile* fp);
+int EbrFeof(EbrFile* fp);
+
+int EbrFputc(int c, EbrFile* fp);
+int EbrRewind(EbrFile* fp);
+int EbrFerror(EbrFile* fp);
+int EbrFgetc(EbrFile* fp);
+int EbrUngetc(int val, EbrFile* fp);
+char* EbrFgets(char* dest, size_t size, EbrFile* fp);
+int EbrFputs(const char* str, EbrFile* fp);
+int EbrFileno(EbrFile* fp);
+FILE* EbrNativeFILE(EbrFile* fp);
+void EbrClearerr(EbrFile* fp);
+EbrFile* EbrFreopen(const char* filename, const char* mode, EbrFile* cur);
+
+int EbrFsetpos(EbrFile* fp, __int64* pos);
+int EbrFgetpos(EbrFile* fp, __int64* pos);

--- a/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
+++ b/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
@@ -164,26 +164,16 @@ public:
             const void* data = NULL;
             bool freeData = false;
             int len = 0;
+            StrongId<NSData> fileData;
 
             switch (img->_imgType) {
                 case CGImageTypePNG: {
                     CGPNGImageBacking* pngImg = (CGPNGImageBacking*)img->Backing();
 
                     if (pngImg->_fileName) {
-                        EbrFile* fpIn;
-                        fpIn = EbrFopen(pngImg->_fileName, "rb");
-                        if (!fpIn) {
-                            FAIL_FAST();
-                        }
-                        EbrFseek(fpIn, 0, SEEK_END);
-                        int fileLen = EbrFtell(fpIn);
-                        EbrFseek(fpIn, 0, SEEK_SET);
-                        void* pngData = (void*)IwMalloc(fileLen);
-                        len = EbrFread(pngData, 1, fileLen, fpIn);
-                        EbrFclose(fpIn);
-
-                        data = pngData;
-                        freeData = true;
+                        fileData.attach([[NSData alloc] initWithContentsOfFile:[NSString stringWithUTF8String:pngImg->_fileName]]);
+                        data = [fileData bytes];
+                        len = [fileData length];
                     } else {
                         data = [(NSData*)pngImg->_data bytes];
                         len = [(NSData*)pngImg->_data length];
@@ -194,20 +184,9 @@ public:
                     CGJPEGImageBacking* jpgImg = (CGJPEGImageBacking*)img->Backing();
 
                     if (jpgImg->_fileName) {
-                        EbrFile* fpIn;
-                        fpIn = EbrFopen(jpgImg->_fileName, "rb");
-                        if (!fpIn) {
-                            FAIL_FAST();
-                        }
-                        EbrFseek(fpIn, 0, SEEK_END);
-                        int fileLen = EbrFtell(fpIn);
-                        EbrFseek(fpIn, 0, SEEK_SET);
-                        void* imgData = (void*)IwMalloc(fileLen);
-                        len = EbrFread(imgData, 1, fileLen, fpIn);
-                        EbrFclose(fpIn);
-
-                        data = imgData;
-                        freeData = true;
+                        fileData.attach([[NSData alloc] initWithContentsOfFile:[NSString stringWithUTF8String:jpgImg->_fileName]]);
+                        data = [fileData bytes];
+                        len = [fileData length];
                     } else {
                         data = [(NSData*)jpgImg->_data bytes];
                         len = [(NSData*)jpgImg->_data length];
@@ -218,9 +197,6 @@ public:
                     break;
             }
             _xamlImage = CreateBitmapFromImageData(data, len);
-            if (freeData) {
-                IwFree((void*)data);
-            }
             return;
         }
         lockPtr = NULL;

--- a/Frameworks/UIKit/UIPasteboard.mm
+++ b/Frameworks/UIKit/UIPasteboard.mm
@@ -283,28 +283,17 @@ WADDataPackageView* _getClipboardContent() {
 
     if (img->_imgType == CGImageTypePNG || img->_imgType == CGImageTypeJPEG) {
         const void* data = NULL;
-        bool freeData = false;
         int len = 0;
+        StrongId<NSData> fileData;
 
         switch (img->_imgType) {
             case CGImageTypePNG: {
                 CGPNGImageBacking* pngImg = (CGPNGImageBacking*)img->Backing();
 
                 if (pngImg->_fileName) {
-                    EbrFile* fpIn;
-                    fpIn = EbrFopen(pngImg->_fileName, "rb");
-                    if (!fpIn) {
-                        FAIL_FAST();
-                    }
-                    EbrFseek(fpIn, 0, SEEK_END);
-                    int fileLen = EbrFtell(fpIn);
-                    EbrFseek(fpIn, 0, SEEK_SET);
-                    void* pngData = (void*)IwMalloc(fileLen);
-                    len = EbrFread(pngData, 1, fileLen, fpIn);
-                    EbrFclose(fpIn);
-
-                    data = pngData;
-                    freeData = true;
+                    fileData.attach([[NSData alloc] initWithContentsOfFile:[NSString stringWithUTF8String:pngImg->_fileName]]);
+                    data = [fileData bytes];
+                    len = [fileData length];
                 } else {
                     data = [(NSData*)pngImg->_data bytes];
                     len = [(NSData*)pngImg->_data length];
@@ -315,20 +304,9 @@ WADDataPackageView* _getClipboardContent() {
                 CGJPEGImageBacking* jpgImg = (CGJPEGImageBacking*)img->Backing();
 
                 if (jpgImg->_fileName) {
-                    EbrFile* fpIn;
-                    fpIn = EbrFopen(jpgImg->_fileName, "rb");
-                    if (!fpIn) {
-                        FAIL_FAST();
-                    }
-                    EbrFseek(fpIn, 0, SEEK_END);
-                    int fileLen = EbrFtell(fpIn);
-                    EbrFseek(fpIn, 0, SEEK_SET);
-                    void* imgData = (void*)IwMalloc(fileLen);
-                    len = EbrFread(imgData, 1, fileLen, fpIn);
-                    EbrFclose(fpIn);
-
-                    data = imgData;
-                    freeData = true;
+                    fileData.attach([[NSData alloc] initWithContentsOfFile:[NSString stringWithUTF8String:jpgImg->_fileName]]);
+                    data = [fileData bytes];
+                    len = [fileData length];
                 } else {
                     data = [(NSData*)jpgImg->_data bytes];
                     len = [(NSData*)jpgImg->_data length];
@@ -341,9 +319,6 @@ WADDataPackageView* _getClipboardContent() {
 
         WSSInMemoryRandomAccessStream* stream = [[WSSInMemoryRandomAccessStream make] autorelease];
         [UIPasteboard _populateStream:stream withData:data withLength:len];
-        if (freeData) {
-            IwFree((void*)data);
-        }
         return stream;
     }
     return nil;

--- a/Frameworks/include/CGDiscardableImage.h
+++ b/Frameworks/include/CGDiscardableImage.h
@@ -75,10 +75,10 @@ public:
 
 class ImageDataStreamFile : public ImageDataStream {
 private:
-    EbrFile* fpIn;
+    StrongId<NSInputStream> _inputStream;
 
 public:
-    ImageDataStreamFile(EbrFile* in);
+    ImageDataStreamFile(NSInputStream* inStream);
     int readData(void* in, int len);
     ~ImageDataStreamFile();
 };

--- a/Frameworks/include/Platform/EbrPlatform.h
+++ b/Frameworks/include/Platform/EbrPlatform.h
@@ -28,85 +28,12 @@ struct EbrTimeval {
     unsigned int tv_usec; /* and microseconds */
 };
 
-enum EbrFileType { EbrFileTypeUnknown, EbrFileTypeIO, EbrFileTypeSocket, EbrFileTypeVirtual, EbrFileTypeZipAsset };
-
-class SB_EXPORT_CLASS EbrFile {
-public:
-    int idx;
-    EbrFileType type;
-
-    EbrFile();
-    virtual ~EbrFile();
-
-    virtual int Close();
-    virtual size_t Read(void* dest, size_t elem, size_t count);
-    virtual size_t Write(const void* dest, size_t elem, size_t count);
-    virtual int Seek(long offset, int origin);
-    virtual int Seek64(__int64 offset, int origin);
-    virtual size_t Tell();
-    virtual int Eof();
-    virtual int Putc(int c);
-    virtual int Rewind();
-    virtual int Error();
-    virtual int Getc();
-    virtual int Ungetc(int val);
-    virtual char* Gets(char* dest, size_t size);
-    virtual int Puts(const char* str);
-    virtual void Clearerr();
-    virtual int Flush();
-    virtual int Setpos(__int64* pos);
-    virtual int Getpos(__int64* pos);
-
-    virtual int HostFd();
-    virtual int Stat(struct stat* ret);
-    virtual int Stat64i32(struct _stat64i32* ret);
-    virtual int Read(void* dest, size_t count);
-    virtual int Write(const void* src, size_t count);
-    virtual int Lseek(__int64 pos, int whence);
-    virtual int Truncate(off_t size);
-    virtual int Truncate64(__int64 size);
-    virtual int Dup();
-
-    virtual void* Mmap(void* addr, size_t size, uint32_t prot, uint32_t flags, uint32_t offset);
-    virtual int Munmap(void* addr, size_t size);
-
-    virtual intptr_t GetOSFHandle();
-};
-
-SB_EXPORT EbrFile* EbrAllocFile(EbrFile* ioInterface);
-SB_EXPORT void EbrFreeFile(EbrFile* pFile);
-SB_EXPORT EbrFile* EbrFileFromFd(int fd);
-SB_EXPORT EbrFileType EbrFileGetType(EbrFile* pFile);
-
 struct stat;
 
-SB_EXPORT EbrFile* EbrFmake(FILE* fp);
-SB_EXPORT EbrFile* EbrFopen(const char* filename, const char* mode);
-SB_EXPORT EbrFile* EbrFdopen(int handle, const char* mode);
-SB_EXPORT int EbrFclose(EbrFile* file);
-SB_EXPORT size_t EbrFread(void* dest, size_t elem, size_t count, EbrFile* file);
-SB_EXPORT size_t EbrFwrite(const void* dest, size_t elem, size_t count, EbrFile* file);
-SB_EXPORT int EbrFseek(EbrFile* fp, long offset, int origin);
-SB_EXPORT int EbrFseek64(EbrFile* fp, __int64 offset, int origin);
-SB_EXPORT size_t EbrFtell(EbrFile* fp);
-SB_EXPORT int EbrFeof(EbrFile* fp);
 SB_EXPORT int EbrStat(const char* filename, struct stat* ret);
 SB_EXPORT int EbrStat64i32(const char* filename, struct _stat64i32* st);
-SB_EXPORT int EbrFputc(int c, EbrFile* fp);
 SB_EXPORT int EbrAccess(const char* file, int mode);
-SB_EXPORT int EbrRewind(EbrFile* fp);
-SB_EXPORT int EbrFerror(EbrFile* fp);
-SB_EXPORT int EbrFgetc(EbrFile* fp);
-SB_EXPORT int EbrUngetc(int val, EbrFile* fp);
-SB_EXPORT char* EbrFgets(char* dest, size_t size, EbrFile* fp);
-SB_EXPORT int EbrFputs(const char* str, EbrFile* fp);
-SB_EXPORT int EbrFileno(EbrFile* fp);
-SB_EXPORT FILE* EbrNativeFILE(EbrFile* fp);
-SB_EXPORT void EbrClearerr(EbrFile* fp);
-SB_EXPORT EbrFile* EbrFreopen(const char* filename, const char* mode, EbrFile* cur);
-SB_EXPORT int EbrFflush(EbrFile* fp);
-SB_EXPORT int EbrFsetpos(EbrFile* fp, __int64* pos);
-SB_EXPORT int EbrFgetpos(EbrFile* fp, __int64* pos);
+SB_EXPORT int EbrFflush(int fd);
 
 SB_EXPORT int EbrOpen(const char* file, int mode, int share);
 SB_EXPORT int EbrOpenWithPermission(const char* file, int mode, int share, int pmode);

--- a/build/Starboard/dll/Starboard.def
+++ b/build/Starboard/dll/Starboard.def
@@ -136,39 +136,13 @@ LIBRARY Starboard
         EbrDecrement
         EbrCompareExchange
         EbrSleep
-        EbrAllocFile
-        EbrFreeFile
-        EbrFileFromFd
-        EbrFileGetType
-        EbrFmake
-        EbrFopen
-        EbrFdopen
-        EbrFclose
-        EbrFread
-        EbrFwrite
-        EbrFseek
-        EbrFseek64
-        EbrFtell
-        EbrFeof
         EbrStat
         EbrStat64i32
         EbrTell
         EbrGetOSFHandle
         EbrFputc
         EbrAccess
-        EbrRewind
-        EbrFerror
-        EbrFgetc
-        EbrUngetc
-        EbrFputs
-        EbrFputs
-        EbrFileno
-        EbrNativeFILE
-        EbrClearerr
-        EbrFreopen
         EbrFflush
-        EbrFsetpos
-        EbrFgetpos
         EbrOpen
         EbrOpenWithPermission
         EbrClose

--- a/build/Tests/UnitTests/Foundation.WindowsOnly/Foundation.WindowsOnly.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Foundation.WindowsOnly/Foundation.WindowsOnly.UnitTests.vcxproj
@@ -25,6 +25,9 @@
     <ProjectReference Include="..\..\..\Logging\dll\Logging.vcxproj">
       <Project>{862D36C2-CC83-4D04-B9B8-BEF07F479905}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\CFNetwork\dll\CFNetwork.vcxproj">
+      <Project>{16E0E9AE-8B17-4C4A-9960-BF90FB9F3424}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\CoreFoundation\dll\CoreFoundation.vcxproj">
       <Project>{81F30AF6-EAC3-4DFA-929A-C25D69E8080B}</Project>
     </ProjectReference>

--- a/include/StarboardExport.h
+++ b/include/StarboardExport.h
@@ -17,18 +17,11 @@
 
 #ifndef SB_IMPEXP
 #define SB_IMPEXP __declspec(dllimport)
-#define SB_IMPEXP_CLASS __declspec(dllimport)
-#else
-// This is used only by the EbrFile class, and new uses should not be added.
-// In general, C++ classes should not be exported, and EbrFile is tolerated
-// only for legacy reasons.
-#define SB_IMPEXP_CLASS __declspec(dllexport)
 #endif
 
 #ifndef SB_EXPORT
 #ifdef __cplusplus
 #define SB_EXPORT extern "C" SB_IMPEXP
-#define SB_EXPORT_CLASS SB_IMPEXP_CLASS
 #else
 #define SB_EXPORT extern SB_IMPEXP
 #endif

--- a/tests/functionaltests/Tests/NSURLConnection.mm
+++ b/tests/functionaltests/Tests/NSURLConnection.mm
@@ -99,7 +99,7 @@ TEST(NSURLConnection, RequestWithURL) {
     // Wait for data.
     if (![connectionTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for connection timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for connection timed out!");
     }
 
     // Give some time for all delegates to be called.

--- a/tests/functionaltests/Tests/NSURLSession.mm
+++ b/tests/functionaltests/Tests/NSURLSession.mm
@@ -168,7 +168,7 @@ TEST(NSURLSession, DataTaskWithURL) {
     // Wait for data.
     if (![dataTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for connection timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for connection timed out!");
     }
 
     // Give some time for all delegates to be called.
@@ -228,7 +228,7 @@ TEST(NSURLSession, DataTaskWithURL_Failure) {
     // Wait for data.
     if (![dataTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for connection timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for connection timed out!");
     }
 
     // Give some time for all delegates to be called.
@@ -290,7 +290,7 @@ TEST(NSURLSession, DataTaskWithURL_WithCompletionHandler) {
     // Wait for data.
     if (![condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for connection timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for connection timed out!");
     }
 
     // Make sure we received a response.
@@ -339,7 +339,7 @@ TEST(NSURLSession, DataTaskWithURL_WithCompletionHandler_Failure) {
     // Wait for data.
     if (![condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for connection timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for connection timed out!");
     }
 
     // Make sure we received a response.
@@ -507,7 +507,7 @@ TEST(NSURLSession, DownloadTaskWithURL) {
     if (![downloadTaskTestHelper.conditionDownloadComplete
             waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testDownloadTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for download timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for download timed out!");
     }
 
     // Give some time for all delegates to be called.
@@ -554,7 +554,7 @@ TEST(NSURLSession, DownloadTaskWithURL_Failure) {
     if (![downloadTaskTestHelper.conditionDownloadComplete
             waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testDownloadTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for download timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for download timed out!");
     }
 
     // Give some time for all delegates to be called.
@@ -608,7 +608,7 @@ TEST(NSURLSession, DownloadTaskWithURL_WithCompletionHandler) {
     // Wait for download to complete.
     if (![condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testDownloadTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for download timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for download timed out!");
     }
 
     // Make sure we get a download location.
@@ -633,7 +633,7 @@ TEST(NSURLSession, DownloadTaskWithURL_WithCancelResume) {
     // Wait for first delegate to be arrive.
     if (![downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for download timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for download timed out!");
     }
 
     // Make sure the download started.
@@ -672,7 +672,7 @@ TEST(NSURLSession, DownloadTaskWithURL_WithCancelResume) {
     // Wait for the task to be cancelled.
     if (![conditionCancelled waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for download timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for download timed out!");
     }
 
     // Make sure download has stopped.
@@ -694,7 +694,7 @@ TEST(NSURLSession, DownloadTaskWithURL_WithCancelResume) {
     // Wait for resume delegate.
     if (![downloadTaskTestHelper.conditionDownloadResumed waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]]) {
         // Wait timed out.
-        ASSERT_FALSE_MSG(false, "FAILED: Waiting for download resume timed out!");
+        ASSERT_FALSE_MSG(true, "FAILED: Waiting for download resume timed out!");
     }
 
     LOG_INFO("Download resumed");

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -52,21 +52,7 @@ static NSString* getPathForFile(const wchar_t* fileName) {
 static NSData* getDataFromImageFile(const wchar_t* imageFilename) {
     NSString* testFileFullPath = getPathForFile(imageFilename);
 
-    EbrFile* fp = EbrFopen([testFileFullPath UTF8String], "rb");
-    if (!fp) {
-        return nil;
-    }
-
-    EbrFseek(fp, 0, SEEK_END);
-    size_t length = EbrFtell(fp);
-    char* byteData = (char*)IwMalloc(length);
-    EbrFseek(fp, 0, SEEK_SET);
-    size_t newLen = EbrFread(byteData, sizeof(char), length, fp);
-    EbrFclose(fp);
-
-    NSData* imgData = [NSData dataWithBytes:(const void*)byteData length:length];
-    IwFree(byteData);
-    return imgData;
+    return [NSData dataWithContentsOfFile:testFileFullPath];
 }
 
 static CFURLRef getURLRefFromFilename(const wchar_t* filename) {
@@ -76,7 +62,7 @@ static CFURLRef getURLRefFromFilename(const wchar_t* filename) {
 
 static CFURLRef getURLRefForOutFile(const wchar_t* filename) {
     NSString* testFileFullPath = getPathForFile(filename);
-    EbrRemove([testFileFullPath UTF8String]);
+    [[NSFileManager defaultManager] removeItemAtPath:testFileFullPath error:nil];
     return (CFURLRef)[NSURL fileURLWithPath:testFileFullPath];
 }
 
@@ -1230,12 +1216,12 @@ TEST(ImageIO, DestinationOptionsTest) {
     int loopCount = 15;
     float delayTime = 0.5;
     NSDictionary* gifEncodeOptions = @{
-        (id)kCGImagePropertyGIFLoopCount : [NSNumber numberWithInt:loopCount],
-        (id)kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:delayTime],
+        (id) kCGImagePropertyGIFLoopCount : [NSNumber numberWithInt:loopCount], (id)
+        kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:delayTime],
     };
 
     NSDictionary* encodeDictionary = @{
-        (id)kCGImagePropertyGIFDictionary : gifEncodeOptions,
+        (id) kCGImagePropertyGIFDictionary : gifEncodeOptions,
     };
 
     myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeGIF, 3, NULL);
@@ -1311,39 +1297,39 @@ TEST(ImageIO, DestinationImageOptionsTIFFTest) {
     CFURLRef imgUrl = getURLRefFromFilename(outFile);
 
     NSDictionary* gpsOptions = @{
-        (id)kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55],
-        (id)kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0],
-        (id)kCGImagePropertyGPSLatitudeRef : @"N",
-        (id)kCGImagePropertyGPSLongitudeRef : @"W",
-        (id)kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25],
-        (id)kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1],
-        (id)kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4],
-        (id)kCGImagePropertyGPSImgDirectionRef : @"test",
-        (id)kCGImagePropertyGPSTimeStamp : @"04:30:51.71",
-        (id)kCGImagePropertyGPSVersion : @"2.2.0.0",
+        (id) kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55], (id)
+        kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0], (id)
+        kCGImagePropertyGPSLatitudeRef : @"N", (id)
+        kCGImagePropertyGPSLongitudeRef : @"W", (id)
+        kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25], (id)
+        kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1], (id)
+        kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4], (id)
+        kCGImagePropertyGPSImgDirectionRef : @"test", (id)
+        kCGImagePropertyGPSTimeStamp : @"04:30:51.71", (id)
+        kCGImagePropertyGPSVersion : @"2.2.0.0",
     };
 
     NSDictionary* exifOptions = @{
-        (id)kCGImagePropertyExifUserComment : @"Test2",
-        (id)kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
+        (id) kCGImagePropertyExifUserComment : @"Test2", (id)
+        kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
     };
 
     NSDictionary* tiffOptions = @{
-        (id)kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100],
-        (id)kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120],
-        (id)kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
+        (id) kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100], (id)
+        kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120], (id)
+        kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
     };
 
     int orientation = 3;
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id)kCGImagePropertyGPSDictionary : gpsOptions,
-        (id)kCGImagePropertyOrientation : encodeOrientation,
-        (id)kCGImagePropertyExifDictionary : exifOptions,
-        (id)kCGImagePropertyTIFFDictionary : tiffOptions,
-        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
-        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id) kCGImagePropertyGPSDictionary : gpsOptions, (id)
+        kCGImagePropertyOrientation : encodeOrientation, (id)
+        kCGImagePropertyExifDictionary : exifOptions, (id)
+        kCGImagePropertyTIFFDictionary : tiffOptions, (id)
+        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
+        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeTIFF, 1, NULL);
@@ -1398,39 +1384,39 @@ TEST(ImageIO, DestinationImageOptionsJPEGTest) {
     CFURLRef imgUrl = getURLRefFromFilename(outFile);
 
     NSDictionary* gpsOptions = @{
-        (id)kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55],
-        (id)kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0],
-        (id)kCGImagePropertyGPSLatitudeRef : @"N",
-        (id)kCGImagePropertyGPSLongitudeRef : @"W",
-        (id)kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25],
-        (id)kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1],
-        (id)kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4],
-        (id)kCGImagePropertyGPSImgDirectionRef : @"test",
-        (id)kCGImagePropertyGPSTimeStamp : @"04:30:51.71",
-        (id)kCGImagePropertyGPSVersion : @"2.2.0.0",
+        (id) kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55], (id)
+        kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0], (id)
+        kCGImagePropertyGPSLatitudeRef : @"N", (id)
+        kCGImagePropertyGPSLongitudeRef : @"W", (id)
+        kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25], (id)
+        kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1], (id)
+        kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4], (id)
+        kCGImagePropertyGPSImgDirectionRef : @"test", (id)
+        kCGImagePropertyGPSTimeStamp : @"04:30:51.71", (id)
+        kCGImagePropertyGPSVersion : @"2.2.0.0",
     };
 
     NSDictionary* exifOptions = @{
-        (id)kCGImagePropertyExifUserComment : @"Test2",
-        (id)kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
+        (id) kCGImagePropertyExifUserComment : @"Test2", (id)
+        kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
     };
 
     NSDictionary* tiffOptions = @{
-        (id)kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100],
-        (id)kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120],
-        (id)kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
+        (id) kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100], (id)
+        kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120], (id)
+        kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
     };
 
     int orientation = 2;
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id)kCGImagePropertyGPSDictionary : gpsOptions,
-        (id)kCGImagePropertyOrientation : encodeOrientation,
-        (id)kCGImagePropertyExifDictionary : exifOptions,
-        (id)kCGImagePropertyTIFFDictionary : tiffOptions,
-        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
-        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id) kCGImagePropertyGPSDictionary : gpsOptions, (id)
+        kCGImagePropertyOrientation : encodeOrientation, (id)
+        kCGImagePropertyExifDictionary : exifOptions, (id)
+        kCGImagePropertyTIFFDictionary : tiffOptions, (id)
+        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
+        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeJPEG, 1, NULL);
@@ -1484,17 +1470,17 @@ TEST(ImageIO, DestinationImageOptionsGIFTest) {
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
     NSDictionary* gifOptions = @{
-        (id)kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:0.05],
+        (id) kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:0.05],
     };
 
     int orientation = 2;
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id)kCGImagePropertyOrientation : encodeOrientation,
-        (id)kCGImagePropertyGIFDictionary : gifOptions,
-        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
-        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id) kCGImagePropertyOrientation : encodeOrientation, (id)
+        kCGImagePropertyGIFDictionary : gifOptions, (id)
+        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
+        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeGIF, 1, NULL);
@@ -1540,17 +1526,17 @@ TEST(ImageIO, DestinationImageOptionsPNGTest) {
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
     NSDictionary* pngOtions = @{
-        (id)kCGImagePropertyPNGGamma : [NSNumber numberWithInt:45045],
+        (id) kCGImagePropertyPNGGamma : [NSNumber numberWithInt:45045],
     };
 
     int orientation = 2;
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id)kCGImagePropertyOrientation : encodeOrientation,
-        (id)kCGImagePropertyPNGDictionary : pngOtions,
-        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
-        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id) kCGImagePropertyOrientation : encodeOrientation, (id)
+        kCGImagePropertyPNGDictionary : pngOtions, (id)
+        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
+        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypePNG, 1, NULL);

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -1311,7 +1311,7 @@ TEST(ImageIO, DestinationImageOptionsTIFFTest) {
 
     NSDictionary* exifOptions = @{
         (id)kCGImagePropertyExifUserComment : @"Test2",
-        (id)kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],uble:12.34],
+        (id)kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
     };
 
     NSDictionary* tiffOptions = @{
@@ -1534,7 +1534,7 @@ TEST(ImageIO, DestinationImageOptionsPNGTest) {
 
     NSDictionary* encodeOptions = @{
         (id)kCGImagePropertyOrientation : encodeOrientation,
-        (id)kCGImagePropertyGIFDictionary : gifOptions,
+        (id)kCGImagePropertyGIFDictionary : pngOtions,
         (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
         (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -1216,8 +1216,8 @@ TEST(ImageIO, DestinationOptionsTest) {
     int loopCount = 15;
     float delayTime = 0.5;
     NSDictionary* gifEncodeOptions = @{
-        (id) kCGImagePropertyGIFLoopCount : [NSNumber numberWithInt:loopCount], (id)
-        kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:delayTime],
+        (id)kCGImagePropertyGIFLoopCount : [NSNumber numberWithInt:loopCount],
+        (id)kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:delayTime],
     };
 
     NSDictionary* encodeDictionary = @{
@@ -1297,39 +1297,39 @@ TEST(ImageIO, DestinationImageOptionsTIFFTest) {
     CFURLRef imgUrl = getURLRefFromFilename(outFile);
 
     NSDictionary* gpsOptions = @{
-        (id) kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55], (id)
-        kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0], (id)
-        kCGImagePropertyGPSLatitudeRef : @"N", (id)
-        kCGImagePropertyGPSLongitudeRef : @"W", (id)
-        kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25], (id)
-        kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1], (id)
-        kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4], (id)
-        kCGImagePropertyGPSImgDirectionRef : @"test", (id)
-        kCGImagePropertyGPSTimeStamp : @"04:30:51.71", (id)
-        kCGImagePropertyGPSVersion : @"2.2.0.0",
+        (id)kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55],
+        (id)kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0],
+        (id)kCGImagePropertyGPSLatitudeRef : @"N",
+        (id)kCGImagePropertyGPSLongitudeRef : @"W",
+        (id)kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25],
+        (id)kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1],
+        (id)kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4],
+        (id)kCGImagePropertyGPSImgDirectionRef : @"test",
+        (id)kCGImagePropertyGPSTimeStamp : @"04:30:51.71",
+        (id)kCGImagePropertyGPSVersion : @"2.2.0.0",
     };
 
     NSDictionary* exifOptions = @{
-        (id) kCGImagePropertyExifUserComment : @"Test2", (id)
-        kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
+        (id)kCGImagePropertyExifUserComment : @"Test2",
+        (id)kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],uble:12.34],
     };
 
     NSDictionary* tiffOptions = @{
-        (id) kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100], (id)
-        kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120], (id)
-        kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
+        (id)kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100],
+        (id)kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120],
+        (id)kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
     };
 
     int orientation = 3;
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id) kCGImagePropertyGPSDictionary : gpsOptions, (id)
-        kCGImagePropertyOrientation : encodeOrientation, (id)
-        kCGImagePropertyExifDictionary : exifOptions, (id)
-        kCGImagePropertyTIFFDictionary : tiffOptions, (id)
-        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
-        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id)kCGImagePropertyGPSDictionary : gpsOptions,
+        (id)kCGImagePropertyOrientation : encodeOrientation,
+        (id)kCGImagePropertyExifDictionary : exifOptions,
+        (id)kCGImagePropertyTIFFDictionary : tiffOptions,
+        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
+        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeTIFF, 1, NULL);
@@ -1384,39 +1384,39 @@ TEST(ImageIO, DestinationImageOptionsJPEGTest) {
     CFURLRef imgUrl = getURLRefFromFilename(outFile);
 
     NSDictionary* gpsOptions = @{
-        (id) kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55], (id)
-        kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0], (id)
-        kCGImagePropertyGPSLatitudeRef : @"N", (id)
-        kCGImagePropertyGPSLongitudeRef : @"W", (id)
-        kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25], (id)
-        kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1], (id)
-        kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4], (id)
-        kCGImagePropertyGPSImgDirectionRef : @"test", (id)
-        kCGImagePropertyGPSTimeStamp : @"04:30:51.71", (id)
-        kCGImagePropertyGPSVersion : @"2.2.0.0",
+        (id)kCGImagePropertyGPSLatitude : [NSNumber numberWithDouble:100.55],
+        (id)kCGImagePropertyGPSLongitude : [NSNumber numberWithDouble:200.0],
+        (id)kCGImagePropertyGPSLatitudeRef : @"N",
+        (id)kCGImagePropertyGPSLongitudeRef : @"W",
+        (id)kCGImagePropertyGPSAltitude : [NSNumber numberWithDouble:150.25],
+        (id)kCGImagePropertyGPSAltitudeRef : [NSNumber numberWithShort:1],
+        (id)kCGImagePropertyGPSImgDirection : [NSNumber numberWithFloat:2.4],
+        (id)kCGImagePropertyGPSImgDirectionRef : @"test",
+        (id)kCGImagePropertyGPSTimeStamp : @"04:30:51.71",
+        (id)kCGImagePropertyGPSVersion : @"2.2.0.0",
     };
 
     NSDictionary* exifOptions = @{
-        (id) kCGImagePropertyExifUserComment : @"Test2", (id)
-        kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
+        (id)kCGImagePropertyExifUserComment : @"Test2",
+        (id)kCGImagePropertyExifExposureTime : [NSNumber numberWithDouble:12.34],
     };
 
     NSDictionary* tiffOptions = @{
-        (id) kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100], (id)
-        kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120], (id)
-        kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
+        (id)kCGImagePropertyTIFFXResolution : [NSNumber numberWithDouble:100],
+        (id)kCGImagePropertyTIFFYResolution : [NSNumber numberWithDouble:120],
+        (id)kCGImagePropertyTIFFResolutionUnit : [NSNumber numberWithInt:1],
     };
 
     int orientation = 2;
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id) kCGImagePropertyGPSDictionary : gpsOptions, (id)
-        kCGImagePropertyOrientation : encodeOrientation, (id)
-        kCGImagePropertyExifDictionary : exifOptions, (id)
-        kCGImagePropertyTIFFDictionary : tiffOptions, (id)
-        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
-        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id)kCGImagePropertyGPSDictionary : gpsOptions,
+        (id)kCGImagePropertyOrientation : encodeOrientation,
+        (id)kCGImagePropertyExifDictionary : exifOptions,
+        (id)kCGImagePropertyTIFFDictionary : tiffOptions,
+        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
+        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeJPEG, 1, NULL);
@@ -1477,10 +1477,10 @@ TEST(ImageIO, DestinationImageOptionsGIFTest) {
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id) kCGImagePropertyOrientation : encodeOrientation, (id)
-        kCGImagePropertyGIFDictionary : gifOptions, (id)
-        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
-        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id)kCGImagePropertyOrientation : encodeOrientation,
+        (id)kCGImagePropertyGIFDictionary : gifOptions,
+        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
+        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypeGIF, 1, NULL);
@@ -1533,10 +1533,10 @@ TEST(ImageIO, DestinationImageOptionsPNGTest) {
     NSNumber* encodeOrientation = [NSNumber numberWithInt:orientation];
 
     NSDictionary* encodeOptions = @{
-        (id) kCGImagePropertyOrientation : encodeOrientation, (id)
-        kCGImagePropertyPNGDictionary : pngOtions, (id)
-        kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000], (id)
-        kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
+        (id)kCGImagePropertyOrientation : encodeOrientation,
+        (id)kCGImagePropertyGIFDictionary : gifOptions,
+        (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
+        (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };
 
     CGImageDestinationRef myImageDest = CGImageDestinationCreateWithURL(imgUrl, kUTTypePNG, 1, NULL);

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -1526,7 +1526,7 @@ TEST(ImageIO, DestinationImageOptionsPNGTest) {
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
     NSDictionary* pngOtions = @{
-        (id) kCGImagePropertyPNGGamma : [NSNumber numberWithInt:45045],
+        (id)kCGImagePropertyPNGGamma : [NSNumber numberWithInt:45045],
     };
 
     int orientation = 2;
@@ -1534,7 +1534,7 @@ TEST(ImageIO, DestinationImageOptionsPNGTest) {
 
     NSDictionary* encodeOptions = @{
         (id)kCGImagePropertyOrientation : encodeOrientation,
-        (id)kCGImagePropertyGIFDictionary : pngOtions,
+        (id)kCGImagePropertyPNGDictionary : pngOtions,
         (id)kCGImagePropertyDPIWidth : [NSNumber numberWithDouble:1000],
         (id)kCGImagePropertyDPIHeight : [NSNumber numberWithDouble:200],
     };


### PR DESCRIPTION
Consolidate uses of Ebr file functions to only where absolutely needed. This helps abstract any weird semantics we have to only a few locations and uses well defined APIs for foundation constructs like NSData and NSStream where possible.