### PR TITLE
Update VSIX to remove API filtering.

### DIFF
--- a/bin/objc-syntax-highlighting.vsix
+++ b/bin/objc-syntax-highlighting.vsix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f36022dd338d70448856a94a1e39c86e17c3f4e2b47b3321140a1459ef990ec
-size 277953
+oid sha256:9cfccbdff583413afb36ec473050c1c67dd88c7079ace11efd398cf543fe09d5
+size 274747

--- a/msvc/language/BuildMonitor/BuildEventProcessor.cs
+++ b/msvc/language/BuildMonitor/BuildEventProcessor.cs
@@ -70,47 +70,6 @@ namespace BuildMonitor
         /// </example>
         private const string IdentifierPattern = @"({([a-zA-Z0-9@.\-_])+})|(([a-zA-Z0-9.\-_])+\\([a-zA-Z0-9.\-_])+)|(([a-zA-Z0-9.\-_])+@([a-zA-Z0-9.\-_])+)|(user(\w){0,2}(\W){0,1}([a-zA-Z0-9.\-_])+)";
 
-        /// <summary>
-        /// Match for classes with the NS- prefix.
-        /// </summary>
-        /// <example>
-        /// matches:  "NSClass", "NSSomeOtherClass1", "NSYetAnother1OfThoseClasses"
-        /// </example>
-        private const string NextStepProtocolPattern = @"(^NS([a-zA-Z0-9])+)|(\WNS([a-zA-Z0-9])+)";
-
-        /// <summary>
-        /// Match for classes with the UI- prefix.
-        /// </summary>
-        /// <example>
-        /// matches:  "UIClass", "UISomeOtherClass1", "UIYetAnother1OfThoseClasses"
-        /// </example>
-        private const string UserInterfaceProtocolPattern = @"(^UI([a-zA-Z0-9])+)|(\WUI([a-zA-Z0-9])+)";
-
-        /// <summary>
-        /// Match for classes with the WU- prefix.
-        /// </summary>
-        /// <example>
-        /// matches:  "WUClass", "WUSomeOtherClass1", "WUYetAnother1OfThoseClasses"
-        /// </example>
-        private const string WindowsUniversalProtocolPattern = @"(^WU([a-zA-Z0-9])+)|(\WWU([a-zA-Z0-9])+)";
-
-        /// <summary>
-        /// Match for task list descriptions that contain specific keywords but that don't match any other criteria.
-        /// </summary>
-        /// <example>
-        /// matches:  "method", "class", "property", "interface", "namespace"
-        /// </example>
-        private const string CodeConstructsPattern = @"((method)|(class)|(property)|(interface)|(namespace))";
-
-        /// <summary>
-        /// Match for methods and properties not yet implemented in WinObjC and marked as "deprecated"
-        /// </summary>
-        /// <example>
-        /// method '{Random}' in 'WU{Random}' is deprecated: property not yet implemented [-Wdeprecated-declarations] keep this string
-        /// method '{Random}' is deprecated: property not yet implemented [-Wdeprecated-declarations] keep this string
-        /// method 'initWithProduct{Random}:' in protocol is deprecated: method not yet implemented[-Wdeprecated-declarations] keep this string
-        /// </example>
-        private const string DeprecationPattern = @"(((property)|(method))(\snot yet implemented))(.)*(\[-Wdeprecated-declarations\])";
         #endregion
 
         #endregion Private Constants
@@ -342,31 +301,18 @@ namespace BuildMonitor
         {
             if (string.IsNullOrEmpty(message) == false)
             { 
-                // does it contain NS*, UI* or WU* class, protocol or interface
-                if (Regex.IsMatch(message, BuildEventProcessor.NextStepProtocolPattern) ||
-                    Regex.IsMatch(message, BuildEventProcessor.UserInterfaceProtocolPattern) ||
-                    Regex.IsMatch(message, BuildEventProcessor.WindowsUniversalProtocolPattern) ||
-                    Regex.IsMatch(message, BuildEventProcessor.DeprecationPattern))
-                {
-                    StringBuilder scrubbedMessage = new StringBuilder(message);
-                    ScrubMessagePrivateInfo(scrubbedMessage, _localPathsMatcher);
-                    ScrubMessagePrivateInfo(scrubbedMessage, _networkPathsMatcher);
-                    ScrubMessagePrivateInfo(scrubbedMessage, _protocolsMatcher);
-                    ScrubMessagePrivateInfo(scrubbedMessage, _identifierMatcher);
+                StringBuilder scrubbedMessage = new StringBuilder(message);
+                ScrubMessagePrivateInfo(scrubbedMessage, _localPathsMatcher);
+                ScrubMessagePrivateInfo(scrubbedMessage, _networkPathsMatcher);
+                ScrubMessagePrivateInfo(scrubbedMessage, _protocolsMatcher);
+                ScrubMessagePrivateInfo(scrubbedMessage, _identifierMatcher);
 
-                    // return scrubbed message with all other information intact
-                    return scrubbedMessage.ToString();
-                }
-
-                // does it contain any other code constructs, e.g. method, class, protocol, et al.
-                if (Regex.IsMatch(message, BuildEventProcessor.CodeConstructsPattern))
-                {
-                    return "Error unrelated to WinObjC.";
-                }
+                // return scrubbed message with all other information intact
+                return scrubbedMessage.ToString();
             }
 
             // return generic error message
-            return "Error unrelated to Objective-C or WinObjC.";
+            return "Error message was empty or null.";
         }
 
         private StringBuilder ScrubMessagePrivateInfo(StringBuilder message, Regex matcher)

--- a/msvc/language/BuildMonitor/BuildMonitor.csproj
+++ b/msvc/language/BuildMonitor/BuildMonitor.csproj
@@ -192,6 +192,15 @@
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ObjectiveC\ObjectiveC.csproj">
+      <Project>{D92AF1E6-7318-4CC0-9E1E-074E96C7E0FB}</Project>
+      <Name>ObjectiveC</Name>
+      <VSIXSubPath>Asset</VSIXSubPath>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/msvc/language/BuildMonitor/source.extension.vsixmanifest
+++ b/msvc/language/BuildMonitor/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="VSIX..9c35fff1-f084-44c1-a38e-68c707163aa2" Version="1.5" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>Objective-C Language Service</DisplayName>
-    <Description xml:space="preserve">This package contains Objective-C language service components such as syntax higlighting etc</Description>
+    <Identity Id="BuildMonitor..0a528553-98c4-4948-a43c-bef2784df92c" Version="1.5" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>BuildMonitor</DisplayName>
+    <Description xml:space="preserve">BuildMonitor watches the solution build process and reports WinObjC errors.</Description>
   </Metadata>
   <Installation>
     <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Community" />

--- a/msvc/language/BuildMonitor/source.extension.vsixmanifest
+++ b/msvc/language/BuildMonitor/source.extension.vsixmanifest
@@ -1,18 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="BuildMonitor..0a528553-98c4-4948-a43c-bef2784df92c" Version="1.0" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>BuildMonitor</DisplayName>
-    <Description xml:space="preserve">BuildMonitor watches the solution build process and reports WinObjC errors.</Description>
+    <Identity Id="VSIX..9c35fff1-f084-44c1-a38e-68c707163aa2" Version="1.5" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>Objective-C Language Service</DisplayName>
+    <Description xml:space="preserve">This package contains Objective-C language service components such as syntax higlighting etc</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[12.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="[14.0]" />
   </Dependencies>
   <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="ObjectiveC" d:VsixSubPath="Asset" Path="|ObjectiveC|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:VsixSubPath="BM" Path="|BuildMonitor;PkgdefProjectOutputGroup|" />
+    <Asset Type="NativeVisualizer" d:Source="File" Path="Visualizers\ObjectiveC.natvis" />
+    <Asset Type="StepFilter" d:Source="File" Path="Visualizers\ObjectiveC.natstepfilter" />
   </Assets>
 </PackageManifest>

--- a/msvc/language/VSIX/source.extension.vsixmanifest
+++ b/msvc/language/VSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="VSIX..9c35fff1-f084-44c1-a38e-68c707163aa2" Version="1.4" Language="en-US" Publisher="Microsoft" />
+    <Identity Id="VSIX..9c35fff1-f084-44c1-a38e-68c707163aa2" Version="1.5" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Objective-C Language Service</DisplayName>
     <Description xml:space="preserve">This package contains Objective-C language service components such as syntax higlighting etc</Description>
   </Metadata>


### PR DESCRIPTION
This update removes filtering of specific API's in the error/warning build event telemetry.  The update includes a rebuilt binary for the VSIX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1424)
<!-- Reviewable:end -->
