### PR TITLE
Implement NSParagraphStyle and refactor CTParagraphStyle

### DIFF
--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -32,7 +32,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
     // Call _DWriteWrapper to get _CTLine object list that makes up this frame
     _CTTypesetter* typesetter = static_cast<_CTTypesetter*>(framesetter->_typesetter);
     if (range.length == 0L) {
-        range.length = typesetter->_characters.size() - range.location;
+        range.length = typesetter->_characters.size();
     }
 
     StrongId<_CTFrame> ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize);
@@ -42,10 +42,8 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
         return ret.detach();
     }
 
-    CTParagraphStyleRef settings =
-        static_cast<CTParagraphStyleRef>([typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName)
-                                                                          atIndex:range.location
-                                                                   effectiveRange:nullptr]);
+    CTParagraphStyleRef settings = static_cast<CTParagraphStyleRef>(
+        [typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName) atIndex:0 effectiveRange:nullptr]);
 
     if (settings == nullptr) {
         return ret.detach();

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -32,7 +32,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
     // Call _DWriteWrapper to get _CTLine object list that makes up this frame
     _CTTypesetter* typesetter = static_cast<_CTTypesetter*>(framesetter->_typesetter);
     if (range.length == 0L) {
-        range.length = typesetter->_characters.size();
+        range.length = typesetter->_characters.size() - range.location;
     }
 
     StrongId<_CTFrame> ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameSize);
@@ -42,10 +42,12 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameSize, CF
         return ret.detach();
     }
 
-    CTParagraphStyleRef settings = static_cast<CTParagraphStyleRef>(
-        [typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName) atIndex:0 effectiveRange:nullptr]);
+    CTParagraphStyleRef settings =
+        static_cast<CTParagraphStyleRef>([typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName)
+                                                                          atIndex:range.location
+                                                                   effectiveRange:nullptr]);
 
-    if (settings == nil) {
+    if (settings == nullptr) {
         return ret.detach();
     }
 

--- a/Frameworks/CoreText/CTParagraphStyle.mm
+++ b/Frameworks/CoreText/CTParagraphStyle.mm
@@ -144,7 +144,7 @@ private:
 
 /**
  @Status Caveat
- @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops
+ @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops not supported
 */
 CTParagraphStyleRef CTParagraphStyleCreate(const CTParagraphStyleSetting* settings, size_t settingsCount) {
     __CTParagraphStyle* style = __CTParagraphStyle::CreateInstance();
@@ -160,7 +160,7 @@ CTParagraphStyleRef CTParagraphStyleCreate(const CTParagraphStyleSetting* settin
 
 /**
  @Status Caveat
- @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops
+ @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops not supported
 */
 CTParagraphStyleRef CTParagraphStyleCreateCopy(CTParagraphStyleRef paragraphStyle) {
     return paragraphStyle ? __CTParagraphStyle::CreateInstance(nullptr, *paragraphStyle) : nullptr;
@@ -168,7 +168,7 @@ CTParagraphStyleRef CTParagraphStyleCreateCopy(CTParagraphStyleRef paragraphStyl
 
 /**
  @Status Caveat
- @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops
+ @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops not supported
 */
 bool CTParagraphStyleGetValueForSpecifier(CTParagraphStyleRef paragraphStyle,
                                           CTParagraphStyleSpecifier spec,

--- a/Frameworks/CoreText/CTParagraphStyle.mm
+++ b/Frameworks/CoreText/CTParagraphStyle.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,235 +17,182 @@
 #import <CoreText/CTParagraphStyle.h>
 #import <StubReturn.h>
 #import "CoreTextInternal.h"
+#import "CFCppBase.h"
 #import <stddef.h>
 
-static const size_t MAX_SPECIFIER_COUNT = 16;
-
-// PropertyInfo is the struct containing the expected size of data and an offset to the struct which has the actual data.
-struct PropertyInfo {
-    size_t expectedSize;
-    size_t offset;
+// Contains the expected size of the data for any specifier
+static constexpr size_t __CTParagraphStyleSizeTable[kCTParagraphStyleSpecifierCount] = {
+        [kCTParagraphStyleSpecifierAlignment] = sizeof(CTTextAlignment),
+        [kCTParagraphStyleSpecifierFirstLineHeadIndent] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierHeadIndent] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierTailIndent] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierTabStops] = sizeof(CFArrayRef),
+        [kCTParagraphStyleSpecifierDefaultTabInterval] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierLineBreakMode] = sizeof(CTLineBreakMode),
+        [kCTParagraphStyleSpecifierLineHeightMultiple] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierMaximumLineHeight] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierMinimumLineHeight] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierLineSpacing] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierParagraphSpacing] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierParagraphSpacingBefore] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierBaseWritingDirection] = sizeof(CTWritingDirection),
+        [kCTParagraphStyleSpecifierMaximumLineSpacing] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierMinimumLineSpacing] = sizeof(CGFloat),
+        [kCTParagraphStyleSpecifierLineSpacingAdjustment] = sizeof(CGFloat),
 };
 
-// this table contains the expected size of the data for any specifier, and its offset in the structure.
-static PropertyInfo propertyInfoTable[] = {
+#pragma region __CTParagraphStyle
+typedef struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> {
+    __CTParagraphStyle() {
+        static CFArrayRef __defaultValues = []() {
+            constexpr CGFloat c_defaultFloat = 0.0;
+            // Need to store Alignment and LineBreakMode as ints in CFNumberRef
+            constexpr int c_defaultAlignment = kCTNaturalTextAlignment;
+            constexpr int c_defaultLineBreakMode = kCTLineBreakByWordWrapping;
+            constexpr CTWritingDirection c_defaultWritingDirection = kCTWritingDirectionNatural;
+            woc::unique_cf<CFNumberRef> __alignment{ CFNumberCreate(nullptr, kCFNumberIntType, &c_defaultAlignment) };
+            woc::unique_cf<CFNumberRef> __lineBreakMode{ CFNumberCreate(nullptr, kCFNumberIntType, &c_defaultLineBreakMode) };
+            woc::unique_cf<CFNumberRef> __writingDirection{ CFNumberCreate(nullptr, kCFNumberSInt8Type, &c_defaultWritingDirection) };
+            woc::unique_cf<CFNumberRef> __floatDefault{ CFNumberCreate(nullptr, kCFNumberCGFloatType, &c_defaultFloat) };
+            CFTypeRef values[kCTParagraphStyleSpecifierCount] = {
+                __alignment.get(),    __floatDefault.get(),  __floatDefault.get(), __floatDefault.get(),     nullptr,
+                __floatDefault.get(), __lineBreakMode.get(), __floatDefault.get(), __floatDefault.get(),     __floatDefault.get(),
+                __floatDefault.get(), __floatDefault.get(),  __floatDefault.get(), __writingDirection.get(), __floatDefault.get(),
+                __floatDefault.get(), __floatDefault.get(),
+            };
+            return CFArrayCreate(nullptr, values, kCTParagraphStyleSpecifierCount, &kCFTypeArrayCallBacks);
+        }();
+        _styles.reset(CFArrayCreateMutableCopy(nullptr, kCTParagraphStyleSpecifierCount, __defaultValues));
+    }
 
-        [kCTParagraphStyleSpecifierAlignment] =
-            {
-                sizeof(CTTextAlignment), offsetof(_CTParagraphStyleProperties, _alignment),
-            },
-
-        [kCTParagraphStyleSpecifierFirstLineHeadIndent] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _firstLineHeadIndent),
-            },
-        [kCTParagraphStyleSpecifierHeadIndent] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _headIndent),
-            },
-        [kCTParagraphStyleSpecifierTailIndent] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _tailIndent),
-            },
-        [kCTParagraphStyleSpecifierDefaultTabInterval] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _tabInterval),
-            },
-        [kCTParagraphStyleSpecifierLineBreakMode] =
-            {
-                sizeof(CTLineBreakMode), offsetof(_CTParagraphStyleProperties, _lineBreakMode),
-            },
-        [kCTParagraphStyleSpecifierLineHeightMultiple] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _lineHeightMultiple),
-            },
-        [kCTParagraphStyleSpecifierMaximumLineHeight] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _maximumLineHeight),
-            },
-        [kCTParagraphStyleSpecifierMinimumLineHeight] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _minimumLineHeight),
-            },
-        [kCTParagraphStyleSpecifierLineSpacing] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _lineSpacing),
-            },
-        [kCTParagraphStyleSpecifierParagraphSpacing] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _paragraphSpacing),
-            },
-        [kCTParagraphStyleSpecifierParagraphSpacingBefore] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _paragraphSpacingBefore),
-            },
-        [kCTParagraphStyleSpecifierBaseWritingDirection] =
-            {
-                sizeof(CTWritingDirection), offsetof(_CTParagraphStyleProperties, _writingDirection),
-            },
-        [kCTParagraphStyleSpecifierMaximumLineSpacing] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _maximumLineSpacing),
-            },
-        [kCTParagraphStyleSpecifierMinimumLineSpacing] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _minimumLineSpacing),
-            },
-        [kCTParagraphStyleSpecifierLineSpacingAdjustment] =
-            {
-                sizeof(CGFloat), offsetof(_CTParagraphStyleProperties, _lineSpacingAdjustment),
-            },
-
-};
-
-@implementation _CTParagraphStyle
-
-- (id)init {
-    self->_properties._maximumLineSpacing._isDefault = true;
-    self->_properties._maximumLineSpacing._value = 10000000.0f;
-
-    return self;
-}
-- (instancetype)copyWithZone:(NSZone*)zone {
-    return [self retain];
-}
-@end
-
-/**
- @Status Caveat
- @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops and kCTParagraphStyleSpecifierCount not supported
-*/
-CTParagraphStyleRef CTParagraphStyleCreate(const CTParagraphStyleSetting* settings, size_t settingsCount) {
-    _CTParagraphStyle* ret = [_CTParagraphStyle new];
-
-    if (settings) {
-        _CTParagraphStyleProperties* paraStyleProperty = &ret->_properties;
-        for (size_t i = 0; i < settingsCount; ++i) {
-            // validate input specifier and the buffer
-            if (settings[i].spec <= MAX_SPECIFIER_COUNT && settings[i].value != nullptr) {
-                size_t expectedSize = propertyInfoTable[settings[i].spec].expectedSize;
-
-                if (settings[i].valueSize == expectedSize) {
-                    // structContainingData is the struct that contains the actual data and a bool varibale _isDefault to store if data has
-                    // a default value or it has been set by the user.
-                    // offsetToDefaultStatus is the offset to this struct, which is also in turn the offset to _isDefault bool variable
-                    // within the struct.
-                    size_t offsetToDefaultStatus = propertyInfoTable[settings[i].spec].offset;
-                    auto structContainingData =
-                        reinterpret_cast<void*>((reinterpret_cast<char*>(paraStyleProperty) + offsetToDefaultStatus));
-                    *(reinterpret_cast<bool*>(structContainingData)) = false;
-
-                    if (expectedSize == sizeof(CGFloat)) {
-                        auto property = reinterpret_cast<_CTParagraphStyleFloatProperty*>(structContainingData);
-
-                        size_t offsetForValue = offsetof(_CTParagraphStyleFloatProperty, _value);
-                        auto locationToWrite = reinterpret_cast<char*>(property) + offsetForValue;
-                        *reinterpret_cast<CGFloat*>(locationToWrite) = *reinterpret_cast<const CGFloat*>(settings[i].value);
-
-                    } else if (settings[i].spec == kCTParagraphStyleSpecifierBaseWritingDirection) {
-                        auto property = reinterpret_cast<_CTParagraphStyleCTWritingDirectionProperty*>(structContainingData);
-
-                        size_t offsetForValue = offsetof(_CTParagraphStyleCTWritingDirectionProperty, _value);
-                        auto locationToWrite = reinterpret_cast<char*>(property) + offsetForValue;
-                        *reinterpret_cast<CTWritingDirection*>(locationToWrite) =
-                            *reinterpret_cast<const CTWritingDirection*>(settings[i].value);
-                    } else if (settings[i].spec == kCTParagraphStyleSpecifierAlignment) {
-                        auto property = reinterpret_cast<_CTParagraphStyleCTTextAlignmentProperty*>(structContainingData);
-
-                        size_t offsetForValue = offsetof(_CTParagraphStyleCTTextAlignmentProperty, _value);
-                        auto locationToWrite = reinterpret_cast<char*>(property) + offsetForValue;
-                        *reinterpret_cast<CTTextAlignment*>(locationToWrite) = *reinterpret_cast<const CTTextAlignment*>(settings[i].value);
-
-                    } else if (settings[i].spec == kCTParagraphStyleSpecifierLineBreakMode) {
-                        auto property = reinterpret_cast<_CTParagraphStyleCTLineBreakModeProperty*>(structContainingData);
-
-                        size_t offsetForValue = offsetof(_CTParagraphStyleCTLineBreakModeProperty, _value);
-                        auto locationToWrite = reinterpret_cast<char*>(property) + offsetForValue;
-                        *reinterpret_cast<CTLineBreakMode*>(locationToWrite) = *reinterpret_cast<const CTLineBreakMode*>(settings[i].value);
-                    }
-                }
-            }
+    __CTParagraphStyle(const __CTParagraphStyle& rhs) {
+        if (this != &rhs) {
+            _styles.reset(CFArrayCreateMutableCopy(nullptr, kCTParagraphStyleSpecifierCount, rhs._styles.get()));
         }
     }
 
-    return static_cast<CTParagraphStyleRef>(ret);
-}
+    bool SetValue(CTParagraphStyleSpecifier specifier, size_t size, const void* value) {
+        if (specifier < kCTParagraphStyleSpecifierCount && size == __CTParagraphStyleSizeTable[specifier]) {
+            woc::unique_cf<CFTypeRef> newValue{};
+            switch (specifier) {
+                case kCTParagraphStyleSpecifierTabStops:
+                    newValue.reset(CFArrayCreateCopy(nullptr, static_cast<CFArrayRef>(value)));
+                    break;
+                case kCTParagraphStyleSpecifierAlignment:
+                case kCTParagraphStyleSpecifierLineBreakMode: {
+                    // CFNumber has no UInt8Type, so store all int values as standard int
+                    int intValue = *static_cast<const uint8_t*>(value);
+                    newValue.reset(CFNumberCreate(nullptr, kCFNumberIntType, &intValue));
+                } break;
+                case kCTParagraphStyleSpecifierBaseWritingDirection:
+                    newValue.reset(CFNumberCreate(nullptr, kCFNumberSInt8Type, value));
+                    break;
+                default:
+                    // All other values are of type CGFloat
+                    newValue.reset(CFNumberCreate(nullptr, kCFNumberCGFloatType, value));
+                    break;
+            }
 
-/**
- @Status Caveat
- @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops and kCTParagraphStyleSpecifierCount not supported
-*/
-CTParagraphStyleRef CTParagraphStyleCreateCopy(CTParagraphStyleRef paragraphStyle) {
-    if (!paragraphStyle) {
-        return nil;
+            CFArraySetValueAtIndex(_styles.get(), specifier, newValue.get());
+            return true;
+        }
+
+        return false;
     }
 
-    _CTParagraphStyle* ret = [static_cast<_CTParagraphStyle*>(paragraphStyle) copy];
-    return static_cast<CTParagraphStyleRef>(ret);
+    bool SetValue(const CTParagraphStyleSetting& setting) {
+        return SetValue(setting.spec, setting.valueSize, setting.value);
+    }
+
+    bool GetValue(CTParagraphStyleSpecifier specifier, size_t size, void* outValue) const {
+        if (specifier <= kCTParagraphStyleSpecifierCount && outValue != nullptr && size == __CTParagraphStyleSizeTable[specifier]) {
+            switch (specifier) {
+                case kCTParagraphStyleSpecifierTabStops:
+                    *static_cast<void**>(outValue) = (void*)CFArrayGetValueAtIndex(_styles.get(), specifier);
+                    return true;
+                case kCTParagraphStyleSpecifierAlignment:
+                case kCTParagraphStyleSpecifierLineBreakMode:
+                    // CFNumber has no UInt8Type, so store all int values as standard int
+                    {
+                        int intValue = 0;
+                        CFNumberGetValue(static_cast<CFNumberRef>(CFArrayGetValueAtIndex(_styles.get(), specifier)),
+                                         kCFNumberIntType,
+                                         &intValue);
+                        *static_cast<uint8_t*>(outValue) = intValue;
+                        return true;
+                    }
+                case kCTParagraphStyleSpecifierBaseWritingDirection:
+                    CFNumberGetValue(static_cast<CFNumberRef>(CFArrayGetValueAtIndex(_styles.get(), specifier)),
+                                     kCFNumberSInt8Type,
+                                     outValue);
+                    return true;
+                default:
+                    // All other values are of type CGFloat
+                    CFNumberGetValue(static_cast<CFNumberRef>(CFArrayGetValueAtIndex(_styles.get(), specifier)),
+                                     kCFNumberCGFloatType,
+                                     outValue);
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+private:
+    woc::unique_cf<CFMutableArrayRef> _styles;
+
+} __CTParagraphStyle;
+
+#pragma endregion
+
+/**
+ @Status Caveat
+ @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops
+*/
+CTParagraphStyleRef CTParagraphStyleCreate(const CTParagraphStyleSetting* settings, size_t settingsCount) {
+    __CTParagraphStyle* style = __CTParagraphStyle::CreateInstance();
+
+    if (settings != nullptr) {
+        for (size_t i = 0; i < settingsCount; ++i) {
+            style->SetValue(settings[i]);
+        }
+    }
+
+    return style;
 }
 
 /**
  @Status Caveat
- @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops and kCTParagraphStyleSpecifierCount not supported
+ @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops
+*/
+CTParagraphStyleRef CTParagraphStyleCreateCopy(CTParagraphStyleRef paragraphStyle) {
+    return paragraphStyle ? __CTParagraphStyle::CreateInstance(nullptr, *paragraphStyle) : nullptr;
+}
+
+/**
+ @Status Caveat
+ @Notes CTParagraphStyleSpecifier kCTParagraphStyleSpecifierTabStops
 */
 bool CTParagraphStyleGetValueForSpecifier(CTParagraphStyleRef paragraphStyle,
                                           CTParagraphStyleSpecifier spec,
                                           size_t valueBufferSize,
                                           void* valueBuffer) {
-    if (!paragraphStyle || !valueBuffer) {
-        return false;
+    RETURN_FALSE_IF(paragraphStyle == nullptr);
+    if (paragraphStyle->GetValue(spec, valueBufferSize, valueBuffer)) {
+        return true;
     }
 
-    _CTParagraphStyle* paraStyle = static_cast<_CTParagraphStyle*>(paragraphStyle);
-    bool isDefaultValue = true;
-
-    if (spec <= MAX_SPECIFIER_COUNT) {
-        _CTParagraphStyleProperties* paraStyleProperty = &paraStyle->_properties;
-
-        // structContainingData is the struct that contains the actual data and a bool varibale _isDefault to store if data has a default
-        // value or it has been set by the user.
-        // offsetToDefaultStatus is the offset to this struct, which is also in turn the offset to _isDefault bool variable within the
-        // struct.
-        size_t offsetToDefaultStatus = propertyInfoTable[spec].offset;
-        auto structContainingData = reinterpret_cast<void*>((reinterpret_cast<char*>(paraStyleProperty) + offsetToDefaultStatus));
-        isDefaultValue = *(reinterpret_cast<bool*>(structContainingData));
-
-        size_t expectedSize = propertyInfoTable[spec].expectedSize;
-        if (expectedSize == sizeof(CGFloat)) {
-            auto property = reinterpret_cast<_CTParagraphStyleFloatProperty*>(structContainingData);
-
-            size_t offsetForValue = offsetof(_CTParagraphStyleFloatProperty, _value);
-            auto locationTocopy = reinterpret_cast<char*>(property) + offsetForValue;
-            *reinterpret_cast<CGFloat*>(valueBuffer) = *reinterpret_cast<CGFloat*>(locationTocopy);
-        } else if (spec == kCTParagraphStyleSpecifierBaseWritingDirection) {
-            auto property = reinterpret_cast<_CTParagraphStyleCTWritingDirectionProperty*>(structContainingData);
-
-            size_t offsetForValue = offsetof(_CTParagraphStyleCTWritingDirectionProperty, _value);
-            auto locationTocopy = reinterpret_cast<char*>(property) + offsetForValue;
-            *reinterpret_cast<CTWritingDirection*>(valueBuffer) = *reinterpret_cast<CTWritingDirection*>(locationTocopy);
-        } else if (spec == kCTParagraphStyleSpecifierAlignment) {
-            auto property = reinterpret_cast<_CTParagraphStyleCTTextAlignmentProperty*>(structContainingData);
-
-            size_t offsetForValue = offsetof(_CTParagraphStyleCTTextAlignmentProperty, _value);
-            auto locationTocopy = reinterpret_cast<char*>(property) + offsetForValue;
-            *reinterpret_cast<CTTextAlignment*>(valueBuffer) = *reinterpret_cast<CTTextAlignment*>(locationTocopy);
-        } else if (spec == kCTParagraphStyleSpecifierLineBreakMode) {
-            auto property = reinterpret_cast<_CTParagraphStyleCTLineBreakModeProperty*>(structContainingData);
-
-            size_t offsetForValue = offsetof(_CTParagraphStyleCTLineBreakModeProperty, _value);
-            auto locationTocopy = reinterpret_cast<char*>(property) + offsetForValue;
-            *reinterpret_cast<CTLineBreakMode*>(valueBuffer) = *reinterpret_cast<CTLineBreakMode*>(locationTocopy);
-        }
+    if (valueBuffer) {
+        memset(valueBuffer, 0, valueBufferSize);
     }
 
-    return !isDefaultValue;
+    return false;
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 CFTypeID CTParagraphStyleGetTypeID() {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return __CTParagraphStyle::GetTypeID();
 }

--- a/Frameworks/CoreText/CTParagraphStyle.mm
+++ b/Frameworks/CoreText/CTParagraphStyle.mm
@@ -42,9 +42,9 @@ static constexpr size_t __CTParagraphStyleSizeTable[kCTParagraphStyleSpecifierCo
 };
 
 #pragma region __CTParagraphStyle
-typedef struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> {
+struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> {
     __CTParagraphStyle() {
-        static CFArrayRef __defaultValues = []() {
+        static woc::unique_cf<CFArrayRef> __defaultValues{ []() {
             constexpr CGFloat c_defaultFloat = 0.0;
             // Need to store Alignment and LineBreakMode as ints in CFNumberRef
             constexpr int c_defaultAlignment = kCTNaturalTextAlignment;
@@ -61,14 +61,12 @@ typedef struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> 
                 __floatDefault.get(), __floatDefault.get(),
             };
             return CFArrayCreate(nullptr, values, kCTParagraphStyleSpecifierCount, &kCFTypeArrayCallBacks);
-        }();
-        _styles.reset(CFArrayCreateMutableCopy(nullptr, kCTParagraphStyleSpecifierCount, __defaultValues));
+        }() };
+        _styles.reset(CFArrayCreateMutableCopy(nullptr, kCTParagraphStyleSpecifierCount, __defaultValues.get()));
     }
 
     __CTParagraphStyle(const __CTParagraphStyle& rhs) {
-        if (this != &rhs) {
-            _styles.reset(CFArrayCreateMutableCopy(nullptr, kCTParagraphStyleSpecifierCount, rhs._styles.get()));
-        }
+        _styles.reset(CFArrayCreateMutableCopy(nullptr, kCTParagraphStyleSpecifierCount, rhs._styles.get()));
     }
 
     bool SetValue(CTParagraphStyleSpecifier specifier, size_t size, const void* value) {
@@ -140,8 +138,7 @@ typedef struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> 
 
 private:
     woc::unique_cf<CFMutableArrayRef> _styles;
-
-} __CTParagraphStyle;
+};
 
 #pragma endregion
 

--- a/Frameworks/UIKit/NSMutableParagraphStyle.mm
+++ b/Frameworks/UIKit/NSMutableParagraphStyle.mm
@@ -24,7 +24,23 @@
  @Status Interoperable
 */
 - (id)copyWithZone:(NSZone*)zone {
-    return [self mutableCopyWithZone:zone];
+    NSParagraphStyle* ret = [NSParagraphStyle new];
+    ret.alignment = self.alignment;
+    ret.firstLineHeadIndent = self.firstLineHeadIndent;
+    ret.headIndent = self.headIndent;
+    ret.tailIndent = self.tailIndent;
+    ret.lineBreakMode = self.lineBreakMode;
+    ret.maximumLineHeight = self.maximumLineHeight;
+    ret.minimumLineHeight = self.minimumLineHeight;
+    ret.lineSpacing = self.lineSpacing;
+    ret.paragraphSpacing = self.paragraphSpacing;
+    ret.paragraphSpacingBefore = self.paragraphSpacingBefore;
+    ret.baseWritingDirection = self.baseWritingDirection;
+    ret.lineHeightMultiple = self.lineHeightMultiple;
+    ret.tabStops = self.tabStops;
+    ret.defaultTabInterval = self.defaultTabInterval;
+    ret.hyphenationFactor = self.hyphenationFactor;
+    return ret;
 }
 
 /**

--- a/Frameworks/UIKit/NSMutableParagraphStyle.mm
+++ b/Frameworks/UIKit/NSMutableParagraphStyle.mm
@@ -25,21 +25,7 @@
 */
 - (id)copyWithZone:(NSZone*)zone {
     NSParagraphStyle* ret = [NSParagraphStyle new];
-    ret.alignment = self.alignment;
-    ret.firstLineHeadIndent = self.firstLineHeadIndent;
-    ret.headIndent = self.headIndent;
-    ret.tailIndent = self.tailIndent;
-    ret.lineBreakMode = self.lineBreakMode;
-    ret.maximumLineHeight = self.maximumLineHeight;
-    ret.minimumLineHeight = self.minimumLineHeight;
-    ret.lineSpacing = self.lineSpacing;
-    ret.paragraphSpacing = self.paragraphSpacing;
-    ret.paragraphSpacingBefore = self.paragraphSpacingBefore;
-    ret.baseWritingDirection = self.baseWritingDirection;
-    ret.lineHeightMultiple = self.lineHeightMultiple;
-    ret.tabStops = self.tabStops;
-    ret.defaultTabInterval = self.defaultTabInterval;
-    ret.hyphenationFactor = self.hyphenationFactor;
+    [ret _setParagraphStyle:self];
     return ret;
 }
 
@@ -48,21 +34,7 @@
  @Notes
 */
 - (void)setParagraphStyle:(NSParagraphStyle*)obj {
-    self.alignment = obj.alignment;
-    self.firstLineHeadIndent = obj.firstLineHeadIndent;
-    self.headIndent = obj.headIndent;
-    self.tailIndent = obj.tailIndent;
-    self.lineBreakMode = obj.lineBreakMode;
-    self.maximumLineHeight = obj.maximumLineHeight;
-    self.minimumLineHeight = obj.minimumLineHeight;
-    self.lineSpacing = obj.lineSpacing;
-    self.paragraphSpacing = obj.paragraphSpacing;
-    self.paragraphSpacingBefore = obj.paragraphSpacingBefore;
-    self.baseWritingDirection = obj.baseWritingDirection;
-    self.lineHeightMultiple = obj.lineHeightMultiple;
-    self.tabStops = obj.tabStops;
-    self.defaultTabInterval = obj.defaultTabInterval;
-    self.hyphenationFactor = obj.hyphenationFactor;
+    [self _setParagraphStyle:obj];
 }
 
 /**

--- a/Frameworks/UIKit/NSMutableParagraphStyle.mm
+++ b/Frameworks/UIKit/NSMutableParagraphStyle.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -21,19 +21,32 @@
 @implementation NSMutableParagraphStyle
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (id)copyWithZone:(NSZone*)zone {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return [self mutableCopyWithZone:zone];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 - (void)setParagraphStyle:(NSParagraphStyle*)obj {
-    UNIMPLEMENTED();
+    self.alignment = obj.alignment;
+    self.firstLineHeadIndent = obj.firstLineHeadIndent;
+    self.headIndent = obj.headIndent;
+    self.tailIndent = obj.tailIndent;
+    self.lineBreakMode = obj.lineBreakMode;
+    self.maximumLineHeight = obj.maximumLineHeight;
+    self.minimumLineHeight = obj.minimumLineHeight;
+    self.lineSpacing = obj.lineSpacing;
+    self.paragraphSpacing = obj.paragraphSpacing;
+    self.paragraphSpacingBefore = obj.paragraphSpacingBefore;
+    self.baseWritingDirection = obj.baseWritingDirection;
+    self.lineHeightMultiple = obj.lineHeightMultiple;
+    self.tabStops = obj.tabStops;
+    self.defaultTabInterval = obj.defaultTabInterval;
+    self.hyphenationFactor = obj.hyphenationFactor;
 }
 
 /**
@@ -50,57 +63,6 @@
 */
 - (void)removeTabStop:(NSTextTab*)anObject {
     UNIMPLEMENTED();
-}
-
-/**
- @Status Caveat
- @Notes Setting this property has no effect
-*/
-- (void)setLineBreakMode:(NSLineBreakMode)lineBreakMode {
-    _lineBreakMode = lineBreakMode;
-}
-
-/**
- @Status Interoperable
- @Notes
-*/
-- (NSLineBreakMode)lineBreakMode {
-    return _lineBreakMode;
-}
-
-/**
-@Status Stub
-@Notes
-*/
-- (instancetype)initWithCoder:(NSCoder*)coder {
-    UNIMPLEMENTED();
-    return StubReturn();
-}
-
-/**
-@Status Stub
-@Notes
-*/
-- (void)encodeWithCoder:(NSCoder*)coder {
-    UNIMPLEMENTED();
-}
-
-/**
-@Status Stub
-@Notes
-*/
-+ (BOOL)supportsSecureCoding {
-    UNIMPLEMENTED();
-    return StubReturn();
-}
-
-/**
-@Status Stub
-@Notes
-*/
-- (id)mutableCopyWithZone:(NSZone*)zone {
-    UNIMPLEMENTED();
-    return StubReturn();
 }
 
 @end

--- a/Frameworks/UIKit/NSParagraphStyle.mm
+++ b/Frameworks/UIKit/NSParagraphStyle.mm
@@ -42,7 +42,8 @@
  @Notes Tab Stops not supported
 */
 + (NSParagraphStyle*)defaultParagraphStyle {
-    return [self new];
+    static StrongId<NSParagraphStyle> _default{[[self new] autorelease] };
+    return _default.get();
 }
 
 /**

--- a/Frameworks/UIKit/NSParagraphStyle.mm
+++ b/Frameworks/UIKit/NSParagraphStyle.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -21,12 +21,17 @@
 #import "NSParagraphStyleInternal.h"
 
 @implementation NSParagraphStyle
+
+- (void)dealloc {
+    _tabStops = nil;
+    [super dealloc];
+}
+
 /**
- @Status Stub
+ @Status Interoperable
 */
 + (NSParagraphStyle*)defaultParagraphStyle {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return [[[self alloc] init] autorelease];
 }
 
 /**
@@ -38,42 +43,95 @@
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (instancetype)copyWithZone:(NSZone*)zone {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return [self retain];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (instancetype)mutableCopyWithZone:(NSZone*)zone {
-    UNIMPLEMENTED();
-    return StubReturn();
+    NSMutableParagraphStyle* copy = [[NSMutableParagraphStyle alloc] init];
+    [copy setParagraphStyle:self];
+    return copy;
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (instancetype)initWithCoder:(NSCoder*)decoder {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (self = [super init]) {
+        _alignment = [[decoder decodeObjectForKey:@"_NSParagraphStyle._alignment"] unsignedIntegerValue];
+        _firstLineHeadIndent = [decoder decodeFloatForKey:@"_NSParagraphStyle._firstLineHeadIndent"];
+        _headIndent = [decoder decodeFloatForKey:@"_NSParagraphStyle._headIndent"];
+        _tailIndent = [decoder decodeFloatForKey:@"_NSParagraphStyle._tailIndent"];
+        _lineBreakMode = [[decoder decodeObjectForKey:@"_NSParagraphStyle._lineBreakMode"] unsignedIntegerValue];
+        _maximumLineHeight = [decoder decodeFloatForKey:@"_NSParagraphStyle._maximumLineHeight"];
+        _minimumLineHeight = [decoder decodeFloatForKey:@"_NSParagraphStyle._minimumLineHeight"];
+        _lineSpacing = [decoder decodeFloatForKey:@"_NSParagraphStyle._lineSpacing"];
+        _paragraphSpacing = [decoder decodeFloatForKey:@"_NSParagraphStyle._paragraphSpacing"];
+        _paragraphSpacingBefore = [decoder decodeFloatForKey:@"_NSParagraphStyle._paragraphSpacingBefore"];
+        _baseWritingDirection =
+            (NSWritingDirection)[[decoder decodeObjectForKey:@"_NSParagraphStyle._baseWritingDirection"] unsignedIntegerValue];
+        _lineHeightMultiple = [decoder decodeFloatForKey:@"_NSParagraphStyle._lineHeightMultiple"];
+        _tabStops = [decoder decodeObjectForKey:@"_NSParagraphStyle._tabStops"];
+        _defaultTabInterval = [decoder decodeFloatForKey:@"_NSParagraphStyle._defaultTabInterval"];
+        _hyphenationFactor = [decoder decodeFloatForKey:@"_NSParagraphStyle._hyphenationFactor"];
+    }
+
+    return self;
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (void)encodeWithCoder:(NSCoder*)encoder {
-    UNIMPLEMENTED();
+    [encoder encodeObject:[NSNumber numberWithUnsignedInteger:_alignment] forKey:@"_NSParagraphStyle._alignment"];
+    [encoder encodeFloat:_firstLineHeadIndent forKey:@"_NSParagraphStyle._firstLineHeadIndent"];
+    [encoder encodeFloat:_headIndent forKey:@"_NSParagraphStyle._headIndent"];
+    [encoder encodeFloat:_tailIndent forKey:@"_NSParagraphStyle._tailIndent"];
+    [encoder encodeObject:[NSNumber numberWithUnsignedInteger:_lineBreakMode] forKey:@"_NSParagraphStyle._lineBreakMode"];
+    [encoder encodeFloat:_maximumLineHeight forKey:@"_NSParagraphStyle._maximumLineHeight"];
+    [encoder encodeFloat:_minimumLineHeight forKey:@"_NSParagraphStyle._minimumLineHeight"];
+    [encoder encodeFloat:_lineSpacing forKey:@"_NSParagraphStyle._lineSpacing"];
+    [encoder encodeFloat:_paragraphSpacing forKey:@"_NSParagraphStyle._paragraphSpacing"];
+    [encoder encodeFloat:_paragraphSpacingBefore forKey:@"_NSParagraphStyle._paragraphSpacingBefore"];
+    [encoder encodeObject:[NSNumber numberWithUnsignedInteger:_baseWritingDirection] forKey:@"_NSParagraphStyle._baseWritingDirection"];
+    [encoder encodeFloat:_lineHeightMultiple forKey:@"_NSParagraphStyle._lineHeightMultiple"];
+    [encoder encodeObject:_tabStops forKey:@"_NSParagraphStyle._tabStops"];
+    [encoder encodeFloat:_defaultTabInterval forKey:@"_NSParagraphStyle._defaultTabInterval"];
+    [encoder encodeFloat:_hyphenationFactor forKey:@"_NSParagraphStyle._hyphenationFactor"];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 + (BOOL)supportsSecureCoding {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return YES;
+}
+
+- (CTParagraphStyleRef)_convertToCTParagraphStyle {
+    CTLineBreakMode lineBreakMode = self.lineBreakMode;
+    CTWritingDirection writingDirection = self.baseWritingDirection;
+    CTTextAlignment alignment = _NSTextAlignmentToCTTextAlignment(self.alignment);
+    CTParagraphStyleSetting settings[14] =
+        { { kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &alignment },
+          { kCTParagraphStyleSpecifierFirstLineHeadIndent, sizeof(CGFloat), &_firstLineHeadIndent },
+          { kCTParagraphStyleSpecifierHeadIndent, sizeof(CGFloat), &_headIndent },
+          { kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &_tailIndent },
+          { kCTParagraphStyleSpecifierTabStops, sizeof(CFArrayRef), &_tabStops },
+          { kCTParagraphStyleSpecifierDefaultTabInterval, sizeof(CGFloat), &_defaultTabInterval },
+          { kCTParagraphStyleSpecifierLineBreakMode, sizeof(CGFloat), &lineBreakMode },
+          { kCTParagraphStyleSpecifierLineHeightMultiple, sizeof(CGFloat), &_lineHeightMultiple },
+          { kCTParagraphStyleSpecifierMaximumLineHeight, sizeof(CGFloat), &_maximumLineHeight },
+          { kCTParagraphStyleSpecifierMinimumLineHeight, sizeof(CGFloat), &_minimumLineHeight },
+          { kCTParagraphStyleSpecifierLineSpacing, sizeof(CGFloat), &_lineSpacing },
+          { kCTParagraphStyleSpecifierParagraphSpacing, sizeof(CGFloat), &_paragraphSpacing },
+          { kCTParagraphStyleSpecifierParagraphSpacingBefore, sizeof(CGFloat), &_paragraphSpacingBefore },
+          { kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(CGFloat), &writingDirection } };
+    return CTParagraphStyleCreate(settings, std::extent<decltype(settings)>::value);
 }
 
 @end

--- a/Frameworks/UIKit/NSParagraphStyle.mm
+++ b/Frameworks/UIKit/NSParagraphStyle.mm
@@ -27,19 +27,22 @@
     [super dealloc];
 }
 
+- (instancetype)init {
+    if (self = [super init]) {
+        self.alignment = NSTextAlignmentNatural;
+        self.lineBreakMode = NSLineBreakByWordWrapping;
+        self.baseWritingDirection = NSWritingDirectionNatural;
+    }
+
+    return self;
+}
+
 /**
  @Status Caveat
  @Notes Tab Stops not supported
 */
 + (NSParagraphStyle*)defaultParagraphStyle {
-    NSParagraphStyle* ret = [self new];
-    if (ret) {
-        ret.alignment = NSTextAlignmentNatural;
-        ret.lineBreakMode = NSLineBreakByWordWrapping;
-        ret.baseWritingDirection = NSWritingDirectionNatural;
-    }
-
-    return ret;
+    return [self new];
 }
 
 /**
@@ -139,6 +142,24 @@
           { kCTParagraphStyleSpecifierParagraphSpacingBefore, sizeof(CGFloat), &_paragraphSpacingBefore },
           { kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(CGFloat), &writingDirection } };
     return CTParagraphStyleCreate(settings, std::extent<decltype(settings)>::value);
+}
+
+- (void)_setParagraphStyle:(NSParagraphStyle*)obj {
+    self.alignment = obj.alignment;
+    self.firstLineHeadIndent = obj.firstLineHeadIndent;
+    self.headIndent = obj.headIndent;
+    self.tailIndent = obj.tailIndent;
+    self.lineBreakMode = obj.lineBreakMode;
+    self.maximumLineHeight = obj.maximumLineHeight;
+    self.minimumLineHeight = obj.minimumLineHeight;
+    self.lineSpacing = obj.lineSpacing;
+    self.paragraphSpacing = obj.paragraphSpacing;
+    self.paragraphSpacingBefore = obj.paragraphSpacingBefore;
+    self.baseWritingDirection = obj.baseWritingDirection;
+    self.lineHeightMultiple = obj.lineHeightMultiple;
+    self.tabStops = obj.tabStops;
+    self.defaultTabInterval = obj.defaultTabInterval;
+    self.hyphenationFactor = obj.hyphenationFactor;
 }
 
 @end

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -22,6 +22,7 @@
 #import <Foundation/NSMutableDictionary.h>
 #import "CoreGraphics/CGContext.h"
 #import "CoreTextInternal.h"
+#import "NSParagraphStyleInternal.h"
 #import <assert.h>
 #import "LoggingNative.h"
 #include "StringHelpers.h"
@@ -40,19 +41,6 @@ NSString* const UITextAttributeTextShadowColor = @"UITextAttributeTextShadowColo
 NSString* const UITextAttributeTextShadowOffset = @"UITextAttributeTextShadowOffset";
 
 @implementation NSString (UIKitAdditions)
-
-// The values of CTTextAlignment and UITextAlignment do not correspond so they can't be simply cast
-static CTTextAlignment __UITextAlignmentToCTTextAlignment(UITextAlignment alignment) {
-    switch (alignment) {
-        case UITextAlignmentLeft:
-            return kCTLeftTextAlignment;
-        case UITextAlignmentRight:
-            return kCTRightTextAlignment;
-        case UITextAlignmentCenter:
-        default:
-            return kCTCenterTextAlignment;
-    }
-}
 
 static void drawString(UIFont* font,
                        CGContextRef context,
@@ -75,7 +63,7 @@ static void drawString(UIFont* font,
     }
 
     CTParagraphStyleSetting styles[2];
-    CTTextAlignment align = __UITextAlignmentToCTTextAlignment(alignment);
+    CTTextAlignment align = _NSTextAlignmentToCTTextAlignment(alignment);
     styles[0] = { kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &align };
 
     CTLineBreakMode breakMode = static_cast<CTLineBreakMode>(lineBreakMode);
@@ -334,7 +322,8 @@ static inline NSParagraphStyle* _paragraphStyleWithLineBreakMode(UILineBreakMode
 - (CGSize)sizeWithFont:(UIFont*)font constrainedToSize:(CGSize)size lineBreakMode:(UILineBreakMode)lineBreakMode {
     return [self _sizeWithAttributes:@{
         NSFontAttributeName : font,
-        NSParagraphStyleAttributeName : _paragraphStyleWithLineBreakMode(lineBreakMode)
+        static_cast<NSString*>(kCTParagraphStyleAttributeName) :
+            (id)[_paragraphStyleWithLineBreakMode(lineBreakMode) _convertToCTParagraphStyle]
     }
                    constrainedToSize:size];
 }

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -323,7 +323,7 @@ static inline NSParagraphStyle* _paragraphStyleWithLineBreakMode(UILineBreakMode
     return [self _sizeWithAttributes:@{
         NSFontAttributeName : font,
         static_cast<NSString*>(kCTParagraphStyleAttributeName) :
-            (id)[_paragraphStyleWithLineBreakMode(lineBreakMode) _convertToCTParagraphStyle]
+            (id)[_paragraphStyleWithLineBreakMode(lineBreakMode) _createCTParagraphStyle]
     }
                    constrainedToSize:size];
 }

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -301,8 +301,9 @@ static NSDictionary* _getDefaultUITextAttributes() {
 - (CGSize)_sizeWithAttributes:(NSDictionary<NSString*, id>*)attributes constrainedToSize:(CGSize)size {
     if ([attributes objectForKey:NSParagraphStyleAttributeName]) {
         NSMutableDictionary* copied = [NSMutableDictionary dictionaryWithDictionary:attributes];
-        [copied setObject:(id)[[attributes objectForKey:NSParagraphStyleAttributeName] _createCTParagraphStyle]
-                   forKey:static_cast<NSString*>(kCTParagraphStyleAttributeName)];
+        woc::unique_cf<CTParagraphStyleRef>
+            paragraphStyle{[[attributes objectForKey:NSParagraphStyleAttributeName] _createCTParagraphStyle] };
+        [copied setObject:(id)paragraphStyle.get() forKey:static_cast<NSString*>(kCTParagraphStyleAttributeName)];
         attributes = copied;
     }
 

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -95,52 +95,6 @@ inline void _SafeRelease(T** p) {
 }
 @end
 
-struct _CTParagraphStyleFloatProperty {
-    bool _isDefault = true;
-    CGFloat _value = 0.0f;
-};
-
-struct _CTParagraphStyleCTTextAlignmentProperty {
-    bool _isDefault = true;
-    CTWritingDirection _value = kCTNaturalTextAlignment;
-};
-
-struct _CTParagraphStyleCTLineBreakModeProperty {
-    bool _isDefault = true;
-    CTLineBreakMode _value = kCTLineBreakByWordWrapping;
-};
-
-struct _CTParagraphStyleCTWritingDirectionProperty {
-    bool _isDefault = true;
-    CTWritingDirection _value = kCTWritingDirectionNatural;
-};
-
-struct _CTParagraphStyleProperties {
-    _CTParagraphStyleCTTextAlignmentProperty _alignment;
-    _CTParagraphStyleCTLineBreakModeProperty _lineBreakMode;
-    _CTParagraphStyleCTWritingDirectionProperty _writingDirection;
-
-    _CTParagraphStyleFloatProperty _firstLineHeadIndent;
-    _CTParagraphStyleFloatProperty _headIndent;
-    _CTParagraphStyleFloatProperty _tailIndent;
-    _CTParagraphStyleFloatProperty _tabInterval;
-    _CTParagraphStyleFloatProperty _lineHeightMultiple;
-    _CTParagraphStyleFloatProperty _maximumLineHeight;
-    _CTParagraphStyleFloatProperty _minimumLineHeight;
-    _CTParagraphStyleFloatProperty _lineSpacing;
-    _CTParagraphStyleFloatProperty _paragraphSpacing;
-    _CTParagraphStyleFloatProperty _paragraphSpacingBefore;
-    _CTParagraphStyleFloatProperty _lineSpacingAdjustment;
-    _CTParagraphStyleFloatProperty _maximumLineSpacing;
-    _CTParagraphStyleFloatProperty _minimumLineSpacing;
-};
-
-@interface _CTParagraphStyle : NSObject {
-@public
-    _CTParagraphStyleProperties _properties;
-}
-@end
-
 // Private helper methods for UIKit
 CORETEXT_EXPORT CGSize _CTFrameGetSize(CTFrameRef frame);
 CORETEXT_EXPORT DWRITE_FONT_WEIGHT _CTFontGetDWriteWeight(CTFontRef font);

--- a/Frameworks/include/NSParagraphStyleInternal.h
+++ b/Frameworks/include/NSParagraphStyleInternal.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -16,13 +16,36 @@
 
 #pragma once
 
-#import <UIKit/NSParagraphStyle.h>
 #import <UIKit/NSMutableParagraphStyle.h>
+#import <CoreText/CTParagraphStyle.h>
 
-@interface NSParagraphStyle () {
-@protected
-    float _hyphenationFactor;
-    NSTextAlignment _alignment;
-    NSLineBreakMode _lineBreakMode;
-}
+@interface NSParagraphStyle ()
+@property (nonatomic) NSTextAlignment alignment;
+@property (nonatomic) CGFloat firstLineHeadIndent;
+@property (nonatomic) CGFloat headIndent;
+@property (nonatomic) CGFloat tailIndent;
+@property (nonatomic) NSLineBreakMode lineBreakMode;
+@property (nonatomic) CGFloat maximumLineHeight;
+@property (nonatomic) CGFloat minimumLineHeight;
+@property (nonatomic) CGFloat lineSpacing;
+@property (nonatomic) CGFloat paragraphSpacing;
+@property (nonatomic) CGFloat paragraphSpacingBefore;
+@property (nonatomic) NSWritingDirection baseWritingDirection;
+@property (nonatomic) CGFloat lineHeightMultiple;
+@property (copy, nonatomic) NSArray* tabStops;
+@property (nonatomic) CGFloat defaultTabInterval;
+@property (nonatomic) float hyphenationFactor;
+- (CTParagraphStyleRef)_convertToCTParagraphStyle;
 @end
+
+// The values of right and center CTTextAlignment and NSTextAlignment do not correspond so they can't be simply cast
+inline CTTextAlignment _NSTextAlignmentToCTTextAlignment(NSTextAlignment alignment) {
+    switch (alignment) {
+        case UITextAlignmentRight:
+            return kCTRightTextAlignment;
+        case UITextAlignmentCenter:
+            return kCTCenterTextAlignment;
+        default:
+            return alignment;
+    }
+}

--- a/Frameworks/include/NSParagraphStyleInternal.h
+++ b/Frameworks/include/NSParagraphStyleInternal.h
@@ -20,30 +20,34 @@
 #import <CoreText/CTParagraphStyle.h>
 
 @interface NSParagraphStyle ()
-@property (nonatomic) NSTextAlignment alignment;
-@property (nonatomic) CGFloat firstLineHeadIndent;
-@property (nonatomic) CGFloat headIndent;
-@property (nonatomic) CGFloat tailIndent;
-@property (nonatomic) NSLineBreakMode lineBreakMode;
-@property (nonatomic) CGFloat maximumLineHeight;
-@property (nonatomic) CGFloat minimumLineHeight;
-@property (nonatomic) CGFloat lineSpacing;
-@property (nonatomic) CGFloat paragraphSpacing;
-@property (nonatomic) CGFloat paragraphSpacingBefore;
-@property (nonatomic) NSWritingDirection baseWritingDirection;
-@property (nonatomic) CGFloat lineHeightMultiple;
-@property (copy, nonatomic) NSArray* tabStops;
-@property (nonatomic) CGFloat defaultTabInterval;
-@property (nonatomic) float hyphenationFactor;
-- (CTParagraphStyleRef)_convertToCTParagraphStyle;
+
+- (CTParagraphStyleRef)_createCTParagraphStyle;
+
+// Redeclaring properties for read/write access in mutable subclass
+@property (nonatomic, readwrite) NSTextAlignment alignment;
+@property (nonatomic, readwrite) CGFloat firstLineHeadIndent;
+@property (nonatomic, readwrite) CGFloat headIndent;
+@property (nonatomic, readwrite) CGFloat tailIndent;
+@property (nonatomic, readwrite) NSLineBreakMode lineBreakMode;
+@property (nonatomic, readwrite) CGFloat maximumLineHeight;
+@property (nonatomic, readwrite) CGFloat minimumLineHeight;
+@property (nonatomic, readwrite) CGFloat lineSpacing;
+@property (nonatomic, readwrite) CGFloat paragraphSpacing;
+@property (nonatomic, readwrite) CGFloat paragraphSpacingBefore;
+@property (nonatomic, readwrite) NSWritingDirection baseWritingDirection;
+@property (nonatomic, readwrite) CGFloat lineHeightMultiple;
+@property (copy, nonatomic, readwrite) NSArray* tabStops;
+@property (nonatomic, readwrite) CGFloat defaultTabInterval;
+@property (nonatomic, readwrite) float hyphenationFactor;
+
 @end
 
 // The values of right and center CTTextAlignment and NSTextAlignment do not correspond so they can't be simply cast
 inline CTTextAlignment _NSTextAlignmentToCTTextAlignment(NSTextAlignment alignment) {
     switch (alignment) {
-        case UITextAlignmentRight:
+        case NSTextAlignmentRight:
             return kCTRightTextAlignment;
-        case UITextAlignmentCenter:
+        case NSTextAlignmentCenter:
             return kCTCenterTextAlignment;
         default:
             return alignment;

--- a/Frameworks/include/NSParagraphStyleInternal.h
+++ b/Frameworks/include/NSParagraphStyleInternal.h
@@ -22,6 +22,7 @@
 @interface NSParagraphStyle ()
 
 - (CTParagraphStyleRef)_createCTParagraphStyle;
+- (void)_setParagraphStyle:(NSParagraphStyle*)obj;
 
 // Redeclaring properties for read/write access in mutable subclass
 @property (nonatomic, readwrite) NSTextAlignment alignment;

--- a/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
@@ -269,7 +269,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIColorTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIFontTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIFontDescriptorTests.mm" />
-    <ClangCompile Include="..\..\..\..\tests\unittests\UIKit\NSParagraphStyleTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSParagraphStyleTests.mm" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(StarboardBasePath)\tests\unittests\UIKit\NullCompositor.h" />

--- a/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
@@ -269,6 +269,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIColorTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIFontTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIFontDescriptorTests.mm" />
+    <ClangCompile Include="..\..\..\..\tests\unittests\UIKit\NSParagraphStyleTests.mm" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(StarboardBasePath)\tests\unittests\UIKit\NullCompositor.h" />

--- a/include/CoreText/CTParagraphStyle.h
+++ b/include/CoreText/CTParagraphStyle.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTParagraphStyle.h
+++ b/include/CoreText/CTParagraphStyle.h
@@ -74,4 +74,4 @@ CORETEXT_EXPORT bool CTParagraphStyleGetValueForSpecifier(CTParagraphStyleRef pa
                                                           CTParagraphStyleSpecifier spec,
                                                           size_t valueBufferSize,
                                                           void* valueBuffer);
-CORETEXT_EXPORT CFTypeID CTParagraphStyleGetTypeID() STUB_METHOD;
+CORETEXT_EXPORT CFTypeID CTParagraphStyleGetTypeID();

--- a/include/UIKit/NSMutableParagraphStyle.h
+++ b/include/UIKit/NSMutableParagraphStyle.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -25,23 +25,23 @@
 
 UIKIT_EXPORT_CLASS
 @interface NSMutableParagraphStyle : NSParagraphStyle <NSCopying, NSMutableCopying, NSSecureCoding>
-- (void)setParagraphStyle:(NSParagraphStyle*)obj STUB_METHOD;
-@property (nonatomic) NSTextAlignment alignment STUB_PROPERTY;
-@property (nonatomic) CGFloat firstLineHeadIndent STUB_PROPERTY;
-@property (nonatomic) CGFloat headIndent STUB_PROPERTY;
-@property (nonatomic) CGFloat tailIndent STUB_PROPERTY;
+- (void)setParagraphStyle:(NSParagraphStyle*)obj;
+@property (nonatomic) NSTextAlignment alignment;
+@property (nonatomic) CGFloat firstLineHeadIndent;
+@property (nonatomic) CGFloat headIndent;
+@property (nonatomic) CGFloat tailIndent;
 @property (nonatomic) NSLineBreakMode lineBreakMode;
-@property (nonatomic) CGFloat maximumLineHeight STUB_PROPERTY;
-@property (nonatomic) CGFloat minimumLineHeight STUB_PROPERTY;
-@property (nonatomic) CGFloat lineSpacing STUB_PROPERTY;
-@property (nonatomic) CGFloat paragraphSpacing STUB_PROPERTY;
-@property (nonatomic) CGFloat paragraphSpacingBefore STUB_PROPERTY;
-@property (nonatomic) NSWritingDirection baseWritingDirection STUB_PROPERTY;
-@property (nonatomic) CGFloat lineHeightMultiple STUB_PROPERTY;
+@property (nonatomic) CGFloat maximumLineHeight;
+@property (nonatomic) CGFloat minimumLineHeight;
+@property (nonatomic) CGFloat lineSpacing;
+@property (nonatomic) CGFloat paragraphSpacing;
+@property (nonatomic) CGFloat paragraphSpacingBefore;
+@property (nonatomic) NSWritingDirection baseWritingDirection;
+@property (nonatomic) CGFloat lineHeightMultiple;
 - (void)addTabStop:(NSTextTab*)anObject STUB_METHOD;
 - (void)removeTabStop:(NSTextTab*)anObject STUB_METHOD;
-@property (copy, nonatomic) NSArray* tabStops STUB_PROPERTY;
-@property (nonatomic) CGFloat defaultTabInterval STUB_PROPERTY;
-@property (nonatomic) float hyphenationFactor STUB_PROPERTY;
+@property (copy, nonatomic) NSArray* tabStops;
+@property (nonatomic) CGFloat defaultTabInterval;
+@property (nonatomic) float hyphenationFactor;
 
 @end

--- a/include/UIKit/NSParagraphStyle.h
+++ b/include/UIKit/NSParagraphStyle.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCParagraphStyleTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCParagraphStyleTestViewController.mm
@@ -182,7 +182,7 @@ cell.accessoryView = FIELD;                                                     
     ADD_TEXT_FIELD(_inputCells, _specifierLineSpacing, @"kCTParagraphStyleSpecifierLineSpacing", @"0.0", width / 2);
     ADD_TEXT_FIELD(_inputCells, _specifierParagraphSpacing, @"kCTParagraphStyleSpecifierParagraphSpacing", @"0.0", width / 2);
     ADD_TEXT_FIELD(_inputCells, _specifierParagraphSpacingBefore, @"kCTParagraphStyleSpecifierParagraphSpacingBefore", @"0.0", width / 2);
-    ADD_TEXT_FIELD(_inputCells, _specifierMaximumLineSpacing, @"kCTParagraphStyleSpecifierMaximumLineSpacing", @"10000000.0", width / 2);
+    ADD_TEXT_FIELD(_inputCells, _specifierMaximumLineSpacing, @"kCTParagraphStyleSpecifierMaximumLineSpacing", @"0.0", width / 2);
     ADD_TEXT_FIELD(_inputCells, _specifierMinimumLineSpacing, @"kCTParagraphStyleSpecifierMinimumLineSpacing", @"0.0", width / 2);
     ADD_TEXT_FIELD(_inputCells, _specifierLineSpacingAdjustment, @"kCTParagraphStyleSpecifierLineSpacingAdjustment", @"0.0", width / 2);
 

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -22,7 +22,7 @@ const static float c_errorDelta = 0.001f;
 
 TEST(CoreText, CTParagraphStyle) {
     CTParagraphStyleRef paragraphStyle = CTParagraphStyleCreate(nullptr, 0);
-    EXPECT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
+    EXPECT_NE_MSG(paragraphStyle, nullptr, "FAILED: Could not create paragraph style");
 
     CGFloat val = 2.0f;
     CTParagraphStyleSetting settings[1] = { {.spec = kCTParagraphStyleSpecifierTailIndent, .valueSize = sizeof(CGFloat), .value = &val } };

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -27,22 +27,22 @@ TEST(CoreText, CTParagraphStyle) {
     CGFloat val = 2.0f;
     CTParagraphStyleSetting settings[1] = { {.spec = kCTParagraphStyleSpecifierTailIndent, .valueSize = sizeof(CGFloat), .value = &val } };
     paragraphStyle = CTParagraphStyleCreate(settings, 1);
-    EXPECT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
+    EXPECT_NE_MSG(paragraphStyle, nullptr, "FAILED: Could not create paragraph style");
 
     CGFloat bufferFloat;
     bool success =
         CTParagraphStyleGetValueForSpecifier(paragraphStyle, kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &bufferFloat);
-    EXPECT_TRUE_MSG(success == true, "FAILED: Could not found the specifier that was set.");
-    EXPECT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
+    EXPECT_NEAR(bufferFloat, val, .0001f);
 
     CTParagraphStyleRef paragraphStyleCopy = CTParagraphStyleCreateCopy(nullptr);
-    EXPECT_TRUE_MSG(paragraphStyleCopy == nil, "FAILED: Incorrect copy received");
+    EXPECT_EQ(paragraphStyleCopy, nil);
 
     paragraphStyleCopy = CTParagraphStyleCreateCopy(paragraphStyle);
     bufferFloat = 3.0f;
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &bufferFloat);
     EXPECT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
-    EXPECT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_NEAR(bufferFloat, val, .0001f);
 
     CTTextAlignment defaultTextAlignment = kCTJustifiedTextAlignment;
     val = 9.0f;
@@ -51,36 +51,36 @@ TEST(CoreText, CTParagraphStyle) {
                                               .value = &defaultTextAlignment },
                                              {.spec = kCTParagraphStyleSpecifierTailIndent, .valueSize = sizeof(CGFloat), .value = &val } };
     paragraphStyle = CTParagraphStyleCreate(settings2, 2);
-    EXPECT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
+    EXPECT_NE_MSG(paragraphStyle, nullptr, "FAILED: Could not create paragraph style");
 
     CTTextAlignment buffer;
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyle, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &buffer);
-    EXPECT_TRUE_MSG(success == true, "FAILED: Could not found the specifier that was set.");
-    EXPECT_TRUE_MSG(buffer == kCTJustifiedTextAlignment, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
+    EXPECT_EQ(buffer, kCTJustifiedTextAlignment);
 
     paragraphStyleCopy = CTParagraphStyleCreateCopy(paragraphStyle);
     success =
         CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &buffer);
     EXPECT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
-    EXPECT_TRUE_MSG(buffer == kCTJustifiedTextAlignment, "FAILED: Incorrect specifier value received");
+    EXPECT_EQ(buffer, kCTJustifiedTextAlignment);
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &bufferFloat);
     EXPECT_TRUE_MSG(success, "FAILED: Could not find the specifier that was set");
-    EXPECT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_NEAR(bufferFloat, val, .0001f);
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy,
                                                    kCTParagraphStyleSpecifierLineHeightMultiple,
                                                    sizeof(CGFloat),
                                                    &bufferFloat);
     EXPECT_TRUE(success);
-    EXPECT_TRUE_MSG(fabs(bufferFloat - 0.0f) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_NEAR(bufferFloat, 0.0f, .0001f);
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy,
                                                    kCTParagraphStyleSpecifierMaximumLineSpacing,
                                                    sizeof(CGFloat),
                                                    &bufferFloat);
     EXPECT_TRUE(success);
-    EXPECT_TRUE_MSG(fabs(bufferFloat - 0.0f) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_NEAR(bufferFloat, 0.0f, .0001f);
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy,
                                                    kCTParagraphStyleSpecifierLineHeightMultiple,

--- a/tests/unittests/CoreText/CTParagraphStyleTests.mm
+++ b/tests/unittests/CoreText/CTParagraphStyleTests.mm
@@ -22,27 +22,27 @@ const static float c_errorDelta = 0.001f;
 
 TEST(CoreText, CTParagraphStyle) {
     CTParagraphStyleRef paragraphStyle = CTParagraphStyleCreate(nullptr, 0);
-    ASSERT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
+    EXPECT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
 
     CGFloat val = 2.0f;
     CTParagraphStyleSetting settings[1] = { {.spec = kCTParagraphStyleSpecifierTailIndent, .valueSize = sizeof(CGFloat), .value = &val } };
     paragraphStyle = CTParagraphStyleCreate(settings, 1);
-    ASSERT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
+    EXPECT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
 
     CGFloat bufferFloat;
     bool success =
         CTParagraphStyleGetValueForSpecifier(paragraphStyle, kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &bufferFloat);
-    ASSERT_TRUE_MSG(success == true, "FAILED: Could not found the specifier that was set.");
-    ASSERT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success == true, "FAILED: Could not found the specifier that was set.");
+    EXPECT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
 
-    CTParagraphStyleRef paragraphStyleCopy = CTParagraphStyleCreateCopy(nil);
-    ASSERT_TRUE_MSG(paragraphStyleCopy == nil, "FAILED: Incorrect copy received");
+    CTParagraphStyleRef paragraphStyleCopy = CTParagraphStyleCreateCopy(nullptr);
+    EXPECT_TRUE_MSG(paragraphStyleCopy == nil, "FAILED: Incorrect copy received");
 
     paragraphStyleCopy = CTParagraphStyleCreateCopy(paragraphStyle);
     bufferFloat = 3.0f;
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &bufferFloat);
-    ASSERT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
-    ASSERT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
+    EXPECT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
 
     CTTextAlignment defaultTextAlignment = kCTJustifiedTextAlignment;
     val = 9.0f;
@@ -51,45 +51,45 @@ TEST(CoreText, CTParagraphStyle) {
                                               .value = &defaultTextAlignment },
                                              {.spec = kCTParagraphStyleSpecifierTailIndent, .valueSize = sizeof(CGFloat), .value = &val } };
     paragraphStyle = CTParagraphStyleCreate(settings2, 2);
-    ASSERT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
+    EXPECT_TRUE_MSG(paragraphStyle != nullptr, "FAILED: Could not create paragraph style");
 
     CTTextAlignment buffer;
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyle, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &buffer);
-    ASSERT_TRUE_MSG(success == true, "FAILED: Could not found the specifier that was set.");
-    ASSERT_TRUE_MSG(buffer == kCTJustifiedTextAlignment, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success == true, "FAILED: Could not found the specifier that was set.");
+    EXPECT_TRUE_MSG(buffer == kCTJustifiedTextAlignment, "FAILED: Incorrect specifier value received");
 
     paragraphStyleCopy = CTParagraphStyleCreateCopy(paragraphStyle);
     success =
         CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &buffer);
-    ASSERT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
-    ASSERT_TRUE_MSG(buffer == kCTJustifiedTextAlignment, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success, "FAILED: Could not found the specifier that was set.");
+    EXPECT_TRUE_MSG(buffer == kCTJustifiedTextAlignment, "FAILED: Incorrect specifier value received");
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, kCTParagraphStyleSpecifierTailIndent, sizeof(CGFloat), &bufferFloat);
-    ASSERT_TRUE_MSG(success, "FAILED: Could not find the specifier that was set");
-    ASSERT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE_MSG(success, "FAILED: Could not find the specifier that was set");
+    EXPECT_TRUE_MSG(fabs(bufferFloat - val) < 0.00001, "FAILED: Incorrect specifier value received");
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy,
                                                    kCTParagraphStyleSpecifierLineHeightMultiple,
                                                    sizeof(CGFloat),
                                                    &bufferFloat);
-    ASSERT_TRUE_MSG(!success, "FAILED: Incorrectly found the specifier that was not set.");
-    ASSERT_TRUE_MSG(fabs(bufferFloat - 0.0f) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE(success);
+    EXPECT_TRUE_MSG(fabs(bufferFloat - 0.0f) < 0.00001, "FAILED: Incorrect specifier value received");
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy,
                                                    kCTParagraphStyleSpecifierMaximumLineSpacing,
                                                    sizeof(CGFloat),
                                                    &bufferFloat);
-    ASSERT_TRUE_MSG(!success, "FAILED: Incorrectly found the specifier that was not set.");
-    ASSERT_TRUE_MSG(fabs(bufferFloat - 10000000.0f) < 0.00001, "FAILED: Incorrect specifier value received");
+    EXPECT_TRUE(success);
+    EXPECT_TRUE_MSG(fabs(bufferFloat - 0.0f) < 0.00001, "FAILED: Incorrect specifier value received");
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy,
                                                    kCTParagraphStyleSpecifierLineHeightMultiple,
                                                    sizeof(CGFloat),
                                                    &bufferFloat);
-    ASSERT_TRUE_MSG(!success, "FAILED: Incorrectly found the specifier that was not set.");
+    EXPECT_TRUE(success);
 
     success = CTParagraphStyleGetValueForSpecifier(paragraphStyleCopy, 513, sizeof(CGFloat), nullptr);
-    ASSERT_TRUE_MSG(!success, "FAILED: An invalid specifier crash should not occur.");
+    EXPECT_FALSE_MSG(success, "FAILED: An invalid specifier crash should not occur.");
 }
 
 TEST(CoreText, KernAttribute) {

--- a/tests/unittests/UIKit/NSParagraphStyleTests.mm
+++ b/tests/unittests/UIKit/NSParagraphStyleTests.mm
@@ -76,12 +76,3 @@ TEST(NSParagraphStyle, CopyShouldBeImmutable) {
     style.lineSpacing = 20.0;
     EXPECT_NEAR(10.0, [copiedStyle lineSpacing], c_errorDelta);
 }
-
-TEST(NSParagraphStyle, DefaultShouldReturnSameInstance) {
-    NSParagraphStyle* first = [NSParagraphStyle defaultParagraphStyle];
-    NSParagraphStyle* second = [NSParagraphStyle defaultParagraphStyle];
-    EXPECT_EQ(first, second);
-
-    NSParagraphStyle* other = [[NSParagraphStyle new] autorelease];
-    EXPECT_NE(first, other);
-}

--- a/tests/unittests/UIKit/NSParagraphStyleTests.mm
+++ b/tests/unittests/UIKit/NSParagraphStyleTests.mm
@@ -1,0 +1,65 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <TestFramework.h>
+#import <Foundation/Foundation.h>
+#import <CoreText/CTParagraphStyle.h>
+#import <UIKit/NSMutableParagraphStyle.h>
+#import "NSParagraphStyleInternal.h"
+#import "Starboard/SmartTypes.h"
+
+TEST(NSParagraphStyle, ShouldConvertToCTParagraphStyle) {
+    NSMutableParagraphStyle* style = [[NSMutableParagraphStyle new] autorelease];
+    style.alignment = NSTextAlignmentCenter;
+    style.lineSpacing = 10.0;
+    woc::unique_cf<CTParagraphStyleRef> convertedStyle{[style _convertToCTParagraphStyle] };
+    CTTextAlignment alignment;
+    EXPECT_TRUE(CTParagraphStyleGetValueForSpecifier(convertedStyle.get(),
+                                                     kCTParagraphStyleSpecifierAlignment,
+                                                     sizeof(CTTextAlignment),
+                                                     &alignment));
+    EXPECT_EQ(kCTCenterTextAlignment, alignment);
+
+    CGFloat lineSpacing;
+    EXPECT_TRUE(
+        CTParagraphStyleGetValueForSpecifier(convertedStyle.get(), kCTParagraphStyleSpecifierLineSpacing, sizeof(CGFloat), &lineSpacing));
+    EXPECT_NEAR(10.0, lineSpacing, .0001);
+
+    CGFloat maximumLineHeight = 123545.67;
+    EXPECT_TRUE(CTParagraphStyleGetValueForSpecifier(convertedStyle.get(),
+                                                     kCTParagraphStyleSpecifierMaximumLineHeight,
+                                                     sizeof(CGFloat),
+                                                     &maximumLineHeight));
+    EXPECT_NEAR(0.0, maximumLineHeight, .0001);
+
+    NSParagraphStyle* copiedStyle = [[style copy] autorelease];
+    convertedStyle.reset([copiedStyle _convertToCTParagraphStyle]);
+    EXPECT_TRUE(CTParagraphStyleGetValueForSpecifier(convertedStyle.get(),
+                                                     kCTParagraphStyleSpecifierAlignment,
+                                                     sizeof(CTTextAlignment),
+                                                     &alignment));
+    EXPECT_EQ(kCTCenterTextAlignment, alignment);
+
+    EXPECT_TRUE(
+        CTParagraphStyleGetValueForSpecifier(convertedStyle.get(), kCTParagraphStyleSpecifierLineSpacing, sizeof(CGFloat), &lineSpacing));
+    EXPECT_NEAR(10.0, lineSpacing, .0001);
+
+    EXPECT_TRUE(CTParagraphStyleGetValueForSpecifier(convertedStyle.get(),
+                                                     kCTParagraphStyleSpecifierMaximumLineHeight,
+                                                     sizeof(CGFloat),
+                                                     &maximumLineHeight));
+    EXPECT_NEAR(0.0, maximumLineHeight, .0001);
+}

--- a/tests/unittests/UIKit/NSParagraphStyleTests.mm
+++ b/tests/unittests/UIKit/NSParagraphStyleTests.mm
@@ -76,3 +76,12 @@ TEST(NSParagraphStyle, CopyShouldBeImmutable) {
     style.lineSpacing = 20.0;
     EXPECT_NEAR(10.0, [copiedStyle lineSpacing], c_errorDelta);
 }
+
+TEST(NSParagraphStyle, DefaultShouldReturnSameInstance) {
+    NSParagraphStyle* first = [NSParagraphStyle defaultParagraphStyle];
+    NSParagraphStyle* second = [NSParagraphStyle defaultParagraphStyle];
+    EXPECT_EQ(first, second);
+
+    NSParagraphStyle* other = [[NSParagraphStyle new] autorelease];
+    EXPECT_NE(first, other);
+}


### PR DESCRIPTION
NSParagraphStyle and CTParagraphStyle are not bridged, but share most attributes and needed to be convertible for NSString+UIKitAdditions' use of CoreText for drawing.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1343)
<!-- Reviewable:end -->
