### PR TITLE
Add location capability back to woccatalog. Fixes #1321.

### DIFF
--- a/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/Package.appxmanifest
+++ b/samples/WOCCatalog/WOCCatalog.vsimporter/WOCCatalog-WinStore10/Package.appxmanifest
@@ -45,5 +45,6 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+	<DeviceCapability Name="location" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
Add location capability back to woccatalog. Fixes #1321.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1322)
<!-- Reviewable:end -->
