### PR TITLE
Fix UIViewController presentedViewController to return a presented view controller

### DIFF
--- a/Frameworks/UIKit/UIViewController.mm
+++ b/Frameworks/UIKit/UIViewController.mm
@@ -2194,11 +2194,13 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
  @Status Interoperable
 */
 - (UIViewController*)presentedViewController {
-    if (priv->_presentedViewController == nil) {
-        return [priv->_parentViewController presentingViewController];
+    if (priv->_presentedViewController) {
+        return priv->_presentedViewController;
+    } else if ([priv->_parentViewController presentedViewController] != self) {
+        return [priv->_parentViewController presentedViewController];
     }
 
-    return priv->_presentingViewController;
+    return nil;
 }
 
 /**


### PR DESCRIPTION
presentedViewController was previously returning a presentingViewController in all cases. Now it returns a presentedViewController.
Fix: #1233.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1247)
<!-- Reviewable:end -->
