### PR TITLE
Refine CGContext's user<->device coordinate space boundary

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -1675,7 +1675,7 @@ void CGContextDrawPath(CGContextRef context, CGPathDrawingMode mode) {
     if (context->HasPath()) {
         ComPtr<ID2D1Geometry> pGeometry;
         FAIL_FAST_IF_FAILED(_CGPathGetGeometry(context->Path(), &pGeometry));
-        FAIL_FAST_IF_FAILED(__CGContextDrawGeometry(context, pGeometry.Get(), mode));
+        FAIL_FAST_IF_FAILED(__CGContextDrawGeometry(context, _kCGCoordinateModeDeviceSpace, pGeometry.Get(), mode));
         context->ClearPath();
     }
 }

--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -495,7 +495,8 @@ void CGContextClosePath(CGContextRef context) {
 void CGContextAddRect(CGContextRef context, CGRect rect) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddRect(context->Path(), &(context->CurrentGState().transform), rect);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddRect(context->Path(), &userToDeviceTransform, rect);
 }
 
 /**
@@ -512,7 +513,8 @@ void CGContextAddRects(CGContextRef context, const CGRect* rects, unsigned count
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
-    CGPathAddRects(context->Path(), &(context->CurrentGState().transform), rects, count);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddRects(context->Path(), &userToDeviceTransform, rects, count);
 
 #pragma clang diagnostic pop
 }
@@ -523,7 +525,8 @@ void CGContextAddRects(CGContextRef context, const CGRect* rects, unsigned count
 void CGContextAddLineToPoint(CGContextRef context, CGFloat x, CGFloat y) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddLineToPoint(context->Path(), &(context->CurrentGState().transform), x, y);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddLineToPoint(context->Path(), &userToDeviceTransform, x, y);
 }
 
 /**
@@ -532,7 +535,8 @@ void CGContextAddLineToPoint(CGContextRef context, CGFloat x, CGFloat y) {
 void CGContextAddCurveToPoint(CGContextRef context, CGFloat cp1x, CGFloat cp1y, CGFloat cp2x, CGFloat cp2y, CGFloat x, CGFloat y) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddCurveToPoint(context->Path(), &(context->CurrentGState().transform), cp1x, cp1y, cp2x, cp2y, x, y);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddCurveToPoint(context->Path(), &userToDeviceTransform, cp1x, cp1y, cp2x, cp2y, x, y);
 }
 
 /**
@@ -541,7 +545,8 @@ void CGContextAddCurveToPoint(CGContextRef context, CGFloat cp1x, CGFloat cp1y, 
 void CGContextAddQuadCurveToPoint(CGContextRef context, CGFloat cpx, CGFloat cpy, CGFloat x, CGFloat y) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddQuadCurveToPoint(context->Path(), &(context->CurrentGState().transform), cpx, cpy, x, y);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddQuadCurveToPoint(context->Path(), &userToDeviceTransform, cpx, cpy, x, y);
 }
 
 /**
@@ -550,7 +555,8 @@ void CGContextAddQuadCurveToPoint(CGContextRef context, CGFloat cpx, CGFloat cpy
 void CGContextMoveToPoint(CGContextRef context, CGFloat x, CGFloat y) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathMoveToPoint(context->Path(), &(context->CurrentGState().transform), x, y);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathMoveToPoint(context->Path(), &userToDeviceTransform, x, y);
 }
 
 /**
@@ -559,7 +565,8 @@ void CGContextMoveToPoint(CGContextRef context, CGFloat x, CGFloat y) {
 void CGContextAddArc(CGContextRef context, CGFloat x, CGFloat y, CGFloat radius, CGFloat startAngle, CGFloat endAngle, int clockwise) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddArc(context->Path(), &(context->CurrentGState().transform), x, y, radius, startAngle, endAngle, clockwise);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddArc(context->Path(), &userToDeviceTransform, x, y, radius, startAngle, endAngle, clockwise);
 }
 
 /**
@@ -568,7 +575,8 @@ void CGContextAddArc(CGContextRef context, CGFloat x, CGFloat y, CGFloat radius,
 void CGContextAddArcToPoint(CGContextRef context, CGFloat x1, CGFloat y1, CGFloat x2, CGFloat y2, CGFloat radius) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddArcToPoint(context->Path(), &(context->CurrentGState().transform), x1, y1, x2, y2, radius);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddArcToPoint(context->Path(), &userToDeviceTransform, x1, y1, x2, y2, radius);
 }
 
 /**
@@ -577,7 +585,8 @@ void CGContextAddArcToPoint(CGContextRef context, CGFloat x1, CGFloat y1, CGFloa
 void CGContextAddEllipseInRect(CGContextRef context, CGRect rect) {
     NOISY_RETURN_IF_NULL(context);
 
-    CGPathAddEllipseInRect(context->Path(), &(context->CurrentGState().transform), rect);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddEllipseInRect(context->Path(), &userToDeviceTransform, rect);
 }
 
 /**
@@ -596,7 +605,8 @@ void CGContextAddPath(CGContextRef context, CGPathRef path) {
         return;
     }
 
-    CGPathAddPath(context->Path(), &(context->CurrentGState().transform), path);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddPath(context->Path(), &userToDeviceTransform, path);
 }
 
 /**
@@ -648,8 +658,7 @@ CGRect CGContextGetPathBoundingBox(CGContextRef context) {
     }
 
     // All queries take place on transformed paths, but return pre-CTM context units.
-    CGAffineTransform invertedCTM = CGAffineTransformInvert(context->CurrentGState().transform);
-    return CGRectApplyAffineTransform(CGPathGetBoundingBox(context->Path()), invertedCTM);
+    return CGContextConvertRectToUserSpace(context, CGPathGetBoundingBox(context->Path()));
 }
 
 /**
@@ -662,7 +671,8 @@ void CGContextAddLines(CGContextRef context, const CGPoint* points, unsigned cou
         return;
     }
 
-    CGPathAddLines(context->Path(), &(context->CurrentGState().transform), points, count);
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    CGPathAddLines(context->Path(), &userToDeviceTransform, points, count);
 }
 #pragma endregion
 
@@ -686,8 +696,8 @@ CGPathRef CGContextCopyPath(CGContextRef context) {
     // This means that the path the user gets back will be in units equivalent to
     // their inputs. We therefore must de-transform the path into which we inserted
     // transformed points.
-    CGAffineTransform invertedCTM = CGAffineTransformInvert(context->CurrentGState().transform);
-    return CGPathCreateCopyByTransformingPath(context->Path(), &invertedCTM);
+    CGAffineTransform invertedDeviceSpaceTransform = CGAffineTransformInvert(CGContextGetUserSpaceToDeviceSpaceTransform(context));
+    return CGPathCreateCopyByTransformingPath(context->Path(), &invertedDeviceSpaceTransform);
 
 #pragma clang diagnostic pop
 }
@@ -704,8 +714,7 @@ CGPoint CGContextGetPathCurrentPoint(CGContextRef context) {
     }
 
     // All queries take place on transformed paths, but return pre-CTM context units.
-    CGAffineTransform invertedCTM = CGAffineTransformInvert(context->CurrentGState().transform);
-    return CGPointApplyAffineTransform(CGPathGetCurrentPoint(context->Path()), invertedCTM);
+    return CGContextConvertPointToUserSpace(context, CGPathGetCurrentPoint(context->Path()));
 }
 
 /**
@@ -715,7 +724,8 @@ CGPoint CGContextGetPathCurrentPoint(CGContextRef context) {
 bool CGContextPathContainsPoint(CGContextRef context, CGPoint point, CGPathDrawingMode mode) {
     NOISY_RETURN_IF_NULL(context, false);
 
-    return context->HasPath() && CGPathContainsPoint(context->Path(), &(context->CurrentGState().transform), point, (mode & kCGPathEOFill));
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+    return context->HasPath() && CGPathContainsPoint(context->Path(), &userToDeviceTransform, point, (mode & kCGPathEOFill));
 }
 #pragma endregion
 

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -18,6 +18,7 @@
 
 #include <COMIncludes.h>
 #import <DWrite.h>
+#import <D2d1.h>
 #include <COMIncludes_End.h>
 
 #import "CGImageInternal.h"
@@ -53,6 +54,7 @@ COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GL
 // TODO 1077:: Remove once D2D render target is implemented
 COREGRAPHICS_EXPORT void _CGContextSetScaleFactor(CGContextRef ctx, float scale);
 
+COREGRAPHICS_EXPORT CGContextRef _CGContextCreateWithD2DRenderTarget(ID2D1RenderTarget* renderTarget);
 COREGRAPHICS_EXPORT void _CGContextSetShadowProjectionTransform(CGContextRef context, CGAffineTransform transform);
 
 #include "CGContextImpl.h"

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -234,6 +234,7 @@ LIBRARY CoreGraphics
         CGContextGetBacking
         CGContextDrawGlyphRun
         _CGContextSetShadowProjectionTransform
+        _CGContextCreateWithD2DRenderTarget
 
         ; CGDataConsumer.mm
         CGDataConsumerCreate

--- a/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
@@ -147,7 +147,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d2d1.lib;windowscodecs.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -173,7 +173,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d2d1.lib;windowscodecs.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -199,7 +199,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d2d1.lib;windowscodecs.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -225,7 +225,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d2d1.lib;windowscodecs.lib;freetype.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>

--- a/include/CoreGraphics/CGContext.h
+++ b/include/CoreGraphics/CGContext.h
@@ -233,10 +233,10 @@ COREGRAPHICS_EXPORT void CGContextShowText(CGContextRef c, const char* string, s
 
 COREGRAPHICS_EXPORT void CGContextShowTextAtPoint(CGContextRef c, CGFloat x, CGFloat y, const char* string, size_t length);
 
-COREGRAPHICS_EXPORT CGAffineTransform CGContextGetUserSpaceToDeviceSpaceTransform(CGContextRef c) STUB_METHOD;
-COREGRAPHICS_EXPORT CGPoint CGContextConvertPointToDeviceSpace(CGContextRef c, CGPoint point) STUB_METHOD;
-COREGRAPHICS_EXPORT CGPoint CGContextConvertPointToUserSpace(CGContextRef c, CGPoint point) STUB_METHOD;
-COREGRAPHICS_EXPORT CGSize CGContextConvertSizeToDeviceSpace(CGContextRef c, CGSize size) STUB_METHOD;
-COREGRAPHICS_EXPORT CGSize CGContextConvertSizeToUserSpace(CGContextRef c, CGSize size) STUB_METHOD;
-COREGRAPHICS_EXPORT CGRect CGContextConvertRectToDeviceSpace(CGContextRef c, CGRect rect) STUB_METHOD;
-COREGRAPHICS_EXPORT CGRect CGContextConvertRectToUserSpace(CGContextRef c, CGRect rect) STUB_METHOD;
+COREGRAPHICS_EXPORT CGAffineTransform CGContextGetUserSpaceToDeviceSpaceTransform(CGContextRef c);
+COREGRAPHICS_EXPORT CGPoint CGContextConvertPointToDeviceSpace(CGContextRef c, CGPoint point);
+COREGRAPHICS_EXPORT CGPoint CGContextConvertPointToUserSpace(CGContextRef c, CGPoint point);
+COREGRAPHICS_EXPORT CGSize CGContextConvertSizeToDeviceSpace(CGContextRef c, CGSize size);
+COREGRAPHICS_EXPORT CGSize CGContextConvertSizeToUserSpace(CGContextRef c, CGSize size);
+COREGRAPHICS_EXPORT CGRect CGContextConvertRectToDeviceSpace(CGContextRef c, CGRect rect);
+COREGRAPHICS_EXPORT CGRect CGContextConvertRectToUserSpace(CGContextRef c, CGRect rect);

--- a/tests/unittests/CoreGraphics/CGContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGContextTests.mm
@@ -22,6 +22,16 @@
 #import <CoreGraphics/CGBitmapContext.h>
 #import <CoreGraphics/CGPattern.h>
 
+#include <COMIncludes.h>
+#import <wrl/client.h>
+#import <d2d1.h>
+#import <wincodec.h>
+#include <COMIncludes_end.h>
+
+#import "CGContextInternal.h"
+
+using namespace Microsoft::WRL;
+
 static NSString* const kPointsKey = @"PointsKey";
 static NSString* const kTypeKey = @"TypeKey";
 // Helper function to know # of points in an element
@@ -262,3 +272,146 @@ DISABLED_TEST(CGPath, CGContextCopyPathCGPathAddQuadCurveToPoint) {
     CGContextRelease(context);
     CGColorSpaceRelease(rgbColorSpace);
 }
+
+bool operator==(const CGPoint& lhs, const CGPoint& rhs) {
+    return ((std::abs(lhs.x - rhs.x) < 0.00001) && (std::abs(lhs.y - rhs.y) < 0.00001));
+}
+
+template <typename T>
+std::basic_ostream<T>& operator<<(std::basic_ostream<T>& os, const CGPoint& pt) {
+    return os << "{" << pt.x << ", " << pt.y << "}";
+}
+
+template <typename T>
+std::basic_ostream<T>& operator<<(std::basic_ostream<T>& os, const CGAffineTransform& transform) {
+    os << "[";
+    if (CGAffineTransformIsIdentity(transform)) {
+        os << "identity transform";
+    } else {
+        os << transform.a << " " << transform.b << " " << transform.c << " " << transform.d << " " << transform.tx << " " << transform.ty;
+    }
+    return os << "]";
+}
+
+class ContextCoordinateTest
+    : public ::testing::TestWithParam<::testing::tuple<CGAffineTransform, std::vector<CGPoint>, std::vector<CGPoint>>> {
+public:
+    woc::unique_cf<CGContextRef> context;
+
+    static ComPtr<ID2D1RenderTarget> renderTarget;
+    static void SetUpTestCase() {
+        // TODO GH#1124: When CGBitmapContext lands, we don't need to do this manually.
+        MULTI_QI multi{
+            .pIID = &IID_IWICImagingFactory, .pItf = nullptr,
+        };
+
+        CGSize dimensions{ 100, 100 };
+
+        ComPtr<IWICImagingFactory> wicFactory;
+        THROW_IF_FAILED(CoCreateInstanceFromApp(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, nullptr, 1, &multi));
+        wicFactory.Attach(static_cast<IWICImagingFactory*>(multi.pItf));
+
+        ComPtr<IWICBitmap> wicBitmap;
+        THROW_IF_FAILED(wicFactory->CreateBitmap(dimensions.width,
+                                                 dimensions.height,
+                                                 GUID_WICPixelFormat32bppPRGBA,
+                                                 WICBitmapCacheOnDemand,
+                                                 &wicBitmap));
+
+        ComPtr<ID2D1Factory> d2dFactory;
+        FAIL_FAST_IF_FAILED(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory), &d2dFactory));
+
+        THROW_IF_FAILED(d2dFactory->CreateWicBitmapRenderTarget(wicBitmap.Get(), D2D1::RenderTargetProperties(), &renderTarget));
+    }
+
+    static void TearDownTestCase() {
+        renderTarget = nullptr;
+    }
+
+    virtual void SetUp() {
+        context.reset(_CGContextCreateWithD2DRenderTarget(renderTarget.Get()));
+        ASSERT_NE(nullptr, context);
+
+        CGAffineTransform contextTransform = ::testing::get<0>(GetParam());
+        if (!CGAffineTransformIsIdentity(contextTransform)) {
+            CGContextConcatCTM(context.get(), contextTransform);
+        }
+    }
+};
+
+/* static */
+ComPtr<ID2D1RenderTarget> ContextCoordinateTest::renderTarget;
+
+TEST_P(ContextCoordinateTest, ConvertToDeviceSpace) {
+    const std::vector<CGPoint>& userSpacePoints = ::testing::get<1>(GetParam());
+    const std::vector<CGPoint>& deviceSpacePoints = ::testing::get<2>(GetParam());
+    for (unsigned int i = 0; i < userSpacePoints.size(); ++i) {
+        const CGPoint& userSpacePoint = userSpacePoints[i];
+        const CGPoint& deviceSpacePoint = deviceSpacePoints[i];
+        EXPECT_EQ(deviceSpacePoint, CGContextConvertPointToDeviceSpace(context.get(), userSpacePoint));
+    }
+}
+
+TEST_P(ContextCoordinateTest, ConvertToUserSpace) {
+    const std::vector<CGPoint>& userSpacePoints = ::testing::get<1>(GetParam());
+    const std::vector<CGPoint>& deviceSpacePoints = ::testing::get<2>(GetParam());
+    for (unsigned int i = 0; i < userSpacePoints.size(); ++i) {
+        const CGPoint& userSpacePoint = userSpacePoints[i];
+        const CGPoint& deviceSpacePoint = deviceSpacePoints[i];
+        EXPECT_EQ(userSpacePoint, CGContextConvertPointToUserSpace(context.get(), deviceSpacePoint));
+    }
+}
+
+// clang-format off
+::testing::tuple<CGAffineTransform, std::vector<CGPoint>, std::vector<CGPoint>> coordinateTestTuples[] = {
+    // { Context Transform, Vector of user points, Vector of device points }
+    {
+        // CoreGraphics is a LLO drawing system, but Direct2D is ULO.
+        // In device space, all coordinates are therefore inverted on the Y axis.
+        // Our test images are 100x100, so 0, 0 maps to 100, 100.
+        CGAffineTransformIdentity,
+        { {  0,   0}, { 50,  50}, {100, 100} },
+        { {  0, 100}, { 50,  50}, {100,   0} },
+    },
+    {
+        // Coordinate system scaled by 2x
+        CGAffineTransformMakeScale(2.0, 2.0),
+        { {  0,   0}, { 25,  25}, { 50,  50} },
+        { {  0, 100}, { 50,  50}, {100,   0} },
+    },
+    {
+        // Coordinate system translated by 20, 20
+        CGAffineTransformMakeTranslation(20, 20),
+        { {  0,   0}, { 50,  50}, {100, 100} },
+        { { 20,  80}, { 70,  30}, {120, -20} },
+    },
+    {
+        // Coordinate system rotated by 45deg
+        // Rotation should be COUNTERCLOCKWISE by default.
+        CGAffineTransformMakeRotation(45. * M_PI / 180.),
+        { {  0,   0}, { 20. * (M_SQRT2/2.), 20. * (M_SQRT2/2.)}, {                 0.,                        20.} },
+        { {  0, 100}, {                 0.,                80.}, {-20. * (M_SQRT2/2.), 100. - (20. * (M_SQRT2/2))} },
+    },
+    {
+        // Coordinate system transformed into ULO
+        CGAffineTransformScale(CGAffineTransformMakeTranslation(0, 100), 1.0, -1.0),
+        { {  0,   0}, { 50,  50}, {100, 100} },
+        { {  0,   0}, { 50,  50}, {100, 100} },
+    },
+    {
+        // Coordinate system transformed into ULO + 2x scale
+        CGAffineTransformScale(CGAffineTransformScale(CGAffineTransformMakeTranslation(0, 100), 1.0, -1.0), 2.0, 2.0),
+        { {  0,   0}, { 25,  25}, { 50,  50} },
+        { {  0,   0}, { 50,  50}, {100, 100} },
+    },
+    {
+        // Coordinate system transformed into ULO + 45deg rotation
+        // Rotation should now be CLOCKWISE.
+        CGAffineTransformRotate(CGAffineTransformScale(CGAffineTransformMakeTranslation(0, 100), 1.0, -1.0), 45. * M_PI / 180.),
+        { {  0,   0}, { 20. * (M_SQRT2/2.), 20. * (M_SQRT2/2.)}, {                 0.,               20.} },
+        { {  0,   0}, {                 0.,                20.}, {-20. * (M_SQRT2/2.), 20. * (M_SQRT2/2)} },
+    },
+};
+// clang-format on
+
+INSTANTIATE_TEST_CASE_P(CGContextCoordinateSpace, ContextCoordinateTest, ::testing::ValuesIn(coordinateTestTuples));

--- a/tests/unittests/CoreGraphics/CGContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGContextTests.mm
@@ -22,6 +22,7 @@
 #import <CoreGraphics/CGBitmapContext.h>
 #import <CoreGraphics/CGPattern.h>
 
+#if TARGET_OS_WIN32
 #include <COMIncludes.h>
 #import <wrl/client.h>
 #import <d2d1.h>
@@ -31,6 +32,7 @@
 #import "CGContextInternal.h"
 
 using namespace Microsoft::WRL;
+#endif
 
 static NSString* const kPointsKey = @"PointsKey";
 static NSString* const kTypeKey = @"TypeKey";
@@ -293,6 +295,7 @@ std::basic_ostream<T>& operator<<(std::basic_ostream<T>& os, const CGAffineTrans
     return os << "]";
 }
 
+#if TARGET_OS_WIN32
 class ContextCoordinateTest
     : public ::testing::TestWithParam<::testing::tuple<CGAffineTransform, std::vector<CGPoint>, std::vector<CGPoint>>> {
 public:
@@ -415,3 +418,4 @@ TEST_P(ContextCoordinateTest, ConvertToUserSpace) {
 // clang-format on
 
 INSTANTIATE_TEST_CASE_P(CGContextCoordinateSpace, ContextCoordinateTest, ::testing::ValuesIn(coordinateTestTuples));
+#endif


### PR DESCRIPTION
CGContext will now strive, wherever possible, to store its internal state in fully-device-transformed units. This transformation includes the device scale (flip+translate from CG to D2D) and the user scale.

To enable this, this pull request also adds the ability to specify that coordinate system a drawn geometry is in: paths will use the premultiplied values, and user-space geometry values will use userspace->device transformation.

This allows us to leverage the Direct2D effect stack without having to apply input and output transformations to the effects, and simplifies shadow rendering (we no longer transform for userspace in the commandlist and then device space when we draw it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1324)
<!-- Reviewable:end -->
