### PR TITLE
Match CT and UI descent to reference platform sign

### DIFF
--- a/Frameworks/CoreGraphics/CGFont.mm
+++ b/Frameworks/CoreGraphics/CGFont.mm
@@ -235,7 +235,8 @@ int CGFontGetAscent(CGFontRef font) {
 */
 int CGFontGetDescent(CGFontRef font) {
     // Value for CGFont metrics are specified in 'glyph space units', which appear to be the same as DWrite's 'design units'
-    return font ? __CGFontGetDWriteMetrics(font).descent : 0;
+    // But CGFont expects descent to be negative for glyphs extending below the baseline, whereas DWrite has them positive
+    return font ? -__CGFontGetDWriteMetrics(font).descent : 0;
 }
 
 /**

--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -569,8 +569,7 @@ CGFloat CTFontGetDescent(CTFontRef font) {
         return 0;
     }
     CF_OBJC_FUNCDISPATCHV(CTFontGetTypeID(), CGFloat, (UIFont*)font, descender);
-    // DWRITE_FONT_METRICS keeps an unsigned value for descent, but CTFontGetDescent is expected to return a negative value
-    return -__CTFontScaleMetric(font, __CTFontGetDWriteMetrics(font).descent);
+    return __CTFontScaleMetric(font, __CTFontGetDWriteMetrics(font).descent);
 }
 
 /**

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -288,12 +288,12 @@ double CTLineGetTypographicBounds(CTLineRef lineRef, CGFloat* ascent, CGFloat* d
     }
 
     // Created with impossible values -FLT_MAX which signify they need to be populated
-    if ((line->_ascent == -FLT_MAX || line->_descent == FLT_MAX || line->_leading == -FLT_MAX) && (ascent || descent || leading)) {
+    if ((line->_ascent == -FLT_MAX || line->_descent == -FLT_MAX || line->_leading == -FLT_MAX) && (ascent || descent || leading)) {
         for (_CTRun* run in static_cast<id<NSFastEnumeration>>(line->_runs)) {
             CGFloat newAscent, newDescent, newLeading;
             CTRunGetTypographicBounds(static_cast<CTRunRef>(run), { 0, 0 }, &newAscent, &newDescent, &newLeading);
             line->_ascent = std::max(line->_ascent, newAscent);
-            line->_descent = std::min(line->_descent, newDescent);
+            line->_descent = std::max(line->_descent, newDescent);
             line->_leading = std::max(line->_leading, newLeading);
         }
     }

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -232,13 +232,13 @@ double CTRunGetTypographicBounds(CTRunRef run, CFRange range, CGFloat* ascent, C
                                                                                 curRun->_dwriteGlyphRun.isSideways));
 
         CGFloat newAscent = -FLT_MAX;
-        CGFloat newDescent = FLT_MAX;
+        CGFloat newDescent = -FLT_MAX;
         for (size_t i = range.location - curRun->_range.location; i < range.location + range.length - curRun->_range.location; ++i) {
-            // CoreText ascent is equivalent of DWrite verticalOriginY, and descent the opposite value of bottomSideBearing
+            // CoreText ascent is equivalent of DWrite verticalOriginY, and descent the value of bottomSideBearing
             // which are in designUnits, so they need to be converted to points for CoreText
             // The ascent and descent of the run is the max and min of the respective values per glyph
             newAscent = std::max(newAscent, glyphMetrics[i].verticalOriginY * scalingFactor);
-            newDescent = std::min(newDescent, -glyphMetrics[i].bottomSideBearing * scalingFactor);
+            newDescent = std::max(newDescent, glyphMetrics[i].bottomSideBearing * scalingFactor);
         }
         if (ascent) {
             *ascent = newAscent;

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -439,7 +439,7 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
 
         // These are created lazily in the first call to CTLineGetTypographicBounds, so initialize with impossible values
         line->_ascent = -FLT_MAX;
-        line->_descent = FLT_MAX;
+        line->_descent = -FLT_MAX;
         line->_leading = -FLT_MAX;
 
         // Glyph runs that have the same _baselineOriginY value are part of the the same Line.

--- a/Frameworks/UIKit/NSLayoutManager.mm
+++ b/Frameworks/UIKit/NSLayoutManager.mm
@@ -85,7 +85,7 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
         double width = CTLineGetTypographicBounds(line, &ascent, &descent, &leading);
 
         // Maximum height of lines on current horizontal, needed to get next yPos
-        CGFloat lineHeight = leading + ascent - descent;
+        CGFloat lineHeight = leading + ascent + descent;
 
         CFRange lineRange = CTLineGetStringRange(line);
 
@@ -290,7 +290,7 @@ static NSRange NSRangeFromCFRange(CFRange range) {
     ret.size.width = _totalSize.width;
 
     CTLineGetTypographicBounds((CTLineRef)_ctLines[lineIdx], &ascent, &descent, &leading);
-    ret.size.height = ascent - descent + leading;
+    ret.size.height = ascent + descent + leading;
 
     return ret;
 }

--- a/Frameworks/UIKit/UICTFont.mm
+++ b/Frameworks/UIKit/UICTFont.mm
@@ -62,7 +62,8 @@ BRIDGED_CLASS_REQUIRED_IMPLS(CTFontRef, CTFontGetTypeID, UIFont, UICTFont)
 }
 
 - (CGFloat)descender {
-    return CTFontGetDescent((CTFontRef)self);
+    // CTFontGetDescent is expected to return a positive value, but descender is expected to return a negative value
+    return -CTFontGetDescent((CTFontRef)self);
 }
 
 - (CGFloat)ascender {

--- a/tests/unittests/CoreGraphics/CGFontTests.mm
+++ b/tests/unittests/CoreGraphics/CGFontTests.mm
@@ -108,3 +108,9 @@ TEST(CGFont, GetBoundingBoxes) {
         EXPECT_EQ(expectedBoxes[i].size.height, boxes[i].size.height);
     }
 }
+
+TEST(CGFont, GetDescent) {
+    CGFontRef font = CGFontCreateWithFontName(c_arialBoldItalicName);
+    CFAutorelease(font);
+    EXPECT_EQ(-434, CGFontGetDescent(font));
+}

--- a/tests/unittests/CoreText/CTLineTests.mm
+++ b/tests/unittests/CoreText/CTLineTests.mm
@@ -274,13 +274,13 @@ TEST(CTLine, CTLineGetTypographicBounds) {
     EXPECT_LT(0, baseWidth);
     EXPECT_EQ_MSG(CTFontGetLeading(font), baseLeading, "Leading should always be the same as the font");
     EXPECT_GE_MSG(CTFontGetAscent(font), baseAscent, "Ascent should never exceed the maximum font ascent");
-    EXPECT_LE_MSG(CTFontGetDescent(font), baseDescent, "Descent should never exceed the maximum font descent");
+    EXPECT_GE_MSG(CTFontGetDescent(font), baseDescent, "Descent should never exceed the maximum font descent");
 
     CGFloat variableWidth = CTLineGetTypographicBounds(variableLine, &variableAscent, &variableDescent, &variableLeading);
     EXPECT_EQ_MSG(CTFontGetLeading(font), variableLeading, "Leading should always be the same as the font");
     EXPECT_LT(0, variableWidth);
     EXPECT_GE_MSG(CTFontGetAscent(font), variableAscent, "Ascent should never exceed the maximum font ascent");
-    EXPECT_LE_MSG(CTFontGetDescent(font), variableDescent, "Descent should never exceed the maximum font descent");
+    EXPECT_GE_MSG(CTFontGetDescent(font), variableDescent, "Descent should never exceed the maximum font descent");
 
     EXPECT_LE_MSG(baseAscent, variableAscent, "The ascent with \'H\' should be no less than the ascent with \'x\'");
     EXPECT_GE_MSG(baseDescent, variableDescent, "The descent with \'g\' should be no greater than the descent with \'x\'");
@@ -288,9 +288,9 @@ TEST(CTLine, CTLineGetTypographicBounds) {
 
 TEST(CTLine, ShouldSeparateRunsBasedOnColor) {
     NSMutableAttributedString* string = getAttributedString(@"ABCDEF");
-    [string addAttribute:NSForegroundColorAttributeName value:[UIColor magentaColor] range:{0, 2}];
-    [string addAttribute:NSForegroundColorAttributeName value:[UIColor yellowColor] range:{2, 2}];
-    [string addAttribute:NSForegroundColorAttributeName value:[UIColor cyanColor] range:{4, 2}];
+    [string addAttribute:NSForegroundColorAttributeName value:[UIColor magentaColor] range:{ 0, 2 }];
+    [string addAttribute:NSForegroundColorAttributeName value:[UIColor yellowColor] range:{ 2, 2 }];
+    [string addAttribute:NSForegroundColorAttributeName value:[UIColor cyanColor] range:{ 4, 2 }];
     CTLineRef line = CTLineCreateWithAttributedString((__bridge CFAttributedStringRef)string);
     EXPECT_EQ(6L, CTLineGetGlyphCount(line));
     EXPECT_EQ(3L, CFArrayGetCount(CTLineGetGlyphRuns(line)));

--- a/tests/unittests/CoreText/CTRunTests.mm
+++ b/tests/unittests/CoreText/CTRunTests.mm
@@ -98,7 +98,7 @@ protected:
 
     static constexpr NSString* const c_testString = @"bp";
     static constexpr float c_ascentExpected = 8.7363f;
-    static constexpr float c_descentExpected = -2.3848f;
+    static constexpr float c_descentExpected = 2.3848f;
     static constexpr float c_leadingExpected = 0.392578f;
 };
 


### PR DESCRIPTION
CoreText descent is expected to be positive when the glyph extends below the baseline, whereas UIFont's descender is expected to be negative.  Now when using CoreText, lineheight := Ascent + Descent + Leading, and in UIKit lineheight := Ascent - Descent + Leading

Fixes #1333

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1376)
<!-- Reviewable:end -->
