### PR TITLE
Make CTFrameDraw from top left origin

### DIFF
--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -75,7 +75,7 @@ CFRange CTFrameGetVisibleStringRange(CTFrameRef frame) {
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 CGPathRef CTFrameGetPath(CTFrameRef frame) {
@@ -128,6 +128,9 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         }
 
         CGContextRestoreGState(ctx);
+
+        // Restoring GState should not return text matrix to original value
+        CGContextSetTextMatrix(ctx, textMatrix);
     }
 }
 

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -18,6 +18,7 @@
 #import <StubReturn.h>
 
 #import "CoreTextInternal.h"
+#import "CGPathInternal.h"
 
 const CFStringRef kCTFrameProgressionAttributeName = static_cast<CFStringRef>(@"kCTFrameProgressionAttributeName");
 const CFStringRef kCTFramePathFillRuleAttributeName = static_cast<CFStringRef>(@"kCTFramePathFillRuleAttributeName");
@@ -78,8 +79,7 @@ CFRange CTFrameGetVisibleStringRange(CTFrameRef frame) {
  @Notes
 */
 CGPathRef CTFrameGetPath(CTFrameRef frame) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return frame ? static_cast<_CTFrame*>(frame)->_path.get() : nil;
 }
 
 /**
@@ -111,16 +111,23 @@ void CTFrameGetLineOrigins(CTFrameRef frameRef, CFRange range, CGPoint origins[]
 /**
  @Status Interoperable
 */
-void CTFrameDraw(CTFrameRef frame, CGContextRef ctx) {
-    uint32_t count = [((_CTFrame*)frame)->_lines count];
-    CGPoint curTextPos = CGContextGetTextPosition(ctx);
+void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
+    _CTFrame* frame = static_cast<_CTFrame*>(frameRef);
     if (frame && ctx) {
-        CGPoint curTextPos = CGContextGetTextPosition(ctx);
-        for (_CTLine* line in static_cast<id<NSFastEnumeration>>(static_cast<_CTFrame*>(frame)->_lines)) {
-            CGPoint newPos = curTextPos + line->_lineOrigin;
-            CGContextSetTextPosition(ctx, newPos.x, newPos.y);
+        // Need to invert and translate coordinates so frame draws from top-left
+        CGContextSaveGState(ctx);
+        CGRect boundingRect;
+        _CGPathGetBoundingBoxInternal(frame->_path.get(), &boundingRect);
+        CGContextTranslateCTM(ctx, 0, boundingRect.size.height);
+        CGAffineTransform textMatrix = CGContextGetTextMatrix(ctx);
+        CGContextSetTextMatrix(ctx, CGAffineTransformScale(textMatrix, 1.0f, -1.0f));
+        CGContextScaleCTM(ctx, 1.0f, -1.0f);
+        for (_CTLine* line in static_cast<id<NSFastEnumeration>>(frame->_lines)) {
+            CGContextSetTextPosition(ctx, line->_lineOrigin.x, line->_lineOrigin.y);
             _CTLineDraw(static_cast<CTLineRef>(line), ctx, false);
         }
+
+        CGContextRestoreGState(ctx);
     }
 }
 

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -119,17 +119,19 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         CGRect boundingRect;
         _CGPathGetBoundingBoxInternal(frame->_path.get(), &boundingRect);
         CGContextTranslateCTM(ctx, 0, boundingRect.size.height);
+
+        // Invert Text Matrix so glyphs are drawn in correct orientation
         CGAffineTransform textMatrix = CGContextGetTextMatrix(ctx);
         CGContextSetTextMatrix(ctx, CGAffineTransformScale(textMatrix, 1.0f, -1.0f));
         CGContextScaleCTM(ctx, 1.0f, -1.0f);
+
         for (_CTLine* line in static_cast<id<NSFastEnumeration>>(frame->_lines)) {
             CGContextSetTextPosition(ctx, line->_lineOrigin.x, line->_lineOrigin.y);
             _CTLineDraw(static_cast<CTLineRef>(line), ctx, false);
         }
 
+        // Restore CTM and Text Matrix to values before we modified them
         CGContextRestoreGState(ctx);
-
-        // Restoring GState should not return text matrix to original value
         CGContextSetTextMatrix(ctx, textMatrix);
     }
 }

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -63,6 +63,7 @@ CTFrameRef CTFramesetterCreateFrame(CTFramesetterRef framesetter, CFRange string
     _CGPathGetBoundingBoxInternal(path, &frameSize);
 
     _CTFrame* ret = __CreateFrame(static_cast<_CTFramesetter*>(framesetter), frameSize, stringRange);
+    ret->_path.reset(CGPathRetain(path));
 
     return static_cast<CTFrameRef>(ret);
 }

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -91,6 +91,7 @@ inline void _SafeRelease(T** p) {
 @public
     StrongId<_CTFramesetter> _framesetter;
     CGRect _frameRect;
+    woc::unique_cf<CGPathRef> _path;
     std::vector<CGPoint> _lineOrigins;
     StrongId<NSMutableArray<_CTLine*>> _lines;
 }

--- a/include/CoreText/CTFrame.h
+++ b/include/CoreText/CTFrame.h
@@ -40,7 +40,7 @@ CORETEXT_EXPORT const CFStringRef kCTFramePathClippingPathAttributeName;
 
 CORETEXT_EXPORT CFRange CTFrameGetStringRange(CTFrameRef frame);
 CORETEXT_EXPORT CFRange CTFrameGetVisibleStringRange(CTFrameRef frame);
-CORETEXT_EXPORT CGPathRef CTFrameGetPath(CTFrameRef frame) STUB_METHOD;
+CORETEXT_EXPORT CGPathRef CTFrameGetPath(CTFrameRef frame);
 CORETEXT_EXPORT CFDictionaryRef CTFrameGetFrameAttributes(CTFrameRef frame) STUB_METHOD;
 CORETEXT_EXPORT CFArrayRef CTFrameGetLines(CTFrameRef frame);
 CORETEXT_EXPORT void CTFrameGetLineOrigins(CTFrameRef frame, CFRange range, CGPoint origins[]);

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFrameTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFrameTestViewController.mm
@@ -243,7 +243,7 @@
                                                                     CTFrameGetVisibleStringRange(frame).length],
                                          width / 2)];
 
-    ADD_UNIMPLEMENTED(_lineCells, @"CTFrameGetPath", width / 2);
+    [_lineCells addObject:createTextCell(@"CTFrameGetPath", [NSString stringWithFormat:@"%@", CTFrameGetPath(frame)], width / 2)];
     ADD_UNIMPLEMENTED(_lineCells, @"CTFrameGetFrameAttributes", width / 2);
     ADD_UNIMPLEMENTED(_lineCells, @"CTFrameGetTypeID", width / 2);
 

--- a/tests/unittests/CoreText/CTFrameTests.mm
+++ b/tests/unittests/CoreText/CTFrameTests.mm
@@ -183,3 +183,20 @@ TEST(CTFrame, GetLineOrigins) {
 
     CGPathRelease(path);
 }
+
+TEST(CTFrame, GetPath) {
+    EXPECT_EQ(nil, CTFrameGetPath(nil));
+
+    CFAttributedStringRef string = (__bridge CFAttributedStringRef)getAttributedString(@"TEST");
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(string);
+    CGMutablePathRef path = CGPathCreateMutable();
+    CGPathAddRect(path, NULL, CGRectMake(0, 0, 60, 300));
+    CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);
+    CFAutorelease(framesetter);
+    CFAutorelease(frame);
+
+    EXPECT_EQ(path, CTFrameGetPath(frame));
+
+    CGPathRelease(path);
+    EXPECT_NE(nil, CTFrameGetPath(frame));
+}


### PR DESCRIPTION
CoreText draws from the bottom left, so CTFrameDraw needs to translate and flip the context to draw from the top left.  To fix this we needed the path, so CTFrameGetPath was implemented incidentally.