### PR TITLE
Properly pass font weight, stretch, style, to XamlCompositor

### DIFF
--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -903,3 +903,30 @@ CFTypeID CTFontGetTypeID() {
     static CFTypeID __kCTFontTypeID = _CFRuntimeRegisterClass(&__CTFontClass);
     return __kCTFontTypeID;
 }
+
+// Private function for getting font weight for XAML
+DWRITE_FONT_WEIGHT _CTFontGetDWriteWeight(CTFontRef font) {
+    ComPtr<IDWriteFontFace3> fontFace3;
+    if (font && SUCCEEDED(font->_dwriteFontFace.As(&fontFace3))) {
+        return fontFace3->GetWeight();
+    }
+    return DWRITE_FONT_WEIGHT_NORMAL;
+}
+
+// Private function for getting font stretch for XAML
+DWRITE_FONT_STRETCH _CTFontGetDWriteStretch(CTFontRef font) {
+    ComPtr<IDWriteFontFace3> fontFace3;
+    if (font && SUCCEEDED(font->_dwriteFontFace.As(&fontFace3))) {
+        return fontFace3->GetStretch();
+    }
+    return DWRITE_FONT_STRETCH_NORMAL;
+}
+
+// Private function for getting font style for XAML
+DWRITE_FONT_STYLE _CTFontGetDWriteStyle(CTFontRef font) {
+    ComPtr<IDWriteFontFace3> fontFace3;
+    if (font && SUCCEEDED(font->_dwriteFontFace.As(&fontFace3))) {
+        return fontFace3->GetStyle();
+    }
+    return DWRITE_FONT_STYLE_NORMAL;
+}

--- a/Frameworks/UIKit/StarboardXaml/CompositorInterface.h
+++ b/Frameworks/UIKit/StarboardXaml/CompositorInterface.h
@@ -21,6 +21,16 @@
 #include "winobjc\winobjc.h"
 #include <ppltasks.h>
 
+#ifdef __clang__
+#include <COMIncludes.h>
+#endif
+
+#include <DWrite_3.h>
+
+#ifdef __clang__
+#include <COMIncludes_End.h>
+#endif
+
 class DisplayNode;
 class DisplayTexture;
 class DisplayAnimation;
@@ -159,8 +169,9 @@ public:
     float _fontSize;
     float _lineHeight;
     bool _centerVertically;
-    bool _isBold = false;
-    bool _isItalic = false;
+    DWRITE_FONT_WEIGHT _fontWeight;
+    DWRITE_FONT_STRETCH _fontStretch;
+    DWRITE_FONT_STYLE _fontStyle;
 
     DisplayTextureXamlGlyphs();
     ~DisplayTextureXamlGlyphs();

--- a/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
+++ b/Frameworks/UIKit/StarboardXaml/CompositorInterface.mm
@@ -329,9 +329,10 @@ public:
         _centerVertically = centerVertically;
         _lineHeight = [font ascender] - [font descender];
 
-        int mask = [font fontDescriptor].symbolicTraits;
-        _isBold = (mask & UIFontDescriptorTraitBold) > 0;
-        _isItalic = (mask & UIFontDescriptorTraitItalic) > 0;
+        _fontWeight = [font _fontWeight];
+        _fontStretch = [font _fontStretch];
+        _fontStyle = [font _fontStyle];
+
         std::wstring wideBuffer = Strings::NarrowToWide<std::wstring>(text);
 
         // The Font Family names DWrite will return are not always compatible with Xaml

--- a/Frameworks/UIKit/StarboardXaml/XamlCompositor.cpp
+++ b/Frameworks/UIKit/StarboardXaml/XamlCompositor.cpp
@@ -561,17 +561,9 @@ void DisplayTextureXamlGlyphs::ConstructGlyphs(const Microsoft::WRL::Wrappers::H
     textControl->Foreground = ref new Windows::UI::Xaml::Media::SolidColorBrush(textColor);
     textControl->FontFamily = ref new Windows::UI::Xaml::Media::FontFamily(reinterpret_cast<Platform::String^>(fontFamilyName.Get()));
 
-    if (_isBold) {
-        textControl->FontWeight = Windows::UI::Text::FontWeights::Bold;
-    } else {
-        textControl->FontWeight = Windows::UI::Text::FontWeights::Normal;
-    }
-
-    if (_isItalic) {
-        textControl->FontStyle = Windows::UI::Text::FontStyle::Italic;
-    } else {
-        textControl->FontStyle = Windows::UI::Text::FontStyle::Normal;
-    }
+    textControl->FontWeight = Windows::UI::Text::FontWeight{ static_cast<unsigned short>(_fontWeight) };
+    textControl->FontStretch = static_cast<Windows::UI::Text::FontStretch>(_fontStretch);
+    textControl->FontStyle = static_cast<Windows::UI::Text::FontStyle>(_fontStyle);
 
     switch (_horzAlignment) {
         case alignLeft:

--- a/Frameworks/UIKit/UIFont.mm
+++ b/Frameworks/UIKit/UIFont.mm
@@ -34,6 +34,7 @@
 #import "LoggingNative.h"
 #import "UICTFont.h"
 #import "UIFontInternal.h"
+#import <CoreTextInternal.h>
 
 #include <COMIncludes.h>
 #import <DWrite.h>
@@ -294,6 +295,24 @@ BASE_CLASS_REQUIRED_IMPLS(UIFont, UIFontPrototype, CTFontGetTypeID);
 // Returns the family name of the font Xaml can use
 - (NSString*)_compatibleFamilyName {
     return static_cast<NSString*>(_DWriteGetFamilyNameForFontName(static_cast<CFStringRef>([self fontName])));
+}
+
+// WinObjC-only extension for compatibility issues between DWrite and Xaml
+// Returns the weight of the font Xaml can use
+- (DWRITE_FONT_WEIGHT)_fontWeight {
+    return _CTFontGetDWriteWeight(static_cast<CTFontRef>(self));
+}
+
+// WinObjC-only extension for compatibility issues between DWrite and Xaml
+// Returns the stretch of the font Xaml can use
+- (DWRITE_FONT_STRETCH)_fontStretch {
+    return _CTFontGetDWriteStretch(static_cast<CTFontRef>(self));
+}
+
+// WinObjC-only extension for compatibility issues between DWrite and Xaml
+// Returns the style of the font Xaml can use
+- (DWRITE_FONT_STYLE)_fontStyle {
+    return _CTFontGetDWriteStyle(static_cast<CTFontRef>(self));
 }
 
 @end

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -150,3 +150,6 @@ CORETEXT_EXTERNC_END
 
 // Private helper methods for UIKit
 CORETEXT_EXPORT CGSize _CTFrameGetSize(CTFrameRef frame);
+CORETEXT_EXPORT DWRITE_FONT_WEIGHT _CTFontGetDWriteWeight(CTFontRef font);
+CORETEXT_EXPORT DWRITE_FONT_STRETCH _CTFontGetDWriteStretch(CTFontRef font);
+CORETEXT_EXPORT DWRITE_FONT_STYLE _CTFontGetDWriteStyle(CTFontRef font);

--- a/Frameworks/include/UIFontInternal.h
+++ b/Frameworks/include/UIFontInternal.h
@@ -18,10 +18,17 @@
 #import <CoreFoundation/CoreFoundation.h>
 #import <UIKit/UIFont.h>
 
+#include <COMIncludes.h>
+#import <DWrite_3.h>
+#include <COMIncludes_End.h>
+
 @interface UIFont ()
 + (UIFont*)defaultFont;
 + (UIFont*)titleFont;
 + (UIFont*)messageFont;
 + (UIFont*)buttonFont;
 - (NSString*)_compatibleFamilyName;
+- (DWRITE_FONT_WEIGHT)_fontWeight;
+- (DWRITE_FONT_STRETCH)_fontStretch;
+- (DWRITE_FONT_STYLE)_fontStyle;
 @end

--- a/build/CoreText/dll/CoreText.def
+++ b/build/CoreText/dll/CoreText.def
@@ -136,6 +136,9 @@ LIBRARY CoreText
         CTFontCopyAvailableTables
         CTFontCopyTable
         CTFontGetTypeID
+        _CTFontGetDWriteWeight
+        _CTFontGetDWriteStretch
+        _CTFontGetDWriteStyle
 
         ; CTFontCollection Reference.mm
         kCTFontCollectionRemoveDuplicatesOption DATA


### PR DESCRIPTION
Update from using simplistic mapping using the font's symbolic traits, which ignored stretch,
to getting the weight/stretch/style directly from the font.

UILabel-rendered narrow or condensed fonts were previously clipped at the sides
because the CoreText-calculated width would be for a narrow font, but UILabel would attempt to render a normal font.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1302)
<!-- Reviewable:end -->
