### PR TITLE
[UIKit] [UIButton] Address incorrect scaling factor for resizable images used as button

### DIFF
--- a/Frameworks/UIKit.Xaml/Button.xaml
+++ b/Frameworks/UIKit.Xaml/Button.xaml
@@ -5,21 +5,15 @@
     xmlns:local="using:UIKit.Xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Width="50"
-    Height="50">
+    mc:Ignorable="d">
     <Button.Template>
         <ControlTemplate TargetType="Button" x:Name="UIKitButtonControlTemplate">
-            <Grid x:Name="rootGrid" Background="{TemplateBinding Background}">
-                <!-- TODO: Since NineGrid works on image pixels, to support an image with 2x scaling we need to multiply the Size and NineGrid, 
-                     and inverse render transform it back to the right size. Grid clips its children, so we need to host it in a Canvas first. -->
-                <Image x:Name="backgroundImage" 
-                       Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" IsHitTestVisible="False" Stretch="Fill"/>
+            <Canvas x:Name="rootCanvas" Background="{TemplateBinding Background}">
                 <Canvas x:Name="contentCanvas" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
                     <Image x:Name="buttonImage" Stretch="Fill" IsHitTestVisible="False" />
                     <TextBlock x:Name="buttonText" MaxLines="1" TextTrimming="CharacterEllipsis" IsHitTestVisible="False"/>
                 </Canvas>
-            </Grid>
+            </Canvas>
         </ControlTemplate>
     </Button.Template>
 </Button>

--- a/Frameworks/UIKit.Xaml/Button.xaml
+++ b/Frameworks/UIKit.Xaml/Button.xaml
@@ -8,11 +8,9 @@
     mc:Ignorable="d">
     <Button.Template>
         <ControlTemplate TargetType="Button" x:Name="UIKitButtonControlTemplate">
-            <Canvas x:Name="rootCanvas" Background="{TemplateBinding Background}">
-                <Canvas x:Name="contentCanvas" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
-                    <Image x:Name="buttonImage" Stretch="Fill" IsHitTestVisible="False" />
-                    <TextBlock x:Name="buttonText" MaxLines="1" TextTrimming="CharacterEllipsis" IsHitTestVisible="False"/>
-                </Canvas>
+            <Canvas x:Name="contentCanvas" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" Background="{TemplateBinding Background}">
+                <Image x:Name="buttonImage" Stretch="Fill" IsHitTestVisible="False" />
+                <TextBlock x:Name="buttonText" MaxLines="1" TextTrimming="CharacterEllipsis" IsHitTestVisible="False"/>
             </Canvas>
         </ControlTemplate>
     </Button.Template>

--- a/Frameworks/UIKit.Xaml/Button.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Button.xaml.cpp
@@ -29,8 +29,6 @@ using namespace Windows::UI::Xaml::Controls;
 namespace UIKit {
 namespace Xaml {
 
-static const float button_padding = 20.0f;
-
 // Method to get default text Foreground brush
 Brush^ GetDefaultWhiteForegroundBrush() {
     static auto ret = ref new SolidColorBrush(Windows::UI::Colors::White);
@@ -47,9 +45,19 @@ Button::Button() {
 
 // Accessor for our Layer content
 Image^ Button::LayerContent::get() {
-    // TODO: Add support for this.  Perhaps we return the same button's image, or we add another image within the canvas.  It should
-    // go just in front of the other button text/image, but behind any sublayers added by CoreAnimation via the SublayerCanvas property.
-    return nullptr;
+    if (!_content) {
+        Canvas^ rootCanvas = safe_cast<Canvas^>(GetTemplateChild(L"rootCanvas"));
+
+        if (rootCanvas) {
+            _content = ref new Image();
+            _content->Name = "LayerContent";
+
+            // Layer content is behind any sublayers
+            rootCanvas->Children->InsertAt(0, _content);
+        }
+    }
+
+    return _content;
 }
 
 // Accessor for our Layer content
@@ -176,7 +184,6 @@ void Button::OnApplyTemplate() {
     // Call GetTemplateChild to grab references to UIElements in our custom control template
     _textBlock = safe_cast<TextBlock^>(GetTemplateChild("buttonText"));
     _image = safe_cast<Image^>(GetTemplateChild("buttonImage"));
-    _backgroundImage = safe_cast<Image^>(GetTemplateChild("backgroundImage"));
     _contentCanvas = safe_cast<Canvas^>(GetTemplateChild(L"contentCanvas"));
 }
 
@@ -204,8 +211,6 @@ UIKIT_XAML_EXPORT void XamlRemoveLayoutEvent(const ComPtr<IInspectable>& inspect
 UIKIT_XAML_EXPORT void XamlButtonApplyVisuals(const ComPtr<IInspectable>& inspectableButton,
     const ComPtr<IInspectable>& inspectableText,
     const ComPtr<IInspectable>& inspectableButtonImage,
-    const ComPtr<IInspectable>& inspectableBackgroundImage,
-    const RECT insets,
     const ComPtr<IInspectable>& inspectableTitleColor) {
 
     auto button = safe_cast<UIKit::Xaml::Button^>(reinterpret_cast<Platform::Object^>(inspectableButton.Get()));
@@ -218,16 +223,6 @@ UIKIT_XAML_EXPORT void XamlButtonApplyVisuals(const ComPtr<IInspectable>& inspec
     // Set the Textblock's title and Foreground Brush color
     button->_textBlock->Text = title;
     button->_textBlock->Foreground = titleColor;
-
-    // Set the background Image and its nine grid
-    auto backgroundImage = safe_cast<Brush^>(reinterpret_cast<Platform::Object^>(inspectableBackgroundImage.Get()));
-    if (backgroundImage) {
-        ImageBrush^ backgroundImageBrush = safe_cast<ImageBrush^>(backgroundImage);
-        button->_backgroundImage->Source = safe_cast<BitmapSource^>(backgroundImageBrush->ImageSource);;
-
-        // Set the NineGrid on the Button's background image which is actually a XAML Image in the Control Template
-        button->_backgroundImage->NineGrid = ThicknessHelper::FromLengths(insets.left, insets.top, insets.right, insets.bottom);
-    }
 
     // Set the Button's Image
     auto image = safe_cast<Brush^>(reinterpret_cast<Platform::Object^>(inspectableButtonImage.Get()));

--- a/Frameworks/UIKit.Xaml/Button.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Button.xaml.cpp
@@ -45,16 +45,12 @@ Button::Button() {
 
 // Accessor for our Layer content
 Image^ Button::LayerContent::get() {
-    if (!_content) {
-        Canvas^ rootCanvas = safe_cast<Canvas^>(GetTemplateChild(L"rootCanvas"));
+    if (!_content && _contentCanvas) {
+        _content = ref new Image();
+        _content->Name = "LayerContent";
 
-        if (rootCanvas) {
-            _content = ref new Image();
-            _content->Name = "LayerContent";
-
-            // Layer content is behind any sublayers
-            rootCanvas->Children->InsertAt(0, _content);
-        }
+        // Layer content is behind any sublayers
+        _contentCanvas->Children->InsertAt(0, _content);
     }
 
     return _content;

--- a/Frameworks/UIKit.Xaml/Button.xaml.h
+++ b/Frameworks/UIKit.Xaml/Button.xaml.h
@@ -69,7 +69,6 @@ internal:
 
     Windows::UI::Xaml::Controls::TextBlock^ _textBlock;
     Windows::UI::Xaml::Controls::Image^ _image;
-    Windows::UI::Xaml::Controls::Image^ _backgroundImage;
 
 private:
     Windows::UI::Xaml::Controls::Canvas^ _contentCanvas; // Contains pre-canned button content, as well as any sublayers added by CoreAnimation.

--- a/Frameworks/UIKit.Xaml/ObjCXamlControls.h
+++ b/Frameworks/UIKit.Xaml/ObjCXamlControls.h
@@ -34,8 +34,6 @@ UIKIT_XAML_EXPORT IInspectable* XamlCreateButton();
 UIKIT_XAML_EXPORT void XamlButtonApplyVisuals(const Microsoft::WRL::ComPtr<IInspectable>& inspectableButton,
                                               const Microsoft::WRL::ComPtr<IInspectable>& inspectableText,
                                               const Microsoft::WRL::ComPtr<IInspectable>& inspectableImage,
-                                              const Microsoft::WRL::ComPtr<IInspectable>& inspectableBackgroundImage,
-                                              const RECT insets,
                                               const Microsoft::WRL::ComPtr<IInspectable>& inspectableTitleColor);
 
 // Hooks pointer events on a UIKit::Button passed in as IInspectable

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -284,6 +284,8 @@ Microsoft Extension
     CGRect imageFrame = [self imageRectForContentRect:contentFrame];
     self.titleLabel.frame = textFrame;
     self.imageView.frame = imageFrame;
+
+    // Use the layer contents to draw the background image, similar to UIImageView.
     UIImageSetLayerContents([self layer], self.currentBackgroundImage);
 
     // Probably important to keep around for after the refactor.
@@ -507,7 +509,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 }
 
 /**
- @Status Caveat
+ @Status Interoperable
  @Notes The xaml element may be modified directly and we could still return stale values.
 */
 - (UIColor*)titleColorForState:(UIControlState)state {

--- a/Frameworks/UIKit/UILabel.mm
+++ b/Frameworks/UIKit/UILabel.mm
@@ -292,6 +292,9 @@
  @Status Interoperable
 */
 - (void)setText:(NSString*)newStr {
+    if (newStr == nil && _text == nil) {
+        return;
+    }
     if (![newStr isKindOfClass:[NSString class]]) {
         newStr = [newStr description];
     }
@@ -367,6 +370,9 @@
  @Status Interoperable
 */
 - (void)setTextColor:(UIColor*)color {
+    if (color == nil && _textColor == nil) {
+        return;
+    }
     if (![_textColor isEqual:color]) {
         [[_textColor retain] autorelease];
         _textColor = color;

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -653,6 +653,10 @@ static std::string _printViewHeirarchy(UIView* leafView) {
     // Create the private backing object
     self->priv = new UIViewPrivateState(self);
 
+    // Since we piggyback on autoresize masks and layoutSubviews for autolayout, we need to
+    // edge-trigger intrinsic content size changes, or we stumble into layout loops
+    priv->_previousIntrinsicContentSize = { UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric };
+
     // Configure autolayout
     static bool isAutoLayoutInitialized = InitializeAutoLayout();
     [self autoLayoutAlloc];
@@ -2442,6 +2446,13 @@ static float doRound(float f) {
 /**
  @Status Interoperable
 */
+- (BOOL)autoresizesSubviews {
+    return priv->autoresizesSubviews;
+}
+
+/**
+ @Status Interoperable
+*/
 - (void)setAutoresizesSubviews:(BOOL)autoresize {
     if (autoresize != priv->autoresizesSubviews) {
         priv->autoresizesSubviews = autoresize;
@@ -3489,10 +3500,12 @@ static float doRound(float f) {
  @Status Interoperable
 */
 - (void)invalidateIntrinsicContentSize {
-    [self autoLayoutInvalidateContentSize];
-
     // The parent is always responsible for autolaying out its children
-    [self.superview setNeedsLayout];
+    if (!CGSizeEqualToSize(priv->_previousIntrinsicContentSize, self.intrinsicContentSize)) {
+        priv->_previousIntrinsicContentSize = self.intrinsicContentSize;
+        [self autoLayoutInvalidateContentSize];
+        [self.superview setNeedsLayout];
+    }
 }
 
 /**

--- a/Frameworks/include/UIViewInternal.h
+++ b/Frameworks/include/UIViewInternal.h
@@ -55,6 +55,7 @@ public:
     UIViewAutoresizing autoresizingMask;
     CGSize _contentHuggingPriority;
     CGSize _contentCompressionResistancePriority;
+    CGSize _previousIntrinsicContentSize;
     BOOL autoresizesSubviews;
     BOOL translatesAutoresizingMaskIntoConstraints;
     CGRect _resizeRoundingError;
@@ -107,7 +108,6 @@ public:
 }
 
 - (UITouchPhase)_processPointerEvent:(WUXIPointerRoutedEventArgs*)pointerEventArgs forTouchPhase:(UITouchPhase)touchPhase;
-- (void)_initPriv;
 
 + (void)_setPageTransitionForView:(UIView*)view fromLeft:(BOOL)fromLeft;
 - (void)_applyConstraints;


### PR DESCRIPTION
backgrounds by adding a Layer Content image element.

Also address overly aggressive layout cycles in UIButton, and autolayout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1361)
<!-- Reviewable:end -->
