### PR TITLE
Change fonts used in unit tests to even more common ones

### DIFF
--- a/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
+++ b/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
@@ -19,10 +19,6 @@
 #import <CoreGraphics/DWriteWrapper.h>
 
 TEST(DWriteWrapper, FontToFamilyName) {
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Narrow")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Narrow Italic")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Narrow Bold")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Narrow Bold Italic")));
     EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial")));
     EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Italic")));
     EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Bold")));

--- a/tests/unittests/CoreText/CTFontTests.mm
+++ b/tests/unittests/CoreText/CTFontTests.mm
@@ -125,13 +125,13 @@ TEST(CTFont, CopyNameHelpers) {
     EXPECT_OBJCEQ(@"Arial Italic", (id)CFAutorelease(CTFontCopyFullName(font)));
     EXPECT_OBJCEQ(@"Arial Italic", (id)CFAutorelease(CTFontCopyDisplayName(font)));
 
-    font = CTFontCreateWithName(CFSTR("Arial Narrow"), 15.0, NULL);
+    font = CTFontCreateWithName(CFSTR("Courier New Bold Italic"), 15.0, NULL);
     CFAutorelease(font);
 
-    EXPECT_OBJCEQ(@"ArialNarrow", (id)CFAutorelease(CTFontCopyPostScriptName(font)));
-    EXPECT_OBJCEQ(@"Arial Narrow", (id)CFAutorelease(CTFontCopyFamilyName(font)));
-    EXPECT_OBJCEQ(@"Arial Narrow", (id)CFAutorelease(CTFontCopyFullName(font)));
-    EXPECT_OBJCEQ(@"Arial Narrow", (id)CFAutorelease(CTFontCopyDisplayName(font)));
+    EXPECT_OBJCEQ(@"CourierNewPS-BoldItalicMT", (id)CFAutorelease(CTFontCopyPostScriptName(font)));
+    EXPECT_OBJCEQ(@"Courier New", (id)CFAutorelease(CTFontCopyFamilyName(font)));
+    EXPECT_OBJCEQ(@"Courier New Bold Italic", (id)CFAutorelease(CTFontCopyFullName(font)));
+    EXPECT_OBJCEQ(@"Courier New Bold Italic", (id)CFAutorelease(CTFontCopyDisplayName(font)));
 }
 
 TEST(CTFont, Metrics) {

--- a/tests/unittests/UIKit/UIFontTests.mm
+++ b/tests/unittests/UIKit/UIFontTests.mm
@@ -108,8 +108,8 @@ TEST(UIFont, Description) {
 
 TEST(UIFont, Metrics) {
     float size = 22.0f;
-    UIFont* font = [UIFont fontWithName:@"Segoe UI Semibold Italic" size:size];
-    ASSERT_OBJCEQ(@"Segoe UI Semibold Italic", [font fontName]);
+    UIFont* font = [UIFont fontWithName:@"Segoe UI" size:size];
+    ASSERT_OBJCEQ(@"Segoe UI", [font fontName]);
 
     ASSERT_NE(0, [font descender]);
     ASSERT_NE(0, [font ascender]);
@@ -121,7 +121,7 @@ TEST(UIFont, Metrics) {
 
 TEST(UIFont, Bridging) {
     float size = 14.5f;
-    NSString* name = @"Lucida Sans Demibold Italic";
+    NSString* name = @"Times New Roman Bold Italic";
 
     UIFont* uiFont = [UIFont fontWithName:name size:size];
     CTFontRef ctFont = CTFontCreateWithName((__bridge CFStringRef)name, size, nullptr);


### PR DESCRIPTION
Fixes #1231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1234)
<!-- Reviewable:end -->
