### PR TITLE
Fix drawing of line with multiple fonts

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -60,7 +60,7 @@ __CGContext::__CGContext(CGImageRef pDest) {
 #ifdef DEBUG_CONTEXT_COUNT
     TraceVerbose(TAG, L"contextCount: %d", contextCount);
 #endif
-    object_setClass((id) this, [CGNSContext class]);
+    object_setClass((id)this, [CGNSContext class]);
     scale = 1.0f;
     _backing = pDest->Backing()->CreateDrawingContext(this);
 }
@@ -1239,8 +1239,8 @@ bool CGContextIsPointInPath(CGContextRef c, bool eoFill, CGFloat x, CGFloat y) {
     return c->Backing()->CGContextIsPointInPath(eoFill, x, y);
 }
 
-void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun) {
-    ctx->Backing()->CGContextDrawGlyphRun(glyphRun);
+void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineHeight) {
+    ctx->Backing()->CGContextDrawGlyphRun(glyphRun, lineHeight);
 }
 // TODO 1077:: Remove once D2D render target is implemented
 void _CGContextSetScaleFactor(CGContextRef ctx, float scale) {

--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -1239,8 +1239,8 @@ bool CGContextIsPointInPath(CGContextRef c, bool eoFill, CGFloat x, CGFloat y) {
     return c->Backing()->CGContextIsPointInPath(eoFill, x, y);
 }
 
-void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineHeight) {
-    ctx->Backing()->CGContextDrawGlyphRun(glyphRun, lineHeight);
+void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineAscent) {
+    ctx->Backing()->CGContextDrawGlyphRun(glyphRun, lineAscent);
 }
 // TODO 1077:: Remove once D2D render target is implemented
 void _CGContextSetScaleFactor(CGContextRef ctx, float scale) {

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -1991,7 +1991,7 @@ CGPathRef CGContextCairo::CGContextCopyPath(void) {
  *
  * @parameter glyphRun DWRITE_GLYPH_RUN object to render
  */
-void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight) {
+void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent) {
     ObtainLock();
 
     CGContextStrokePath();
@@ -2019,14 +2019,14 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, flo
     // Technically there should be a horizontal translation to the center as well,
     // but it's to the center of _each individual glyph_, as the reference platform applies the text matrix to each glyph individually
     // Uncertain whether it's ever going to be worth it to support this using DWrite, so just ignore it for now
-    CGAffineTransform transform = CGAffineTransformMake(1, 0, 0, -1, 0, lineHeight / 2.0f);
+    CGAffineTransform transform = CGAffineTransformMake(1, 0, 0, -1, 0, lineAscent / 2.0f);
 
     // Apply text transforms
     transform = CGAffineTransformConcat(curState->curTextMatrix, transform);
     transform = CGAffineTransformTranslate(transform, curState->curTextPosition.x, curState->curTextPosition.y);
 
     // Undo transform to text space
-    transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, -lineHeight / 2.0f), transform);
+    transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, -lineAscent / 2.0f), transform);
 
     // Apply the context CTM
     transform = CGAffineTransformConcat(curState->curTransform, transform);

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -788,7 +788,7 @@ CGPathRef CGContextImpl::CGContextCopyPath(void) {
     return NULL;
 }
 
-void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight) {
+void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent) {
 }
 
 // TODO 1077:: Remove once D2D render target is implemented

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -788,7 +788,7 @@ CGPathRef CGContextImpl::CGContextCopyPath(void) {
     return NULL;
 }
 
-void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
+void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight) {
 }
 
 // TODO 1077:: Remove once D2D render target is implemented

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -240,7 +240,10 @@ void _CTLineDraw(CTLineRef lineRef, CGContextRef ctx, bool adjustTextPosition) {
             CGContextSetTextPosition(ctx, curTextPos.x + curRun->_relativeXOffset, curTextPos.y);
         }
 
-        _CTRunDraw(static_cast<CTRunRef>(curRun), ctx, CFRange{}, false);
+        // Get height of the line so we draw with the correct baseline for each run
+        CGFloat ascent, descent;
+        CTLineGetTypographicBounds(lineRef, &ascent, &descent, nullptr);
+        _CTRunDraw(static_cast<CTRunRef>(curRun), ctx, CFRange{}, false, ascent - descent);
     }
 }
 

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -241,9 +241,9 @@ void _CTLineDraw(CTLineRef lineRef, CGContextRef ctx, bool adjustTextPosition) {
         }
 
         // Get height of the line so we draw with the correct baseline for each run
-        CGFloat ascent, descent;
-        CTLineGetTypographicBounds(lineRef, &ascent, &descent, nullptr);
-        _CTRunDraw(static_cast<CTRunRef>(curRun), ctx, CFRange{}, false, ascent - descent);
+        CGFloat ascent;
+        CTLineGetTypographicBounds(lineRef, &ascent, nullptr, nullptr);
+        _CTRunDraw(static_cast<CTRunRef>(curRun), ctx, CFRange{}, false, ascent);
     }
 }
 

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -263,7 +263,7 @@ CGRect CTRunGetImageBounds(CTRunRef run, CGContextRef context, CFRange range) {
     return StubReturn();
 }
 
-void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineHeight) {
+void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineAscent) {
     _CTRun* curRun = static_cast<_CTRun*>(run);
     if (!curRun || textRange.length < 0L || textRange.location < 0L ||
         textRange.location + textRange.length > curRun->_dwriteGlyphRun.glyphCount) {
@@ -289,7 +289,7 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
 
     if (textRange.location == 0L && (textRange.length == 0L || textRange.length == curRun->_dwriteGlyphRun.glyphCount)) {
         // Print the whole glyph run
-        CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun, lineHeight);
+        CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun, lineAscent);
     } else {
         if (textRange.length == 0L) {
             textRange.length = curRun->_dwriteGlyphRun.glyphCount - textRange.location;
@@ -297,7 +297,7 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
 
         // Only print glyphs in range
         DWRITE_GLYPH_RUN runInRange = __GetGlyphRunForDrawingInRange(curRun->_dwriteGlyphRun, textRange);
-        CGContextDrawGlyphRun(ctx, &runInRange, lineHeight);
+        CGContextDrawGlyphRun(ctx, &runInRange, lineAscent);
     }
 }
 
@@ -307,9 +307,9 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
 */
 void CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange) {
     if (run && ctx) {
-        CGFloat ascent, descent;
-        CTRunGetTypographicBounds(run, {}, &ascent, &descent, nullptr);
-        _CTRunDraw(run, ctx, textRange, true, ascent - descent);
+        CGFloat ascent;
+        CTRunGetTypographicBounds(run, {}, &ascent, nullptr, nullptr);
+        _CTRunDraw(run, ctx, textRange, true, ascent);
     }
 }
 

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -138,7 +138,7 @@ public:
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 
-    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
+    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight);
 
     // TODO 1077:: Remove once D2D render target is implemented
     virtual void _CGContextSetScaleFactor(float scale);

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -138,7 +138,7 @@ public:
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 
-    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight);
+    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent);
 
     // TODO 1077:: Remove once D2D render target is implemented
     virtual void _CGContextSetScaleFactor(float scale);

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -179,7 +179,7 @@ public:
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 
-    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
+    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight);
 
     // TODO 1077:: Remove once D2D render target is implemented
     virtual void _CGContextSetScaleFactor(float scale);

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -179,7 +179,7 @@ public:
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 
-    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineHeight);
+    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent);
 
     // TODO 1077:: Remove once D2D render target is implemented
     virtual void _CGContextSetScaleFactor(float scale);

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -50,7 +50,7 @@ COREGRAPHICS_EXPORT CGImageRef CGJPEGImageCreateFromFile(NSString* path);
 COREGRAPHICS_EXPORT CGImageRef CGJPEGImageCreateFromData(NSData* data);
 COREGRAPHICS_EXPORT bool CGContextIsPointInPath(CGContextRef c, bool eoFill, float x, float y);
 
-COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineHeight);
+COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineAscent);
 
 // TODO 1077:: Remove once D2D render target is implemented
 COREGRAPHICS_EXPORT void _CGContextSetScaleFactor(CGContextRef ctx, float scale);

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -50,7 +50,7 @@ COREGRAPHICS_EXPORT CGImageRef CGJPEGImageCreateFromFile(NSString* path);
 COREGRAPHICS_EXPORT CGImageRef CGJPEGImageCreateFromData(NSData* data);
 COREGRAPHICS_EXPORT bool CGContextIsPointInPath(CGContextRef c, bool eoFill, float x, float y);
 
-COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun);
+COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineHeight);
 
 // TODO 1077:: Remove once D2D render target is implemented
 COREGRAPHICS_EXPORT void _CGContextSetScaleFactor(CGContextRef ctx, float scale);

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -151,5 +151,5 @@ CORETEXT_EXPORT CFIndex _CTTypesetterSuggestLineBreakWithOffsetAndCallback(
 // Note: For some reason namemangling does not happen for these functions causing a linker error. Bug??
 CORETEXT_EXTERNC_BEGIN
 void _CTLineDraw(CTLineRef line, CGContextRef ctx, bool adjustTextPosition);
-void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition);
+void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineHeight);
 CORETEXT_EXTERNC_END

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -151,5 +151,5 @@ CORETEXT_EXPORT CFIndex _CTTypesetterSuggestLineBreakWithOffsetAndCallback(
 // Note: For some reason namemangling does not happen for these functions causing a linker error. Bug??
 CORETEXT_EXTERNC_BEGIN
 void _CTLineDraw(CTLineRef line, CGContextRef ctx, bool adjustTextPosition);
-void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineHeight);
+void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineAscent);
 CORETEXT_EXTERNC_END


### PR DESCRIPTION
When we flip the coordinate system to draw for CoreText we need to know the height of the entire line or we will end up with runs with different baselines based upon their respective fonts.