### PR TITLE
Fixing two newly-found regressions with the compositor refactor.

### DIFF
--- a/Frameworks/UIKit.Xaml/Label.xaml
+++ b/Frameworks/UIKit.Xaml/Label.xaml
@@ -4,5 +4,5 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UIKit.Xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
-    <TextBlock VerticalAlignment="Center" Height="{x:Bind Height}" Width="{x:Bind Width}"/>
+    <TextBlock VerticalAlignment="Center"/>
 </Grid>

--- a/Frameworks/UIKit.Xaml/Label.xaml
+++ b/Frameworks/UIKit.Xaml/Label.xaml
@@ -4,5 +4,5 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:UIKit.Xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
-    <TextBlock VerticalAlignment="Center"/>
+    <TextBlock VerticalAlignment="Center" Height="{x:Bind Height}" Width="{x:Bind Width}"/>
 </Grid>

--- a/Frameworks/UIKit.Xaml/Label.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Label.xaml.cpp
@@ -59,6 +59,16 @@ Canvas^ Label::SublayerCanvas::get() {
     return _sublayerCanvas;
 }
 
+Windows::Foundation::Size Label::ArrangeOverride(Windows::Foundation::Size finalSize) {
+    // Make sure we render vertically-centered text if possible, else cap at the containing layer's height.
+    TextBlock->Measure(finalSize);
+    if (TextBlock->DesiredSize.Height >= finalSize.Height) {
+        TextBlock->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Top;
+    }
+
+    return __super::ArrangeOverride(finalSize);
+}
+
 TextBlock^ Label::TextBlock::get() {
     return safe_cast<Windows::UI::Xaml::Controls::TextBlock^>(Children->GetAt(0));
 }

--- a/Frameworks/UIKit.Xaml/Label.xaml.h
+++ b/Frameworks/UIKit.Xaml/Label.xaml.h
@@ -27,6 +27,7 @@ namespace Xaml {
 public ref class Label sealed : public Private::CoreAnimation::ILayer {
 public:
     Label();
+    Windows::Foundation::Size ArrangeOverride(Windows::Foundation::Size finalSize) override;
 
     // Accessor for our Layer content; we create one on demand
     virtual property Windows::UI::Xaml::Controls::Image^ LayerContent {

--- a/Frameworks/UIKit/StarboardXaml/LayerAnimation.cpp
+++ b/Frameworks/UIKit/StarboardXaml/LayerAnimation.cpp
@@ -149,12 +149,9 @@ concurrency::task<Layer^> _SnapshotLayer(Layer^ layer) {
             // Copy display properties from the old layer to the new layer
             LayerCoordinator::SetValue(newLayer, "opacity", LayerCoordinator::GetValue(layer, "opacity"));
             LayerCoordinator::SetValue(newLayer, "position", LayerCoordinator::GetValue(layer, "position"));
-            newLayer->Width = layer->Width;
-            newLayer->Height = layer->Height;
+            LayerCoordinator::SetValue(newLayer, "size", LayerCoordinator::GetValue(layer, "size"));
             LayerCoordinator::SetValue(newLayer, "anchorPoint", LayerCoordinator::GetValue(layer, "anchorPoint"));
 
-            int width = snapshot->PixelWidth;
-            int height = snapshot->PixelHeight;
             auto dispInfo = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 
             // Set the snapshot as the content of the new layer

--- a/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
@@ -98,8 +98,6 @@ void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, b
         }
     }
 
-    ((PlaneProjection^)layer->Projection)->CenterOfRotationX = LayerCoordinator::GetVisualWidth(layer) / 2;
-    ((PlaneProjection^)layer->Projection)->CenterOfRotationY = LayerCoordinator::GetVisualHeight(layer) / 2;
     Storyboard::SetTargetProperty(rotateAnim, "(UIElement.Projection).(PlaneProjection.RotationY)");
     Storyboard::SetTarget(rotateAnim, layer);
     m_container->Children->Append(rotateAnim);
@@ -148,6 +146,10 @@ void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, b
                 unsigned int index = 0;
                 parentPanel->Children->IndexOf(layer, &index);
                 parentPanel->Children->RemoveAt(index);
+            } else {
+                // TODO: Track down why we sometimes don't have a parent when the animation completes.
+                TraceWarning(TAG, L"Failed to remove flip animation from scene; didn't have a parent to remove from!");
+                layer->Visibility = Visibility::Collapsed;
             }
         });
     } else {
@@ -199,6 +201,10 @@ void StoryboardManager::_CreateWoosh(Layer^ layer, bool fromRight, bool invert, 
                 unsigned int index = 0;
                 parentPanel->Children->IndexOf(layer, &index);
                 parentPanel->Children->RemoveAt(index);
+            } else {
+                // TODO: Track down why we sometimes don't have a parent when the animation completes.
+                TraceWarning(TAG, L"Failed to remove woosh animation from scene; didn't have a parent to remove from!");
+                layer->Visibility = Visibility::Collapsed;
             }
         });
     } else {
@@ -235,8 +241,7 @@ void StoryboardManager::AddTransition(Layer^ realLayer, Layer^ snapshotLayer, St
         }
 
         _CreateFlip(realLayer, flipToLeft, true, false);
-    }
-    else {
+    } else {
         TimeSpan timeSpan = TimeSpan();
         timeSpan.Duration = (long long)(0.5 * c_hundredNanoSeconds);
         m_container->Duration = Duration(timeSpan);

--- a/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
@@ -150,6 +150,12 @@ void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, b
                 // TODO: Track down why we sometimes don't have a parent when the animation completes.
                 TraceWarning(TAG, L"Failed to remove flip animation from scene; didn't have a parent to remove from!");
                 layer->Visibility = Visibility::Collapsed;
+                LayerCoordinator::SetContent(
+                    layer,
+                    nullptr,
+                    static_cast<float>(0),
+                    static_cast<float>(0),
+                    static_cast<float>(0));
             }
         });
     } else {
@@ -205,6 +211,12 @@ void StoryboardManager::_CreateWoosh(Layer^ layer, bool fromRight, bool invert, 
                 // TODO: Track down why we sometimes don't have a parent when the animation completes.
                 TraceWarning(TAG, L"Failed to remove woosh animation from scene; didn't have a parent to remove from!");
                 layer->Visibility = Visibility::Collapsed;
+                LayerCoordinator::SetContent(
+                    layer,
+                    nullptr,
+                    static_cast<float>(0),
+                    static_cast<float>(0),
+                    static_cast<float>(0));
             }
         });
     } else {

--- a/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
@@ -22,6 +22,9 @@
 
 #include <ErrorHandling.h>
 
+#include <algorithm>
+#include <collection.h>
+
 using namespace Platform;
 using namespace UIKit::Xaml::Private::CoreAnimation;
 using namespace Windows::Foundation;
@@ -33,6 +36,9 @@ using namespace Windows::UI::Xaml::Media::Animation;
 using namespace Windows::UI::Xaml::Media::Imaging;
 
 static const wchar_t* TAG = L"StoryboardManager";
+
+static const bool DEBUG_ALL = false;
+static const bool DEBUG_TRANSITIONS = DEBUG_ALL || false;
 
 namespace CoreAnimation {
 
@@ -71,6 +77,17 @@ void StoryboardManager::Start() {
 
 void StoryboardManager::Stop() {
     m_container->Stop();
+
+    // Enumerate any pending snapshots and make sure they're all removed from their respective scenes
+    for (auto snapshotLayer : _animatingSnapshots) {
+        if (DEBUG_TRANSITIONS) {
+            TraceVerbose(TAG, L"StoryboardManager::Stop clearing out pending transition animation snapshot.");
+        }
+
+        _RemoveSnapshotLayer(snapshotLayer);
+    }
+
+    _animatingSnapshots.clear();
 }
 
 void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, bool removeFromParent) {
@@ -117,6 +134,7 @@ void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, b
     Storyboard::SetTarget(fade1, layer);
     Storyboard::SetTargetProperty(fade1, "(UIElement.Opacity)");
 
+    Platform::WeakReference weakLayer(layer);
     if (!invert) {
         TimeSpan fade1TimeSpan = TimeSpan();
         fade1TimeSpan.Duration = m_container->Duration.TimeSpan.Duration / 2;
@@ -135,33 +153,48 @@ void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, b
         fade1->To = 1.0;
         fade1->FillBehavior = FillBehavior::HoldEnd;
 
-        fade1->Completed += ref new EventHandler<Object^>([layer](Object^ sender, Object^ args) { layer->Opacity = 1.0; });
+        fade1->Completed += ref new EventHandler<Object^>([weakLayer](Object^ sender, Object^ args) {
+            Layer^ strongLayer = weakLayer.Resolve<Layer>();
+            if (strongLayer) {
+                strongLayer->Opacity = 1.0;
+            } else if (DEBUG_TRANSITIONS) {
+                TraceVerbose(TAG, L"fade1->Completed (for original layer) wasn't able to resolve its weak reference.");
+            }
+        });
     }
 
     if (removeFromParent) {
-        fade1->Completed += ref new EventHandler<Object^>([layer](Object^ sender, Object^ args) {
-            // Remove the snapshot layer from the parent panel
-            auto parentPanel = safe_cast<Panel^>(layer->Parent);
-            if (parentPanel) {
-                unsigned int index = 0;
-                parentPanel->Children->IndexOf(layer, &index);
-                parentPanel->Children->RemoveAt(index);
-            } else {
-                // TODO: Track down why we sometimes don't have a parent when the animation completes.
-                TraceWarning(TAG, L"Failed to remove flip animation from scene; didn't have a parent to remove from!");
-                layer->Visibility = Visibility::Collapsed;
-                LayerCoordinator::SetContent(
-                    layer,
-                    nullptr,
-                    static_cast<float>(0),
-                    static_cast<float>(0),
-                    static_cast<float>(0));
+        Platform::WeakReference weakThis(this);
+        fade1->Completed += ref new EventHandler<Object^>([weakThis, weakLayer](Object^ sender, Object^ args) {
+            auto strongThis = weakThis.Resolve<StoryboardManager>();
+            if (strongThis) {
+                auto strongLayer = weakLayer.Resolve<Layer>();
+                if (strongLayer) {
+                    // Remove the snapshot layer from the scene and from our tracking vector
+                    strongThis->_RemoveSnapshotLayer(strongLayer);
+                    strongThis->_animatingSnapshots.erase(
+                        std::remove_if(
+                            std::begin(strongThis->_animatingSnapshots), 
+                            std::end(strongThis->_animatingSnapshots), 
+                            [strongLayer](Layer^ snapshotLayer) {
+                                return snapshotLayer = strongLayer;
+                            }));
+                } else if (DEBUG_TRANSITIONS) {
+                    TraceVerbose(TAG, L"fade1->Completed (for snapshot layer) wasn't able to resolve its weakLayer reference.");
+                }
+            } else if (DEBUG_TRANSITIONS) {
+                TraceVerbose(TAG, L"fade1->Completed (for snapshot layer) wasn't able to resolve its weakThis reference.");
             }
         });
     } else {
-        rotateAnim->Completed += ref new EventHandler<Object^>([layer](Object^ sender, Object^ args) {
-            // Using Projection transforms (even Identity) causes less-than-pixel-perfect rendering.
-            layer->Projection = nullptr;
+        rotateAnim->Completed += ref new EventHandler<Object^>([weakLayer](Object^ sender, Object^ args) {
+            Layer^ strongLayer = weakLayer.Resolve<Layer>();
+            if (strongLayer) {
+                // Using Projection transforms (even Identity) causes less-than-pixel-perfect rendering.
+                strongLayer->Projection = nullptr;
+            } else if (DEBUG_TRANSITIONS) {
+                TraceVerbose(TAG, L"rotateAnim->Completed (for original layer) wasn't able to resolve its weak reference.");
+            }
         });
     }
 
@@ -199,34 +232,63 @@ void StoryboardManager::_CreateWoosh(Layer^ layer, bool fromRight, bool invert, 
     Storyboard::SetTargetProperty(wooshAnim, "(UIElement.Projection).(PlaneProjection.LocalOffsetX)");
     Storyboard::SetTarget(wooshAnim, layer);
 
+    Platform::WeakReference weakLayer(layer);
     if (removeFromParent) {
-        wooshAnim->Completed += ref new EventHandler<Object^>([layer](Object^ sender, Object^ args) {
-            // Remove the snapshot layer from the parent panel
-            auto parentPanel = safe_cast<Panel^>(layer->Parent);
-            if (parentPanel) {
-                unsigned int index = 0;
-                parentPanel->Children->IndexOf(layer, &index);
-                parentPanel->Children->RemoveAt(index);
-            } else {
-                // TODO: Track down why we sometimes don't have a parent when the animation completes.
-                TraceWarning(TAG, L"Failed to remove woosh animation from scene; didn't have a parent to remove from!");
-                layer->Visibility = Visibility::Collapsed;
-                LayerCoordinator::SetContent(
-                    layer,
-                    nullptr,
-                    static_cast<float>(0),
-                    static_cast<float>(0),
-                    static_cast<float>(0));
+        Platform::WeakReference weakThis(this);
+        wooshAnim->Completed += ref new EventHandler<Object^>([weakThis, weakLayer](Object^ sender, Object^ args) {
+            auto strongThis = weakThis.Resolve<StoryboardManager>();
+            if (strongThis) {
+                auto strongLayer = weakLayer.Resolve<Layer>();
+                if (strongLayer) {
+                    // Remove the snapshot layer from the scene and from our tracking vector
+                    strongThis->_RemoveSnapshotLayer(strongLayer);
+                    strongThis->_animatingSnapshots.erase(
+                        std::remove_if(
+                            std::begin(strongThis->_animatingSnapshots), 
+                            std::end(strongThis->_animatingSnapshots), 
+                            [strongLayer](Layer^ snapshotLayer) {
+                                return snapshotLayer = strongLayer;
+                            }));
+                } else if (DEBUG_TRANSITIONS) {
+                    TraceVerbose(TAG, L"wooshAnim->Completed (for snapshot layer) wasn't able to resolve its weakLayer reference.");
+                }
+            } else if (DEBUG_TRANSITIONS) {
+                TraceVerbose(TAG, L"wooshAnim->Completed (for snapshot layer) wasn't able to resolve its weakThis reference.");
             }
         });
     } else {
-        wooshAnim->Completed += ref new EventHandler<Object^>([layer](Object^ sender, Object^ args) {
-            // Using Projection transforms (even Identity) causes less-than-pixel-perfect rendering.
-            layer->Projection = nullptr;
+        wooshAnim->Completed += ref new EventHandler<Object^>([weakLayer](Object^ sender, Object^ args) {
+            Layer^ strongLayer = weakLayer.Resolve<Layer>();
+            if (strongLayer) {
+                // Using Projection transforms (even Identity) causes less-than-pixel-perfect rendering.
+                strongLayer->Projection = nullptr;
+            } else if (DEBUG_TRANSITIONS) {
+                TraceVerbose(TAG, L"wooshAnim->Completed (for original layer) wasn't able to resolve its weak reference.");
+            }
         });
     }
 
     m_container->Children->Append(wooshAnim);
+}
+
+void StoryboardManager::_RemoveSnapshotLayer(Layer^ snapshotLayer) {
+    // Remove the snapshot layer from the parent panel
+    auto parentPanel = safe_cast<Panel^>(snapshotLayer->Parent);
+    if (parentPanel) {
+        unsigned int index = 0;
+        parentPanel->Children->IndexOf(snapshotLayer, &index);
+        parentPanel->Children->RemoveAt(index);
+    } else {
+        // TODO: Determine why the internal news test app occasionally hits this path.
+        TraceWarning(TAG, L"Failed to remove snapshot layer from scene; didn't have a parent to remove from!");
+        snapshotLayer->Visibility = Visibility::Collapsed;
+        LayerCoordinator::SetContent(
+            snapshotLayer,
+            nullptr,
+            static_cast<float>(0),
+            static_cast<float>(0),
+            static_cast<float>(0));
+    }
 }
 
 void StoryboardManager::AddTransition(Layer^ realLayer, Layer^ snapshotLayer, String^ type, String^ subtype) {
@@ -244,6 +306,10 @@ void StoryboardManager::AddTransition(Layer^ realLayer, Layer^ snapshotLayer, St
 
         // We don't need to animate a snapshot if it doesn't exist
         if (snapshotLayer) {
+
+            // Store the snapshot so we can clean up adequately in the event that animations are aborted early
+            _animatingSnapshots.push_back(snapshotLayer);
+
             unsigned int idx;
             parent->Children->IndexOf(realLayer, &idx);
             parent->Children->InsertAt(idx + 1, snapshotLayer);
@@ -267,6 +333,9 @@ void StoryboardManager::AddTransition(Layer^ realLayer, Layer^ snapshotLayer, St
         if (fromRight) {
             // We don't need to animate a snapshot if it doesn't exist
             if (snapshotLayer) {
+                // Store the snapshot so we can clean up adequately in the event that animations are aborted early
+                _animatingSnapshots.push_back(snapshotLayer);
+
                 unsigned int idx;
                 parent->Children->IndexOf(realLayer, &idx);
                 parent->Children->InsertAt(idx, snapshotLayer);
@@ -278,6 +347,9 @@ void StoryboardManager::AddTransition(Layer^ realLayer, Layer^ snapshotLayer, St
         } else {
             // We don't need to animate a snapshot if it doesn't exist
             if (snapshotLayer) {
+                // Store the snapshot so we can clean up adequately in the event that animations are aborted early
+                _animatingSnapshots.push_back(snapshotLayer);
+
                 unsigned int idx;
                 parent->Children->IndexOf(realLayer, &idx);
                 parent->Children->InsertAt(idx + 1, snapshotLayer);

--- a/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
@@ -263,8 +263,7 @@ void StoryboardManager::AddTransition(Layer^ realLayer, Layer^ snapshotLayer, St
             }
 
             _CreateWoosh(realLayer, fromRight, false, false);
-        }
-        else {
+        } else {
             // We don't need to animate a snapshot if it doesn't exist
             if (snapshotLayer) {
                 unsigned int idx;

--- a/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StoryboardManager.cpp
@@ -177,7 +177,7 @@ void StoryboardManager::_CreateFlip(Layer^ layer, bool flipRight, bool invert, b
                             std::begin(strongThis->_animatingSnapshots), 
                             std::end(strongThis->_animatingSnapshots), 
                             [strongLayer](Layer^ snapshotLayer) {
-                                return snapshotLayer = strongLayer;
+                                return snapshotLayer == strongLayer;
                             }));
                 } else if (DEBUG_TRANSITIONS) {
                     TraceVerbose(TAG, L"fade1->Completed (for snapshot layer) wasn't able to resolve its weakLayer reference.");
@@ -247,7 +247,7 @@ void StoryboardManager::_CreateWoosh(Layer^ layer, bool fromRight, bool invert, 
                             std::begin(strongThis->_animatingSnapshots), 
                             std::end(strongThis->_animatingSnapshots), 
                             [strongLayer](Layer^ snapshotLayer) {
-                                return snapshotLayer = strongLayer;
+                                return snapshotLayer == strongLayer;
                             }));
                 } else if (DEBUG_TRANSITIONS) {
                     TraceVerbose(TAG, L"wooshAnim->Completed (for snapshot layer) wasn't able to resolve its weakLayer reference.");

--- a/Frameworks/UIKit/StarboardXaml/StoryboardManager.h
+++ b/Frameworks/UIKit/StarboardXaml/StoryboardManager.h
@@ -17,6 +17,7 @@
 // clang-format off
 #pragma once
 
+#include <vector>
 #include <ppltasks.h>
 
 namespace CoreAnimation {
@@ -67,7 +68,9 @@ internal:
 private:
     void _CreateFlip(UIKit::Xaml::Private::CoreAnimation::Layer^ layer, bool flipRight, bool invert, bool removeFromParent);
     void _CreateWoosh(UIKit::Xaml::Private::CoreAnimation::Layer^ layer, bool fromRight, bool invert, bool removeFromParent);
+    void _RemoveSnapshotLayer(UIKit::Xaml::Private::CoreAnimation::Layer^ snapshotLayer);
 
+    std::vector<UIKit::Xaml::Private::CoreAnimation::Layer^> _animatingSnapshots;
     AnimationMethod^ m_completed;
     Windows::UI::Xaml::Media::Animation::Storyboard^ m_container = ref new Windows::UI::Xaml::Media::Animation::Storyboard();
     Windows::UI::Xaml::Media::Animation::EasingFunctionBase^ m_animationEase;


### PR DESCRIPTION
[News Test App: Main article title is cropped]
The TextBox within UIKit.Label needs to bind its width/height to that of its parent (the containing Grid).

[News Test App: Contents get obscured when scrolling quickly]
Fixed, along with some other pre-existing flip animation issues that existed on develop (the snapshot layer was often the wrong size - larger than the actual contents we're flipping to).  I also fixed another regression with the flip animation in ux/uxe  the center of the flip rotation has to be between 0 and 1, but we were setting it to width/height of the layer divided by 2 (attempting to rotate at the center).  This accidentally worked on develop due to the hard-coded 1x1 CALayerXaml size, but it was incorrect and led to funny fly-in behavior in ux/uxe.  Fixed by removing the calls altogether since the default PlaneProjection CenterOfRotationX/CenterOfRotationY is .5 (the center).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1378)
<!-- Reviewable:end -->
