### PR TITLE
Fix missing open brackets in winrt templates for vsimporter.

### DIFF
--- a/msvc/vsimporter-templates/WinStore10-WinRT/WinRT.vcxproj
+++ b/msvc/vsimporter-templates/WinStore10-WinRT/WinRT.vcxproj
@@ -32,10 +32,10 @@
   <ItemDefinitionGroup VSImporterLabel="ConfigurationItemDefinitions">
     <ClCompile>
       <RuntimeLibrary VSImporterConfigName="Debug">MultiThreadedDebugDLL</RuntimeLibrary>
-    <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-    PrecompiledHeader>NotUsing</PrecompiledHeader>
-    <CompileAsWinRT>false</CompileAsWinRT>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
     <ClangCompile>
       <RuntimeLibrary VSImporterConfigName="Debug">MultiThreadedDebugDLL</RuntimeLibrary>


### PR DESCRIPTION
Fix missing open brackets in winrt templates for vsimporter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1351)
<!-- Reviewable:end -->
