### PR TITLE
Fix CoreText Drawing

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -1239,8 +1239,8 @@ bool CGContextIsPointInPath(CGContextRef c, bool eoFill, CGFloat x, CGFloat y) {
     return c->Backing()->CGContextIsPointInPath(eoFill, x, y);
 }
 
-void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineAscent) {
-    ctx->Backing()->CGContextDrawGlyphRun(glyphRun, lineAscent);
+void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun) {
+    ctx->Backing()->CGContextDrawGlyphRun(glyphRun);
 }
 // TODO 1077:: Remove once D2D render target is implemented
 void _CGContextSetScaleFactor(CGContextRef ctx, float scale) {

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -1832,7 +1832,7 @@ CGPathRef CGContextCairo::CGContextCopyPath(void) {
  *
  * @parameter glyphRun DWRITE_GLYPH_RUN object to render
  */
-void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent) {
+void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     ObtainLock();
 
     CGContextStrokePath();
@@ -1853,34 +1853,25 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, flo
 
     // Apply the text transformation (text position, text matrix) in text space rather than user space
     // This means flipping the coordinate system,
-    // and applying the transformation about the center of the glyph run rather than about the baseline
-    // Flip and translate by the difference between the center and the baseline, apply text transforms, then flip and translate back
+    // Apply text position, where it will be translated to correct position given text matrix value
+    CGAffineTransform textTransform =
+        CGAffineTransformTranslate(curState->curTextMatrix, curState->curTextPosition.x, curState->curTextPosition.y);
 
-    // Transform to text space
-    // Technically there should be a horizontal translation to the center as well,
-    // but it's to the center of _each individual glyph_, as the reference platform applies the text matrix to each glyph individually
-    // Uncertain whether it's ever going to be worth it to support this using DWrite, so just ignore it for now
-    CGAffineTransform transform = CGAffineTransformMake(1, 0, 0, -1, 0, -lineAscent / 2.0f);
-
-    // Apply text transforms
-    transform = CGAffineTransformConcat(curState->curTextMatrix, transform);
-
-    // Undo transform to text space
-    transform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, lineAscent / 2.0f), transform);
-
-    // Translate to the drawing point
-    transform = CGAffineTransformTranslate(transform, curState->curTextPosition.x, curState->curTextPosition.y);
+    // Undo assumed inversion about Y axis
+    textTransform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, 0), textTransform);
 
     // Find transform that user created by multiplying given transform by necessary transforms to draw with CoreText
+    // First multiply by inverse scale to get properly scaled values
+    // Then undo assumed inversion about Y axis
+    // Finally inverse translate by height
+    // All of which are rolled into one concatenation
     float height = _imgDest->Backing()->Height();
     CGAffineTransform userTransform =
-        CGAffineTransformConcat(curState->curTransform, CGAffineTransformMake(1.0f / _scale, 0, 0, 1.0f / _scale, 0, -height / _scale));
+        CGAffineTransformConcat(curState->curTransform, CGAffineTransformMake(1.0f / _scale, 0, 0, -1.0f / _scale, 0, height / _scale));
 
-    // Apply the context CTM to get total matrix
-    transform = CGAffineTransformConcat(transform, userTransform);
-
-    // Perform anti-clockwise rotation required to match the reference platform.
-    imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, -transform.b, -transform.c, transform.d, transform.tx, -transform.ty));
+    // Apply the two transforms giving us the final result
+    CGAffineTransform transform = CGAffineTransformConcat(textTransform, userTransform);
+    imgRenderTarget->SetTransform(D2D1::Matrix3x2F(transform.a, transform.b, transform.c, transform.d, transform.tx, transform.ty));
 
     // Draw the glyph using ID2D1RenderTarget
     ComPtr<ID2D1SolidColorBrush> brush;

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -779,7 +779,7 @@ CGPathRef CGContextImpl::CGContextCopyPath(void) {
     return NULL;
 }
 
-void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent) {
+void CGContextImpl::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
 }
 
 // TODO 1077:: Remove once D2D render target is implemented

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -122,8 +122,9 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         CGContextScaleCTM(ctx, 1.0f, -1.0f);
 
         for (_CTLine* line in static_cast<id<NSFastEnumeration>>(frame->_lines)) {
+            // Y position must be negative because the context is inverted
             CGContextSetTextPosition(ctx, line->_lineOrigin.x, -line->_lineOrigin.y);
-            _CTLineDraw(static_cast<CTLineRef>(line), ctx, false);
+            CTLineDraw(static_cast<CTLineRef>(line), ctx);
         }
 
         // Restore CTM and Text Matrix to values before we modified them

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -215,38 +215,26 @@ CTLineRef CTLineCreateJustifiedLine(CTLineRef line, CGFloat justificationFactor,
     return StubReturn();
 }
 
-void _CTLineDraw(CTLineRef lineRef, CGContextRef ctx, bool adjustTextPosition) {
-    if (!lineRef) {
+/**
+ @Status Interoperable
+*/
+void CTLineDraw(CTLineRef lineRef, CGContextRef ctx) {
+    if (lineRef == nil || ctx == nil) {
         return;
     }
 
     _CTLine* line = static_cast<_CTLine*>(lineRef);
-    CGPoint curTextPos = {};
-    if (adjustTextPosition) {
-        curTextPos = CGContextGetTextPosition(ctx);
-        CGContextSetTextPosition(ctx, curTextPos.x, curTextPos.y + line->_relativeYOffset);
-    }
 
     for (size_t i = 0; i < [line->_runs count]; ++i) {
         _CTRun* curRun = [line->_runs objectAtIndex:i];
         if (i > 0) {
             // Adjusts x position relative to the last run drawn
-            curTextPos = CGContextGetTextPosition(ctx);
+            CGPoint curTextPos = CGContextGetTextPosition(ctx);
             CGContextSetTextPosition(ctx, curTextPos.x + curRun->_relativeXOffset, curTextPos.y);
         }
 
-        // Get height of the line so we draw with the correct baseline for each run
-        CGFloat ascent;
-        CTLineGetTypographicBounds(lineRef, &ascent, nullptr, nullptr);
-        _CTRunDraw(static_cast<CTRunRef>(curRun), ctx, CFRange{}, false, ascent);
+        CTRunDraw(static_cast<CTRunRef>(curRun), ctx, CFRange{});
     }
-}
-
-/**
- @Status Interoperable
-*/
-void CTLineDraw(CTLineRef lineRef, CGContextRef ctx) {
-    _CTLineDraw(lineRef, ctx, true);
 }
 
 /**

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -268,16 +268,15 @@ CGRect CTRunGetImageBounds(CTRunRef run, CGContextRef context, CFRange range) {
     return StubReturn();
 }
 
-void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineAscent) {
+/**
+ @Status Interoperable
+ @Notes
+*/
+void CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange) {
     _CTRun* curRun = static_cast<_CTRun*>(run);
     if (!curRun || textRange.length < 0L || textRange.location < 0L ||
         textRange.location + textRange.length > curRun->_dwriteGlyphRun.glyphCount) {
         return;
-    }
-
-    if (adjustTextPosition) {
-        CGPoint curTextPos = CGContextGetTextPosition(ctx);
-        CGContextSetTextPosition(ctx, curTextPos.x, curTextPos.y + curRun->_relativeYOffset);
     }
 
     id fontColor = [curRun->_attributes objectForKey:(id)kCTForegroundColorAttributeName];
@@ -294,7 +293,7 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
 
     if (textRange.location == 0L && (textRange.length == 0L || textRange.length == curRun->_dwriteGlyphRun.glyphCount)) {
         // Print the whole glyph run
-        CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun, lineAscent);
+        CGContextDrawGlyphRun(ctx, &curRun->_dwriteGlyphRun);
     } else {
         if (textRange.length == 0L) {
             textRange.length = curRun->_dwriteGlyphRun.glyphCount - textRange.location;
@@ -302,19 +301,7 @@ void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTe
 
         // Only print glyphs in range
         DWRITE_GLYPH_RUN runInRange = __GetGlyphRunForDrawingInRange(curRun->_dwriteGlyphRun, textRange);
-        CGContextDrawGlyphRun(ctx, &runInRange, lineAscent);
-    }
-}
-
-/**
- @Status Interoperable
- @Notes
-*/
-void CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange) {
-    if (run && ctx) {
-        CGFloat ascent;
-        CTRunGetTypographicBounds(run, {}, &ascent, nullptr, nullptr);
-        _CTRunDraw(run, ctx, textRange, true, ascent);
+        CGContextDrawGlyphRun(ctx, &runInRange);
     }
 }
 

--- a/Frameworks/UIKit/NSLayoutManager.mm
+++ b/Frameworks/UIKit/NSLayoutManager.mm
@@ -246,11 +246,7 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
     for (int curLine = 0; curLine < count; curLine++) {
         CTLineRef line = (CTLineRef)_ctLines[curLine];
         CGContextSaveGState(curCtx);
-
-        // Ignore descent to keep from drawing descending characters from drawing into exclusion zones
-        CGFloat ascent, leading;
-        CTLineGetTypographicBounds(line, &ascent, nullptr, &leading);
-        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -(_lineOrigins[curLine].y + ascent + leading));
+        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -_lineOrigins[curLine].y);
         CTLineDraw(line, curCtx);
         CGContextRestoreGState(curCtx);
     }

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -104,10 +104,7 @@ static void drawString(UIFont* font,
     for (size_t i = 0; i < origins.size(); ++i) {
         // Need to set text position so each line will be drawn in the correct position relative to each other
         // Y positions will be negative because we are drawing with the coordinate system flipped to what CoreText is expecting
-        // Translated down by lineheight (ascent - descent + leading) to set origin in the correct position
-        CGFloat ascent, descent, leading;
-        CTLineGetTypographicBounds(static_cast<CTLineRef>(lines[i]), &ascent, &descent, &leading);
-        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, -(rect.origin.y + origins[i].y + ascent - descent + leading));
+        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, -(rect.origin.y + origins[i].y));
         CTLineDraw(static_cast<CTLineRef>(lines[i]), context);
     }
 

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -138,7 +138,7 @@ public:
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 
-    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent);
+    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
 
     // TODO 1077:: Remove once D2D render target is implemented
     virtual void _CGContextSetScaleFactor(float scale);

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -179,7 +179,7 @@ public:
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 
-    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, float lineAscent);
+    virtual void CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun);
 
     // TODO 1077:: Remove once D2D render target is implemented
     virtual void _CGContextSetScaleFactor(float scale);

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -50,7 +50,7 @@ COREGRAPHICS_EXPORT CGImageRef CGJPEGImageCreateFromFile(NSString* path);
 COREGRAPHICS_EXPORT CGImageRef CGJPEGImageCreateFromData(NSData* data);
 COREGRAPHICS_EXPORT bool CGContextIsPointInPath(CGContextRef c, bool eoFill, float x, float y);
 
-COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun, float lineAscent);
+COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun);
 
 // TODO 1077:: Remove once D2D render target is implemented
 COREGRAPHICS_EXPORT void _CGContextSetScaleFactor(CGContextRef ctx, float scale);

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -142,11 +142,5 @@ struct _CTParagraphStyleProperties {
 }
 @end
 
-// Note: For some reason namemangling does not happen for these functions causing a linker error. Bug??
-CORETEXT_EXTERNC_BEGIN
-void _CTLineDraw(CTLineRef line, CGContextRef ctx, bool adjustTextPosition);
-void _CTRunDraw(CTRunRef run, CGContextRef ctx, CFRange textRange, bool adjustTextPosition, CGFloat lineAscent);
-CORETEXT_EXTERNC_END
-
 // Private helper methods for UIKit
 CORETEXT_EXPORT CGSize _CTFrameGetSize(CTFrameRef frame);


### PR DESCRIPTION
It seems our drawing implementation was overcomplicated, doing unnecessary transformations which made assumptions about the state of the context which were not always true.  Removes now unnecessary private drawing functions and removes ascent as well as simplifying CGContextDrawGlyphRun.

This *should* be the last change we need for drawing

Fixes #1290

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1297)
<!-- Reviewable:end -->
