### PR TITLE
Make Starboard/SmartTypes C++-clean.

### DIFF
--- a/include/xplat/Starboard/SmartTypes.h
+++ b/include/xplat/Starboard/SmartTypes.h
@@ -29,6 +29,8 @@
 #include <memory>
 #include <type_traits>
 
+#if defined(__OBJC__)
+
 extern "C" id objc_storeStrong(id* object, id value); // Forward decl for non-objc.h users.
 
 // Puzzlingly, this checks whether ARC is enabled instead of whether the compiler supports it.
@@ -299,7 +301,9 @@ bool operator!=(const Any& other, const AutoId<TObj, TLifetimeTraits>& val) {
 #define idretaintype(type) AutoId<type>
 #define idretainproto(type) AutoId<id<type>>
 
-#if defined(__OBJC__)
+#endif
+
+#ifdef CF_EXPORT // Quick way to detect CoreFoundation.
 namespace woc {
 template <typename T>
 class unique_cf : public std::unique_ptr<typename std::remove_pointer<T>::type, decltype(&CFRelease)> {
@@ -312,7 +316,9 @@ public:
     }
 };
 }
+#endif
 
+#ifdef WINOBJCRT_EXPORT // Quick way to detect WinObjCRT.
 namespace woc {
 template <typename T>
 class unique_iw : public std::unique_ptr<T, void (*)(T*)> {
@@ -324,7 +330,6 @@ public:
     }
 };
 }
-
 #endif
 
 #else // else(!defined(__cplusplus))

--- a/include/xplat/Starboard/TypeTraits.h
+++ b/include/xplat/Starboard/TypeTraits.h
@@ -30,7 +30,6 @@ struct IsBlock<Ret (^)(Args...)> : std::true_type {};
 // for variadic blocks.
 template <typename Ret, typename... Args>
 struct IsBlock<Ret (^)(Args..., ...)> : std::true_type {};
-#endif
 
 // MakeObjcPointer conditionally applies pointer semantics to Objective-C class types without damaging
 // id or block pointers.
@@ -43,4 +42,5 @@ public:
     static_assert(std::is_convertible<_type, id>::value, "MakeObjcPointer can't wrap non-Objective-C types.");
     using type = _type;
 };
+#endif
 }


### PR DESCRIPTION
* SmartTypes leaks a reference to `id` and `CFRelease`
* TypeTraits leaks a reference to `id`.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1347)
<!-- Reviewable:end -->
