### PR TITLE
Updated objc2winmd binaries: Support marshalling NSError as PropertySet

### DIFF
--- a/bin/objc2winmd.exe
+++ b/bin/objc2winmd.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:28ca1ae759100fde74bbd3de2ea15306791f34c25ae544360f52d8175c73e66c
-size 512512
+oid sha256:11c19ead4b010e163db0f5249be70ddd39bf8899aefabf2ec8dc26cfc60f376b
+size 522240


### PR DESCRIPTION
This binary update supports marshalling NSError as PropertySet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1403)
<!-- Reviewable:end -->
