### PR TITLE
Fix incorrect math surrounding text transforms in CGContextDrawGlyphRun

### DIFF
--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2011,7 +2011,32 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     // We need some special handling in transform as CoreText in iOS renders from bottom left but DWrite on Windows does top left.
     //     1. Scaling - to handle scaling once text has been scaled, apply translation to the scaled height
     //     2. Rotation - CoreText rotates text anti-clockwise but DWrite performs clockwise rotation
-    CGAffineTransform transform = CGAffineTransformConcat(curState->curTransform, curState->curTextMatrix);
+    CGAffineTransform transform = CGAffineTransformIdentity;
+
+    // Apply the text transformation (text position, text matrix) in text space rather than user space
+    // This means flipping the coordinate system,
+    // and applying the transformation about the center of the glyph run rather than about the baseline
+    // Flip and translate by the difference between the center and the baseline, apply text transforms, then flip and translate back
+    DWRITE_FONT_METRICS fontMetrics;
+    glyphRun->fontFace->GetMetrics(&fontMetrics);
+    float baselineCenterDelta = (fontMetrics.ascent - fontMetrics.descent) * glyphRun->fontEmSize / fontMetrics.designUnitsPerEm / 2;
+
+    // Transform to text space
+    // Technically there should be a horizontal translation to the center as well,
+    // but it's to the center of _each individual glyph_, as the reference platform applies the text matrix to each glyph individually
+    // Uncertain whether it's ever going to be worth it to support this using DWrite, so just ignore it for now
+    transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, baselineCenterDelta), transform);
+
+    // Apply text transforms
+    transform = CGAffineTransformConcat(curState->curTextMatrix, transform);
+    transform = CGAffineTransformTranslate(transform, curState->curTextPosition.x, curState->curTextPosition.y);
+
+    // Undo transform to text space
+    transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, -baselineCenterDelta), transform);
+
+    // Apply the context CTM
+    transform = CGAffineTransformConcat(curState->curTransform, transform);
+
     // Perform translation required to handle scaling.
     CGFloat verticalScalingFactor = sqrt((transform.b * transform.b) + (transform.d * transform.d));
     // TODO::
@@ -2024,17 +2049,15 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     static float hostDisplayScale = static_cast<float>([[WGDDisplayInformation getForCurrentView] resolutionScale] / 100.0f);
     verticalScalingFactor /= hostDisplayScale;
     height /= hostDisplayScale;
-    transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor) - height);
+    transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor));
+
     // Perform anti-clockwise rotation required to match the reference platform.
     imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, transform.c, transform.d, transform.tx, transform.ty));
 
     // Draw the glyph using ID2D1RenderTarget
     ComPtr<ID2D1SolidColorBrush> brush;
     THROW_IF_FAILED(imgRenderTarget->CreateSolidColorBrush(brushColor, &brush));
-    imgRenderTarget->DrawGlyphRun(D2D1::Point2F(curState->curTextPosition.x, curState->curTextPosition.y),
-                                  glyphRun,
-                                  brush.Get(),
-                                  DWRITE_MEASURING_MODE_NATURAL);
+    imgRenderTarget->DrawGlyphRun(D2D1::Point2F(0, 0), glyphRun, brush.Get(), DWRITE_MEASURING_MODE_NATURAL);
 
     THROW_IF_FAILED(imgRenderTarget->EndDraw());
 }

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2011,7 +2011,6 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     // We need some special handling in transform as CoreText in iOS renders from bottom left but DWrite on Windows does top left.
     //     1. Scaling - to handle scaling once text has been scaled, apply translation to the scaled height
     //     2. Rotation - CoreText rotates text anti-clockwise but DWrite performs clockwise rotation
-    CGAffineTransform transform = CGAffineTransformIdentity;
 
     // Apply the text transformation (text position, text matrix) in text space rather than user space
     // This means flipping the coordinate system,
@@ -2025,7 +2024,7 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     // Technically there should be a horizontal translation to the center as well,
     // but it's to the center of _each individual glyph_, as the reference platform applies the text matrix to each glyph individually
     // Uncertain whether it's ever going to be worth it to support this using DWrite, so just ignore it for now
-    transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, baselineCenterDelta), transform);
+    CGAffineTransform transform = CGAffineTransformMake(1, 0, 0, -1, 0, baselineCenterDelta);
 
     // Apply text transforms
     transform = CGAffineTransformConcat(curState->curTextMatrix, transform);


### PR DESCRIPTION
The text transforms were being incorrectly applied, directly concatenated onto the final transform.
The text transform must be applied in text space (centered on the glyph run, inverted)

Fixes #1113
Fixes #1135