### PR TITLE
Fix scaling and translation text drawing issues

### DIFF
--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -1877,6 +1877,10 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, flo
     float height = _imgDest->Backing()->Height();
     transform = CGAffineTransformTranslate(transform, 0, (height / verticalScalingFactor));
 
+    // TODO 1077:: Remove once D2D render target is implemented
+    // Perform inverse-scaling to return to proper drawing scale
+    transform = CGAffineTransformScale(transform, 1.0f / _scale, 1.0f / _scale);
+
     // Perform anti-clockwise rotation required to match the reference platform.
     imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, transform.c, transform.d, transform.tx, transform.ty));
 

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -122,7 +122,7 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         CGContextScaleCTM(ctx, 1.0f, -1.0f);
 
         for (_CTLine* line in static_cast<id<NSFastEnumeration>>(frame->_lines)) {
-            CGContextSetTextPosition(ctx, line->_lineOrigin.x, line->_lineOrigin.y);
+            CGContextSetTextPosition(ctx, line->_lineOrigin.x, -line->_lineOrigin.y);
             _CTLineDraw(static_cast<CTLineRef>(line), ctx, false);
         }
 

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -221,7 +221,7 @@ void _CTLineDraw(CTLineRef lineRef, CGContextRef ctx, bool adjustTextPosition) {
     }
 
     _CTLine* line = static_cast<_CTLine*>(lineRef);
-    CGPoint curTextPos = { 0, 0 };
+    CGPoint curTextPos = {};
     if (adjustTextPosition) {
         curTextPos = CGContextGetTextPosition(ctx);
         CGContextSetTextPosition(ctx, curTextPos.x + line->_relativeXOffset, curTextPos.y + line->_relativeYOffset);

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -224,7 +224,7 @@ void _CTLineDraw(CTLineRef lineRef, CGContextRef ctx, bool adjustTextPosition) {
     CGPoint curTextPos = {};
     if (adjustTextPosition) {
         curTextPos = CGContextGetTextPosition(ctx);
-        CGContextSetTextPosition(ctx, curTextPos.x + line->_relativeXOffset, curTextPos.y + line->_relativeYOffset);
+        CGContextSetTextPosition(ctx, curTextPos.x, curTextPos.y + line->_relativeYOffset);
     }
 
     for (size_t i = 0; i < [line->_runs count]; ++i) {

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -277,7 +277,7 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
 
     if (adjustTextPosition) {
         CGPoint curTextPos = CGContextGetTextPosition(ctx);
-        CGContextSetTextPosition(ctx, curTextPos.x + curRun->_relativeXOffset, curTextPos.y + curRun->_relativeYOffset);
+        CGContextSetTextPosition(ctx, curTextPos.x, curTextPos.y + curRun->_relativeYOffset);
     }
 
     id fontColor = [curRun->_attributes objectForKey:(id)kCTForegroundColorAttributeName];

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -455,7 +455,7 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
             i++;
         }
 
-        if ([runs objectAtIndex:0]) {
+        if ([runs count] > 0) {
             prevYPosForDraw = yPos;
             line->_runs = runs;
             line->_strRange.location = static_cast<_CTRun*>(line->_runs[0])->_range.location;

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -625,6 +625,7 @@ CGContextRef CreateLayerContentsBitmapContext32(int width, int height) {
         if (priv->contentsScale != 1.0f) {
             // TODO 1077:: Remove once D2D render target is implemented
             _CGContextSetScaleFactor(drawContext, priv->contentsScale);
+            CGContextScaleCTM(drawContext, priv->contentsScale, priv->contentsScale);
         }
 
         CGContextScaleCTM(drawContext, 1.0f, -1.0f);

--- a/Frameworks/UIKit/NSLayoutManager.mm
+++ b/Frameworks/UIKit/NSLayoutManager.mm
@@ -156,7 +156,7 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
 
             // Save line and origin for when it is drawn
             [_ctLines addObject:(id)fitLine];
-            _lineOrigins.push_back(rect.origin);
+            _lineOrigins.emplace_back(CGPoint{ rect.origin.x, rect.origin.y + lineHeight });
 
             double fitWidth = CTLineGetTypographicBounds(fitLine, nullptr, nullptr, nullptr);
             drawnWidth += fitWidth;
@@ -245,12 +245,11 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
     int count = [_ctLines count];
     for (int curLine = 0; curLine < count; curLine++) {
         CTLineRef line = (CTLineRef)_ctLines[curLine];
-
-        float ascent, descent, leading;
-        CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
-
         CGContextSaveGState(curCtx);
-        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, _lineOrigins[curLine].y);
+
+        CGFloat ascent, leading;
+        CTLineGetTypographicBounds(line, &ascent, nullptr, &leading);
+        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -(_lineOrigins[curLine].y + ascent + leading));
         CTLineDraw(line, curCtx);
         CGContextRestoreGState(curCtx);
     }
@@ -745,10 +744,10 @@ static NSRange NSRangeFromCFRange(CFRange range) {
  @Notes
 */
 - (void)setGlyphs:(const CGGlyph*)glyphs
-       properties:(const NSGlyphProperty*)props
- characterIndexes:(const NSUInteger*)charIndexes
-             font:(UIFont*)aFont
-    forGlyphRange:(NSRange)glyphRange {
+          properties:(const NSGlyphProperty*)props
+    characterIndexes:(const NSUInteger*)charIndexes
+                font:(UIFont*)aFont
+       forGlyphRange:(NSRange)glyphRange {
     UNIMPLEMENTED();
 }
 

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -41,6 +41,7 @@ NSString* const UITextAttributeTextShadowOffset = @"UITextAttributeTextShadowOff
 
 @implementation NSString (UIKitAdditions)
 
+// The values of CTTextAlignment and UITextAlignment do not correspond so they can't be simply cast
 static CTTextAlignment __UITextAlignmentToCTTextAlignment(UITextAlignment alignment) {
     switch (alignment) {
         case UITextAlignmentLeft:
@@ -100,11 +101,13 @@ static void drawString(UIFont* font,
     NSArray* lines = static_cast<NSArray*>(CTFrameGetLines(frame));
     std::vector<CGPoint> origins([lines count]);
     CTFrameGetLineOrigins(frame, {}, origins.data());
-    CGFloat lastYPosition = rect.origin.y;
     for (size_t i = 0; i < origins.size(); ++i) {
         // Need to set text position so each line will be drawn in the correct position relative to each other
-        CGContextSetTextPosition(context, rect.origin.x, lastYPosition);
-        lastYPosition = origins[i].y;
+        // Y positions will be negative because we are drawing with the coordinate system flipped to what CoreText is expecting
+        // Translated down by lineheight (ascent - descent + leading) to set origin in the correct position
+        CGFloat ascent, descent, leading;
+        CTLineGetTypographicBounds(static_cast<CTLineRef>(lines[i]), &ascent, &descent, &leading);
+        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, -(rect.origin.y + origins[i].y + ascent - descent + leading));
         CTLineDraw(static_cast<CTLineRef>(lines[i]), context);
     }
 

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -102,7 +102,7 @@ static void drawString(UIFont* font,
     CTFrameGetLineOrigins(frame, {}, origins.data());
     CGFloat lastYPosition = rect.origin.y;
     for (size_t i = 0; i < origins.size(); ++i) {
-        // Need to set text position so each line will be drawn in the correct position relative to eachother
+        // Need to set text position so each line will be drawn in the correct position relative to each other
         CGContextSetTextPosition(context, rect.origin.x, lastYPosition);
         lastYPosition = origins[i].y;
         CTLineDraw(static_cast<CTLineRef>(lines[i]), context);

--- a/include/UIKit/UIKitTypes.h
+++ b/include/UIKit/UIKitTypes.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSUInteger, NSWritingDirection) {
 };
 
 enum {
-    UITextAlignmentLeft,
+    UITextAlignmentLeft = 0,
     UITextAlignmentCenter,
     UITextAlignmentRight,
 };


### PR DESCRIPTION
CALayers were being scaled twice, and NSString draw methods were being translated twice, causing issues in internal test apps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1254)
<!-- Reviewable:end -->
