### PR TITLE
Fix infinite loop in __CreateDWriteTextLayout

### DIFF
--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -204,7 +204,7 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(CFAttributedStringRef 
     for (size_t i = 0; i < [subString length]; i += attributeRange.length) {
         NSDictionary* attribs = [static_cast<NSAttributedString*>(string) attributesAtIndex:i + range.location
                                                                       longestEffectiveRange:&attributeRange
-                                                                                    inRange:{ i, [subString length] }];
+                                                                                    inRange:{ i + range.location, [subString length] }];
 
         const DWRITE_TEXT_RANGE dwriteRange = { attributeRange.location, attributeRange.length };
 

--- a/tests/unittests/CoreText/CTFramesetterTests.mm
+++ b/tests/unittests/CoreText/CTFramesetterTests.mm
@@ -113,19 +113,15 @@ TEST(CTFramesetter, ShouldBeAbleToCreateMultipleFramesFromSameFramesetter) {
     CFAutorelease(framesetter);
     CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, FLT_MAX, FLT_MAX), nullptr);
     CTFrameRef firstFrame = CTFramesetterCreateFrame(framesetter, { 0, 5 }, path, nullptr);
-    ;
     EXPECT_NE(nil, firstFrame);
 
     CTFrameRef secondFrame = CTFramesetterCreateFrame(framesetter, { 1, 8 }, path, nullptr);
-    ;
     EXPECT_NE(nil, secondFrame);
 
     CTFrameRef thirdFrame = CTFramesetterCreateFrame(framesetter, { 8, 2 }, path, nullptr);
-    ;
     EXPECT_NE(nil, thirdFrame);
 
     CTFrameRef fullFrame = CTFramesetterCreateFrame(framesetter, {}, path, nullptr);
-    ;
     EXPECT_NE(nil, fullFrame);
     CFRelease(firstFrame);
     CFRelease(secondFrame);

--- a/tests/unittests/CoreText/CTFramesetterTests.mm
+++ b/tests/unittests/CoreText/CTFramesetterTests.mm
@@ -22,7 +22,7 @@
 
 static const float c_errorDelta = 0.0005f;
 
-static NSAttributedString* getAttributedString(NSString* str) {
+static NSMutableAttributedString* getAttributedString(NSString* str) {
     UIFontDescriptor* fontDescriptor = [UIFontDescriptor fontDescriptorWithName:@"Times New Roman" size:40];
     UIFont* font = [UIFont fontWithDescriptor:fontDescriptor size:40];
 
@@ -103,4 +103,32 @@ TEST(CTFramesetter, ShouldNotThrowWhenCreatingFrameWithEmptyLines) {
     EXPECT_EQ(5L, CFArrayGetCount(CTFrameGetLines(frame)));
     CFRelease(frame);
     CGPathRelease(path);
+}
+
+TEST(CTFramesetter, ShouldBeAbleToCreateMultipleFramesFromSameFramesetter) {
+    NSMutableAttributedString* attrString = getAttributedString(@"ABCDEFGHIJ");
+    [attrString addAttribute:NSForegroundColorAttributeName value:[UIColor blueColor] range:NSMakeRange(0, 7)];
+    CFAttributedStringRef string = (__bridge CFAttributedStringRef)attrString;
+    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(string);
+    CFAutorelease(framesetter);
+    CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, FLT_MAX, FLT_MAX), nullptr);
+    CTFrameRef firstFrame = CTFramesetterCreateFrame(framesetter, { 0, 5 }, path, nullptr);
+    ;
+    EXPECT_NE(nil, firstFrame);
+
+    CTFrameRef secondFrame = CTFramesetterCreateFrame(framesetter, { 1, 8 }, path, nullptr);
+    ;
+    EXPECT_NE(nil, secondFrame);
+
+    CTFrameRef thirdFrame = CTFramesetterCreateFrame(framesetter, { 8, 2 }, path, nullptr);
+    ;
+    EXPECT_NE(nil, thirdFrame);
+
+    CTFrameRef fullFrame = CTFramesetterCreateFrame(framesetter, {}, path, nullptr);
+    ;
+    EXPECT_NE(nil, fullFrame);
+    CFRelease(firstFrame);
+    CFRelease(secondFrame);
+    CFRelease(thirdFrame);
+    CFRelease(fullFrame);
 }


### PR DESCRIPTION
Were not handling edge case where frames were being created with ranges not aligned with attributes in attributed strings.

Fixes #1294

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1306)
<!-- Reviewable:end -->
