### PR TITLE
Support kCTParagraphStyleSpecifierLineHeightMultiple

### DIFF
--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -125,7 +125,7 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         for (size_t i = 0; i < frame->_lineOrigins.size(); ++i) {
             _CTLine* line = static_cast<_CTLine*>([frame->_lines objectAtIndex:i]);
             CGContextSetTextPosition(ctx, frame->_lineOrigins[i].x, -frame->_lineOrigins[i].y);
-            _CTLineDraw(static_cast<CTLineRef>(line), ctx, false);
+            CTLineDraw(static_cast<CTLineRef>(line), ctx);
         }
 
         // Restore CTM and Text Matrix to values before we modified them

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -61,8 +61,9 @@ CFRange CTFrameGetVisibleStringRange(CTFrameRef frame) {
     _CTFrame* framePtr = static_cast<_CTFrame*>(frame);
     CFIndex count = 0;
     if (framePtr) {
-        for (_CTLine* line in static_cast<id<NSFastEnumeration>>(framePtr->_lines)) {
-            if (line->_lineOrigin.y < framePtr->_frameRect.size.height && line->_lineOrigin.y > 0) {
+        for (size_t i = 0; i < framePtr->_lineOrigins.size(); ++i) {
+            if (framePtr->_lineOrigins[i].y < framePtr->_frameRect.size.height && framePtr->_lineOrigins[i].y > 0) {
+                _CTLine* line = static_cast<_CTLine*>([framePtr->_lines objectAtIndex:i]);
                 count += line->_strRange.length;
             }
         }
@@ -121,10 +122,10 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         CGContextSetTextMatrix(ctx, CGAffineTransformScale(textMatrix, 1.0f, -1.0f));
         CGContextScaleCTM(ctx, 1.0f, -1.0f);
 
-        for (_CTLine* line in static_cast<id<NSFastEnumeration>>(frame->_lines)) {
-            // Y position must be negative because the context is inverted
-            CGContextSetTextPosition(ctx, line->_lineOrigin.x, -line->_lineOrigin.y);
-            CTLineDraw(static_cast<CTLineRef>(line), ctx);
+        for (size_t i = 0; i < frame->_lineOrigins.size(); ++i) {
+            _CTLine* line = static_cast<_CTLine*>([frame->_lines objectAtIndex:i]);
+            CGContextSetTextPosition(ctx, frame->_lineOrigins[i].x, -frame->_lineOrigins[i].y);
+            _CTLineDraw(static_cast<CTLineRef>(line), ctx, false);
         }
 
         // Restore CTM and Text Matrix to values before we modified them

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -62,7 +62,7 @@ CFRange CTFrameGetVisibleStringRange(CTFrameRef frame) {
     CFIndex count = 0;
     if (framePtr) {
         for (size_t i = 0; i < framePtr->_lineOrigins.size(); ++i) {
-            if (framePtr->_lineOrigins[i].y < framePtr->_frameRect.size.height && framePtr->_lineOrigins[i].y > 0) {
+            if (framePtr->_lineOrigins[i].y < framePtr->_frameRect.size.height) {
                 _CTLine* line = static_cast<_CTLine*>([framePtr->_lines objectAtIndex:i]);
                 count += line->_strRange.length;
             }

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -35,18 +35,18 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
         range.length = typesetter->_characters.size();
     }
 
-    _CTFrame* ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize);
+    StrongId<_CTFrame> ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize);
 
     // Trying to access attributes without any text will throw an error
     if (range.length <= 0L) {
-        return [ret retain];
+        return ret.detach();
     }
 
     CTParagraphStyleRef settings = static_cast<CTParagraphStyleRef>(
         [typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName) atIndex:0 effectiveRange:nullptr]);
 
     if (settings == nil) {
-        return [ret retain];
+        return ret.detach();
     }
 
     // DWrite only gives manual control of lineheight when it is constant through a frame
@@ -71,7 +71,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
         ret->_frameRect.size.height += totalShifted;
     }
 
-    return [ret retain];
+    return ret.detach();
 }
 
 /**

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -37,7 +37,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
 
     _CTFrame* ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize);
 
-    // Trying to access attributes without any text with throw an error
+    // Trying to access attributes without any text will throw an error
     if (range.length <= 0L) {
         return [ret retain];
     }

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -27,7 +27,7 @@ using namespace std;
 @end
 
 static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CFRange range) {
-    RETURN_NULL_IF(!framesetter);
+    RETURN_NULL_IF(framesetter == nil);
 
     // Call _DWriteWrapper to get _CTLine object list that makes up this frame
     _CTTypesetter* typesetter = static_cast<_CTTypesetter*>(framesetter->_typesetter);
@@ -35,7 +35,40 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
         range.length = typesetter->_characters.size();
     }
 
-    return [_DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize) retain];
+    _CTFrame* ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize);
+
+    // Trying to access attributes without any text with throw an error
+    if (range.length != 0L) {
+        CTParagraphStyleRef settings =
+            static_cast<CTParagraphStyleRef>([typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName)
+                                                                              atIndex:0
+                                                                       effectiveRange:nullptr]);
+        if (settings) {
+            // DWrite only gives manual control of lineheight when it is constant through a frame
+            // We need to shift each line by the difference in lineheight manually
+            CGFloat lineHeightMultiple = 0.0f;
+            if (CTParagraphStyleGetValueForSpecifier(settings,
+                                                     kCTParagraphStyleSpecifierLineHeightMultiple,
+                                                     sizeof(lineHeightMultiple),
+                                                     &lineHeightMultiple) &&
+                lineHeightMultiple > 0) {
+                // The actual ratio we need to change the line height by is multiple - 1
+                lineHeightMultiple -= 1.0f;
+                CGFloat totalShifted = 0.0f;
+                CGFloat lastOriginY = frameSize.origin.y;
+                for (size_t i = 0; i < ret->_lineOrigins.size(); ++i) {
+                    totalShifted += lineHeightMultiple * (ret->_lineOrigins[i].y - lastOriginY);
+                    lastOriginY = ret->_lineOrigins[i].y;
+                    ret->_lineOrigins[i].y += totalShifted;
+                }
+
+                // Adjust framesize to account for changes in lineheights
+                ret->_frameRect.size.height += totalShifted;
+            }
+        }
+    }
+
+    return [ret retain];
 }
 
 /**

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -463,13 +463,15 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
             line->_glyphCount = glyphCount;
             line->_relativeXOffset = static_cast<_CTRun*>(line->_runs[0])->_relativeXOffset;
             line->_relativeYOffset = static_cast<_CTRun*>(line->_runs[0])->_relativeYOffset;
+
+            CGPoint lineOrigin = CGPointZero;
             if (static_cast<_CTRun*>([line->_runs objectAtIndex:0])->_dwriteGlyphRun.glyphCount != 0) {
-                line->_lineOrigin.x = static_cast<_CTRun*>(line->_runs[0])->_glyphOrigins[0].x;
-                line->_lineOrigin.y = static_cast<_CTRun*>(line->_runs[0])->_glyphOrigins[0].y;
+                lineOrigin = { static_cast<_CTRun*>(line->_runs[0])->_glyphOrigins[0].x,
+                               static_cast<_CTRun*>(line->_runs[0])->_glyphOrigins[0].y };
             }
 
             [frame->_lines addObject:line];
-            frame->_lineOrigins.emplace_back(line->_lineOrigin);
+            frame->_lineOrigins.emplace_back(lineOrigin);
         }
     }
 

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -77,7 +77,6 @@ inline void _SafeRelease(T** p) {
 @interface _CTLine : NSObject {
 @public
     CFRange _strRange;
-    CGPoint _lineOrigin;
     CGFloat _relativeXOffset;
     CGFloat _relativeYOffset;
     CGFloat _width;

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -155,7 +155,6 @@ TEST_P(CoreTextLineSpaceMultipleTest, OriginsShouldBeMovedByRatio) {
     };
     NSDictionary* attributes = @{ static_cast<NSString*>(kCTParagraphStyleAttributeName) : (id)CTParagraphStyleCreate(settings, 1) };
     [multipleString setAttributes:attributes range:NSMakeRange(0, 14)];
-
     CTFramesetterRef multipleFramesetter = CTFramesetterCreateWithAttributedString(static_cast<CFAttributedStringRef>(multipleString));
     CFAutorelease(multipleFramesetter);
     CTFrameRef multipleFrame = CTFramesetterCreateFrame(multipleFramesetter, {}, path, nullptr);
@@ -168,4 +167,8 @@ TEST_P(CoreTextLineSpaceMultipleTest, OriginsShouldBeMovedByRatio) {
 
 INSTANTIATE_TEST_CASE_P(OriginsShouldBeMovedByRatio,
                         CoreTextLineSpaceMultipleTest,
-                        ::testing::Values(0.5, 1.0, 1.5, 2.0, 4.0, 16.0, 255.9));
+                        ::testing::Values(0.5, 1.0, 1.5, 2.0, 4.0, 16.0, 255.9, []() {
+                            // Need to seed rand before calling to prevent getting the same value each time
+                            srand(time(nullptr));
+                            return (CGFloat)rand() / (CGFloat)RAND_MAX;
+                        }()));

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -149,9 +149,9 @@ public:
 
 TEST_P(CoreTextLineSpaceMultipleTest, OriginsShouldBeMovedByRatio) {
     NSMutableAttributedString* multipleString = [[[NSMutableAttributedString alloc] initWithString:@"TEST\nTEST\nTEST"] autorelease];
-    CGFloat param = GetParam();
+    CGFloat multiple = GetParam();
     CTParagraphStyleSetting settings[1] = {
-        {.spec = kCTParagraphStyleSpecifierLineHeightMultiple, .valueSize = sizeof(CGFloat), .value = &param }
+        {.spec = kCTParagraphStyleSpecifierLineHeightMultiple, .valueSize = sizeof(CGFloat), .value = &multiple }
     };
     NSDictionary* attributes = @{ static_cast<NSString*>(kCTParagraphStyleAttributeName) : (id)CTParagraphStyleCreate(settings, 1) };
     [multipleString setAttributes:attributes range:NSMakeRange(0, 14)];
@@ -162,8 +162,8 @@ TEST_P(CoreTextLineSpaceMultipleTest, OriginsShouldBeMovedByRatio) {
     CFAutorelease(multipleFrame);
     CGPoint multipleOrigins[3];
     CTFrameGetLineOrigins(multipleFrame, {}, multipleOrigins);
-    EXPECT_NEAR(param * normalLineSpaceFirst, multipleOrigins[1].y - multipleOrigins[0].y, c_errorDelta);
-    EXPECT_NEAR(param * normalLineSpaceSecond, multipleOrigins[2].y - multipleOrigins[0].y, c_errorDelta);
+    EXPECT_NEAR(multiple * normalLineSpaceFirst, multipleOrigins[1].y - multipleOrigins[0].y, c_errorDelta);
+    EXPECT_NEAR(multiple * normalLineSpaceSecond, multipleOrigins[2].y - multipleOrigins[0].y, c_errorDelta);
 }
 
 INSTANTIATE_TEST_CASE_P(OriginsShouldBeMovedByRatio,


### PR DESCRIPTION
Adds support for kCTParagraphStyleSpecifierLineHeightMultiple.  DWrite only allows line height multiples if the line height is kept constant through the frame, which is not guaranteed, so we need to manually manipulate the line origins.  Also removes the redundant line origin variable in _CTLine.

Fixes #1090

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1298)
<!-- Reviewable:end -->
