### PR TITLE
Suppressing ignore extern-initialize warning in winrt template.

### DIFF
--- a/msvc/vsimporter-templates/WinStore10-WinRT/WinRT.vcxproj
+++ b/msvc/vsimporter-templates/WinStore10-WinRT/WinRT.vcxproj
@@ -32,15 +32,17 @@
   <ItemDefinitionGroup VSImporterLabel="ConfigurationItemDefinitions">
     <ClCompile>
       <RuntimeLibrary VSImporterConfigName="Debug">MultiThreadedDebugDLL</RuntimeLibrary>
-	  <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+    <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-	  <PrecompiledHeader>NotUsing</PrecompiledHeader>
-	  <CompileAsWinRT>false</CompileAsWinRT>
+    PrecompiledHeader>NotUsing</PrecompiledHeader>
+    <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
     <ClangCompile>
       <RuntimeLibrary VSImporterConfigName="Debug">MultiThreadedDebugDLL</RuntimeLibrary>
-	  <IncludePaths>$(SolutionPublicHeadersDir);$(WINOBJC_SDK_ROOT)\include\xplat;$(WINOBJC_SDK_ROOT)\Frameworks\include;%(IncludePaths)</IncludePaths>
+    <IncludePaths>$(SolutionPublicHeadersDir);$(WINOBJC_SDK_ROOT)\include\xplat;$(WINOBJC_SDK_ROOT)\Frameworks\include;%(IncludePaths)</IncludePaths>
       <PreprocessorDefinitions>__MIDL_USE_C_ENUM</PreprocessorDefinitions>
+      <OtherCFlags>-Wno-extern-initializer</OtherCFlags>
+      <OtherCPlusPlusFlags>-Wno-extern-initializer</OtherCPlusPlusFlags>
     </ClangCompile>
     <Midl>
       <OutputDirectory>$(Objc2WinmdGeneratedFilesDir)</OutputDirectory>
@@ -51,15 +53,15 @@
       <GenerateClientFiles>None</GenerateClientFiles>
       <GenerateServerFiles>None</GenerateServerFiles>
     </Midl>
-	<Link>
-	  <AdditionalDependencies>WinObjCRT.lib;Logging.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    <Link>
+    <AdditionalDependencies>WinObjCRT.lib;Logging.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-	</Link>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup VSImporterLabel="ProjectItems">
     <ClCompile Include="Module.cpp" />
-	<_MdMergeOutput Include="$(OutDir)\$(ProjectName).winmd" />
-	<ClangCompile Condition="'$(Objc2WinmdGeneratedFilesDir)' != ''" Include="$(Objc2WinmdGeneratedFilesDir)\*.mm" />
+    <_MdMergeOutput Include="$(OutDir)\$(ProjectName).winmd" />
+    <ClangCompile Condition="'$(Objc2WinmdGeneratedFilesDir)' != ''" Include="$(Objc2WinmdGeneratedFilesDir)\*.mm" />
     <Midl Condition="'$(Objc2WinmdGeneratedFilesDir)' != ''" Include="$(Objc2WinmdGeneratedFilesDir)\*.idl" />
     <ClInclude Condition="'$(Objc2WinmdGeneratedFilesDir)' != ''" Include="$(Objc2WinmdGeneratedFilesDir)\*.h" />
   </ItemGroup>


### PR DESCRIPTION
Updating template to ignore extern-initialize warning since the ABI headers generated by MIDL initialize GUID's.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1329)
<!-- Reviewable:end -->
