### PR TITLE
Fixing heap corruption when using core text to draw into opaque layers.

### DIFF
--- a/Frameworks/CoreGraphics/CGBitmapImage.mm
+++ b/Frameworks/CoreGraphics/CGBitmapImage.mm
@@ -389,6 +389,11 @@ CGBitmapImageBacking::CGBitmapImageBacking(CGImageRef img) {
 }
 
 CGBitmapImageBacking::~CGBitmapImageBacking() {
+    // release the render target first as it may hold locks on the image
+    if (_renderTarget != nullptr) {
+        _renderTarget->Release();
+    }
+
     if (_cairoLocks != 0 || _imageLocks != 0) {
         TraceWarning(TAG, L"Warning: Image data not unlocked (refcnt=%d, %d)", _cairoLocks, _imageLocks);
 
@@ -398,10 +403,6 @@ CGBitmapImageBacking::~CGBitmapImageBacking() {
         while (_imageLocks > 0) {
             ReleaseImageData();
         }
-    }
-
-    if (_renderTarget != nullptr) {
-        _renderTarget->Release();
     }
 
     _data->_refCount--;

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -574,7 +574,7 @@ CGContextRef CreateLayerContentsBitmapContext32(int width, int height) {
                 if (useVector) {
                     // target = new CGVectorImage(width, height, _ColorBGR);
                 } else {
-                    drawContext = _CGBitmapContextCreateWithFormat(width, height, _ColorBGR);
+                    drawContext = _CGBitmapContextCreateWithFormat(width, height, _ColorBGRX);
                 }
                 priv->drewOpaque = TRUE;
             } else {

--- a/Frameworks/include/CGIWICBitmap.h
+++ b/Frameworks/include/CGIWICBitmap.h
@@ -81,12 +81,13 @@ inline WICPixelFormatGUID SurfaceFormatToWICPixelFormat(__CGSurfaceFormat format
         case _ColorARGB:
             return GUID_WICPixelFormat32bppPBGRA;
         case _ColorBGRX:
-        case _ColorBGR:
             return GUID_WICPixelFormat32bppBGR;
         case _ColorGrayscale:
         case _ColorA8:
             return GUID_WICPixelFormat8bppAlpha;
+        case _ColorBGR:
         default:
+            UNIMPLEMENTED_WITH_MSG("Unsupported pixel format (%d) used in CGIWICBitmap");
             break;
     }
     // our default format is alpha premultiplied BGRA


### PR DESCRIPTION
Fixing heap corruption when using core text to draw into opaque layers.

The heap corruption happened in an internal test app.

The fix is to use BGRX pixel format for opaque layers - this is supported
by WIC render target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1295)
<!-- Reviewable:end -->
