### PR TITLE
Fixing regression in our SDK due to recent UIKit.Xaml namespace colli…

### DIFF
--- a/build/Package/Package.nativeproj
+++ b/build/Package/Package.nativeproj
@@ -66,7 +66,7 @@
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.lib" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.dll" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.winmd" />
-      <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\UIKit.pri" />
+      <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\UIKit.Xaml.pri" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.bitmap" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\*.data" />
       <SBLibsWin10Win32 Include="..\Win32\$(Configuration)\Universal Windows\**\*.xaml" />
@@ -107,7 +107,7 @@
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.lib" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.dll" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.winmd" />
-      <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\UIKit.pri" />
+      <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\UIKit.Xaml.pri" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.bitmap" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\*.data" />
       <SBLibsWin10ARM Include="..\ARM\$(Configuration)\Universal Windows\**\*.xaml" />


### PR DESCRIPTION
…sion fix.  We were copying the wrong .pri file into the SDK output for UIKit.Xaml.dll.  Validated the fix locally after rebuilding the entire SDK project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1372)
<!-- Reviewable:end -->
