### PR TITLE
Turns out our CG context cairo doesn't support BGRX.  

### DIFF
--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -574,7 +574,7 @@ CGContextRef CreateLayerContentsBitmapContext32(int width, int height) {
                 if (useVector) {
                     // target = new CGVectorImage(width, height, _ColorBGR);
                 } else {
-                    drawContext = _CGBitmapContextCreateWithFormat(width, height, _ColorBGRX);
+                    drawContext = _CGBitmapContextCreateWithFormat(width, height, _ColorXBGR);
                 }
                 priv->drewOpaque = TRUE;
             } else {


### PR DESCRIPTION
Turns out our CG context cairo doesn't support BGRX.  Use any other pixel format, in this case, XBGR.  Fixes #1335.

The issue can only be seen opaque layers. In my discussions with @jaredhms we will just have one code path in the near future when ux/uxe merges, so i might as well wait for that change to merge instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1387)
<!-- Reviewable:end -->
