### PR TITLE
Handle empty lines, background drawing, and multicolor lines

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -1242,3 +1242,7 @@ bool CGContextIsPointInPath(CGContextRef c, bool eoFill, CGFloat x, CGFloat y) {
 void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun) {
     ctx->Backing()->CGContextDrawGlyphRun(glyphRun);
 }
+// TODO 1077:: Remove once D2D render target is implemented
+void _CGContextSetScaleFactor(CGContextRef ctx, float scale) {
+    ctx->Backing()->_CGContextSetScaleFactor(scale);
+}

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2016,8 +2016,7 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     CGFloat verticalScalingFactor = sqrt((transform.b * transform.b) + (transform.d * transform.d));
     // TODO::
     // Issue #1057 - CG today talks in Pixels but DirectWrite and D2D only understand DIPs. Because CG talks in Pixels,
-    // curState->curTransform contains both the device scaling factor and any user scale applied to it causing the below D2D render
-    // target
+    // curState->curTransform contains both the device scaling factor and any user scale applied to it causing the below D2D render target
     // transform calculation to be way off on devices that have scaling. Workaround for now is to divide the verticalScalingFactor and
     // height here with the device scaling factor so they get converted to DIPs and then apply the transform to the D2D render target.
     // Though this workaround is sufficient to get text rendered on the user screen on all Windows form factor devices, this will not

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2027,9 +2027,6 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 
     transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor) - height);
 
-    const float dpi = _scale * 96.0f;
-    imgRenderTarget->SetDpi(dpi, dpi);
-
     const float inverseScale = 1.0f / _scale;
     transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale( inverseScale, inverseScale));
 
@@ -2050,4 +2047,6 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 // TODO 1077:: Remove once D2D render target is implemented
 void CGContextCairo::_CGContextSetScaleFactor(CGFloat scale) {
     _scale = scale;
+    const float dpi = _scale * 96.0f;
+    _imgDest->Backing()->GetRenderTarget()->SetDpi(dpi, dpi);
 }

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2016,15 +2016,20 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     CGFloat verticalScalingFactor = sqrt((transform.b * transform.b) + (transform.d * transform.d));
     // TODO::
     // Issue #1057 - CG today talks in Pixels but DirectWrite and D2D only understand DIPs. Because CG talks in Pixels,
-    // curState->curTransform contains both the device scaling factor and any user scale applied to it causing the below D2D render target
+    // curState->curTransform contains both the device scaling factor and any user scale applied to it causing the below D2D render
+    // target
     // transform calculation to be way off on devices that have scaling. Workaround for now is to divide the verticalScalingFactor and
     // height here with the device scaling factor so they get converted to DIPs and then apply the transform to the D2D render target.
-    // Though this workaround is sufficient to get text rendered on the user screen on all Windows form factor devices, this will not work
-    // when text is rendered on a PDF or printer.
-    static float hostDisplayScale = static_cast<float>([[WGDDisplayInformation getForCurrentView] resolutionScale] / 100.0f);
-    verticalScalingFactor /= hostDisplayScale;
-    height /= hostDisplayScale;
+    // Though this workaround is sufficient to get text rendered on the user screen on all Windows form factor devices, this will not
+    // work when text is rendered on a PDF or printer.
+    verticalScalingFactor /= _scale;
+    height /= _scale;
+
     transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor) - height);
+
+    imgRenderTarget->SetDpi(_scale * 96.0f, _scale * 96.0f);
+    transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale( 1.0f / _scale, 1.0f / _scale));
+
     // Perform anti-clockwise rotation required to match the reference platform.
     imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, transform.c, transform.d, transform.tx, transform.ty));
 
@@ -2037,4 +2042,9 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
                                   DWRITE_MEASURING_MODE_NATURAL);
 
     THROW_IF_FAILED(imgRenderTarget->EndDraw());
+}
+
+// TODO 1077:: Remove once D2D render target is implemented
+void CGContextCairo::_CGContextSetScaleFactor(CGFloat scale) {
+    _scale = scale;
 }

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2027,8 +2027,11 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 
     transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor) - height);
 
-    imgRenderTarget->SetDpi(_scale * 96.0f, _scale * 96.0f);
-    transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale( 1.0f / _scale, 1.0f / _scale));
+    const float dpi = _scale * 96.0f;
+    imgRenderTarget->SetDpi(dpi, dpi);
+
+    const float inverseScale = 1.0f / _scale;
+    transform = CGAffineTransformConcat(transform, CGAffineTransformMakeScale( inverseScale, inverseScale));
 
     // Perform anti-clockwise rotation required to match the reference platform.
     imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, transform.c, transform.d, transform.tx, transform.ty));

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -790,3 +790,7 @@ CGPathRef CGContextImpl::CGContextCopyPath(void) {
 
 void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 }
+
+// TODO 1077:: Remove once D2D render target is implemented
+void CGContextImpl::_CGContextSetScaleFactor(float scale) {
+}

--- a/Frameworks/CoreText/DWriteWrapper.mm
+++ b/Frameworks/CoreText/DWriteWrapper.mm
@@ -279,7 +279,7 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(_CTTypesetter* ts, CFR
     //  These can be done using the DWrite IDWriteTextFormat range property methods.
 
     // Used to separate runs for attributes which DWrite does not handle until drawing (e.g. Foreground Color)
-    uint32_t incompatableAttributeFlag = 0;
+    uint32_t incompatibleAttributeFlag = 0;
 
     NSRange attributeRange;
     for (size_t i = 0; i < [ts->_attributedString length]; i += attributeRange.length) {
@@ -289,11 +289,6 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(_CTTypesetter* ts, CFR
 
         const DWRITE_TEXT_RANGE dwriteRange = { attributeRange.location, attributeRange.length };
 
-        ComPtr<IDWriteTypography> typography;
-        THROW_IF_FAILED(textLayout->GetTypography(dwriteRange.startPosition, &typography));
-        if (!typography.Get()) {
-            THROW_IF_FAILED(dwriteFactory->CreateTypography(&typography));
-        }
 
         CTFontRef font = static_cast<CTFontRef>([attribs objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
         CGFloat fontSize = kCTFontSystemFontSize;
@@ -312,6 +307,12 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(_CTTypesetter* ts, CFR
             THROW_IF_FAILED(textLayout->SetFontStretch(stretch, dwriteRange));
             THROW_IF_FAILED(textLayout->SetFontStyle(style, dwriteRange));
             THROW_IF_FAILED(textLayout->SetFontFamilyName(familyName.data(), dwriteRange));
+        }
+
+        ComPtr<IDWriteTypography> typography;
+        THROW_IF_FAILED(textLayout->GetTypography(dwriteRange.startPosition, &typography));
+        if (!typography.Get()) {
+            THROW_IF_FAILED(dwriteFactory->CreateTypography(&typography));
         }
 
         CFNumberRef extraKerningRef = static_cast<CFNumberRef>([attribs objectForKey:static_cast<NSString*>(kCTKernAttributeName)]);
@@ -334,7 +335,7 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(_CTTypesetter* ts, CFR
 
         // Forces run breaks without interfering with any layout features
         // Necessary for attributes which DWrite does not support during layout (e.g. Color)
-        THROW_IF_FAILED(typography->AddFontFeature({ DWRITE_FONT_FEATURE_TAG_DEFAULT, ++incompatableAttributeFlag }));
+        THROW_IF_FAILED(typography->AddFontFeature({ DWRITE_FONT_FEATURE_TAG_DEFAULT, ++incompatibleAttributeFlag }));
         THROW_IF_FAILED(textLayout->SetTypography(typography.Get(), dwriteRange));
     }
     return textLayout;

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -624,6 +624,9 @@ CGContextRef CreateLayerContentsBitmapContext32(int width, int height) {
         }
         if (priv->contentsScale != 1.0f) {
             CGContextScaleCTM(drawContext, priv->contentsScale, priv->contentsScale);
+
+            // TODO 1077:: Remove once D2D render target is implemented
+            _CGContextSetScaleFactor(drawContext, priv->contentsScale);
         }
 
         CGContextScaleCTM(drawContext, 1.0f, -1.0f);

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -141,5 +141,5 @@ public:
     virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
 
     // TODO 1077:: Remove once D2D render target is implemented
-    virtual void CGContextCairo::_CGContextSetScaleFactor(float scale);
+    virtual void _CGContextSetScaleFactor(float scale);
 };

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -35,6 +35,9 @@ private:
     void _cairoImageSurfaceBlur(cairo_surface_t* surface);
     void _cairoContextStrokePathShadow();
 
+    // TODO 1077:: Remove once D2D render target is implemented
+    float _scale = 1.0f;
+
 protected:
     cairo_t* _drawContext;
 
@@ -136,4 +139,7 @@ public:
     virtual CGPathRef CGContextCopyPath(void);
 
     virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
+
+    // TODO 1077:: Remove once D2D render target is implemented
+    virtual void CGContextCairo::_CGContextSetScaleFactor(float scale);
 };

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -180,6 +180,9 @@ public:
     virtual CGPathRef CGContextCopyPath(void);
 
     virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
+
+    // TODO 1077:: Remove once D2D render target is implemented
+    virtual void _CGContextSetScaleFactor(float scale);
 };
 
 #define LOCK_CAIRO() pthread_mutex_lock(&_cairoLock);

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -52,6 +52,9 @@ COREGRAPHICS_EXPORT bool CGContextIsPointInPath(CGContextRef c, bool eoFill, flo
 
 COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun);
 
+// TODO 1077:: Remove once D2D render target is implemented
+COREGRAPHICS_EXPORT void _CGContextSetScaleFactor(CGContextRef ctx, float scale);
+
 class __CGContext : private objc_object {
 public:
     float scale;

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -219,6 +219,7 @@ LIBRARY CoreGraphics
         CGContextGetBacking
         CGContextDrawGlyphRun
         EbrCenterTextInRectVertically
+        _CGContextSetScaleFactor
 
         ; CGDataConsumer.mm
         CGDataConsumerCreate

--- a/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
@@ -144,7 +144,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libdispatch.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -166,7 +166,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libdispatch.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -192,7 +192,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libdispatch.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -218,7 +218,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libdispatch.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
@@ -84,7 +84,7 @@ static const CFRange c_visibleRange = CFRangeMake(1, 5);
     CTRunRef run = static_cast<CTRunRef>(CFArrayGetValueAtIndex(runs, 0));
 
     // Flips y-axis for our frame
-    CGContextSetTextPosition(context, 0.0, 10.0);
+    CGContextSetTextPosition(context, 0.0, 0.0);
     CTRunDraw(run, context, c_visibleRange);
 
     // Creates outline

--- a/tests/unittests/CoreText/CTFramesetterTests.mm
+++ b/tests/unittests/CoreText/CTFramesetterTests.mm
@@ -92,3 +92,15 @@ TEST(CTFramesetter, SuggestFrameSizeWithConstraints) {
     EXPECT_EQ(0, fitRange.location);
     EXPECT_LT(fitRange.length, 4);
 }
+
+TEST(CTFramesetter, ShouldNotThrowWhenCreatingFrameWithEmptyLines) {
+    CFAttributedStringRef string = (__bridge CFAttributedStringRef)getAttributedString(@"TEST\n \n\n\t\nTEST");
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(string);
+    CFAutorelease(framesetter);
+    CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, FLT_MAX, FLT_MAX), nullptr);
+    CTFrameRef frame = nil;
+    EXPECT_NO_THROW(frame = CTFramesetterCreateFrame(framesetter, {}, path, nullptr));
+    EXPECT_EQ(5L, CFArrayGetCount(CTFrameGetLines(frame)));
+    CFRelease(frame);
+    CGPathRelease(path);
+} 


### PR DESCRIPTION
Handle edge case where a line is made up of white space, fix bug where trying to call CTRunDraw on a background thread would crash, and fix regression of not being able to have multiple colors in the same line.  

Fixes #1130, #1109, and #1171