### PR TITLE
NSString+UIKitAdditions treat zero constraints as unlimited

### DIFF
--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -311,11 +311,11 @@ static NSDictionary* _getDefaultUITextAttributes() {
     woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)attributedSelf) };
 
     if (size.width == 0.0) {
-        size.width = FLT_MAX;
+        size.width = std::numeric_limits<CGFloat>::max();
     }
 
     if (size.height == 0.0) {
-        size.height = FLT_MAX;
+        size.height = std::numeric_limits<CGFloat>::max();
     }
 
     return CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, self.length), nullptr, size, nullptr);

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -308,11 +308,17 @@ static NSDictionary* _getDefaultUITextAttributes() {
     }
 
     NSAttributedString* attributedSelf = [[[NSAttributedString alloc] initWithString:self attributes:attributes] autorelease];
+    woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)attributedSelf) };
 
-    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString((__bridge CFAttributedStringRef)attributedSelf);
-    CFAutorelease(framesetter);
+    if (size.width == 0.0) {
+        size.width = FLT_MAX;
+    }
 
-    return CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, self.length), nullptr, size, nullptr);
+    if (size.height == 0.0) {
+        size.height = FLT_MAX;
+    }
+
+    return CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, self.length), nullptr, size, nullptr);
 }
 
 // Private helper that converts a UILineBreakMode -> NSParagraphStyle

--- a/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
@@ -270,6 +270,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIFontTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIFontDescriptorTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSParagraphStyleTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSString+UIKitAdditionsTests.mm" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(StarboardBasePath)\tests\unittests\UIKit\NullCompositor.h" />

--- a/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
+++ b/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
@@ -1,0 +1,25 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <TestFramework.h>
+#import <Starboard/SmartTypes.h>
+#import <UIKit/UIKit.h>
+
+TEST(NSString_UIKitAdditions, ShouldNotReturnSizeOfZeroWidth) {
+    NSString* string = @"TEST";
+    CGSize size = [string sizeWithFont:[UIFont systemFontOfSize:12.0f] constrainedToSize:{ 0, 0 } lineBreakMode:NSLineBreakByWordWrapping];
+    EXPECT_NE(0, size.width);
+}

--- a/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
+++ b/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
@@ -15,11 +15,11 @@
 //******************************************************************************
 
 #import <TestFramework.h>
-#import <Starboard/SmartTypes.h>
 #import <UIKit/UIKit.h>
 
 TEST(NSString_UIKitAdditions, ShouldNotReturnSizeOfZeroWidth) {
-    NSString* string = @"TEST";
-    CGSize size = [string sizeWithFont:[UIFont systemFontOfSize:12.0f] constrainedToSize:{ 0, 0 } lineBreakMode:NSLineBreakByWordWrapping];
-    EXPECT_NE(0, size.width);
+    CGSize size =
+        [@"TEST" sizeWithFont:[UIFont systemFontOfSize:12.0f] constrainedToSize:CGSizeZero lineBreakMode:NSLineBreakByWordWrapping];
+    EXPECT_LT(0.0, size.width);
+    EXPECT_LT(0.0, size.height);
 }


### PR DESCRIPTION
When the reference platform gives size constraints of zero to any NSString+UIKitAdditions methods it expects it to be treated as unlimited width and/or height.

Fixes #1334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1367)
<!-- Reviewable:end -->
