### PR TITLE
Fix stackoverflow from regression in NSNumberFormatter nilSymbol property implementation

### DIFF
--- a/Frameworks/Foundation/NSNumberFormatter.mm
+++ b/Frameworks/Foundation/NSNumberFormatter.mm
@@ -30,6 +30,7 @@ CFStringRef kCFNumberFormatterUsesCharacterDirectionKey = static_cast<CFStringRe
     woc::unique_cf<CFNumberFormatterRef> _cfNumberFormatter;
     BOOL _wasMaxFractionDigitsSet;
     BOOL _wasMaxIntegerDigitsSet;
+    StrongId<NSString> _nilSymbol;
 }
 
 /**
@@ -278,25 +279,17 @@ CFStringRef kCFNumberFormatterUsesCharacterDirectionKey = static_cast<CFStringRe
  @Status Interoperable
 */
 - (void)setNilSymbol:(NSString*)symbol {
-    @synchronized(self) {
-        if (self.nilSymbol != symbol) {
-            [self.nilSymbol autorelease];
-            self.nilSymbol = [symbol copy];
-        }
-    }
+    _nilSymbol.attach([symbol copy]);
 }
 
 /**
  @Status Interoperable
 */
 - (NSString*)nilSymbol {
-    @synchronized(self) {
-        if (self.nilSymbol == nil) {
-            return @"";
-        }
-
-        return self.nilSymbol;
+    if (!_nilSymbol) {
+        return @"";
     }
+    return _nilSymbol;
 }
 
 /**


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1436)
<!-- Reviewable:end -->
