### PR TITLE
Fix forward declarations for NSArray and NSDictionary in UIPasteboard.h

### DIFF
--- a/include/UIKit/UIPasteboard.h
+++ b/include/UIKit/UIPasteboard.h
@@ -20,7 +20,8 @@
 #import <Foundation/NSObject.h>
 
 @class NSString;
-@class NSArray;
+@class NSArray<ObjectType>;
+@class NSDictionary<KeyType, ObjectType>;
 @class NSData;
 @class NSIndexSet;
 @class UIImage;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1433)
<!-- Reviewable:end -->
