### PR TITLE
Use surface format to pick the wic bitmap format for render target

### DIFF
--- a/Frameworks/CoreGraphics/CGBitmapImage.mm
+++ b/Frameworks/CoreGraphics/CGBitmapImage.mm
@@ -454,7 +454,7 @@ int CGBitmapImageBacking::BitsPerComponent() {
 ID2D1RenderTarget* CGBitmapImageBacking::GetRenderTarget() {
     if (_renderTarget == nullptr) {
         BYTE* imageData = static_cast<BYTE*>(LockImageData());
-        ComPtr<IWICBitmap> wicBitmap = Make<CGIWICBitmap>(this, GUID_WICPixelFormat32bppPBGRA);
+        ComPtr<IWICBitmap> wicBitmap = Make<CGIWICBitmap>(this, SurfaceFormat());
         ComPtr<ID2D1Factory> d2dFactory;
         THROW_IF_FAILED(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory), &d2dFactory));
         ComPtr<ID2D1RenderTarget> renderTarget;

--- a/Frameworks/CoreGraphics/CGGraphicBufferImage.mm
+++ b/Frameworks/CoreGraphics/CGGraphicBufferImage.mm
@@ -158,7 +158,7 @@ int CGGraphicBufferImageBacking::BitsPerComponent() {
 ID2D1RenderTarget* CGGraphicBufferImageBacking::GetRenderTarget() {
     if (_renderTarget == nullptr) {
         BYTE* imageData = static_cast<BYTE*>(LockImageData());
-        ComPtr<IWICBitmap> wicBitmap = Make<CGIWICBitmap>(this, GUID_WICPixelFormat32bppPBGRA);
+        ComPtr<IWICBitmap> wicBitmap = Make<CGIWICBitmap>(this, SurfaceFormat());
         ComPtr<ID2D1Factory> d2dFactory;
         THROW_IF_FAILED(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory), &d2dFactory));
         ComPtr<ID2D1RenderTarget> renderTarget;

--- a/Frameworks/include/CGIWICBitmap.h
+++ b/Frameworks/include/CGIWICBitmap.h
@@ -72,10 +72,31 @@ private:
     BYTE* m_dataBuffer;
 };
 
+inline WICPixelFormatGUID SurfaceFormatToWICPixelFormat(__CGSurfaceFormat format) {
+    switch (format) {
+        case _ColorABGR:
+        case _ColorXBGR:
+            // XBGR is not supported by wic bitmap render target
+            return GUID_WICPixelFormat32bppPRGBA;
+        case _ColorARGB:
+            return GUID_WICPixelFormat32bppPBGRA;
+        case _ColorBGRX:
+        case _ColorBGR:
+            return GUID_WICPixelFormat32bppBGR;
+        case _ColorGrayscale:
+        case _ColorA8:
+            return GUID_WICPixelFormat8bppAlpha;
+        default:
+            break;
+    }
+    // our default format is alpha premultiplied BGRA
+    return GUID_WICPixelFormat32bppPBGRA;
+}
+
 class CGIWICBitmap : public RuntimeClass<RuntimeClassFlags<RuntimeClassType::ClassicCom>, IAgileObject, FtmBase, IWICBitmap> {
 public:
-    CGIWICBitmap(_In_ CGImageBacking* imageBacking, _In_ WICPixelFormatGUID pixelFormat)
-        : m_imageBacking(imageBacking), m_pixelFormat(pixelFormat) {
+    CGIWICBitmap(_In_ CGImageBacking* imageBacking, _In_ __CGSurfaceFormat format)
+        : m_imageBacking(imageBacking), m_pixelFormat(SurfaceFormatToWICPixelFormat(format)) {
     }
 
     // IWICBitmap interface

--- a/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
@@ -34,6 +34,9 @@
     <ProjectReference Include="..\..\..\CoreGraphics\dll\CoreGraphics.vcxproj">
       <Project>{26da08da-d0b9-4579-b168-e7f0a5f20e57}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\CoreText\dll\CoreText.vcxproj">
+        <Project>{36deec5d-f77b-4c94-a63c-86fb716833de}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\AutoLayout\dll\AutoLayout.vcxproj">
       <Project>{D036FDB1-F82C-40C7-B1B4-65F499EAE116}</Project>
     </ProjectReference>

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -66,3 +66,104 @@ TEST(CGBitmapContext, BitmapInfoAPIs_Gray) {
     CGColorSpaceRelease(grayColorSpace);
     CGContextRelease(context);
 }
+
+void _DrawText(CGContextRef context, NSString* text, const CGRect bounds) {
+    // Aligns origin for our frame
+    CGContextTranslateCTM(context, 0.0f, bounds.size.height);
+
+    // Flips y-axis for our frame
+    CGContextScaleCTM(context, 1.0f, -1.0f);
+
+    // Creates path with current rectangle
+    CGMutablePathRef path = CGPathCreateMutable();
+    CGPathAddRect(path, NULL, bounds);
+
+    CTFontRef myCFFont = CTFontCreateWithName((__bridge CFStringRef) @"Arial", 10, NULL);
+    CFAutorelease(myCFFont);
+
+    // Make dictionary for attributed string with font, color, and alignment
+    NSDictionary* attributesDict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)myCFFont,
+                                                                              (id)kCTFontAttributeName,
+                                                                              kCFBooleanTrue,
+                                                                              (id)kCTForegroundColorFromContextAttributeName,
+                                                                              nil];
+
+    CFAttributedStringRef attrString =
+        CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)text, (__bridge CFDictionaryRef)attributesDict);
+    CFAutorelease(attrString);
+
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(attrString);
+    CFAutorelease(framesetter);
+
+    // Creates frame for framesetter with current attributed string
+    CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);
+    CFAutorelease(frame);
+
+    // Draws the text in the frame
+    CTFrameDraw(frame, context);
+}
+
+// we will create a 10x10 bitmap context and :
+// 1. Fill context with R=0.0, G=0.0, B=0.5, A=1.
+// data buffer in little endian format: R = 0, G=0, B > 0, A = FF
+// 2. Set R=1, G=0.5, B=0, A=1.0
+// Draw "||" into the buffer
+// The data buffer should contain R > G > B.
+// Due to text aliasing, we won't get the actual values we specify hence this
+
+// The test will break under two circumstances:
+// 1. pixel format breaks due to CG drawing code change (for as long as we use cairo)
+// 2. pixel format breaks due to changes in render target pixel format for bitmap context.
+
+void _TestPixelFormat(const CGRect bounds, const CGBitmapInfo info, DWORD expectedBG, DWORD expectedFG1, DWORD expectedFG2) {
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+
+    const size_t width = bounds.size.width;
+    const size_t height = bounds.size.height;
+    const size_t bytesPerPixel = 4;
+    const size_t bitsPerChannel = 8;
+    const CGFloat color[] = { 1.0, 0.5, 0.0, 1.0 };
+    const CGFloat bgColor[] = { 0.0, 0.0, 0.5, 1.0 };
+
+    woc::unique_iw<uint8_t> data(static_cast<uint8_t*>(IwMalloc(width * height * 4)));
+    CGContextRef context = CGBitmapContextCreate(data.get(),
+                                                 width,
+                                                 height,
+                                                 bitsPerChannel,
+                                                 width * 4, // bytes per row
+                                                 colorSpace,
+                                                 info);
+
+    CGContextSetFillColor(context, bgColor);
+    CGContextFillRect(context, bounds);
+
+    DWORD* pixel = (DWORD*)data.get();
+    EXPECT_EQ(*pixel, expectedBG);
+
+    CGContextSetFillColor(context, color);
+    _DrawText(context, @"||", bounds);
+
+    EXPECT_EQ(*pixel, expectedFG1);
+    pixel++;
+    EXPECT_EQ(*pixel, expectedFG2);
+
+    CGColorSpaceRelease(colorSpace);
+    CGContextRelease(context);
+}
+TEST(CGBitmapContext, VerifyPixelFormatRGBA) {
+    _TestPixelFormat(CGRect{ 0, 0, 10, 10 },
+                     kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast,
+                     0xff800000, // expectedbg
+                     0xff631d3a, // expectedfg1
+                     0xff2759b1 // expectedfg2
+                     );
+}
+
+TEST(CGBitmapContext, VerifyPixelFormatBGRA) {
+    _TestPixelFormat(CGRect{ 0, 0, 10, 10 },
+                     kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedFirst,
+                     0xff000080, // expectedbg
+                     0xff3a1d63, // expectedfg1
+                     0xffb15927 // expectedfg2
+                     );
+}

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -101,6 +101,7 @@ void _DrawText(CGContextRef context, NSString* text, const CGRect bounds) {
 
     // Draws the text in the frame
     CTFrameDraw(frame, context);
+    CGPathRelease(path);
 }
 
 // we will create a 10x10 bitmap context and :


### PR DESCRIPTION
The bitmap render targets we were creating always used same pixel format(GUID_WICPixelFormat32bppPBGRA) regardless of the surface type of the
bitmap context.

This change is to use the surface format as the guide in choosing the
pixel format.  Incidentally, this also fixes other text issues in the
graphics app, where the library was using grayscale context to render
black text.

Fixes #1216