### PR TITLE
Disable every drawing test manually instead of using exit(0).

### DIFF
--- a/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DRAW_TEST_F(CGContext, RedBox, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGContext, RedBox, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -24,7 +24,7 @@ DRAW_TEST_F(CGContext, RedBox, UIKitMimicTest) {
     CGContextFillRect(context, CGRectInset(bounds, 10, 10));
 }
 
-DRAW_TEST_F(CGContext, FillThenStrokeIsSameAsDrawFillStroke, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, FillThenStrokeIsSameAsDrawFillStroke, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -62,7 +62,7 @@ static void _drawThreeCirclesInContext(CGContextRef context, CGRect bounds) {
     }
 }
 
-DRAW_TEST_F(CGContext, OverlappingCirclesColorAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesColorAlpha, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -73,7 +73,7 @@ DRAW_TEST_F(CGContext, OverlappingCirclesColorAlpha, WhiteBackgroundTest) {
     _drawThreeCirclesInContext(context, bounds);
 }
 
-DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlpha, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -86,7 +86,7 @@ DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlpha, WhiteBackgroundTest) {
     _drawThreeCirclesInContext(context, bounds);
 }
 
-DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlphaStackedWithColorAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlphaStackedWithColorAlpha, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -119,7 +119,7 @@ DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesTransparencyLayerAlpha, WhiteB
 // This test proves that the path is stored fully transformed;
 // changing the CTM before stroking it does not cause it to scale!
 // However, the stroke width _is_ scaled (!)
-DRAW_TEST_F(CGContext, ChangeCTMAfterCreatingPath, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, ChangeCTMAfterCreatingPath, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/UnitTests/CoreGraphics.drawing/EntryPoint.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/EntryPoint.cpp
@@ -23,9 +23,6 @@ using namespace Microsoft::WRL::Wrappers;
 #endif
 
 int main(int argc, char** argv) {
-    // TODO GH#1124 When we have a bitmap context, enable all these tests.
-    exit(0);
-
 #ifdef WIN32
     // Initialize the windows runtime, with uninitialized upon destructor invocation.
     RoInitializeWrapper initialize(RO_INIT_MULTITHREADED);

--- a/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_FillTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_FillTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DRAW_TEST_F(CGContextFill, ConcentricCirclesWinding, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesWinding, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -38,7 +38,7 @@ DRAW_TEST_F(CGContextFill, ConcentricCirclesWinding, WhiteBackgroundTest) {
     CGPathRelease(concentricCirclesPath);
 }
 
-DRAW_TEST_F(CGContextFill, ConcentricCirclesEvenOdd, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesEvenOdd, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -60,7 +60,7 @@ DRAW_TEST_F(CGContextFill, ConcentricCirclesEvenOdd, WhiteBackgroundTest) {
     CGPathRelease(concentricCirclesPath);
 }
 
-DRAW_TEST_F(CGContextFill, ConcentricRectsWinding, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsWinding, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -82,7 +82,7 @@ DRAW_TEST_F(CGContextFill, ConcentricRectsWinding, WhiteBackgroundTest) {
     CGPathRelease(path);
 }
 
-DRAW_TEST_F(CGContextFill, ConcentricRectsEvenOdd, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsEvenOdd, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_ShadowTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_ShadowTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DRAW_TEST_F(CGContext, Shadow, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, Shadow, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -31,7 +31,7 @@ DRAW_TEST_F(CGContext, Shadow, WhiteBackgroundTest) {
     CGContextStrokeRect(context, rect);
 }
 
-DRAW_TEST_F(CGContext, ShadowWithRotatedCTM, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, ShadowWithRotatedCTM, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -36,7 +36,7 @@ DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -58,7 +58,7 @@ DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -116,7 +116,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest) {
     CGPathRelease(theSecondPath);
 }
 
-DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -141,7 +141,7 @@ DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -159,7 +159,7 @@ DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -196,7 +196,7 @@ DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -223,7 +223,7 @@ DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DRAW_TEST_F(CGPath, GetBoundingBox, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, GetBoundingBox, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
@@ -78,7 +78,7 @@ TEST_P(CGContextBlendMode, OverlappedEllipses) {
     CGContextFillEllipseInRect(context, _CGRectCenteredOnPoint({ bounds.size.height, bounds.size.height }, secondEllipseCenter));
 }
 
-INSTANTIATE_TEST_CASE_P(CompositionModes,
+INSTANTIATE_TEST_CASE_P(DISABLED_CompositionModes,
                         CGContextBlendMode,
                         ::testing::Combine(::testing::ValuesIn(alphas), ::testing::ValuesIn(compositionModes)));
 


### PR DESCRIPTION
78 disabled tests, but now the XML file gets generated properly!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1434)
<!-- Reviewable:end -->
