### PR TITLE
Apply layer contents scale to support high DPI scenarios.  

### DIFF
--- a/Frameworks/UIKit.Xaml/Label.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Label.xaml.cpp
@@ -64,6 +64,8 @@ Windows::Foundation::Size Label::ArrangeOverride(Windows::Foundation::Size final
     TextBlock->Measure(finalSize);
     if (TextBlock->DesiredSize.Height >= finalSize.Height) {
         TextBlock->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Top;
+    } else {
+        TextBlock->VerticalAlignment = Windows::UI::Xaml::VerticalAlignment::Center;
     }
 
     return __super::ArrangeOverride(finalSize);

--- a/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
+++ b/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
@@ -684,7 +684,7 @@ void LayerCoordinator::AnimateValue(
 }
 
 // CALayer content support
-void LayerCoordinator::SetContent(FrameworkElement^ element, ImageSource^ source, float width, float height, float scale /* TODO: scale no longer needed?*/) {
+void LayerCoordinator::SetContent(FrameworkElement^ element, ImageSource^ source, float width, float height, float scale) {
     // Get content
     bool createIfPossible = (source != nullptr); // Only create the Image if we have a valid source to set
     Image^ contentImage = _GetContentImage(element, createIfPossible);
@@ -695,8 +695,12 @@ void LayerCoordinator::SetContent(FrameworkElement^ element, ImageSource^ source
     // Apply content source
     contentImage->Source = source;
 
-    // Store content size
-    _SetContentSize(element, Size(width, height));
+    // Store content size with the scale factor applied
+    // TODO: This check existed on the old codebase; was it necessary?
+    if (scale <= 0.0) {
+        scale = 1.0f;
+    }
+    _SetContentSize(element, Size(width / scale, height / scale));
 
     // Refresh any content center settings
     _ApplyContentCenter(element, _GetContentCenter(element));
@@ -1057,7 +1061,6 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
     const double elementHeight = element->Height;
 
     // Apply gravity mapping
-    double scale = 1.0; // TODO: Do we even need this anymore?  It doesn't look like it.
     HorizontalAlignment horizontalAlignment;
     VerticalAlignment verticalAlignment;
     double finalContentWidth = 0.0;
@@ -1071,8 +1074,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Center;
 
         // ContentGravity::Center does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Vertically and horizontally center the content within its containing layer.
         contentLeft = (elementWidth / 2) - (contentSize.Width / 2);
@@ -1085,8 +1088,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Top;
 
         // ContentGravity::Top does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Bottom-align and horizontally-center the content within its containing layer.
         // Note: This is counter-intuitive; Top/Bottom gravity is swapped for CALayer.
@@ -1100,8 +1103,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Bottom;
 
         // ContentGravity::Bottom does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Top-align and horizontally-center the content within its containing layer.
         // Note: This is counter-intuitive; Top/Bottom gravity is swapped for CALayer.
@@ -1115,8 +1118,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Center;
 
         // ContentGravity::Left does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Left-align and vertically-center the content within its containing layer.
         contentLeft = 0;
@@ -1129,8 +1132,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Center;
 
         // ContentGravity::Right does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Right-align and vertically-center the content within its containing layer.
         contentLeft = (elementWidth - contentSize.Width);
@@ -1143,8 +1146,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Top;
 
         // ContentGravity::TopLeft does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Left and *bottom* align the content within its containing layer.
         // Note: This is counter-intuitive; Top/Bottom gravity is swapped for CALayer.
@@ -1158,8 +1161,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Top;
 
         // ContentGravity::TopRight does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Right and *bottom* align the content within its containing layer.
         // Note: This is counter-intuitive; Top/Bottom gravity is swapped for CALayer.
@@ -1173,8 +1176,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Bottom;
 
         // ContentGravity::BottomLeft does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Left and *top* align the content within its containing layer.
         // Note: This is counter-intuitive; Top/Bottom gravity is swapped for CALayer.
@@ -1188,8 +1191,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Bottom;
 
         // ContentGravity::BottomRight does not resize the content
-        finalContentWidth = contentSize.Width * scale;
-        finalContentHeight = contentSize.Height * scale;
+        finalContentWidth = contentSize.Width;
+        finalContentHeight = contentSize.Height;
 
         // Right and *top* align the content within its containing layer.
         // Note: This is counter-intuitive; Top/Bottom gravity is swapped for CALayer.
@@ -1203,8 +1206,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
         verticalAlignment = VerticalAlignment::Top;
 
         // Resize content to that of its containing layer
-        finalContentWidth = elementWidth * scale;
-        finalContentHeight = elementHeight * scale;
+        finalContentWidth = elementWidth;
+        finalContentHeight = elementHeight;
 
         // Completely fill/align the content within its containing layer.
         contentLeft = 0;
@@ -1222,8 +1225,8 @@ void LayerCoordinator::_ApplyContentGravity(FrameworkElement^ element, ContentGr
             const double widthAspect = elementWidth / contentSize.Width;
             const double heightAspect = elementHeight / contentSize.Height;
             const double minAspect = std::min<double>(widthAspect, heightAspect);
-            finalContentWidth = (contentSize.Width * static_cast<float>(minAspect) * scale);
-            finalContentHeight = (contentSize.Height * static_cast<float>(minAspect) * scale);
+            finalContentWidth = (contentSize.Width * static_cast<float>(minAspect));
+            finalContentHeight = (contentSize.Height * static_cast<float>(minAspect));
 
             // Vertically and horizontally center the content within its containing layer
             contentLeft = (elementWidth / 2) - (finalContentWidth / 2);

--- a/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
+++ b/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
@@ -696,7 +696,6 @@ void LayerCoordinator::SetContent(FrameworkElement^ element, ImageSource^ source
     contentImage->Source = source;
 
     // Store content size with the scale factor applied
-    // TODO: This check existed on the old codebase; was it necessary?
     if (scale <= 0.0) {
         scale = 1.0f;
     }


### PR DESCRIPTION
Tested high DPI scenarios in the partner typography app, but we also need to add these scenarios (for the various scale vs. content gravity settings) to our test app asap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1402)
<!-- Reviewable:end -->
