### PR TITLE
Update CT/CG/UI Font creation functions to support both PostScript an…

### DIFF
--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -20,8 +20,8 @@
 #include <COMIncludes_End.h>
 
 #import <CoreGraphics/DWriteWrapper.h>
-#import <Starboard.h>
 
+#import <unordered_map>
 #import <vector>
 
 using namespace std;
@@ -42,6 +42,115 @@ static wstring __GetUserDefaultLocaleName() {
     // If the default locale is returned, find that locale name, otherwise use "en-us".
     return wstring(defaultLocaleSuccess ? localeName : c_defaultUserLanguage);
 }
+
+/**
+ * Private helper that creates an uppercase copy of a CFString
+ */
+CFStringRef __CFStringCreateUppercaseCopy(CFStringRef string, CFLocaleRef locale) {
+    CFMutableStringRef ret = CFStringCreateMutableCopy(nullptr, CFStringGetLength(string), string);
+    CFStringUppercase(ret, locale);
+    return ret;
+}
+
+/**
+ * Private helper that creates the IDWriteFontList for a given font family name
+ */
+HRESULT __DWriteGetFontListForFamilyName(CFStringRef familyName, IDWriteFontList** outFontList) {
+    ComPtr<IDWriteFactory> dwriteFactory;
+    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
+
+    // Get the system font collection.
+    ComPtr<IDWriteFontCollection> fontCollection;
+    RETURN_IF_FAILED(dwriteFactory->GetSystemFontCollection(&fontCollection));
+
+    // Get the font family.
+    CFIndex familyNameLength = CFStringGetLength(familyName);
+    std::vector<UniChar> unicharFamilyName(familyNameLength + 1);
+    CFStringGetCharacters(familyName, CFRangeMake(0, familyNameLength), unicharFamilyName.data());
+
+    size_t index = 0;
+    BOOL exists = false;
+
+    RETURN_IF_FAILED(fontCollection->FindFamilyName(reinterpret_cast<wchar_t*>(unicharFamilyName.data()), &index, &exists));
+    RETURN_HR_IF(E_INVALIDARG, !exists);
+
+    ComPtr<IDWriteFontFamily> fontFamily;
+    RETURN_IF_FAILED(fontCollection->GetFontFamily(index, &fontFamily));
+
+    RETURN_IF_FAILED(
+        fontFamily->GetMatchingFonts(DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, outFontList));
+
+    return S_OK;
+}
+
+/**
+ * Private struct that exposes CFHash and CFEqual to an STL container
+ */
+struct __CFStringHashEqual {
+    std::size_t operator()(const woc::unique_cf<CFStringRef>& item) const {
+        return CFHash(item.get());
+    }
+
+    bool operator()(const woc::unique_cf<CFStringRef>& item1, const woc::unique_cf<CFStringRef>& item2) const {
+        return CFEqual(item1.get(), item2.get());
+    }
+};
+
+/**
+ * Private static map, that maps uppercase display name and postscript name, to a _DWriteFontProperties struct for the corresponding font.
+ */
+static std::unordered_map<woc::unique_cf<CFStringRef>, std::shared_ptr<_DWriteFontProperties>, __CFStringHashEqual, __CFStringHashEqual>
+    c_fontPropertiesMap = []() {
+        decltype(c_fontPropertiesMap) ret;
+
+        woc::unique_cf<CFArrayRef> familyNames(_DWriteCopyFontFamilyNames());
+        woc::unique_cf<CFLocaleRef> locale(CFLocaleCopyCurrent());
+
+        for (size_t i = 0; i < CFArrayGetCount(familyNames.get()); ++i) {
+            woc::unique_cf<CFStringRef> familyName(static_cast<CFStringRef>(CFRetain(CFArrayGetValueAtIndex(familyNames.get(), i))));
+            ComPtr<IDWriteFontList> fontList;
+
+            if (FAILED(__DWriteGetFontListForFamilyName(familyName.get(), &fontList))) {
+                continue;
+            }
+
+            size_t count = fontList->GetFontCount();
+
+            for (size_t j = 0; j < count; j++) {
+                ComPtr<IDWriteFont> font;
+                if (FAILED(fontList->GetFont(j, &font))) {
+                    continue;
+                }
+
+                // For each font in that family, fill out a _DWriteFontProperties
+                auto info = std::make_shared<_DWriteFontProperties>();
+                ComPtr<IDWriteLocalizedStrings> displayName;
+                ComPtr<IDWriteLocalizedStrings> postScriptName;
+                BOOL exist;
+
+                if (SUCCEEDED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_FULL_NAME, &displayName, &exist)) && exist) {
+                    info->displayName.reset(__CFStringCreateUppercaseCopy(_CFStringFromLocalizedString(displayName.Get()), locale.get()));
+                    woc::unique_cf<CFStringRef> uppercaseNameKey(__CFStringCreateUppercaseCopy(info->displayName.get(), locale.get()));
+                    ret.emplace(std::move(uppercaseNameKey), info);
+                }
+
+                if (SUCCEEDED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, &postScriptName, &exist)) &&
+                    exist) {
+                    info->postScriptName.reset(_CFStringFromLocalizedString(postScriptName.Get()));
+                    woc::unique_cf<CFStringRef> uppercaseNameKey(__CFStringCreateUppercaseCopy(info->postScriptName.get(), locale.get()));
+                    ret.emplace(std::move(uppercaseNameKey), info);
+                }
+
+                info->familyName.reset(CFStringCreateCopy(nullptr, familyName.get()));
+
+                info->weight = font->GetWeight();
+                info->stretch = font->GetStretch();
+                info->style = font->GetStyle();
+            }
+        }
+
+        return ret;
+    }();
 
 /**
  * Helper method to convert IDWriteLocalizedStrings object to CFString object.
@@ -133,33 +242,8 @@ CFArrayRef _DWriteCopyFontFamilyNames() {
 CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName) {
     woc::unique_cf<CFMutableArrayRef> fontNames(CFArrayCreateMutable(kCFAllocatorSystemDefault, 0, &kCFTypeArrayCallBacks));
 
-    ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_NULL_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
-
-    // Get the system font collection.
-    ComPtr<IDWriteFontCollection> fontCollection;
-    RETURN_NULL_IF_FAILED(dwriteFactory->GetSystemFontCollection(&fontCollection));
-
-    // Get the font family.
-    CFIndex familyNameLength = CFStringGetLength(familyName);
-    std::vector<UniChar> unicharFamilyName(familyNameLength + 1);
-    CFStringGetCharacters(familyName, CFRangeMake(0, familyNameLength), unicharFamilyName.data());
-
-    size_t index = 0;
-    BOOL exists = false;
-
-    RETURN_NULL_IF_FAILED(fontCollection->FindFamilyName(reinterpret_cast<wchar_t*>(unicharFamilyName.data()), &index, &exists));
-    if (!exists) {
-        TraceError(TAG, L"Failed to find the font family name.");
-        return fontNames.release();
-    }
-
-    ComPtr<IDWriteFontFamily> fontFamily;
-    RETURN_NULL_IF_FAILED(fontCollection->GetFontFamily(index, &fontFamily));
-
     ComPtr<IDWriteFontList> fontList;
-    RETURN_NULL_IF_FAILED(
-        fontFamily->GetMatchingFonts(DWRITE_FONT_WEIGHT_THIN, DWRITE_FONT_STRETCH_UNDEFINED, DWRITE_FONT_STYLE_NORMAL, &fontList));
+    RETURN_NULL_IF_FAILED(__DWriteGetFontListForFamilyName(familyName, &fontList));
 
     size_t count = fontList->GetFontCount();
 
@@ -191,151 +275,22 @@ CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName) {
  * Note: This function currently uses a cache, meaning that fonts installed during runtime will not be reflected
  */
 CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName) {
-    static CFDictionaryRef fontToFamilyMap = []() {
-        woc::unique_cf<CFLocaleRef> locale(CFLocaleCopyCurrent());
-
-        // initialize fontToFamilyMap
-        woc::unique_cf<CFMutableDictionaryRef> initMap(
-            CFDictionaryCreateMutable(kCFAllocatorSystemDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-
-        woc::unique_cf<CFArrayRef> familyNames(_DWriteCopyFontFamilyNames());
-
-        for (size_t i = 0; i < CFArrayGetCount(familyNames.get()); ++i) {
-            CFStringRef familyName = static_cast<CFStringRef>(CFArrayGetValueAtIndex(familyNames.get(), i));
-            woc::unique_cf<CFArrayRef> fontNames(_DWriteCopyFontNamesForFamilyName(familyName));
-
-            for (size_t j = 0; j < CFArrayGetCount(fontNames.get()); j++) {
-                CFStringRef systemFontName = static_cast<CFStringRef>(CFArrayGetValueAtIndex(fontNames.get(), j));
-                woc::unique_cf<CFMutableStringRef> upperSystemFontName(
-                    CFStringCreateMutableCopy(nullptr, CFStringGetLength(systemFontName), systemFontName));
-                CFStringUppercase(upperSystemFontName.get(), locale.get());
-                CFDictionaryAddValue(initMap.get(), upperSystemFontName.get(), familyName);
-            }
-        }
-
-        return CFDictionaryCreateCopy(kCFAllocatorSystemDefault, initMap.get());
-    }();
-
-    woc::unique_cf<CFLocaleRef> locale(CFLocaleCopyCurrent());
-
-    woc::unique_cf<CFMutableStringRef> upperFontName(CFStringCreateMutableCopy(nullptr, CFStringGetLength(fontName), fontName));
-    CFStringUppercase(upperFontName.get(), locale.get());
-    return static_cast<CFStringRef>(CFDictionaryGetValue(fontToFamilyMap, upperFontName.get()));
+    return _DWriteGetFontPropertiesFromName(fontName)->familyName.get();
 }
-
-// Represents a mapping between multiple representations of the same font weight across font names, DWrite, and CoreText
-// eg: CFSTR("BOLD") = DWRITE_FONT_WEIGHT_BOLD = kCTFontWeightBold
-struct WeightMapping {
-    CFStringRef stringValue;
-    DWRITE_FONT_WEIGHT dwriteValue;
-};
-
-// Mapping for weight
-// Some loss of precision here as CT presents fewer values than DWrite
-// Note also that Thin and Ultra/Extra-Light are in opposite order in DWrite and CoreText/UIKit constants
-// (However, "Thin" fonts on the reference platform have UIFontWeightUltraLight...)
-static const struct WeightMapping c_weightMap[] = { { CFSTR("THIN"), DWRITE_FONT_WEIGHT_THIN },
-                                                    { CFSTR("EXTRALIGHT"), DWRITE_FONT_WEIGHT_EXTRA_LIGHT },
-                                                    { CFSTR("ULTRALIGHT"), DWRITE_FONT_WEIGHT_ULTRA_LIGHT },
-                                                    { CFSTR("LIGHT"), DWRITE_FONT_WEIGHT_LIGHT },
-                                                    { CFSTR("SEMILIGHT"), DWRITE_FONT_WEIGHT_SEMI_LIGHT },
-                                                    { CFSTR("NORMAL"), DWRITE_FONT_WEIGHT_NORMAL },
-                                                    { CFSTR("REGULAR"), DWRITE_FONT_WEIGHT_REGULAR },
-                                                    { CFSTR("MEDIUM"), DWRITE_FONT_WEIGHT_REGULAR },
-                                                    { CFSTR("DEMIBOLD"), DWRITE_FONT_WEIGHT_DEMI_BOLD },
-                                                    { CFSTR("DEMI"), DWRITE_FONT_WEIGHT_DEMI_BOLD },
-                                                    { CFSTR("SEMIBOLD"), DWRITE_FONT_WEIGHT_SEMI_BOLD },
-                                                    { CFSTR("BOLD"), DWRITE_FONT_WEIGHT_BOLD },
-                                                    { CFSTR("EXTRABOLD"), DWRITE_FONT_WEIGHT_EXTRA_BOLD },
-                                                    { CFSTR("ULTRABOLD"), DWRITE_FONT_WEIGHT_ULTRA_BOLD },
-                                                    { CFSTR("BLACK"), DWRITE_FONT_WEIGHT_BLACK },
-                                                    { CFSTR("HEAVY"), DWRITE_FONT_WEIGHT_HEAVY },
-                                                    { CFSTR("EXTRABLACK"), DWRITE_FONT_WEIGHT_EXTRA_BLACK },
-                                                    { CFSTR("ULTRABLACK"), DWRITE_FONT_WEIGHT_ULTRA_BLACK } };
 
 /**
  * Helper that parses a font name, and returns appropriate weight, stretch, style, and family name values
  */
-_DWriteFontProperties _DWriteGetFontPropertiesFromName(CFStringRef fontName) {
-    // Set some defaults for when weight/stretch/style are not mentioned in the name
-    _DWriteFontProperties ret{ DWRITE_FONT_WEIGHT_NORMAL,
-                               DWRITE_FONT_STRETCH_NORMAL,
-                               DWRITE_FONT_STYLE_NORMAL,
-                               _DWriteGetFamilyNameForFontName(fontName) };
+std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName) {
+    woc::unique_cf<CFLocaleRef> locale(CFLocaleCopyCurrent());
+    woc::unique_cf<CFStringRef> upperFontName(__CFStringCreateUppercaseCopy(fontName, locale.get()));
 
-    // Relationship of family name -> font name not always consistent
-    // Usually, properties are added to the end (eg: Arial -> Arial Narrow Bold)
-    // However, this is not always the case (eg: Eras ITC -> Eras Bold ITC)
-    // In addition, some fonts with properties are occasionally placed into their own family (eg: Segoe WP SemiLight -> Segoe WP SemiLight)
-    // Try to be more prudent about these edge cases, by looking only at the difference between the font name and family name
-    woc::unique_cf<CFArrayRef> fontNameTokens(CFStringCreateArrayBySeparatingStrings(kCFAllocatorDefault, fontName, CFSTR(" ")));
-    woc::unique_cf<CFMutableSetRef> propertyTokens(CFSetCreateMutable(kCFAllocatorDefault, 0, &kCFTypeSetCallBacks));
-
-    for (size_t i = 0; i < CFArrayGetCount(fontNameTokens.get()); ++i) {
-        CFSetAddValue(propertyTokens.get(), CFArrayGetValueAtIndex(fontNameTokens.get(), i));
+    const auto& info = c_fontPropertiesMap.find(upperFontName);
+    if (info != c_fontPropertiesMap.end()) {
+        return info->second;
     }
 
-    if (ret.familyName) {
-        woc::unique_cf<CFArrayRef> familyNameTokens(
-            CFStringCreateArrayBySeparatingStrings(kCFAllocatorDefault, ret.familyName, CFSTR(" ")));
-        for (size_t i = 0; i < CFArrayGetCount(familyNameTokens.get()); ++i) {
-            CFSetRemoveValue(propertyTokens.get(), CFArrayGetValueAtIndex(familyNameTokens.get(), i));
-        }
-    }
-
-    CFSetApplierFunction initPropertyFromToken = [](const void* value, void* context) {
-        CFMutableStringRef propertyToken = CFStringCreateMutableCopy(kCFAllocatorDefault, 0, static_cast<CFStringRef>(value));
-        _DWriteFontProperties* properties = reinterpret_cast<_DWriteFontProperties*>(context);
-
-        // Font names are not always consistent about capitalization (SemiLight vs Semilight)
-        // Standardize on uppercase
-        CFStringUppercase(propertyToken, CFLocaleGetSystem());
-
-        // Possible optimization here that can be done by using a dictionary,
-        // but seems excessive given that font names generally don't have more than three modifiers
-        for (const auto& weightMapping : c_weightMap) {
-            if (CFEqual(propertyToken, weightMapping.stringValue)) {
-                properties->weight = weightMapping.dwriteValue;
-                break;
-            }
-        }
-
-        if (CFEqual(propertyToken, CFSTR("UNDEFINED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_UNDEFINED;
-        } else if (CFEqual(propertyToken, CFSTR("ULTRACONDENSED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_ULTRA_CONDENSED;
-        } else if (CFEqual(propertyToken, CFSTR("EXTRACONDENSED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_EXTRA_CONDENSED;
-        } else if (CFEqual(propertyToken, CFSTR("CONDENSED")) || CFEqual(propertyToken, CFSTR("NARROW")) ||
-                   CFEqual(propertyToken, CFSTR("COND"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_CONDENSED;
-        } else if (CFEqual(propertyToken, CFSTR("SEMICONDENSED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_SEMI_CONDENSED;
-            // skip since this is the default
-            // } else if (CFEqual(propertyToken, CFSTR("NORMAL"))) {
-            //     properties->stretch = DWRITE_FONT_STRETCH_NORMAL;
-
-        } else if (CFEqual(propertyToken, CFSTR("SEMIEXPANDED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_SEMI_EXPANDED;
-        } else if (CFEqual(propertyToken, CFSTR("EXPANDED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_EXPANDED;
-        } else if (CFEqual(propertyToken, CFSTR("EXTRAEXPANDED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_EXTRA_EXPANDED;
-        } else if (CFEqual(propertyToken, CFSTR("ULTRAEXPANDED"))) {
-            properties->stretch = DWRITE_FONT_STRETCH_ULTRA_EXPANDED;
-
-            // skip since this is the default
-            // } else if (CFEqual(propertyToken, CFSTR("NORMAL"))) {
-            //     properties->style = DWRITE_FONT_STYLE_NORMAL;
-        } else if (CFEqual(propertyToken, CFSTR("OBLIQUE"))) {
-            properties->style = DWRITE_FONT_STYLE_OBLIQUE;
-        } else if (CFEqual(propertyToken, CFSTR("ITALIC"))) {
-            properties->style = DWRITE_FONT_STYLE_ITALIC;
-        }
-    };
-
-    CFSetApplyFunction(propertyTokens.get(), initPropertyFromToken, &ret);
-    return ret;
+    return std::make_shared<_DWriteFontProperties>();
 }
 
 /**
@@ -393,24 +348,24 @@ HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamil
 HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace) {
     // Parse the font name for font weight, stretch, and style
     // Eg: Bold, Condensed, Light, Italic
-    _DWriteFontProperties properties = _DWriteGetFontPropertiesFromName(name);
+    std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(name);
 
     // TODO: #1250: Need to be able to load fonts from the app's bundle
     // For now return a default font to avoid crashes in case of missing fonts
     // When #1250 is completed, remove this
-    if (!properties.familyName) {
+    if (!properties->familyName.get()) {
         name = CFSTR("Segoe UI");
         properties = _DWriteGetFontPropertiesFromName(name);
     }
 
-    RETURN_HR_IF_NULL(E_INVALIDARG, properties.familyName);
+    RETURN_HR_IF_NULL(E_INVALIDARG, properties->familyName.get());
 
     ComPtr<IDWriteFontFamily> fontFamily;
-    RETURN_IF_FAILED(_DWriteCreateFontFamilyWithName(properties.familyName, &fontFamily));
+    RETURN_IF_FAILED(_DWriteCreateFontFamilyWithName(properties->familyName.get(), &fontFamily));
     RETURN_HR_IF_NULL(E_INVALIDARG, fontFamily);
 
     ComPtr<IDWriteFont> font;
-    RETURN_IF_FAILED(fontFamily->GetFirstMatchingFont(properties.weight, properties.stretch, properties.style, &font));
+    RETURN_IF_FAILED(fontFamily->GetFirstMatchingFont(properties->weight, properties->stretch, properties->style, &font));
 
     return font->CreateFontFace(outFontFace);
 }

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -46,7 +46,7 @@ static wstring __GetUserDefaultLocaleName() {
 /**
  * Private helper that creates an uppercase copy of a CFString
  */
-CFStringRef __CFStringCreateUppercaseCopy(CFStringRef string, CFLocaleRef locale) {
+static CFStringRef __CFStringCreateUppercaseCopy(CFStringRef string, CFLocaleRef locale) {
     CFMutableStringRef ret = CFStringCreateMutableCopy(nullptr, CFStringGetLength(string), string);
     CFStringUppercase(ret, locale);
     return ret;
@@ -69,7 +69,7 @@ HRESULT __DWriteGetFontListForFamilyName(CFStringRef familyName, IDWriteFontList
     CFStringGetCharacters(familyName, CFRangeMake(0, familyNameLength), unicharFamilyName.data());
 
     size_t index = 0;
-    BOOL exists = false;
+    BOOL exists = FALSE;
 
     RETURN_IF_FAILED(fontCollection->FindFamilyName(reinterpret_cast<wchar_t*>(unicharFamilyName.data()), &index, &exists));
     RETURN_HR_IF(E_INVALIDARG, !exists);
@@ -169,7 +169,7 @@ CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedStrin
     wstring localeName = __GetUserDefaultLocaleName();
 
     uint32_t index = 0;
-    BOOL exists = false;
+    BOOL exists = FALSE;
 
     // If the default locale is returned, find that locale name, otherwise use "en-us".
     RETURN_NULL_IF_FAILED(localizedString->FindLocaleName(localeName.c_str(), &index, &exists));

--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -189,7 +189,7 @@ CTFontRef __CTFontCreateWithAttributes(CFDictionaryRef attributes, CGFloat size,
 CTFontDescriptorRef __CTFontDescriptorCreateWithDWriteFontFace(CGFloat size,
                                                                const CGAffineTransform* matrix,
                                                                Microsoft::WRL::ComPtr<IDWriteFontFace> fontFace) {
-    CFStringRef name = _DWriteFontCopyName(fontFace, kCTFontFullNameKey);
+    CFStringRef name = _DWriteFontCopyName(fontFace, kCTFontPostScriptNameKey);
     CFAutorelease(name);
     if (matrix) {
         CFStringRef keys[] = { kCTFontNameAttribute, kCTFontSizeAttribute, kCTFontMatrixAttribute };
@@ -392,6 +392,13 @@ CTFontDescriptorRef CTFontCopyFontDescriptor(CTFontRef font) {
 */
 CFTypeRef CTFontCopyAttribute(CTFontRef font, CFStringRef attribute) {
     RETURN_NULL_IF(!font);
+
+    if (CFEqual(attribute, kCTFontDisplayNameAttribute)) {
+        return CTFontCopyDisplayName(font);
+    } else if (CFEqual(attribute, kCTFontNameAttribute)) {
+        return CTFontCopyPostScriptName(font);
+    }
+
     return CTFontDescriptorCopyAttribute(font->_descriptor, attribute);
 }
 

--- a/Frameworks/CoreText/CTFontDescriptor.mm
+++ b/Frameworks/CoreText/CTFontDescriptor.mm
@@ -269,9 +269,8 @@ CFTypeRef CTFontDescriptorCopyLocalizedAttribute(CTFontDescriptorRef descriptor,
 */
 CFTypeID CTFontDescriptorGetTypeID() {
     static dispatch_once_t initOnce = 0;
-    dispatch_once(&initOnce,
-                  ^{
-                      __kCTFontDescriptorTypeID = _CFRuntimeRegisterClass(&__CTFontDescriptorClass);
-                  });
+    dispatch_once(&initOnce, ^{
+        __kCTFontDescriptorTypeID = _CFRuntimeRegisterClass(&__CTFontDescriptorClass);
+    });
     return __kCTFontDescriptorTypeID;
 }

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -115,21 +115,23 @@ static ComPtr<IDWriteTextFormat> __CreateDWriteTextFormat(CFAttributedStringRef 
     CTFontRef font = static_cast<CTFontRef>([attribs objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
     std::vector<wchar_t> familyName;
 
-    _DWriteFontProperties properties = { DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, nullptr };
+    std::shared_ptr<_DWriteFontProperties> properties;
 
     if (font) {
         fontSize = CTFontGetSize(font);
         CFStringRef fontFullName = CTFontCopyName(font, kCTFontFullNameKey);
         CFAutorelease(fontFullName);
         properties = _DWriteGetFontPropertiesFromName(fontFullName);
+    } else {
+        properties = std::make_shared<_DWriteFontProperties>();
     }
 
-    familyName.resize(CFStringGetLength(properties.familyName) + 1, 0);
-    CFStringGetCharacters(properties.familyName, CFRangeMake(0, familyName.size()), reinterpret_cast<UniChar*>(familyName.data()));
+    familyName.resize(CFStringGetLength(properties->familyName.get()) + 1, 0);
+    CFStringGetCharacters(properties->familyName.get(), CFRangeMake(0, familyName.size()), reinterpret_cast<UniChar*>(familyName.data()));
 
     ComPtr<IDWriteTextFormat> textFormat;
     RETURN_NULL_IF_FAILED(
-        _DWriteCreateTextFormat(familyName.data(), properties.weight, properties.style, properties.stretch, fontSize, &textFormat));
+        _DWriteCreateTextFormat(familyName.data(), properties->weight, properties->style, properties->stretch, fontSize, &textFormat));
 
     CTParagraphStyleRef settings =
         static_cast<CTParagraphStyleRef>([attribs valueForKey:static_cast<NSString*>(kCTParagraphStyleAttributeName)]);
@@ -239,14 +241,16 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(CFAttributedStringRef 
         CGFloat fontSize = kCTFontSystemFontSize;
         if (font != nil) {
             fontSize = CTFontGetSize(font);
-            _DWriteFontProperties properties = _DWriteGetFontPropertiesFromName(CTFontCopyName(font, kCTFontFullNameKey));
-            std::vector<wchar_t> familyName(CFStringGetLength(properties.familyName) + 1);
-            CFStringGetCharacters(properties.familyName, CFRangeMake(0, familyName.size()), reinterpret_cast<UniChar*>(familyName.data()));
+            std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(CTFontCopyName(font, kCTFontFullNameKey));
+            std::vector<wchar_t> familyName(CFStringGetLength(properties->familyName.get()) + 1);
+            CFStringGetCharacters(properties->familyName.get(),
+                                  CFRangeMake(0, familyName.size()),
+                                  reinterpret_cast<UniChar*>(familyName.data()));
 
             RETURN_NULL_IF_FAILED(textLayout->SetFontSize(fontSize, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontWeight(properties.weight, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontStretch(properties.stretch, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontStyle(properties.style, dwriteRange));
+            RETURN_NULL_IF_FAILED(textLayout->SetFontWeight(properties->weight, dwriteRange));
+            RETURN_NULL_IF_FAILED(textLayout->SetFontStretch(properties->stretch, dwriteRange));
+            RETURN_NULL_IF_FAILED(textLayout->SetFontStyle(properties->style, dwriteRange));
             RETURN_NULL_IF_FAILED(textLayout->SetFontFamilyName(familyName.data(), dwriteRange));
         }
 

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -24,7 +24,9 @@
 #import <wrl/client.h>
 #include <COMIncludes_End.h>
 
+#import <Starboard.h>
 #import <string>
+#import <memory>
 
 // General DWrite helpers
 COREGRAPHICS_EXPORT CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedString);
@@ -35,14 +37,17 @@ COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef fam
 COREGRAPHICS_EXPORT CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName);
 
 struct _DWriteFontProperties {
-    DWRITE_FONT_WEIGHT weight;
-    DWRITE_FONT_STRETCH stretch;
-    DWRITE_FONT_STYLE style;
-    CFStringRef familyName;
+    DWRITE_FONT_WEIGHT weight = DWRITE_FONT_WEIGHT_NORMAL;
+    DWRITE_FONT_STRETCH stretch = DWRITE_FONT_STRETCH_NORMAL;
+    DWRITE_FONT_STYLE style = DWRITE_FONT_STYLE_NORMAL;
+
+    woc::unique_cf<CFStringRef> displayName;
+    woc::unique_cf<CFStringRef> postScriptName;
+    woc::unique_cf<CFStringRef> familyName;
 };
 
 // Create DWrite objects
-COREGRAPHICS_EXPORT _DWriteFontProperties _DWriteGetFontPropertiesFromName(CFStringRef fontName);
+extern "C++" std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName);
 
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateTextFormat(const wchar_t* fontFamilyName,
                                                     DWRITE_FONT_WEIGHT weight,

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -47,7 +47,9 @@ struct _DWriteFontProperties {
 };
 
 // Create DWrite objects
+#ifdef __cplusplus
 extern "C++" std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName);
+#endif
 
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateTextFormat(const wchar_t* fontFamilyName,
                                                     DWRITE_FONT_WEIGHT weight,

--- a/tests/unittests/CoreGraphics/CGFontTests.mm
+++ b/tests/unittests/CoreGraphics/CGFontTests.mm
@@ -22,16 +22,9 @@
 // CTFont functionality is generally a superset of CGFont functionality, and hits the same code path
 // Thus, CTFont unit tests can also be thought of as CGFont test coverage
 
-// Font names differ slightly between platforms
-#if TARGET_OS_WIN32
-static const CFStringRef c_arialBoldItalicName = CFSTR("Arial Bold Italic");
-static const CFStringRef c_arialItalicName = CFSTR("Arial Italic");
-static const CFStringRef c_courierNewItalicName = CFSTR("Courier New Italic");
-#else
 static const CFStringRef c_arialBoldItalicName = CFSTR("Arial-BoldItalicMT");
 static const CFStringRef c_arialItalicName = CFSTR("Arial-ItalicMT");
 static const CFStringRef c_courierNewItalicName = CFSTR("CourierNewPS-ItalicMT");
-#endif
 
 TEST(CGFont, GetFontBBox) {
     // Windows font bounding boxes differ from ref plat's in 'interesting' but inconsistent ways

--- a/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
+++ b/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
@@ -28,4 +28,5 @@ TEST(DWriteWrapper, FontToFamilyName) {
     EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman Italic")));
     EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman Bold")));
     EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman Bold Italic")));
+    EXPECT_OBJCEQ(nil, (id)_DWriteGetFamilyNameForFontName(CFSTR("NotAFont")));
 }

--- a/tests/unittests/CoreText/CTFontTests.mm
+++ b/tests/unittests/CoreText/CTFontTests.mm
@@ -133,6 +133,9 @@ TEST(CTFont, CopyNameHelpers) {
     EXPECT_OBJCEQ(@"Courier New", (id)CFAutorelease(CTFontCopyFamilyName(font)));
     EXPECT_OBJCEQ(@"Courier New Bold Italic", (id)CFAutorelease(CTFontCopyFullName(font)));
     EXPECT_OBJCEQ(@"Courier New Bold Italic", (id)CFAutorelease(CTFontCopyDisplayName(font)));
+
+    EXPECT_OBJCEQ(@"CourierNewPS-BoldItalicMT", (id)CFAutorelease(CTFontCopyAttribute(font, kCTFontNameAttribute)));
+    EXPECT_OBJCEQ(@"Courier New Bold Italic", (id)CFAutorelease(CTFontCopyAttribute(font, kCTFontDisplayNameAttribute)));
 }
 
 TEST(CTFont, Metrics) {
@@ -187,16 +190,18 @@ TEST(CTFont, CaseInsensitive) {
     EXPECT_TRUE(CFEqual(font1, font4));
 }
 
-// Font names differ slightly between platforms
-#if TARGET_OS_WIN32
-static const CFStringRef c_arialBoldItalicName = CFSTR("Arial Bold Italic");
-static const CFStringRef c_arialItalicName = CFSTR("Arial Italic");
-static const CFStringRef c_courierNewItalicName = CFSTR("Courier New Italic");
-static const CFStringRef c_courierNewBoldName = CFSTR("Courier New Bold");
-static const CFStringRef c_courierNewBoldItalicName = CFSTR("Courier New Bold Italic");
-static const CFStringRef c_trebuchetMSItalicName = CFSTR("Trebuchet MS Italic");
-static const CFStringRef c_timesNewRomanName = CFSTR("Times New Roman");
-#else
+TEST(CTFont, CreateWithPostScriptName) {
+    CTFontRef font1 = CTFontCreateWithName(CFSTR("Times New Roman"), 12.0, NULL);
+    CTFontRef font2 = CTFontCreateWithName(CFSTR("TimesNewRomanPSMT"), 12.0, NULL);
+    CFAutorelease(font1);
+    CFAutorelease(font2);
+
+    EXPECT_OBJCNE(nil, (id)font1);
+    EXPECT_OBJCNE(nil, (id)font2);
+
+    EXPECT_OBJCEQ((id)font1, (id)font2);
+}
+
 static const CFStringRef c_arialBoldItalicName = CFSTR("Arial-BoldItalicMT");
 static const CFStringRef c_arialItalicName = CFSTR("Arial-ItalicMT");
 static const CFStringRef c_courierNewItalicName = CFSTR("CourierNewPS-ItalicMT");
@@ -204,7 +209,7 @@ static const CFStringRef c_courierNewBoldName = CFSTR("CourierNewPS-BoldMT");
 static const CFStringRef c_courierNewBoldItalicName = CFSTR("CourierNewPS-BoldItalicMT");
 static const CFStringRef c_trebuchetMSItalicName = CFSTR("TrebuchetMS-Italic");
 static const CFStringRef c_timesNewRomanName = CFSTR("TimesNewRomanPSMT");
-#endif
+
 static const float c_errorMargin = 0.001f;
 
 TEST(CTFont, Traits) {


### PR DESCRIPTION
…d Display names

 - Redesigned _DWriteGetFontPropertiesForName to depend on an internal map,
   rather than string parsing, which was fragile against edge cases
 - Updated kCTFontNameAttribute to return the PostScript name, in accordance with documentation
 - Removed #ifdef in unit tests dividing the font names used on each platform

Fixes #1221

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1366)
<!-- Reviewable:end -->
