### PR TITLE
Fix UISegmentedControl/UISegment garbage ivar crash

### DIFF
--- a/Frameworks/UIKit/UISegment.h
+++ b/Frameworks/UIKit/UISegment.h
@@ -23,7 +23,7 @@
     idretain _dividerImage;
     idretain _segmentFont;
     idretain _textColor[2];
-    id _tintColor;
+    StrongId<UIColor> _tintColor;
     unsigned _position;
     unsigned _type, _selected;
     unsigned _disabled;
@@ -55,6 +55,6 @@
 - (id)_setAttributes:(id)attributes forState:(DWORD)state;
 - (id)_setDividerImage:(id)image;
 - (id)_setNoDefaultImages:(BOOL)noDefault;
-- (id)_setTintColor:(id)color;
+- (id)_setTintColor:(UIColor*)color;
 + (instancetype)initialize;
 @end

--- a/Frameworks/UIKit/UISegment.mm
+++ b/Frameworks/UIKit/UISegment.mm
@@ -40,9 +40,6 @@ static idretain _defaultTextColor[2];
         id info = [[coder decodeObjectForKey:@"UISegmentInfo"] retain];
         _position = [coder decodeInt32ForKey:@"UISegmentPosition"];
 
-        CGRect frame;
-        frame = [self bounds];
-
         if ([info isKindOfClass:[NSString class]]) {
             _title = info;
         } else if ([info isKindOfClass:[UIImage class]]) {
@@ -50,7 +47,8 @@ static idretain _defaultTextColor[2];
         } else {
             assert(0);
         }
-        [self setOpaque:FALSE];
+
+        [self setOpaque:NO];
         _textColor[0] = nil;
         _textColor[1] = nil;
         _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
@@ -66,7 +64,7 @@ static idretain _defaultTextColor[2];
         _title.attach([title copy]);
         _position = 0;
 
-        [self setOpaque:FALSE];
+        [self setOpaque:NO];
         _textColor[0] = nil;
         _textColor[1] = nil;
         _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
@@ -81,7 +79,7 @@ static idretain _defaultTextColor[2];
         _image = image;
         _position = 0;
 
-        [self setOpaque:FALSE];
+        [self setOpaque:NO];
         _textColor[0] = nil;
         _textColor[1] = nil;
         _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
@@ -160,10 +158,10 @@ static idretain _defaultTextColor[2];
 
 - (BOOL)isEnabled {
     if (_disabled) {
-        return FALSE;
+        return NO;
     }
 
-    return TRUE;
+    return YES;
 }
 
 - (id)drawRect:(CGRect)inRect {
@@ -224,7 +222,7 @@ static idretain _defaultTextColor[2];
     if (isOSTarget(@"7.0")) {
         if (_tintColor != nil) {
             if (_selected == 1) {
-                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)_tintColor.get());
+                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), [_tintColor CGColor]);
                 CGContextFillRect(UIGraphicsGetCurrentContext(), bounds);
             }
             if ((_type & 2) == 0) {
@@ -233,7 +231,7 @@ static idretain _defaultTextColor[2];
 
                 rect.origin.x = rect.size.width - lineWidth;
                 rect.size.width = lineWidth;
-                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)_tintColor.get());
+                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), [_tintColor CGColor]);
                 CGContextFillRect(UIGraphicsGetCurrentContext(), rect);
             }
         }
@@ -243,15 +241,15 @@ static idretain _defaultTextColor[2];
 
             if (_selected) {
                 // No border, just fill with background color
-                CGContextSetFillColorWithColor(ctx, (CGColorRef)bgColor);
+                CGContextSetFillColorWithColor(ctx, [bgColor CGColor]);
                 CGContextFillRect(ctx, bounds);
             } else {
                 // Fill with background color and draw border with text color
                 const CGRect borderRect = bounds;
                 const CGRect fillRect = CGRectInset(bounds, 1.0, 1.0);
-                CGContextSetFillColorWithColor(ctx, (CGColorRef)bgColor);
+                CGContextSetFillColorWithColor(ctx, [bgColor CGColor]);
                 CGContextFillRect(ctx, fillRect);
-                CGContextSetStrokeColorWithColor(ctx, (CGColorRef)textColor);
+                CGContextSetStrokeColorWithColor(ctx, [textColor CGColor]);
                 CGContextSetLineWidth(ctx, 1.0);
                 CGContextStrokeRect(ctx, borderRect);
             }
@@ -290,7 +288,7 @@ static idretain _defaultTextColor[2];
     }
 
     if (_title != nil) {
-        CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)textColor);
+        CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), [textColor CGColor]);
 
         CGSize size;
         CGRect rect;

--- a/Frameworks/UIKit/UISegment.mm
+++ b/Frameworks/UIKit/UISegment.mm
@@ -36,53 +36,56 @@ static idretain _defaultTextColor[2];
 }
 
 - (instancetype)initWithCoder:(NSCoder*)coder {
-    id result = [super initWithCoder:coder];
-    id info = [[coder decodeObjectForKey:@"UISegmentInfo"] retain];
-    _position = [coder decodeInt32ForKey:@"UISegmentPosition"];
+    if (self = [super initWithCoder:coder]) {
+        id info = [[coder decodeObjectForKey:@"UISegmentInfo"] retain];
+        _position = [coder decodeInt32ForKey:@"UISegmentPosition"];
 
-    CGRect frame;
-    frame = [self bounds];
+        CGRect frame;
+        frame = [self bounds];
 
-    if ([info isKindOfClass:[NSString class]]) {
-        _title = info;
-    } else if ([info isKindOfClass:[UIImage class]]) {
-        _image = info;
-    } else {
-        assert(0);
+        if ([info isKindOfClass:[NSString class]]) {
+            _title = info;
+        } else if ([info isKindOfClass:[UIImage class]]) {
+            _image = info;
+        } else {
+            assert(0);
+        }
+        [self setOpaque:FALSE];
+        _textColor[0] = nil;
+        _textColor[1] = nil;
+        _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
     }
-    [self setOpaque:FALSE];
-    _textColor[0] = nil;
-    _textColor[1] = nil;
-    _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
 
     return self;
 }
 
 - (instancetype)initWithTitle:(id)title {
-    _title.attach([title copy]);
-    _position = 0;
-
     CGRect frame = { 0 };
-    [self initWithFrame:frame];
-    [self setOpaque:FALSE];
-    _textColor[0] = nil;
-    _textColor[1] = nil;
-    _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
 
+    if (self = [super initWithFrame:frame]) {
+        _title.attach([title copy]);
+        _position = 0;
+
+        [self setOpaque:FALSE];
+        _textColor[0] = nil;
+        _textColor[1] = nil;
+        _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
+    }
     return self;
 }
 
 - (instancetype)initWithImage:(id)image {
-    _image = image;
-    _position = 0;
-
     CGRect frame = { 0.0f, 0.0f, 0.0f, 0.0f };
 
-    [self initWithFrame:frame];
-    [self setOpaque:FALSE];
-    _textColor[0] = nil;
-    _textColor[1] = nil;
-    _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
+    if (self = [super initWithFrame:frame]) {
+        _image = image;
+        _position = 0;
+
+        [self setOpaque:FALSE];
+        _textColor[0] = nil;
+        _textColor[1] = nil;
+        _segmentFont = [UIFont boldSystemFontOfSize:15.0f];
+    }
 
     return self;
 }
@@ -185,7 +188,8 @@ static idretain _defaultTextColor[2];
 
     bounds = [self bounds];
 
-    id bgColor, textColor;
+    UIColor* bgColor;
+    UIColor* textColor;
 
     if (isOSTarget(@"7.0") && _selected == 0 && _tintColor != nil) {
         textColor = _tintColor;
@@ -220,7 +224,7 @@ static idretain _defaultTextColor[2];
     if (isOSTarget(@"7.0")) {
         if (_tintColor != nil) {
             if (_selected == 1) {
-                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)_tintColor);
+                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)_tintColor.get());
                 CGContextFillRect(UIGraphicsGetCurrentContext(), bounds);
             }
             if ((_type & 2) == 0) {
@@ -229,7 +233,7 @@ static idretain _defaultTextColor[2];
 
                 rect.origin.x = rect.size.width - lineWidth;
                 rect.size.width = lineWidth;
-                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)_tintColor);
+                CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), (CGColorRef)_tintColor.get());
                 CGContextFillRect(UIGraphicsGetCurrentContext(), rect);
             }
         }
@@ -383,7 +387,7 @@ static idretain _defaultTextColor[2];
     return self;
 }
 
-- (id)_setTintColor:(id)color {
+- (id)_setTintColor:(UIColor*)color {
     _tintColor = color;
     return self;
 }

--- a/Frameworks/UIKit/UISegmentedControl.mm
+++ b/Frameworks/UIKit/UISegmentedControl.mm
@@ -30,7 +30,7 @@
 
 @implementation UISegmentedControl {
     StrongId<NSMutableArray> _segments;
-    id _tintColor;
+    StrongId<UIColor> _tintColor;
     idretain _backgroundImages[16];
     idretain _segmentAttributes[16];
     idretain _dividerImage;
@@ -520,7 +520,7 @@ static void positionSegments(UISegmentedControl* self) {
     _tintColor = uiColor;
 
     if (isOSTarget(@"7.0")) {
-        [[self layer] setBorderColor:(CGColorRef)_tintColor];
+        [[self layer] setBorderColor:(CGColorRef)_tintColor.get()];
     }
 }
 
@@ -586,7 +586,6 @@ static void positionSegments(UISegmentedControl* self) {
 */
 - (void)dealloc {
     _segments = nil;
-    _tintColor = nil;
     _dividerImage = nil;
 
     for (int i = 0; i < 16; i++) {

--- a/Frameworks/UIKit/UISegmentedControl.mm
+++ b/Frameworks/UIKit/UISegmentedControl.mm
@@ -54,7 +54,7 @@
         [super setFrame:frame];
 
         [[self layer] setBorderWidth:1.0f];
-        [[self layer] setBorderColor:(CGColorRef)[UIColor blackColor]];
+        [[self layer] setBorderColor:[[UIColor blackColor] CGColor]];
         [self setClipsToBounds:TRUE];
     }
 
@@ -520,7 +520,7 @@ static void positionSegments(UISegmentedControl* self) {
     _tintColor = uiColor;
 
     if (isOSTarget(@"7.0")) {
-        [[self layer] setBorderColor:(CGColorRef)_tintColor.get()];
+        [[self layer] setBorderColor:[_tintColor CGColor]];
     }
 }
 


### PR DESCRIPTION
```
 	LIBOBJC2.DLL!objc_msgSend(objc_class * self, void * _cmd)	C++
>	COREGRAPHICS.DLL!CGContextCairo::CGContextSetStrokeColorWithColor(objc_object * color) Line 705	Objective-C++
 	COREGRAPHICS.DLL!CGContextSetStrokeColorWithColor(__CGContext * ctx, __CGColor * color) Line 292	Objective-C++
 	UIKIT.DLL!-[UISegment drawRect:](UISegment * self, objc_selector * _cmd, CGRect inRect) Line 250	Objective-C++
 	UIKIT.DLL!-[UIView drawLayer:inContext:](UIView * self, objc_selector * _cmd, CALayer * layer, __CGContext * context) Line 2231	Objective-C++
 	QUARTZCORE.DLL!-[CALayer display](CALayer * self, objc_selector * _cmd) Line 536	Objective-C++
 	QUARTZCORE.DLL!-[CALayer displayIfNeeded](CALayer * self, objc_selector * _cmd) Line 354	Objective-C++
 	QUARTZCORE.DLL!-[CALayer _getDisplayTexture](CALayer * self, objc_selector * _cmd) Line 1821	Objective-C++
 	QUARTZCORE.DLL!DoDisplayList(CALayer * layer) Line 208	Objective-C++
 	QUARTZCORE.DLL!__26-[CALayer _displayChanged]_block_invoke(void * .block_descriptor) Line 2229	Objective-C++
 	LIBDISPATCH.DLL!_dispatch_call_block_and_release(void * block) Line 124	C
 	LIBDISPATCH.DLL!_dispatch_continuation_pop(dispatch_object_t dou) Line 415	C
 	LIBDISPATCH.DLL!_dispatch_queue_drain(dispatch_queue_s * dq) Line 1548	C
 	LIBDISPATCH.DLL!_dispatch_queue_serial_drain_till_empty(dispatch_queue_s * dq) Line 1405	C
 	LIBDISPATCH.DLL!_dispatch_manual_queue_drain(dispatch_queue_s * q) Line 107	C
 	LIBDISPATCH.DLL!dispatch_main_queue_callback() Line 309	C
 	FOUNDATION.DLL!-[NSRunLoop(Internal) _processMainRunLoop:](NSRunLoop * self, objc_selector * _cmd, int value) Line 536	Objective-C++
 	FOUNDATION.DLL!_ProcessMainRunLoop(int signaled) Line 66	Objective-C++
 	FOUNDATION.DLL!??R<lambda_1>@?_DispatchMainRunLoopOnUIThread@@YAXH@Z@QBEJXZ() Line 79	Objective-C++
 	FOUNDATION.DLL! ?? :: ?? ::Invoke() Line 240	Objective-C++
 	[External Code]	
 	[Frames below may be incorrect and/or missing, no symbols loaded for ntdll.dll]	

```

Crash from improper memory management of _tintColor ivar. Note: The changes to the init methods in UISegment.mm aren't necessary to fix the crash (just a cleanup).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1441)
<!-- Reviewable:end -->
