### PR TITLE
Yet again increase the robustness of the NSURLSession tests.

### DIFF
--- a/tests/functionaltests/Tests/NSURLSession.mm
+++ b/tests/functionaltests/Tests/NSURLSession.mm
@@ -516,7 +516,7 @@ TEST(NSURLSession, DownloadTaskWithURL) {
                   "FAILED: didWriteData should be the first delegate to be called!");
     double fileSizeInMB = (double)downloadTaskTestHelper.totalBytesExpectedToWrite / 1024 / 1024;
     LOG_INFO("Downloaded file size is %fMB", fileSizeInMB);
-    ASSERT_EQ_MSG(10, std::floor(fileSizeInMB), "FAILED: Expected download file size does not match!");
+    ASSERT_EQ_MSG(11, std::lround(fileSizeInMB), "FAILED: Expected download file size does not match!");
 
     // Make sure the didFinishDownloadingToURL got called.
     ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidFinishDownloadingToURL,
@@ -639,7 +639,7 @@ TEST(NSURLSession, DownloadTaskWithURL_WithCancelResume) {
                   "FAILED: didWriteData should be the first delegate to be called!");
     double fileSizeInMB = (double)downloadTaskTestHelper.totalBytesExpectedToWrite / 1024 / 1024;
     LOG_INFO("Downloaded file size is %fMB", fileSizeInMB);
-    ASSERT_EQ_MSG(500, std::floor(fileSizeInMB), "FAILED: Expected download file size does not match!");
+    ASSERT_EQ_MSG(500, std::lround(fileSizeInMB), "FAILED: Expected download file size does not match!");
 
     // Make sure download is in progress.
     double lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;


### PR DESCRIPTION
Description:
These tests also used floor instead of round and it turns out the expected size was 11Mb. Oops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1289)
<!-- Reviewable:end -->
