### PR TITLE
Fix Sample App with CAF Decoder

### DIFF
--- a/Frameworks/AudioToolbox/CAFDecoder.h
+++ b/Frameworks/AudioToolbox/CAFDecoder.h
@@ -114,9 +114,6 @@ private:
         int64_t mNumberValidFrames;
         int32_t mPrimingFrames;
         int32_t mRemainderFrames;
-
-        uint8_t mPacketDescriptions[1]; // this is a variable length array of
-        // mNumberPackets elements
     } CAFPacketTableHeader;
 
     typedef struct CAFDataChunk { uint32_t mEditCount; } CAFDataChunk;
@@ -142,7 +139,6 @@ private:
     CAFAudioDescription cafDesc;
     CAFPacketTableHeader cafPacketTbl;
 
-    
     ChannelStateList channelStates;
 
 public:


### PR DESCRIPTION
Description:
A recent change regressed the CAF decoder work due to a few small issues.
This change address those as follows:
1. Fixes subscript out of bounds on Debug due to misuse of reserve vs resize
2. Fixes divide by 0 due to incorrect struct size with variable length array.
3. Fixes infinite loop due to issue with setup of number of packets to read. That
code is still incredibly obtuse for whats its doing and should be refactored at a later
point for maintainability.

How verified:
Sample app launches now. There was much rejoicing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1252)
<!-- Reviewable:end -->
