### PR TITLE
Fix UIButton layout issues when using titleLabel and imageView

### DIFF
--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -213,6 +213,7 @@ struct ButtonState {
         // by XAML.
         // The size of XAML elements(for eg Image) is calculated at runtime and then the
         // intrinsicContentSize is invalidated.
+        [self invalidateIntrinsicContentSize];
         [weakSelf setNeedsLayout];
     });
 }
@@ -266,6 +267,13 @@ Microsoft Extension
         _states[state].inspectableImage = [imageBrush comObj];
     }
 
+    // Update the Xaml elements immediately, so the proxies reflect reality
+    XamlButtonApplyVisuals([_xamlButton comObj],
+                           _currentInspectableTitle(self),
+                           _currentInspectableImage(self),
+                           _currentInspectableTitleColor(self));
+
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 
@@ -432,6 +440,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 - (void)setBackgroundImage:(UIImage*)image forState:(UIControlState)state {
     _states[state].backgroundImage = image;
 
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 
@@ -477,6 +486,13 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
         _states[state].inspectableTitle = [rtString comObj];
     }
 
+    // Update the Xaml elements immediately, so the proxies reflect reality
+    XamlButtonApplyVisuals([_xamlButton comObj],
+                           _currentInspectableTitle(self),
+                           _currentInspectableImage(self),
+                           _currentInspectableTitleColor(self));
+
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 
@@ -507,6 +523,13 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
         _states[state].inspectableTitleColor = [titleColorBrush comObj];
     }
 
+    // Update the Xaml elements immediately, so the proxies reflect reality
+    XamlButtonApplyVisuals([_xamlButton comObj],
+                           _currentInspectableTitle(self),
+                           _currentInspectableImage(self),
+                           _currentInspectableTitleColor(self));
+
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 
@@ -578,6 +601,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
     // Relayout when new state is different than old state
     if (_curState != newState) {
         _curState = newState;
+        [self invalidateIntrinsicContentSize];
         [self setNeedsLayout];
     }
 
@@ -601,6 +625,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
     // Relayout when new state is different than old state
     if (_curState != newState) {
         _curState = newState;
+        [self invalidateIntrinsicContentSize];
         [self setNeedsLayout];
     }
 
@@ -624,6 +649,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
     // Relayout when new state is different than old state
     if (_curState != newState) {
         _curState = newState;
+        [self invalidateIntrinsicContentSize];
         [self setNeedsLayout];
     }
 
@@ -682,6 +708,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 */
 - (void)setTitleEdgeInsets:(UIEdgeInsets)insets {
     _titleInsets = insets;
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 
@@ -690,6 +717,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 */
 - (void)setImageEdgeInsets:(UIEdgeInsets)insets {
     _imageInsets = insets;
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 
@@ -698,6 +726,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 */
 - (void)setContentEdgeInsets:(UIEdgeInsets)insets {
     _contentInsets = insets;
+    [self invalidateIntrinsicContentSize];
     [self setNeedsLayout];
 }
 

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -213,7 +213,7 @@ struct ButtonState {
         // by XAML.
         // The size of XAML elements(for eg Image) is calculated at runtime and then the
         // intrinsicContentSize is invalidated.
-        [self invalidateIntrinsicContentSize];
+        [weakSelf invalidateIntrinsicContentSize];
         [weakSelf setNeedsLayout];
     });
 }

--- a/samples/WOCCatalog/WOCCatalog/AutoLayoutViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/AutoLayoutViewController.m
@@ -66,8 +66,9 @@
     UIButton* button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     
     [button setTitle:@"Button For Baseline" forState:UIControlStateNormal];
-    [button invalidateIntrinsicContentSize];
+    [button setTitle:@"Highlighted State Changes Intrinsic Content Size" forState:UIControlStateHighlighted];
     [button setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisVertical];
+    button.contentEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
     button.translatesAutoresizingMaskIntoConstraints = NO;
     button.layer.cornerRadius = 5.0f;
     button.backgroundColor = [UIColor lightGrayColor];
@@ -75,8 +76,6 @@
     
     [self.view addConstraint:[NSLayoutConstraint constraintWithItem:button attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:bottomLabel attribute:NSLayoutAttributeTop multiplier:1.0 constant:-8.0f]];
     [self.view addConstraint:[NSLayoutConstraint constraintWithItem:button attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:button.superview attribute:NSLayoutAttributeLeft multiplier:1.0 constant:20.0f]];
-    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:button attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:button.intrinsicContentSize.width + 20]];
-    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:button attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1.0 constant:button.intrinsicContentSize.height + 20]];
     
     CenteredAutoLayoutLabel* buttonLabel = [CenteredAutoLayoutLabel new];
     


### PR DESCRIPTION
lazy intrinsic content size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1407)
<!-- Reviewable:end -->
