### PR TITLE
[UIKit] [UITextField] Add implementations for some missing selectors

### DIFF
--- a/Frameworks/CoreText/CTParagraphStyle.mm
+++ b/Frameworks/CoreText/CTParagraphStyle.mm
@@ -74,7 +74,7 @@ struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> {
             woc::unique_cf<CFTypeRef> newValue{};
             switch (specifier) {
                 case kCTParagraphStyleSpecifierTabStops:
-                 //   newValue.reset(CFArrayCreateCopy(nullptr, static_cast<CFArrayRef>(value)));
+                    newValue.reset(CFArrayCreateCopy(nullptr, static_cast<CFArrayRef>(value)));
                     break;
                 case kCTParagraphStyleSpecifierAlignment:
                 case kCTParagraphStyleSpecifierLineBreakMode: {

--- a/Frameworks/CoreText/CTParagraphStyle.mm
+++ b/Frameworks/CoreText/CTParagraphStyle.mm
@@ -74,7 +74,7 @@ struct __CTParagraphStyle : CoreFoundation::CppBase<__CTParagraphStyle> {
             woc::unique_cf<CFTypeRef> newValue{};
             switch (specifier) {
                 case kCTParagraphStyleSpecifierTabStops:
-                    newValue.reset(CFArrayCreateCopy(nullptr, static_cast<CFArrayRef>(value)));
+                 //   newValue.reset(CFArrayCreateCopy(nullptr, static_cast<CFArrayRef>(value)));
                     break;
                 case kCTParagraphStyleSpecifierAlignment:
                 case kCTParagraphStyleSpecifierLineBreakMode: {

--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -409,20 +409,23 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 }
 
 - (void)_adjustFontSizeToFitWidthOrApply {
-    if (self.adjustsFontSizeToFitWidth && (self.minimumFontSize != self.font.pointSize) && self.text && self.text.length) {
-        _adjustedFont = self.font;
+    _adjustedFont = self.font;
+
+    if (_adjustedFont == nil) {
+        _adjustedFont = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
+    }
+
+    // If the min size is greater than our font size, the font wins out.
+    // If the font's pointsize is smaller than the global min font size, the font wins out.
+    if (self.adjustsFontSizeToFitWidth && (self.minimumFontSize < _adjustedFont.pointSize) && (_adjustedFont.pointSize > g_minimumFontSize) && self.text && self.text.length) {
         NSString* passwordString = nil;
         CGFloat elementWidth = 0.0f;
 
-        if (_adjustedFont == nil) {
-            _adjustedFont = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
-        }
-        
         // Measure using the password masking character, not the verbatim text
         if (self->_secureTextMode) {
             if (_passwordContentElement == nil) {
                 // Not an error, we just might not be loaded yet.
-                [self _applyFont:self.font];
+                [self _applyFont:_adjustedFont];
                 return;
             }
             passwordString = [@"" stringByPaddingToLength:self.text.length withString:_passwordBox.passwordChar startingAtIndex:0];
@@ -430,7 +433,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
         } else {
             if (_textContentElement == nil) {
                 // Not an error, we just might not be loaded yet.
-                [self _applyFont:self.font];
+                [self _applyFont:_adjustedFont];
                 return;
             }
             elementWidth = _textContentElement.actualWidth - _textContentElement.padding.left - _textContentElement.padding.right;

--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -43,7 +43,7 @@
 
 #import <UWP/WindowsUIXamlControls.h>
 
-// Emperically discovered global minimum font size
+// Empirically discovered global minimum font size
 static const CGFloat g_minimumFontSize = 14.0f;
 
 static const wchar_t* TAG = L"UITextField";
@@ -139,7 +139,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
         }
         [_secureModeLock unlock];
 
-        [self _adjustFontSizeToFitWidthOrApply];
+        [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
     }
 }
 
@@ -232,7 +232,8 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     } else {
         _font = font;
     }
-    [self _adjustFontSizeToFitWidthOrApply];
+
+    [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
 }
 
 - (void)_applyFont:(UIFont*)font {
@@ -398,7 +399,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 */
 - (void)setAdjustsFontSizeToFitWidth:(BOOL)adjust {
     _adjustsFontSizeToFitWidth = adjust;
-    [self _adjustFontSizeToFitWidthOrApply];
+    [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
 }
 
 /**
@@ -408,7 +409,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     return _adjustsFontSizeToFitWidth;
 }
 
-- (void)_adjustFontSizeToFitWidthOrApply {
+- (void)_adjustFontSizeToFitWidthOrApplyCurrentFont {
     _adjustedFont = self.font;
 
     if (_adjustedFont == nil) {
@@ -462,6 +463,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
                 _adjustedFont = [_adjustedFont fontWithSize:self.minimumFontSize];
                 break;
             }
+
             _adjustedFont = [_adjustedFont fontWithSize:newFontSize];
         }
         [self _applyFont:_adjustedFont];
@@ -475,7 +477,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 */
 - (void)setMinimumFontSize:(CGFloat)fontSize {
     _minimumFontSize = fontSize;
-    [self _adjustFontSizeToFitWidthOrApply];
+    [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
 }
 
 /**
@@ -492,7 +494,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (BOOL)isEditing {
-    if (self.secureTextEntry) {
+    if (_secureTextMode) {
         return _passwordBox.focusState != WXFocusStateUnfocused;
     } else {
         return _textBox.focusState != WXFocusStateUnfocused;
@@ -996,7 +998,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
         _isFirstResponder = NO;
 
         [self _initUITextField:nil];
-        [self _adjustFontSizeToFitWidthOrApply];
+        [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
     }
 
     return self;
@@ -1246,7 +1248,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 
             // Update the collapsed/visible state of the cancel button and adjust text size.
             [weakControl updateLayout];
-            [strongSelf _adjustFontSizeToFitWidthOrApply];
+            [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
         }
     }];
 }
@@ -1285,7 +1287,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 
             // Update the collapsed/visible state of the cancel button and adjust text size.
             [weakControl updateLayout];
-            [strongSelf _adjustFontSizeToFitWidthOrApply];
+            [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
         }
     }];
 }
@@ -1360,7 +1362,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
                 TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");
             }
 
-            [strongSelf _adjustFontSizeToFitWidthOrApply];
+            [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
         }
     }];
 
@@ -1428,7 +1430,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
                 TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");
             }
 
-            [strongSelf _adjustFontSizeToFitWidthOrApply];
+            [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
         }
     }];
 

--- a/include/UIKit/UITextField.h
+++ b/include/UIKit/UITextField.h
@@ -77,11 +77,11 @@ UIKIT_EXPORT_CLASS
 @property (nonatomic, copy) NSDictionary* typingAttributes STUB_PROPERTY;
 
 // Sizing the Text Field’s Text
-@property (nonatomic) BOOL adjustsFontSizeToFitWidth STUB_PROPERTY;
-@property (nonatomic) CGFloat minimumFontSize STUB_PROPERTY;
+@property (nonatomic) BOOL adjustsFontSizeToFitWidth;
+@property (nonatomic) CGFloat minimumFontSize;
 
 // Managing the Editing Behavior
-@property (nonatomic, readonly, getter=isEditing) BOOL editing STUB_PROPERTY;
+@property (nonatomic, readonly, getter=isEditing) BOOL editing;
 @property (nonatomic) BOOL clearsOnBeginEditing STUB_PROPERTY;
 @property (nonatomic) BOOL clearsOnInsertion STUB_PROPERTY;
 @property (nonatomic) BOOL allowsEditingTextAttributes STUB_PROPERTY;

--- a/samples/XAMLCatalog/XAMLCatalog/UITextFieldViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UITextFieldViewController.m
@@ -75,6 +75,28 @@ placeHolder : (NSString*)placeHolder
     return textField;
 }
 
+-(UITextField*)_createTextFieldWithColor:(UIColor*)color
+placeHolder : (NSString*)placeHolder
+    borderStyle : (UITextBorderStyle)borderStyle
+    fontSize : (CGFloat)fontSize
+    minimumFontSize : (CGFloat)minFontSize {
+    CGRect frame = CGRectMake(c_originX, c_originY, c_width, c_height);
+    UITextField* textField = [[UITextField alloc] initWithFrame:frame];
+    textField.textColor = color;
+    textField.font = [UIFont systemFontOfSize: fontSize];
+    textField.placeholder = placeHolder;
+    textField.borderStyle = borderStyle;
+    textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
+    textField.delegate = self;
+    textField.adjustsFontSizeToFitWidth = YES;
+    textField.minimumFontSize = minFontSize;
+
+    // Set the accessibility identifier so we can access these controls via automation
+    textField.accessibilityIdentifier = [NSString stringWithFormat : @"textField_%ld", [_textFields count]];
+
+    return textField;
+}
+
 -(void)viewDidLoad {
     [super viewDidLoad];
 
@@ -197,6 +219,27 @@ placeHolder : (NSString*)placeHolder
         placeHolder : @"background image"
         borderStyle : UITextBorderStyleLine
         backgroundImage : [UIImage imageNamed : @"photo1.jpg"]]];
+
+    // Row 12. Adjusts font size to fit width (should clamp to 14.0f)
+    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
+        placeHolder : @"Adjusts font size 17pt"
+        borderStyle : UITextBorderStyleLine
+        fontSize : 17.0f 
+        minimumFontSize : 1.0f ]];
+
+    // Row 13. Should not adjust font size to width (10.0f < system min size)
+    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
+        placeHolder : @"Adjusts font size 10pt"
+        borderStyle : UITextBorderStyleLine
+        fontSize : 10.0f 
+        minimumFontSize : 1.0f ]];
+
+    // Row 14. Adjusts font size to fit width down to 17.0f
+    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
+        placeHolder : @"Adjusts font size 22pt"
+        borderStyle : UITextBorderStyleLine
+        fontSize : 22.0f 
+        minimumFontSize : 17.0f ]];
 
     [self tableView].allowsSelection = NO;
 }


### PR DESCRIPTION
Tested with some local changes to XAMLCatalog. I'll push those local changes if requested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1396)
<!-- Reviewable:end -->
