### PR TITLE
Fix rotation and nslayout line drawing

### DIFF
--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -1868,6 +1868,7 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, flo
     // Undo transform to text space
     transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, lineAscent / 2.0f), transform);
 
+    // Translate to the drawing point
     transform = CGAffineTransformTranslate(transform, curState->curTextPosition.x, curState->curTextPosition.y);
 
     // Find transform that user created by multiplying given transform by necessary transforms to draw with CoreText
@@ -1875,11 +1876,11 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, flo
     CGAffineTransform userTransform =
         CGAffineTransformConcat(curState->curTransform, CGAffineTransformMake(1.0f / _scale, 0, 0, 1.0f / _scale, 0, -height / _scale));
 
-    // Apply the context CTM
+    // Apply the context CTM to get total matrix
     transform = CGAffineTransformConcat(transform, userTransform);
 
     // Perform anti-clockwise rotation required to match the reference platform.
-    imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, transform.c, transform.d, transform.tx, -transform.ty));
+    imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, -transform.c, transform.d, transform.tx, -transform.ty));
 
     // Draw the glyph using ID2D1RenderTarget
     ComPtr<ID2D1SolidColorBrush> brush;

--- a/Frameworks/UIKit/NSLayoutManager.mm
+++ b/Frameworks/UIKit/NSLayoutManager.mm
@@ -247,9 +247,10 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
         CTLineRef line = (CTLineRef)_ctLines[curLine];
         CGContextSaveGState(curCtx);
 
-        CGFloat ascent, descent, leading;
+        // Ignore descent to keep from drawing descending characters from drawing into exclusion zones
+        CGFloat ascent, leading;
         CTLineGetTypographicBounds(line, &ascent, nullptr, &leading);
-        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -(_lineOrigins[curLine].y + ascent - descent + leading));
+        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -(_lineOrigins[curLine].y + ascent + leading));
         CTLineDraw(line, curCtx);
         CGContextRestoreGState(curCtx);
     }

--- a/Frameworks/UIKit/NSLayoutManager.mm
+++ b/Frameworks/UIKit/NSLayoutManager.mm
@@ -247,9 +247,9 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
         CTLineRef line = (CTLineRef)_ctLines[curLine];
         CGContextSaveGState(curCtx);
 
-        CGFloat ascent, leading;
+        CGFloat ascent, descent, leading;
         CTLineGetTypographicBounds(line, &ascent, nullptr, &leading);
-        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -(_lineOrigins[curLine].y + ascent + leading));
+        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -(_lineOrigins[curLine].y + ascent - descent + leading));
         CTLineDraw(line, curCtx);
         CGContextRestoreGState(curCtx);
     }

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-Headers-WinStore10/CTCatalog-Headers.vcxitems
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-Headers-WinStore10/CTCatalog-Headers.vcxitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\AppDelegate.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\Tests\CTCAffineTransformationTestViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\Tests\CTCAlignmentTestViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\CTCRootViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\CTCBaseViewController.h" />

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-Headers-WinStore10/CTCatalog-Headers.vcxitems.filters
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-Headers-WinStore10/CTCatalog-Headers.vcxitems.filters
@@ -39,5 +39,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\Tests\CTCRunTestViewController.h">
       <Filter>CTCatalog\Test</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\CTCatalog\Tests\CTCAffineTransformationTestViewController.h">
+      <Filter>CTCatalog\Test</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj
@@ -177,6 +177,7 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
+    <ClangCompile Include="..\..\CTCatalog\Tests\CTCAffineTransformationTestViewController.mm" />
     <ClangCompile Include="..\..\CTCatalog\Tests\CTCFontTestViewController.mm" />
     <ClangCompile Include="..\..\CTCatalog\Tests\CTCFramesetterTestViewController.mm" />
     <ClangCompile Include="..\..\CTCatalog\Tests\CTCFrameTestViewController.mm" />

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj.filters
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj.filters
@@ -110,5 +110,8 @@
     <ClangCompile Include="..\..\CTCatalog\CTCBaseViewController.mm">
       <Filter>CTCatalog</Filter>
     </ClangCompile>
+    <ClangCompile Include="..\..\CTCatalog\Tests\CTCAffineTransformationTestViewController.mm">
+      <Filter>CTCatalog\Test</Filter>
+    </ClangCompile>
   </ItemGroup>
 </Project>

--- a/tests/testapps/CTCatalog/CTCatalog.xcodeproj/project.pbxproj
+++ b/tests/testapps/CTCatalog/CTCatalog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0005A0501DC7D76C00921DDB /* CTCAffineTransformationTestViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0005A04F1DC7D76C00921DDB /* CTCAffineTransformationTestViewController.mm */; };
 		002AB41B1D6CA1F1002082A5 /* CTCFontTestViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 002AB4101D6CA1F1002082A5 /* CTCFontTestViewController.mm */; };
 		002AB41C1D6CA1F1002082A5 /* CTCFramesetterTestViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 002AB4121D6CA1F1002082A5 /* CTCFramesetterTestViewController.mm */; };
 		002AB41D1D6CA1F1002082A5 /* CTCFrameTestViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 002AB4141D6CA1F1002082A5 /* CTCFrameTestViewController.mm */; };
@@ -24,6 +25,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0005A04E1DC7D76C00921DDB /* CTCAffineTransformationTestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CTCAffineTransformationTestViewController.h; path = Tests/CTCAffineTransformationTestViewController.h; sourceTree = "<group>"; };
+		0005A04F1DC7D76C00921DDB /* CTCAffineTransformationTestViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CTCAffineTransformationTestViewController.mm; path = Tests/CTCAffineTransformationTestViewController.mm; sourceTree = "<group>"; };
 		002AB40F1D6CA1F1002082A5 /* CTCFontTestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CTCFontTestViewController.h; path = Tests/CTCFontTestViewController.h; sourceTree = "<group>"; };
 		002AB4101D6CA1F1002082A5 /* CTCFontTestViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CTCFontTestViewController.mm; path = Tests/CTCFontTestViewController.mm; sourceTree = "<group>"; };
 		002AB4111D6CA1F1002082A5 /* CTCFramesetterTestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CTCFramesetterTestViewController.h; path = Tests/CTCFramesetterTestViewController.h; sourceTree = "<group>"; };
@@ -109,6 +112,8 @@
 		002E8DAD1D59314E00D5DC64 /* Test */ = {
 			isa = PBXGroup;
 			children = (
+				0005A04E1DC7D76C00921DDB /* CTCAffineTransformationTestViewController.h */,
+				0005A04F1DC7D76C00921DDB /* CTCAffineTransformationTestViewController.mm */,
 				002AB40F1D6CA1F1002082A5 /* CTCFontTestViewController.h */,
 				002AB4101D6CA1F1002082A5 /* CTCFontTestViewController.mm */,
 				002AB4111D6CA1F1002082A5 /* CTCFramesetterTestViewController.h */,
@@ -198,6 +203,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				002AB41F1D6CA1F1002082A5 /* CTCParagraphStyleTestViewController.mm in Sources */,
+				0005A0501DC7D76C00921DDB /* CTCAffineTransformationTestViewController.mm in Sources */,
 				002AB41C1D6CA1F1002082A5 /* CTCFramesetterTestViewController.mm in Sources */,
 				002AB41D1D6CA1F1002082A5 /* CTCFrameTestViewController.mm in Sources */,
 				002E8D9A1D592A3500D5DC64 /* CTCRootViewController.m in Sources */,

--- a/tests/testapps/CTCatalog/CTCatalog/CTCRootViewController.m
+++ b/tests/testapps/CTCatalog/CTCatalog/CTCRootViewController.m
@@ -22,6 +22,7 @@
 #import "CTCFrameTestViewController.h"
 #import "CTCParagraphStyleTestViewController.h"
 #import "CTCFramesetterTestViewController.h"
+#import "CTCAffineTransformationTestViewController.h"
 
 @interface TestRow : NSObject
 
@@ -59,7 +60,8 @@
             [TestRow row:@"Frame Functions" testClass:[CTCFrameTestViewController class]],
             [TestRow row:@"ParagraphStyle Tests" testClass:[CTCParagraphStyleTestViewController class]],
             [TestRow row:@"Line Functions" testClass:[CTCLineTestViewController class]],
-            [TestRow row:@"Framesetter Functions" testClass:[CTCFramesetterTestViewController class]]
+            [TestRow row:@"Framesetter Functions" testClass:[CTCFramesetterTestViewController class]],
+            [TestRow row:@"Affine Transformation Tests" testClass:[CTCAffineTransformationTestViewController class]]
         ];
     }
     return _tests;

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.h
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.h
@@ -1,0 +1,22 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//*****************************************************************************
+
+#pragma once
+
+#import "CTCBaseViewController.h"
+
+@interface CTCAffineTransformationTestViewController : CTCBaseViewController
+@end

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.mm
@@ -16,7 +16,10 @@
 
 #import "CTCAffineTransformationTestViewController.h"
 
-static const NSString* text = @"The quick brown dog jumps over the lazy fox. THE QUICK BROWN DOG JUMPS OVER THE LAZY FOX.";
+static const NSString* text = @"This frame is manipulated by the above sliders.  The leftmost slider changes rotation, which should be "
+                              @"about the origin in the bottom-left of this frame with left being clockwise rotation and right being "
+                              @"counterclockwise.  The middle sliders change the X and Y scale respectively.  The rightmost sliders "
+                              @"change the position of the X, Y origins of the drawn frame respectively.";
 
 @interface CTAffineTransformationTestView : UIView {
 }
@@ -55,7 +58,7 @@ static const NSString* text = @"The quick brown dog jumps over the lazy fox. THE
 
     setting.spec = kCTParagraphStyleSpecifierAlignment;
     setting.valueSize = sizeof(CTTextAlignment);
-    CTTextAlignment alignment = kCTCenterTextAlignment;
+    CTTextAlignment alignment = kCTLeftTextAlignment;
     setting.value = &alignment;
     CTParagraphStyleRef paragraphStyle = CTParagraphStyleCreate(&setting, 1);
     CFAutorelease(paragraphStyle);
@@ -139,23 +142,23 @@ static const NSString* text = @"The quick brown dog jumps over the lazy fox. THE
     [self.view addSubview:_scaleYSlider];
 
     _translateXSlider = [[UISlider alloc] initWithFrame:CGRectMake(2.0f * width / 3, 10, width / 4, 50)];
-    _translateXSlider.minimumValue = -100;
-    _translateXSlider.maximumValue = 100;
+    _translateXSlider.minimumValue = -200;
+    _translateXSlider.maximumValue = 200;
     _translateXSlider.value = 0.0f;
     _translateXSlider.continuous = YES;
     [_translateXSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
     [self.view addSubview:_translateXSlider];
 
     _translateYSlider = [[UISlider alloc] initWithFrame:CGRectMake(2.0f * width / 3, 70, width / 4, 50)];
-    _translateYSlider.minimumValue = -100;
-    _translateYSlider.maximumValue = 100;
+    _translateYSlider.minimumValue = -200;
+    _translateYSlider.maximumValue = 200;
     _translateYSlider.value = 0.0f;
     _translateYSlider.continuous = YES;
     [_translateYSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
     [self.view addSubview:_translateYSlider];
 
     // Create frame of text
-    _textView = [[CTAffineTransformationTestView alloc] initWithFrame:CGRectMake(width / 4, 150, width / 2, 100)];
+    _textView = [[CTAffineTransformationTestView alloc] initWithFrame:CGRectMake(width / 4, 150, width / 2, 200)];
     _textView.backgroundColor = [UIColor whiteColor];
     _textView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     // Sets view to call updateTableViews when done drawing
@@ -170,7 +173,7 @@ static const NSString* text = @"The quick brown dog jumps over the lazy fox. THE
 
 - (void)viewDidLayoutSubviews {
     CGFloat width = CGRectGetWidth(self.view.bounds);
-    _textView.frame = CGRectMake(width / 4, 150, width / 2, 100);
+    _textView.frame = CGRectMake(width / 4, 150, width / 2, 200);
     [_textView setNeedsDisplay];
 
     _rotationSlider.frame = CGRectMake(0, 10, width / 4, 50);
@@ -187,15 +190,6 @@ static const NSString* text = @"The quick brown dog jumps over the lazy fox. THE
 
     _translateYSlider.frame = CGRectMake(2.0f * width / 3, 70, width / 4, 50);
     [_translateYSlider setNeedsDisplay];
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
 }
 
 - (void)drawTests {

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.mm
@@ -91,14 +91,12 @@ static const NSString* text = @"This frame is manipulated by the above sliders. 
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
 
     CGPathRelease(path);
-    CGColorSpaceRelease(colorspace);
 }
 
 @end

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAffineTransformationTestViewController.mm
@@ -1,0 +1,209 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//*****************************************************************************
+
+#import "CTCAffineTransformationTestViewController.h"
+
+static const NSString* text = @"The quick brown dog jumps over the lazy fox. THE QUICK BROWN DOG JUMPS OVER THE LAZY FOX.";
+
+@interface CTAffineTransformationTestView : UIView {
+}
+
+@property (nonatomic) CGFloat rotationCTM;
+@property (nonatomic) CGPoint translationCTM;
+@property (nonatomic) CGPoint scaleCTM;
+
+@end
+
+@implementation CTAffineTransformationTestView {
+}
+
+- (void)drawRect:(CGRect)rect {
+    UIColor* color = [UIColor blackColor];
+
+    CGContextRef context = UIGraphicsGetCurrentContext();
+
+    // Aligns origin for our frame
+    CGContextTranslateCTM(context, 0.0f, self.bounds.size.height);
+
+    // Flips y-axis for our frame
+    CGContextScaleCTM(context, 1.0f, -1.0f);
+
+    // Apply user given transformations
+    CGContextRotateCTM(context, _rotationCTM);
+    CGContextScaleCTM(context, _scaleCTM.x, _scaleCTM.y);
+    CGContextTranslateCTM(context, _translationCTM.x, _translationCTM.y);
+
+    // Creates path with current rectangle
+    CGMutablePathRef path = CGPathCreateMutable();
+    CGPathAddRect(path, NULL, self.bounds);
+
+    // Create style setting to match given alignment
+    CTParagraphStyleSetting setting;
+
+    setting.spec = kCTParagraphStyleSpecifierAlignment;
+    setting.valueSize = sizeof(CTTextAlignment);
+    CTTextAlignment alignment = kCTCenterTextAlignment;
+    setting.value = &alignment;
+    CTParagraphStyleRef paragraphStyle = CTParagraphStyleCreate(&setting, 1);
+    CFAutorelease(paragraphStyle);
+
+    UIFont* font = [UIFont systemFontOfSize:20];
+    CTFontRef myCFFont = CTFontCreateWithName((__bridge CFStringRef)[font fontName], [font pointSize], NULL);
+    CFAutorelease(myCFFont);
+    // Make dictionary for attributed string with font, color, and alignment
+    NSDictionary* attributesDict = [NSDictionary dictionaryWithObjectsAndKeys:(__bridge id)myCFFont,
+                                                                              (id)kCTFontAttributeName,
+                                                                              color.CGColor,
+                                                                              (id)kCTForegroundColorAttributeName,
+                                                                              (__bridge id)paragraphStyle,
+                                                                              (id)kCTParagraphStyleAttributeName,
+                                                                              nil];
+
+    CFAttributedStringRef attrString =
+        CFAttributedStringCreate(kCFAllocatorDefault, (__bridge CFStringRef)text, (__bridge CFDictionaryRef)attributesDict);
+    CFAutorelease(attrString);
+
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(attrString);
+    CFAutorelease(framesetter);
+
+    // Creates frame for framesetter with current attributed string
+    CTFrameRef frame = CTFramesetterCreateFrame(framesetter, CFRangeMake(0, 0), path, NULL);
+    CFAutorelease(frame);
+
+    // Draws the text in the frame
+    CTFrameDraw(frame, context);
+
+    // Creates outline
+    CGContextSetLineWidth(context, 2.0);
+    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
+    CGContextSetStrokeColorWithColor(context, color.CGColor);
+    CGContextMoveToPoint(context, 0, 0);
+    CGContextAddRect(context, rect);
+    CGContextStrokePath(context);
+
+    CGPathRelease(path);
+    CGColorSpaceRelease(colorspace);
+}
+
+@end
+
+@implementation CTCAffineTransformationTestViewController {
+    CTAffineTransformationTestView* _textView;
+    UISlider* _rotationSlider;
+    UISlider* _scaleXSlider;
+    UISlider* _scaleYSlider;
+    UISlider* _translateXSlider;
+    UISlider* _translateYSlider;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.view.backgroundColor = [UIColor whiteColor];
+    CGFloat width = CGRectGetWidth(self.view.bounds);
+
+    _rotationSlider = [[UISlider alloc] initWithFrame:CGRectMake(0, 10, width / 4, 50)];
+    _rotationSlider.minimumValue = -2.0f * M_PI;
+    _rotationSlider.maximumValue = 2.0f * M_PI;
+    _rotationSlider.value = 0.0f;
+    _rotationSlider.continuous = YES;
+    [_rotationSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
+    [self.view addSubview:_rotationSlider];
+
+    _scaleXSlider = [[UISlider alloc] initWithFrame:CGRectMake(width / 3, 10, width / 4, 50)];
+    _scaleXSlider.minimumValue = -2.0f;
+    _scaleXSlider.maximumValue = 2.0f;
+    _scaleXSlider.value = 1.0f;
+    _scaleXSlider.continuous = YES;
+    [_scaleXSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
+    [self.view addSubview:_scaleXSlider];
+
+    _scaleYSlider = [[UISlider alloc] initWithFrame:CGRectMake(width / 3, 70, width / 4, 50)];
+    _scaleYSlider.minimumValue = -2.0f;
+    _scaleYSlider.maximumValue = 2.0f;
+    _scaleYSlider.value = 1.0f;
+    _scaleYSlider.continuous = YES;
+    [_scaleYSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
+    [self.view addSubview:_scaleYSlider];
+
+    _translateXSlider = [[UISlider alloc] initWithFrame:CGRectMake(2.0f * width / 3, 10, width / 4, 50)];
+    _translateXSlider.minimumValue = -100;
+    _translateXSlider.maximumValue = 100;
+    _translateXSlider.value = 0.0f;
+    _translateXSlider.continuous = YES;
+    [_translateXSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
+    [self.view addSubview:_translateXSlider];
+
+    _translateYSlider = [[UISlider alloc] initWithFrame:CGRectMake(2.0f * width / 3, 70, width / 4, 50)];
+    _translateYSlider.minimumValue = -100;
+    _translateYSlider.maximumValue = 100;
+    _translateYSlider.value = 0.0f;
+    _translateYSlider.continuous = YES;
+    [_translateYSlider addTarget:self action:@selector(drawTests) forControlEvents:UIControlEventValueChanged];
+    [self.view addSubview:_translateYSlider];
+
+    // Create frame of text
+    _textView = [[CTAffineTransformationTestView alloc] initWithFrame:CGRectMake(width / 4, 150, width / 2, 100)];
+    _textView.backgroundColor = [UIColor whiteColor];
+    _textView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    // Sets view to call updateTableViews when done drawing
+    _textView.rotationCTM = 0.0f;
+    _textView.scaleCTM = { 1.0f, 1.0f };
+    _textView.translationCTM = { 0.0f, 0.0f };
+    [self.view addSubview:_textView];
+
+    // Draws the frameview
+    [self drawTests];
+}
+
+- (void)viewDidLayoutSubviews {
+    CGFloat width = CGRectGetWidth(self.view.bounds);
+    _textView.frame = CGRectMake(width / 4, 150, width / 2, 100);
+    [_textView setNeedsDisplay];
+
+    _rotationSlider.frame = CGRectMake(0, 10, width / 4, 50);
+    [_rotationSlider setNeedsDisplay];
+
+    _scaleXSlider.frame = CGRectMake(width / 3, 10, width / 4, 50);
+    [_scaleXSlider setNeedsDisplay];
+
+    _scaleYSlider.frame = CGRectMake(width / 3, 70, width / 4, 50);
+    [_scaleYSlider setNeedsDisplay];
+
+    _translateXSlider.frame = CGRectMake(2.0f * width / 3, 10, width / 4, 50);
+    [_translateXSlider setNeedsDisplay];
+
+    _translateYSlider.frame = CGRectMake(2.0f * width / 3, 70, width / 4, 50);
+    [_translateYSlider setNeedsDisplay];
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+}
+
+- (void)drawTests {
+    // Update the text in the frame
+    // Allows input of \n and \t to insert newlines and tabs respectively
+    _textView.rotationCTM = _rotationSlider.value;
+    _textView.scaleCTM = { _scaleXSlider.value, _scaleYSlider.value };
+    _textView.translationCTM = { _translateXSlider.value, _translateYSlider.value };
+    [_textView setNeedsDisplay];
+}
+@end

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAlignmentTestViewController.m
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCAlignmentTestViewController.m
@@ -80,14 +80,12 @@
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
 
     CGPathRelease(path);
-    CGColorSpaceRelease(colorspace);
 }
 @end
 

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
@@ -93,13 +93,11 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
 
-    CGColorSpaceRelease(colorspace);
     CGPathRelease(path);
 }
 @end

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFrameTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFrameTestViewController.mm
@@ -119,14 +119,12 @@
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
 
     CGPathRelease(path);
-    CGColorSpaceRelease(colorspace);
 
     [_drawDelegate refreshValuesForFrame:frame];
 }

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFramesetterTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFramesetterTestViewController.mm
@@ -80,14 +80,12 @@
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
 
     CGPathRelease(path);
-    CGColorSpaceRelease(colorspace);
 
     [_drawDelegate refreshValuesForFramesetter:framesetter];
 }

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCLineTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCLineTestViewController.mm
@@ -109,13 +109,11 @@
 
         // Creates outline
         CGContextSetLineWidth(context, 2.0);
-        CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
         CGContextSetStrokeColorWithColor(context, color.CGColor);
         CGContextMoveToPoint(context, 0, 0);
         CGContextAddRect(context, rect);
         CGContextStrokePath(context);
 
-        CGColorSpaceRelease(colorspace);
         [_drawDelegate refreshValuesForLine:line];
     }
 

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCParagraphStyleTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCParagraphStyleTestViewController.mm
@@ -95,14 +95,12 @@ cell.accessoryView = FIELD;                                                     
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
 
     CGPathRelease(path);
-    CGColorSpaceRelease(colorspace);
     CFRelease(_paragraphStyle);
 }
 

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCRunTestViewController.mm
@@ -89,13 +89,10 @@ static const CFRange c_visibleRange = CFRangeMake(1, 5);
 
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
-    CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     CGContextSetStrokeColorWithColor(context, color.CGColor);
     CGContextMoveToPoint(context, 0, 0);
     CGContextAddRect(context, rect);
     CGContextStrokePath(context);
-
-    CGColorSpaceRelease(colorspace);
 
     [_drawDelegate refreshValuesForRun:run];
 }


### PR DESCRIPTION
Fixes incorrect rotation introduced by my recent math changes and adds descent to nslayoutmanager line drawing to make exclusion zones more accurate

Fixes #1275
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1274)
<!-- Reviewable:end -->
