### PR TITLE
Create CTFrame without going past string length

### DIFF
--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -32,7 +32,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CF
     // Call _DWriteWrapper to get _CTLine object list that makes up this frame
     _CTTypesetter* typesetter = static_cast<_CTTypesetter*>(framesetter->_typesetter);
     if (range.length == 0L) {
-        range.length = typesetter->_characters.size();
+        range.length = typesetter->_characters.size() - range.location;
     }
 
     StrongId<_CTFrame> ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameRect);
@@ -42,8 +42,10 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CF
         return ret.detach();
     }
 
-    CTParagraphStyleRef settings = static_cast<CTParagraphStyleRef>(
-        [typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName) atIndex:0 effectiveRange:nullptr]);
+    CTParagraphStyleRef settings =
+        static_cast<CTParagraphStyleRef>([typesetter->_attributedString attribute:static_cast<NSString*>(kCTParagraphStyleAttributeName)
+                                                                          atIndex:range.location
+                                                                   effectiveRange:nullptr]);
 
     if (settings == nil) {
         return ret.detach();

--- a/tests/unittests/CoreText/CTFramesetterTests.mm
+++ b/tests/unittests/CoreText/CTFramesetterTests.mm
@@ -134,7 +134,7 @@ TEST(CTFramesetter, ShouldNotCreatePastEndOfString) {
     NSMutableAttributedString* attrString = getAttributedString(@"ABCDEFGHIJ");
     CFAttributedStringRef string = (__bridge CFAttributedStringRef)attrString;
     woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString(string) };
-    CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, FLT_MAX, FLT_MAX), nullptr);
-    woc::unique_cf<CTFrameRef> firstFrame{ CTFramesetterCreateFrame(framesetter.get(), { 5, 0 }, path, nullptr) };
+    woc::unique_cf<CGPathRef> path{ CGPathCreateWithRect(CGRectMake(0, 0, FLT_MAX, FLT_MAX), nullptr) };
+    woc::unique_cf<CTFrameRef> firstFrame{ CTFramesetterCreateFrame(framesetter.get(), { 5, 0 }, path.get(), nullptr) };
     EXPECT_NE(firstFrame.get(), nil);
 }

--- a/tests/unittests/CoreText/CTFramesetterTests.mm
+++ b/tests/unittests/CoreText/CTFramesetterTests.mm
@@ -19,6 +19,7 @@
 #import <CoreText/CoreText.h>
 #import <UIKit/UIKit.h>
 #import <StubReturn.h>
+#import "Starboard/SmartTypes.h"
 
 static const float c_errorDelta = 0.0005f;
 
@@ -127,4 +128,13 @@ TEST(CTFramesetter, ShouldBeAbleToCreateMultipleFramesFromSameFramesetter) {
     CFRelease(secondFrame);
     CFRelease(thirdFrame);
     CFRelease(fullFrame);
+}
+
+TEST(CTFramesetter, ShouldNotCreatePastEndOfString) {
+    NSMutableAttributedString* attrString = getAttributedString(@"ABCDEFGHIJ");
+    CFAttributedStringRef string = (__bridge CFAttributedStringRef)attrString;
+    woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString(string) };
+    CGPathRef path = CGPathCreateWithRect(CGRectMake(0, 0, FLT_MAX, FLT_MAX), nullptr);
+    woc::unique_cf<CTFrameRef> firstFrame{ CTFramesetterCreateFrame(framesetter.get(), { 5, 0 }, path, nullptr) };
+    EXPECT_NE(firstFrame.get(), nil);
 }


### PR DESCRIPTION
Our private helper method __CreateFrame was assuming that when given a CFRange with length 0, the location would also be 0, so when given a non-zero location we would try and read past the end of the string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1353)
<!-- Reviewable:end -->
