### PR TITLE
Return a default font when a font name cannot be found

### DIFF
--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -395,6 +395,14 @@ HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFon
     // Eg: Bold, Condensed, Light, Italic
     _DWriteFontProperties properties = _DWriteGetFontPropertiesFromName(name);
 
+    // TODO: #1250: Need to be able to load fonts from the app's bundle
+    // For now return a default font to avoid crashes in case of missing fonts
+    // When #1250 is completed, remove this
+    if (!properties.familyName) {
+        name = CFSTR("Segoe UI");
+        properties = _DWriteGetFontPropertiesFromName(name);
+    }
+
     RETURN_HR_IF_NULL(E_INVALIDARG, properties.familyName);
 
     ComPtr<IDWriteFontFamily> fontFamily;

--- a/tests/unittests/CoreText/CTFontTests.mm
+++ b/tests/unittests/CoreText/CTFontTests.mm
@@ -165,7 +165,9 @@ TEST(CTFont, GlyphCount) {
 }
 
 // OSX returns a default font, but iOS returns nullptr
-OSX_DISABLED_TEST(CTFont, UnknownName) {
+// TODO #1250: A default font is currently returned as a short-term fix for another issue
+// Return this test to OSX_DISABLED_TEST when #1250 is completed.
+DISABLED_TEST(CTFont, UnknownName) {
     EXPECT_OBJCEQ(nil, (id)CFAutorelease(CTFontCreateWithName(CFSTR("DoesNotExistFont"), 12.0, NULL)));
 }
 


### PR DESCRIPTION
 - Disabled a related unit test
 - Revert this change when #1250 is finished

Fixes #1251

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1253)
<!-- Reviewable:end -->
