### PR TITLE
Support multiple line break modes

### DIFF
--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -72,9 +72,11 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CF
     }
 
     // CoreText binds the origin of each line to the left for clipped lines no matter the writing direction / alignment
+    // TODO 1121:: DWrite does not support line breaking by truncation, so we are using clipping, so need to adjust for truncation as well
     CTLineBreakMode lineBreakMode;
     if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierLineBreakMode, sizeof(lineBreakMode), &lineBreakMode) &&
-        lineBreakMode == kCTLineBreakByClipping) {
+        (lineBreakMode == kCTLineBreakByClipping || lineBreakMode == kCTLineBreakByTruncatingHead ||
+         lineBreakMode == kCTLineBreakByTruncatingTail || lineBreakMode == kCTLineBreakByTruncatingMiddle)) {
         for (size_t i = 0; i < ret->_lineOrigins.size(); ++i) {
             if (CTLineGetTypographicBounds(static_cast<CTLineRef>([ret->_lines objectAtIndex:i]), nullptr, nullptr, nullptr) >
                 frameRect.size.width) {

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -156,6 +156,32 @@ static ComPtr<IDWriteTextFormat> __CreateDWriteTextFormat(CFAttributedStringRef 
 
             RETURN_NULL_IF_FAILED(textFormat->SetReadingDirection(dwriteDirection));
         }
+
+        CTLineBreakMode lineBreakMode;
+        if (CTParagraphStyleGetValueForSpecifier(settings,
+                                                 kCTParagraphStyleSpecifierLineBreakMode,
+                                                 sizeof(lineBreakMode),
+                                                 &lineBreakMode)) {
+            DWRITE_WORD_WRAPPING wrapping;
+            switch (lineBreakMode) {
+                case kCTLineBreakByClipping:
+                    wrapping = DWRITE_WORD_WRAPPING_NO_WRAP;
+                    break;
+                case kCTLineBreakByCharWrapping:
+                    wrapping = DWRITE_WORD_WRAPPING_CHARACTER;
+                    break;
+                // TODO 1121:: DWrite does not support line breaking by truncation, so just use default for now
+                case kCTLineBreakByTruncatingHead:
+                case kCTLineBreakByTruncatingTail:
+                case kCTLineBreakByTruncatingMiddle:
+                case kCTLineBreakByWordWrapping:
+                default:
+                    wrapping = DWRITE_WORD_WRAPPING_WRAP;
+                    break;
+            }
+
+            THROW_IF_FAILED(textFormat->SetWordWrapping(wrapping));
+        }
     }
 
     return textFormat;

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -164,16 +164,16 @@ static ComPtr<IDWriteTextFormat> __CreateDWriteTextFormat(CFAttributedStringRef 
                                                  &lineBreakMode)) {
             DWRITE_WORD_WRAPPING wrapping;
             switch (lineBreakMode) {
+                // TODO 1121:: DWrite does not support line breaking by truncation, so just use clipping for now
+                case kCTLineBreakByTruncatingHead:
+                case kCTLineBreakByTruncatingTail:
+                case kCTLineBreakByTruncatingMiddle:
                 case kCTLineBreakByClipping:
                     wrapping = DWRITE_WORD_WRAPPING_NO_WRAP;
                     break;
                 case kCTLineBreakByCharWrapping:
                     wrapping = DWRITE_WORD_WRAPPING_CHARACTER;
                     break;
-                // TODO 1121:: DWrite does not support line breaking by truncation, so just use default for now
-                case kCTLineBreakByTruncatingHead:
-                case kCTLineBreakByTruncatingTail:
-                case kCTLineBreakByTruncatingMiddle:
                 case kCTLineBreakByWordWrapping:
                 default:
                     wrapping = DWRITE_WORD_WRAPPING_WRAP;

--- a/Frameworks/include/CppUtils.h
+++ b/Frameworks/include/CppUtils.h
@@ -21,28 +21,28 @@
 
 #pragma region CFRange
 bool operator==(const CFRange& lhs, const CFRange& rhs) {
-    return lhs.location == rhs.location && rhs.length == rhs.length;
+    return lhs.location == rhs.location && lhs.length == rhs.length;
 }
 
 #pragma endregion
 
 #pragma region CGPoint
 bool operator==(const CGPoint& lhs, const CGPoint& rhs) {
-    return lhs.x == rhs.x && rhs.y == rhs.y;
+    return lhs.x == rhs.x && lhs.y == rhs.y;
 }
 
 #pragma endregion
 
 #pragma region CGSize
 bool operator==(const CGSize& lhs, const CGSize& rhs) {
-    return lhs.width == rhs.width && rhs.height == rhs.height;
+    return lhs.width == rhs.width && lhs.height == rhs.height;
 }
 
 #pragma endregion
 
 #pragma region CGRect
 bool operator==(const CGRect& lhs, const CGRect& rhs) {
-    return lhs.origin == rhs.origin && rhs.size == rhs.size;
+    return lhs.origin == rhs.origin && lhs.size == rhs.size;
 }
 
 #pragma endregion

--- a/Frameworks/include/CppUtils.h
+++ b/Frameworks/include/CppUtils.h
@@ -1,0 +1,50 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//*****************************************************************************/
+#pragma once
+
+#import <CoreGraphics/CoreGraphics.h>
+
+#ifdef __cplusplus
+
+#pragma region CFRange
+bool operator==(const CFRange& lhs, const CFRange& rhs) {
+    return lhs.location == rhs.location && rhs.length == rhs.length;
+}
+
+#pragma endregion
+
+#pragma region CGPoint
+bool operator==(const CGPoint& lhs, const CGPoint& rhs) {
+    return lhs.x == rhs.x && rhs.y == rhs.y;
+}
+
+#pragma endregion
+
+#pragma region CGSize
+bool operator==(const CGSize& lhs, const CGSize& rhs) {
+    return lhs.width == rhs.width && rhs.height == rhs.height;
+}
+
+#pragma endregion
+
+#pragma region CGRect
+bool operator==(const CGRect& lhs, const CGRect& rhs) {
+    return lhs.origin == rhs.origin && rhs.size == rhs.size;
+}
+
+#pragma endregion
+
+#endif

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -80,6 +80,7 @@
     </SBResourceCopy>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CppUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\MockClass.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\unittests\Tests.Shared\ByteUtils.h" />
   </ItemGroup>


### PR DESCRIPTION
Now support kCTLineBreakByWordWrapping, kCTLineBreakByCharWrapping, and kCTLineBreakByClipping.  Also adds a helper file for unit tests to use default testing macros with CG/CF structs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1319)
<!-- Reviewable:end -->
