### PR TITLE
Undo merge error in CT-DW

### DIFF
--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -1996,8 +1996,6 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 
     CGContextStrokePath();
 
-    float height = _imgDest->Backing()->Height();
-
     ID2D1RenderTarget* imgRenderTarget = _imgDest->Backing()->GetRenderTarget();
     THROW_NS_IF_NULL(E_UNEXPECTED, imgRenderTarget);
 
@@ -2038,14 +2036,7 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 
     // Perform translation required to handle scaling.
     CGFloat verticalScalingFactor = sqrt((transform.b * transform.b) + (transform.d * transform.d));
-    // TODO::
-    // Issue #1057 - CG today talks in Pixels but DirectWrite and D2D only understand DIPs. Because CG talks in Pixels,
-    // curState->curTransform contains both the device scaling factor and any user scale applied to it causing the below D2D render target
-    // transform calculation to be way off on devices that have scaling. Workaround for now is to divide the verticalScalingFactor and
-    // height here with the device scaling factor so they get converted to DIPs and then apply the transform to the D2D render target.
-
-    // Though this workaround is sufficient to get text rendered on the user screen on all Windows form factor devices, this will not
-    // work when text is rendered on a PDF or printer.
+    float height = _imgDest->Backing()->Height();
     transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor));
 
     // Perform anti-clockwise rotation required to match the reference platform.

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -2046,12 +2046,6 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 
     // Though this workaround is sufficient to get text rendered on the user screen on all Windows form factor devices, this will not
     // work when text is rendered on a PDF or printer.
-    verticalScalingFactor /= _scale;
-    height /= _scale;
-
-    transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor) - height);
-
-    const float inverseScale = 1.0f / _scale;
     transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor));
 
     // Perform anti-clockwise rotation required to match the reference platform.


### PR DESCRIPTION
When merging on top of most recent CT-DW changes I accidentally left a copy of the old transform code in.  