### PR TITLE
Add support for registering and unregistering fonts

### DIFF
--- a/Frameworks/CoreGraphics/CGDataProvider.mm
+++ b/Frameworks/CoreGraphics/CGDataProvider.mm
@@ -75,11 +75,9 @@ CGDataProviderRef CGDataProviderCreateWithURL(CFURLRef url) {
  @Status Interoperable
 */
 CFDataRef CGDataProviderCopyData(CGDataProviderRef provider) {
-    void* data = (void*)[(NSData*)provider bytes];
-    DWORD size = [(NSData*)provider length];
-    id ret = [[CGDataProvider alloc] initWithBytes:data length:size];
-
-    return (CFDataRef)ret;
+    uint8_t* bytes = (uint8_t*)[(NSData*)provider bytes];
+    size_t length = [(NSData*)provider length];
+    return CFDataCreate(nullptr, bytes, length);
 }
 
 /**

--- a/Frameworks/CoreGraphics/CGFont.mm
+++ b/Frameworks/CoreGraphics/CGFont.mm
@@ -374,6 +374,9 @@ CFTypeID CGFontGetTypeID() {
     return __kCGFontTypeID;
 }
 
+// TODO 1450: Convert this and all references to CGDataProviderRef
+// Currently CGDataProviderRef is broken for the needs of CTFontManager
+// So to prevent potentially copying multiple times, save a reference to the data
 CFDataRef _CGFontGetData(CGFontRef font) {
     return font ? font->_data.get() : nullptr;
 }

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -725,7 +725,7 @@ public:
 
         CFIndex count = CFArrayGetCount(fontDatas);
         for (CFIndex i = 0; i < count; ++i) {
-            CFDataRef data = (CFDataRef)CFArrayGetValueAtIndex(fontDatas, i);
+            CFDataRef data = static_cast<CFDataRef>(CFArrayGetValueAtIndex(fontDatas, i));
             if (data) {
                 if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
                     __AppendErrorIfExists(outErrors, kCTFontManagerErrorAlreadyRegistered);
@@ -749,7 +749,7 @@ public:
 
         CFIndex count = CFArrayGetCount(fontDatas);
         for (CFIndex i = 0; i < count; ++i) {
-            CFDataRef data = (CFDataRef)CFArrayGetValueAtIndex(fontDatas, i);
+            CFDataRef data = static_cast<CFDataRef>(CFArrayGetValueAtIndex(fontDatas, i));
             if (data) {
                 if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
                     CFSetRemoveValue(m_fontDatasSet.get(), data);

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -190,9 +190,8 @@ static __DWritePropertiesMap __CreatePropertiesMapForFontCollection(IDWriteFontC
 
 /**
  * Private static map, that maps display name and postscript name to a _DWriteFontProperties struct for the corresponding user defined font.
- * Kept separate from c_systemFontPropertiesMap because this needs to be edited whenever a font is (un)registered
  */
-static __DWritePropertiesMap _userFontPropertiesMap;
+static __DWritePropertiesMap s_userFontPropertiesMap;
 
 /**
  * Helper method to convert IDWriteLocalizedStrings object to CFString object.
@@ -335,8 +334,8 @@ std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFString
     if (info != systemFontPropertiesMap.end()) {
         return info->second;
     }
-    const auto& userFontInfo = _userFontPropertiesMap.find(upperFontName);
-    if (userFontInfo != _userFontPropertiesMap.end()) {
+    const auto& userFontInfo = s_userFontPropertiesMap.find(upperFontName);
+    if (userFontInfo != s_userFontPropertiesMap.end()) {
         return userFontInfo->second;
     }
 
@@ -839,8 +838,8 @@ static HRESULT __DWriteUpdateUserCreatedFontCollection(CFArrayRef datas, CFArray
     RETURN_IF_FAILED(
         dwriteFactory->CreateCustomFontCollection(loader.Get(), &(collectionKey), sizeof(collectionKey), &_userCreatedFontCollection));
 
-    // Update _userFontPropertiesMap with new values
-    _userFontPropertiesMap = __CreatePropertiesMapForFontCollection(_userCreatedFontCollection.Get());
+    // Update s_userFontPropertiesMap with new values
+    s_userFontPropertiesMap = __CreatePropertiesMapForFontCollection(_userCreatedFontCollection.Get());
 
     return S_OK;
 }

--- a/Frameworks/CoreText/CTFontManager.mm
+++ b/Frameworks/CoreText/CTFontManager.mm
@@ -52,7 +52,7 @@ static bool __CTFontManagerUpdateWithFont(CFURLRef fontURL, CTFontManagerScope s
 }
 
 // Converts CFURLs to CFDatas which are passed into DWriteWrapper methods
-// TLambda :: (CFArrayRef -> CFArrayRef*) -> bool
+// TLambda :: (CFArrayRef -> CFArrayRef*) -> HRESULT
 template <typename TLambda>
 static bool __CTFontManagerUpdateWithFonts(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors, TLambda&& func) {
     CFIndex count = CFArrayGetCount(fontURLs);
@@ -69,7 +69,7 @@ static bool __CTFontManagerUpdateWithFonts(CFArrayRef fontURLs, CTFontManagerSco
 
 // Gets CFData from CGFontRef if available, which are passed into DWriteWrapper methods
 // When graphics font was not created from data, return false with error containing error code
-// TLambda :: (CFArrayRef -> CFArrayRef*) -> bool
+// TLambda :: (CFArrayRef -> CFArrayRef*) -> HRESULT
 template <typename TLambda>
 static bool __CTFontManagerUpdateWithGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error, CFIndex errorCode, TLambda&& func) {
     CFDataRef data = _CGFontGetData(font);
@@ -131,12 +131,12 @@ bool CTFontManagerUnregisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope
  @Status Interoperable
  @Notes
 */
-bool CTFontManagerRegisterGraphicsFont(CGFontRef font, CFErrorRef* error) {
+bool CTFontManagerRegisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error) {
     return __CTFontManagerUpdateWithGraphicsFont(font, error, kCTFontManagerErrorAlreadyRegistered, &_DWriteRegisterFontsWithDatas);
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool CTFontManagerUnregisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error) {

--- a/Frameworks/CoreText/CTFontManager.mm
+++ b/Frameworks/CoreText/CTFontManager.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,8 +17,8 @@
 #import <CoreText/CTFontManager.h>
 #import <StubReturn.h>
 #import <Starboard.h>
-#import <UIFontInternal.h>
-#import <UIKit/UIFont.h>
+#import <CoreGraphics/DWriteWrapper.h>
+#import <CoreGraphics/CGFontInternal.h>
 
 const CFStringRef kCTFontManagerRegisteredFontsChangedNotification =
     static_cast<CFStringRef>(@"kCTFontManagerRegisteredFontsChangedNotification");
@@ -34,53 +34,103 @@ CFArrayRef CTFontManagerCreateFontDescriptorsFromURL(CFURLRef fileURL) {
     return StubReturn();
 }
 
+// Helper functions to reduce code duplication, as (un)registering fonts have almost identical path
+// (Un)Registers font by creating temporary CFArray and calling into function for multiple fonts
+template <typename TLambda>
+static bool __CTFontManagerUpdateWithFont(CFURLRef fontURL, CTFontManagerScope scope, CFErrorRef _Nullable* error, const TLambda&& func) {
+    woc::unique_cf<CFArrayRef> fontURLs{ CFArrayCreate(nullptr, (const void**)&fontURL, 1, &kCFTypeArrayCallBacks) };
+    if (error) {
+        CFArrayRef errors = nil;
+        bool ret = func(fontURLs.get(), scope, &errors);
+        if (errors != nil) {
+            *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
+        }
+
+        CFRelease(errors);
+        return ret;
+    }
+
+    return func(fontURLs.get(), scope, nullptr);
+}
+
+// Converts CFURLs to CFDatas which are passed into DWriteWrapper methods
+template <typename TLambda>
+static bool __CTFontManagerUpdateWithFonts(CFArrayRef fontURLs,
+                                           CTFontManagerScope scope,
+                                           CFArrayRef _Nullable* errors,
+                                           const TLambda&& func) {
+    CFIndex count = CFArrayGetCount(fontURLs);
+    woc::unique_cf<CFMutableArrayRef> fontDatas{ CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks) };
+    for (size_t i = 0; i < count; ++i) {
+        NSData* data = [NSData dataWithContentsOfURL:static_cast<NSURL*>(CFArrayGetValueAtIndex(fontURLs, i))];
+        if (data != nullptr) {
+            CFArrayAppendValue(fontDatas.get(), (CFDataRef)data);
+        }
+    }
+
+    return SUCCEEDED(func(fontDatas.get(), errors));
+}
+
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes scope unsupported
 */
 bool CTFontManagerRegisterFontsForURL(CFURLRef fontURL, CTFontManagerScope scope, CFErrorRef _Nullable* error) {
-    // TODO::
-    // Implement this method with DWrite #1022
-    UNIMPLEMENTED();
-    return StubReturn();
+    return __CTFontManagerUpdateWithFont(fontURL, scope, error, &CTFontManagerRegisterFontsForURLs);
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes scope unsupported
 */
 bool CTFontManagerUnregisterFontsForURL(CFURLRef fontURL, CTFontManagerScope scope, CFErrorRef _Nullable* error) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return __CTFontManagerUpdateWithFont(fontURL, scope, error, &CTFontManagerUnregisterFontsForURLs);
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes scope unsupported
 */
 bool CTFontManagerRegisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return __CTFontManagerUpdateWithFonts(fontURLs, scope, errors, &_DWriteRegisterFontsWithDatas);
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes scope unsupported
 */
 bool CTFontManagerUnregisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return __CTFontManagerUpdateWithFonts(fontURLs, scope, errors, &_DWriteUnregisterFontsWithDatas);
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
 bool CTFontManagerRegisterGraphicsFont(CGFontRef font, CFErrorRef* error) {
-    // TODO::
-    // Implement this method with DWrite #1022
-    UNIMPLEMENTED();
-    return StubReturn();
+    CFDataRef data = _CGFontGetData(font);
+    if (data == nullptr) {
+        // Font was created from registered font, so it must already be registered
+        if (error) {
+            *error = CFErrorCreate(nullptr, kCFErrorDomainCocoa, kCTFontManagerErrorAlreadyRegistered, nullptr);
+        }
+
+        return false;
+    }
+
+    woc::unique_cf<CFArrayRef> fontDatas{ CFArrayCreate(nullptr, (const void**)&data, 1, &kCFTypeArrayCallBacks) };
+    if (error) {
+        CFArrayRef errors = nil;
+        bool ret = SUCCEEDED(_DWriteRegisterFontsWithDatas(fontDatas.get(), &errors));
+        if (errors != nil) {
+            *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
+        }
+
+        CFRelease(errors);
+        return ret;
+    }
+
+    return SUCCEEDED(_DWriteRegisterFontsWithDatas(fontDatas.get(), nullptr));
 }
 
 /**

--- a/Frameworks/CoreText/CTFontManager.mm
+++ b/Frameworks/CoreText/CTFontManager.mm
@@ -40,18 +40,14 @@ CFArrayRef CTFontManagerCreateFontDescriptorsFromURL(CFURLRef fileURL) {
 template <typename TLambda>
 static bool __CTFontManagerUpdateWithFont(CFURLRef fontURL, CTFontManagerScope scope, CFErrorRef _Nullable* error, TLambda&& func) {
     woc::unique_cf<CFArrayRef> fontURLs{ CFArrayCreate(nullptr, (const void**)&fontURL, 1, &kCFTypeArrayCallBacks) };
-    if (error) {
-        CFArrayRef errors = nil;
-        bool ret = func(fontURLs.get(), scope, &errors);
-        if (errors != nil) {
-            *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
-        }
-
-        CFRelease(errors);
-        return ret;
+    CFArrayRef errors = nil;
+    bool ret = func(fontURLs.get(), scope, &errors);
+    if (error != nil && errors != nil && CFArrayGetCount(errors) > 0L) {
+        *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
     }
 
-    return func(fontURLs.get(), scope, nullptr);
+    CFRelease(errors);
+    return ret;
 }
 
 // Converts CFURLs to CFDatas which are passed into DWriteWrapper methods
@@ -118,18 +114,14 @@ bool CTFontManagerRegisterGraphicsFont(CGFontRef font, CFErrorRef* error) {
     }
 
     woc::unique_cf<CFArrayRef> fontDatas{ CFArrayCreate(nullptr, (const void**)&data, 1, &kCFTypeArrayCallBacks) };
-    if (error) {
-        CFArrayRef errors = nil;
-        bool ret = SUCCEEDED(_DWriteRegisterFontsWithDatas(fontDatas.get(), &errors));
-        if (errors != nil) {
-            *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
-        }
-
-        CFRelease(errors);
-        return ret;
+    CFArrayRef errors = nil;
+    bool ret = SUCCEEDED(_DWriteRegisterFontsWithDatas(fontDatas.get(), &errors));
+    if (error != nil && errors != nil && CFArrayGetCount(errors) > 0L) {
+        *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
     }
 
-    return SUCCEEDED(_DWriteRegisterFontsWithDatas(fontDatas.get(), nullptr));
+    CFRelease(errors);
+    return ret;
 }
 
 /**

--- a/Frameworks/UIKit/UIApplicationMain.mm
+++ b/Frameworks/UIKit/UIApplicationMain.mm
@@ -168,6 +168,7 @@ int UIApplicationMainInit(NSString* principalClassName,
         if (fonts != nil) {
             NSMutableArray* fontURLs = [NSMutableArray array];
             for (NSString* curFontName in fonts) {
+                // curFontName contains extension, so pass in nil
                 NSURL* url = [[NSBundle mainBundle] URLForResource:curFontName withExtension:nil];
                 if (url != nil) {
                     [fontURLs addObject:url];

--- a/Frameworks/UIKit/UIApplicationMain.mm
+++ b/Frameworks/UIKit/UIApplicationMain.mm
@@ -166,18 +166,15 @@ int UIApplicationMainInit(NSString* principalClassName,
     if (infoDict != nil) {
         NSArray* fonts = [infoDict objectForKey:@"UIAppFonts"];
         if (fonts != nil) {
+            NSMutableArray* fontURLs = [NSMutableArray array];
             for (NSString* curFontName in fonts) {
-                NSString* path = [[NSBundle mainBundle] pathForResource:curFontName ofType:nil];
-                if (path != nil) {
-                    NSData* data = [NSData dataWithContentsOfFile:path];
-                    if (data != nil) {
-                        UIFont* font = [UIFont fontWithData:data];
-                        if (font != nil) {
-                            CTFontManagerRegisterGraphicsFont((CGFontRef)font, NULL);
-                        }
-                    }
+                NSURL* url = [[NSBundle mainBundle] URLForResource:curFontName withExtension:nil];
+                if (url != nil) {
+                    [fontURLs addObject:url];
                 }
             }
+
+            CTFontManagerRegisterFontsForURLs((CFArrayRef)fontURLs, kCTFontManagerScopeNone, nil);
         }
 
         if (defaultOrientation != UIInterfaceOrientationUnknown) {

--- a/Frameworks/include/CoreGraphics/CGFontInternal.h
+++ b/Frameworks/include/CoreGraphics/CGFontInternal.h
@@ -1,0 +1,18 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#pragma once
+
+COREGRAPHICS_EXPORT CFDataRef _CGFontGetData(CGFontRef font);

--- a/Frameworks/include/CoreGraphics/CGFontInternal.h
+++ b/Frameworks/include/CoreGraphics/CGFontInternal.h
@@ -15,4 +15,6 @@
 //******************************************************************************
 #pragma once
 
+#include <CoreGraphics/CGFont.h>
+
 COREGRAPHICS_EXPORT CFDataRef _CGFontGetData(CGFontRef font);

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -59,7 +59,9 @@ COREGRAPHICS_EXPORT HRESULT _DWriteCreateTextFormat(const wchar_t* fontFamilyNam
                                                     IDWriteTextFormat** outTextFormat);
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily);
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace);
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithDataProvider(CGDataProviderRef dataProvider, IDWriteFontFace** outFontFace);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, IDWriteFontFace** outFontFace);
+COREGRAPHICS_EXPORT HRESULT _DWriteRegisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
+COREGRAPHICS_EXPORT HRESULT _DWriteUnregisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
 
 // DWriteFont getters that convert to a CF/CG object or struct
 COREGRAPHICS_EXPORT CFStringRef _DWriteFontCopyInformationalString(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace,

--- a/Frameworks/include/CppUtils.h
+++ b/Frameworks/include/CppUtils.h
@@ -20,28 +20,28 @@
 #ifdef __cplusplus
 
 #pragma region CFRange
-bool operator==(const CFRange& lhs, const CFRange& rhs) {
+inline bool operator==(const CFRange& lhs, const CFRange& rhs) {
     return lhs.location == rhs.location && lhs.length == rhs.length;
 }
 
 #pragma endregion
 
 #pragma region CGPoint
-bool operator==(const CGPoint& lhs, const CGPoint& rhs) {
+inline bool operator==(const CGPoint& lhs, const CGPoint& rhs) {
     return lhs.x == rhs.x && lhs.y == rhs.y;
 }
 
 #pragma endregion
 
 #pragma region CGSize
-bool operator==(const CGSize& lhs, const CGSize& rhs) {
+inline bool operator==(const CGSize& lhs, const CGSize& rhs) {
     return lhs.width == rhs.width && lhs.height == rhs.height;
 }
 
 #pragma endregion
 
 #pragma region CGRect
-bool operator==(const CGRect& lhs, const CGRect& rhs) {
+inline bool operator==(const CGRect& lhs, const CGRect& rhs) {
     return lhs.origin == rhs.origin && lhs.size == rhs.size;
 }
 

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -45,12 +45,14 @@ LIBRARY CoreGraphics
         _DWriteCreateTextFormat
         _DWriteCreateFontFamilyWithName
         _DWriteCreateFontFaceWithName
-        _DWriteCreateFontFaceWithDataProvider
+        _DWriteCreateFontFaceWithData
         _DWriteFontCopyInformationalString
         _DWriteFontCopyTable
         _DWriteFontGetSlantDegrees
         _DWriteFontGetBoundingBox
         _DWriteFontGetBoundingBoxesForGlyphs
+        _DWriteRegisterFontsWithDatas
+        _DWriteUnregisterFontsWithDatas
 
         ; CGColor.mm
         CGColorRelease
@@ -291,6 +293,7 @@ LIBRARY CoreGraphics
         CGFontGetNumberOfGlyphs
         CGFontGetGlyphAdvances
         CGFontGetUnitsPerEm
+        _CGFontGetData
 
         ; CGFunction.mm
         CGFunctionCreate

--- a/build/CoreGraphics/lib/CoreGraphicsLib.vcxproj
+++ b/build/CoreGraphics/lib/CoreGraphicsLib.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">

--- a/build/Headers/Headers.Shared/Internal.Shared.vcxitems
+++ b/build/Headers/Headers.Shared/Internal.Shared.vcxitems
@@ -11,9 +11,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <Text Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\**\*.h" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
 </Project>

--- a/build/Headers/Headers.Shared/Internal.Shared.vcxitems
+++ b/build/Headers/Headers.Shared/Internal.Shared.vcxitems
@@ -11,6 +11,9 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <Text Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\**\*.h" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectCapability Include="SourceItemsFromImports" />
   </ItemGroup>
 </Project>

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -80,6 +80,7 @@
     </SBResourceCopy>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CppUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\MockClass.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\unittests\Tests.Shared\ByteUtils.h" />
   </ItemGroup>

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -80,7 +80,6 @@
     </SBResourceCopy>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CppUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\MockClass.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\unittests\Tests.Shared\ByteUtils.h" />
   </ItemGroup>

--- a/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
@@ -242,7 +242,14 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreText\CTRunTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreText\CTTypesetterTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreText\CTFramesetterTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreText\CTFontManagerTests.mm" />
   </ItemGroup>
+  <Target Name="CopyTestResourcesToOutput" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <TestResourceFile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics\data\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(TestResourceFile)" DestinationFolder="$(OutDir)\data" SkipUnchangedFiles="True" />
+  </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(StarboardBasePath)\msvc\starboard-cmdline.targets" />

--- a/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreText/CoreText.UnitTests.vcxproj
@@ -246,7 +246,7 @@
   </ItemGroup>
   <Target Name="CopyTestResourcesToOutput" AfterTargets="AfterBuild">
     <ItemGroup>
-      <TestResourceFile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics\data\*" />
+      <TestResourceFile Include="$(StarboardBasePath)\tests\unittests\CoreText\data\*" />
     </ItemGroup>
     <Copy SourceFiles="@(TestResourceFile)" DestinationFolder="$(OutDir)\data" SkipUnchangedFiles="True" />
   </Target>

--- a/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
@@ -272,6 +272,12 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSParagraphStyleTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSString+UIKitAdditionsTests.mm" />
   </ItemGroup>
+  <Target Name="CopyTestResourcesToOutput" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <TestResourceFile Include="$(StarboardBasePath)\tests\unittests\UIKit\data\*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(TestResourceFile)" DestinationFolder="$(OutDir)\data" SkipUnchangedFiles="True" />
+  </Target>
   <ItemGroup>
     <ClInclude Include="$(StarboardBasePath)\tests\unittests\UIKit\NullCompositor.h" />
   </ItemGroup>

--- a/include/CoreText/CTFontManager.h
+++ b/include/CoreText/CTFontManager.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -57,15 +57,9 @@ CORETEXT_EXPORT const CFStringRef kCTFontManagerErrorFontURLsKey;
 
 CORETEXT_EXPORT CFArrayRef CTFontManagerCreateFontDescriptorsFromURL(CFURLRef fileURL) STUB_METHOD;
 CORETEXT_EXPORT bool CTFontManagerRegisterFontsForURL(CFURLRef fontURL, CTFontManagerScope scope, CFErrorRef _Nullable* error);
-CORETEXT_EXPORT bool CTFontManagerUnregisterFontsForURL(CFURLRef fontURL,
-                                                        CTFontManagerScope scope,
-                                                        CFErrorRef _Nullable* error) STUB_METHOD;
-CORETEXT_EXPORT bool CTFontManagerRegisterFontsForURLs(CFArrayRef fontURLs,
-                                                       CTFontManagerScope scope,
-                                                       CFArrayRef _Nullable* errors) STUB_METHOD;
-CORETEXT_EXPORT bool CTFontManagerUnregisterFontsForURLs(CFArrayRef fontURLs,
-                                                         CTFontManagerScope scope,
-                                                         CFArrayRef _Nullable* errors) STUB_METHOD;
+CORETEXT_EXPORT bool CTFontManagerUnregisterFontsForURL(CFURLRef fontURL, CTFontManagerScope scope, CFErrorRef _Nullable* error);
+CORETEXT_EXPORT bool CTFontManagerRegisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors);
+CORETEXT_EXPORT bool CTFontManagerUnregisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors);
 CORETEXT_EXPORT bool CTFontManagerRegisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error);
 CORETEXT_EXPORT bool CTFontManagerUnregisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error) STUB_METHOD;
 CORETEXT_EXPORT bool CTFontManagerIsSupportedFont(CFURLRef fontURL) STUB_METHOD;

--- a/include/CoreText/CTFontManager.h
+++ b/include/CoreText/CTFontManager.h
@@ -61,5 +61,5 @@ CORETEXT_EXPORT bool CTFontManagerUnregisterFontsForURL(CFURLRef fontURL, CTFont
 CORETEXT_EXPORT bool CTFontManagerRegisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors);
 CORETEXT_EXPORT bool CTFontManagerUnregisterFontsForURLs(CFArrayRef fontURLs, CTFontManagerScope scope, CFArrayRef _Nullable* errors);
 CORETEXT_EXPORT bool CTFontManagerRegisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error);
-CORETEXT_EXPORT bool CTFontManagerUnregisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error) STUB_METHOD;
+CORETEXT_EXPORT bool CTFontManagerUnregisterGraphicsFont(CGFontRef font, CFErrorRef _Nullable* error);
 CORETEXT_EXPORT bool CTFontManagerIsSupportedFont(CFURLRef fontURL) STUB_METHOD;

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj
@@ -233,7 +233,11 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC-Bold.ttf" />
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC-Italic.ttf" />
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC.ttf" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(WINOBJC_SDK_ROOT)\msvc\starboard.targets" />

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj.filters
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj.filters
@@ -117,4 +117,9 @@
       <Filter>CTCatalog\Test</Filter>
     </ClangCompile>
   </ItemGroup>
+  <ItemGroup>
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC.ttf" />
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC-Bold.ttf" />
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC-Italic.ttf" />
+  </ItemGroup>
 </Project>

--- a/tests/testapps/CTCatalog/CTCatalog/Fonts/WinObjC-Bold.ttf
+++ b/tests/testapps/CTCatalog/CTCatalog/Fonts/WinObjC-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166411edb4e0334fcf288cb45302d0e25f90e649d4f9f387f815c603f53f224a
+size 1452

--- a/tests/testapps/CTCatalog/CTCatalog/Fonts/WinObjC-Italic.ttf
+++ b/tests/testapps/CTCatalog/CTCatalog/Fonts/WinObjC-Italic.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11df5ebba52a883ca67085ad8559bf9a430934091209b85ae2ff91bb0fe63106
+size 1476

--- a/tests/testapps/CTCatalog/CTCatalog/Fonts/WinObjC.ttf
+++ b/tests/testapps/CTCatalog/CTCatalog/Fonts/WinObjC.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02f3175200cdb9fa79594fe7c5a560a8c6744e716877617189b5f4ccd0d8a86
+size 1452

--- a/tests/testapps/CTCatalog/CTCatalog/Info.plist
+++ b/tests/testapps/CTCatalog/CTCatalog/Info.plist
@@ -30,6 +30,12 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>WinObjC.ttf</string>
+		<string>WinObjC-Bold.ttf</string>
+		<string>WinObjC-Italic.ttf</string>
+	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/tests/unittests/CoreGraphics/CGFontTests.mm
+++ b/tests/unittests/CoreGraphics/CGFontTests.mm
@@ -18,6 +18,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/DWriteWrapper.h>
 
 // CTFont functionality is generally a superset of CGFont functionality, and hits the same code path
 // Thus, CTFont unit tests can also be thought of as CGFont test coverage
@@ -111,8 +112,8 @@ TEST(CGFont, GetDescent) {
 TEST(CGFont, CreateWithDataProvider) {
     char fullPath[_MAX_PATH];
     GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
-    NSURL* testFileURL = [NSURL
-        fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC-Regular.ttf"]];
+    NSURL* testFileURL =
+        [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC.ttf"]];
 
     CGDataProviderRef dataProvider = CGDataProviderCreateWithURL((__bridge CFURLRef)testFileURL);
     CFAutorelease(dataProvider);
@@ -121,12 +122,12 @@ TEST(CGFont, CreateWithDataProvider) {
     CFAutorelease(font);
 
     // Check some very basic properties to make sure that the right font was loaded
-    EXPECT_OBJCEQ((id)CFSTR("The Windows Bridge for iOS"), (id)CFAutorelease(CGFontCopyFullName(font)));
+    EXPECT_OBJCEQ((id)CFSTR("WinObjC"), (id)CFAutorelease(CGFontCopyFullName(font)));
     EXPECT_EQ(1638, CGFontGetAscent(font));
     EXPECT_EQ(-410, CGFontGetDescent(font));
 
     // Validate that creating a second time will still work (IDWriteFactory has some finnickiness regarding this)
     CGFontRef font2 = CGFontCreateWithDataProvider(dataProvider);
     CFAutorelease(font2);
-    EXPECT_OBJCEQ((id)CFSTR("The Windows Bridge for iOS"), (id)CFAutorelease(CGFontCopyFullName(font2)));
+    EXPECT_OBJCEQ((id)CFSTR("WinObjC"), (id)CFAutorelease(CGFontCopyFullName(font2)));
 }

--- a/tests/unittests/CoreGraphics/CGFontTests.mm
+++ b/tests/unittests/CoreGraphics/CGFontTests.mm
@@ -18,7 +18,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <Foundation/Foundation.h>
-#import <CoreGraphics/DWriteWrapper.h>
 
 // CTFont functionality is generally a superset of CGFont functionality, and hits the same code path
 // Thus, CTFont unit tests can also be thought of as CGFont test coverage

--- a/tests/unittests/CoreGraphics/data/WinObjC-Bold.ttf
+++ b/tests/unittests/CoreGraphics/data/WinObjC-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166411edb4e0334fcf288cb45302d0e25f90e649d4f9f387f815c603f53f224a
+size 1452

--- a/tests/unittests/CoreGraphics/data/WinObjC-Italic.ttf
+++ b/tests/unittests/CoreGraphics/data/WinObjC-Italic.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11df5ebba52a883ca67085ad8559bf9a430934091209b85ae2ff91bb0fe63106
+size 1476

--- a/tests/unittests/CoreGraphics/data/WinObjC-Regular.ttf
+++ b/tests/unittests/CoreGraphics/data/WinObjC-Regular.ttf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1946e85eb807d0b96d14c8af96f96ed155cc0e61a628523bbedc3d5635d90c1e
-size 1724

--- a/tests/unittests/CoreGraphics/data/WinObjC.ttf
+++ b/tests/unittests/CoreGraphics/data/WinObjC.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02f3175200cdb9fa79594fe7c5a560a8c6744e716877617189b5f4ccd0d8a86
+size 1452

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -20,7 +20,7 @@
 #import <CoreText/CoreText.h>
 #import <Starboard/SmartTypes.h>
 
-static NSURL* __GetURLFromPathRelativeToCurrentDirectory(NSString* relativePath) {
+static NSURL* __GetURLFromPathRelativeToModuleDirectory(NSString* relativePath) {
     static char fullPath[_MAX_PATH];
     static int unused = [](char* path) { return GetModuleFileNameA(NULL, path, _MAX_PATH); }(fullPath);
     return [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:relativePath]];
@@ -28,7 +28,7 @@ static NSURL* __GetURLFromPathRelativeToCurrentDirectory(NSString* relativePath)
 
 TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
     woc::unique_cf<CFStringRef> fontName{ CFSTR("WinObjC") };
-    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_EQ(nullptr, error);
@@ -54,7 +54,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
 
 TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
     woc::unique_cf<CFStringRef> fontName{ CFSTR("WinObjC-Italic") };
-    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC-Italic.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC-Italic.ttf");
     woc::unique_cf<CGDataProviderRef> dataProvider{ CGDataProviderCreateWithURL((__bridge CFURLRef)testFileURL) };
     woc::unique_cf<CGFontRef> graphicsFont{ CGFontCreateWithDataProvider(dataProvider.get()) };
     EXPECT_NE(nullptr, graphicsFont);
@@ -83,7 +83,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
 }
 
 TEST(CTFontManager, ShouldFailToUnregisterNonregisteredFonts) {
-    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_NE(nullptr, error);

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -20,7 +20,7 @@
 #import <CoreText/CoreText.h>
 #import <Starboard/SmartTypes.h>
 
-NSURL* __GetRelativeURL(NSString* relativePath) {
+static NSURL* __GetRelativeURL(NSString* relativePath) {
     static char fullPath[_MAX_PATH];
     static int unused = [](char* path) { return GetModuleFileNameA(NULL, path, _MAX_PATH); }(fullPath);
     return [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:relativePath]];

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -14,20 +14,20 @@
 //
 //******************************************************************************
 
-#include <TestFramework.h>
+#import <TestFramework.h>
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <CoreText/CoreText.h>
 #import <Starboard/SmartTypes.h>
 
-static NSURL* __GetRelativeURL(NSString* relativePath) {
+static NSURL* __GetURLFromPathRelativeToCurrentDirectory(NSString* relativePath) {
     static char fullPath[_MAX_PATH];
     static int unused = [](char* path) { return GetModuleFileNameA(NULL, path, _MAX_PATH); }(fullPath);
     return [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:relativePath]];
 }
 
 TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
-    NSURL* testFileURL = __GetRelativeURL(@"/data/WinObjC.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_EQ(nullptr, error);
@@ -48,7 +48,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
 }
 
 TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
-    NSURL* testFileURL = __GetRelativeURL(@"/data/WinObjC-Italic.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC-Italic.ttf");
     woc::unique_cf<CGDataProviderRef> dataProvider{ CGDataProviderCreateWithURL((__bridge CFURLRef)testFileURL) };
     woc::unique_cf<CGFontRef> graphicsFont{ CGFontCreateWithDataProvider(dataProvider.get()) };
     EXPECT_NE(nullptr, graphicsFont);
@@ -74,7 +74,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
 }
 
 TEST(CTFontManager, ShouldFailToUnregisterNonregisteredFonts) {
-    NSURL* testFileURL = __GetRelativeURL(@"/data/WinObjC.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_NE(nullptr, error);

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -1,0 +1,85 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <TestFramework.h>
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
+#import <Starboard/SmartTypes.h>
+
+TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
+    char fullPath[_MAX_PATH];
+    GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
+    NSURL* testFileURL =
+        [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC.ttf"]];
+    CFErrorRef error = nullptr;
+    EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
+    woc::unique_cf<CTFontRef> font{ CTFontCreateWithName(CFSTR("WinObjC"), 20, nullptr) };
+    EXPECT_NE(nullptr, font);
+
+    StrongId<NSString> familyName = (NSString*)CTFontCopyFamilyName(font.get());
+    EXPECT_OBJCEQ(@"WinObjC", familyName);
+
+    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
+
+    woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(CFSTR("WinObjC"), 20, nullptr) };
+    EXPECT_NE(nullptr, failedFont);
+
+    familyName = (NSString*)CTFontCopyFullName(failedFont.get());
+    EXPECT_OBJCEQ(@"Segoe UI", familyName);
+}
+
+TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
+    char fullPath[_MAX_PATH];
+    GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
+    NSURL* testFileURL = [NSURL
+        fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC-Italic.ttf"]];
+    woc::unique_cf<CGDataProviderRef> dataProvider{ CGDataProviderCreateWithURL((__bridge CFURLRef)testFileURL) };
+    woc::unique_cf<CGFontRef> graphicsFont{ CGFontCreateWithDataProvider(dataProvider.get()) };
+    EXPECT_NE(nullptr, graphicsFont);
+
+    CFErrorRef error = nullptr;
+    EXPECT_TRUE(CTFontManagerRegisterGraphicsFont(graphicsFont.get(), &error));
+    EXPECT_EQ(nullptr, error);
+
+    woc::unique_cf<CTFontRef> font{ CTFontCreateWithName(CFSTR("WinObjC-Italic"), 20, nullptr) };
+    EXPECT_NE(nullptr, font);
+
+    StrongId<NSString> familyName = (NSString*)CTFontCopyFullName(font.get());
+    EXPECT_OBJCEQ(@"WinObjC Italic", familyName);
+
+    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
+
+    woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(CFSTR("WinObjC-Italic"), 20, nullptr) };
+    EXPECT_NE(nullptr, failedFont);
+
+    StrongId<NSString> failedFamilyName = (NSString*)CTFontCopyFullName(failedFont.get());
+    EXPECT_OBJCEQ(@"Segoe UI", failedFamilyName);
+}
+
+TEST(CTFontManager, ShouldFailToUnregisterNonregisteredFonts) {
+    char fullPath[_MAX_PATH];
+    GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
+    NSURL* testFileURL =
+        [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC.ttf"]];
+    CFErrorRef error = nullptr;
+    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_NE(nullptr, error);
+    EXPECT_EQ(kCTFontManagerErrorNotRegistered, CFErrorGetCode(error));
+}

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -89,22 +89,3 @@ TEST(CTFontManager, ShouldFailToUnregisterNonregisteredFonts) {
     EXPECT_NE(nullptr, error);
     EXPECT_EQ(kCTFontManagerErrorNotRegistered, CFErrorGetCode(error));
 }
-
-TEST(CTFontManager, UIFontFamilyNamesShouldContainRegisteredFonts) {
-    NSArray* familyNames = [UIFont familyNames];
-    EXPECT_FALSE([familyNames containsObject:@"WinObjC"]);
-
-    woc::unique_cf<CFStringRef> fontName{ CFSTR("WinObjC") };
-    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC.ttf");
-    CFErrorRef error = nullptr;
-    EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
-
-    familyNames = [UIFont familyNames];
-    EXPECT_TRUE([familyNames containsObject:@"WinObjC"]);
-
-    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
-    EXPECT_EQ(nullptr, error);
-
-    familyNames = [UIFont familyNames];
-    EXPECT_FALSE([familyNames containsObject:@"WinObjC"]);
-}

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -20,11 +20,14 @@
 #import <CoreText/CoreText.h>
 #import <Starboard/SmartTypes.h>
 
+NSURL* __GetRelativeURL(NSString* relativePath) {
+    static char fullPath[_MAX_PATH];
+    static int unused = [](char* path) { return GetModuleFileNameA(NULL, path, _MAX_PATH); }(fullPath);
+    return [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:relativePath]];
+}
+
 TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
-    char fullPath[_MAX_PATH];
-    GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
-    NSURL* testFileURL =
-        [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC.ttf"]];
+    NSURL* testFileURL = __GetRelativeURL(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_EQ(nullptr, error);
@@ -45,10 +48,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
 }
 
 TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
-    char fullPath[_MAX_PATH];
-    GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
-    NSURL* testFileURL = [NSURL
-        fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC-Italic.ttf"]];
+    NSURL* testFileURL = __GetRelativeURL(@"/data/WinObjC-Italic.ttf");
     woc::unique_cf<CGDataProviderRef> dataProvider{ CGDataProviderCreateWithURL((__bridge CFURLRef)testFileURL) };
     woc::unique_cf<CGFontRef> graphicsFont{ CGFontCreateWithDataProvider(dataProvider.get()) };
     EXPECT_NE(nullptr, graphicsFont);
@@ -74,10 +74,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
 }
 
 TEST(CTFontManager, ShouldFailToUnregisterNonregisteredFonts) {
-    char fullPath[_MAX_PATH];
-    GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
-    NSURL* testFileURL =
-        [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"/data/WinObjC.ttf"]];
+    NSURL* testFileURL = __GetRelativeURL(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_NE(nullptr, error);

--- a/tests/unittests/CoreText/data/WinObjC-Bold.ttf
+++ b/tests/unittests/CoreText/data/WinObjC-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166411edb4e0334fcf288cb45302d0e25f90e649d4f9f387f815c603f53f224a
+size 1452

--- a/tests/unittests/CoreText/data/WinObjC-Italic.ttf
+++ b/tests/unittests/CoreText/data/WinObjC-Italic.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11df5ebba52a883ca67085ad8559bf9a430934091209b85ae2ff91bb0fe63106
+size 1476

--- a/tests/unittests/CoreText/data/WinObjC.ttf
+++ b/tests/unittests/CoreText/data/WinObjC.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02f3175200cdb9fa79594fe7c5a560a8c6744e716877617189b5f4ccd0d8a86
+size 1452

--- a/tests/unittests/UIKit/UIFontTests.mm
+++ b/tests/unittests/UIKit/UIFontTests.mm
@@ -19,7 +19,7 @@
 #import <CoreText/CoreText.h>
 #import <Starboard/SmartTypes.h>
 
-static NSURL* __GetURLFromPathRelativeToCurrentDirectory(NSString* relativePath) {
+static NSURL* __GetURLFromPathRelativeToModuleDirectory(NSString* relativePath) {
     static char fullPath[_MAX_PATH];
     static int unused = [](char* path) { return GetModuleFileNameA(NULL, path, _MAX_PATH); }(fullPath);
     return [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:relativePath]];
@@ -148,7 +148,7 @@ TEST(CTFontManager, UIFontFamilyNamesShouldContainRegisteredFonts) {
     EXPECT_FALSE([familyNames containsObject:@"WinObjC"]);
 
     woc::unique_cf<CFStringRef> fontName{ CFSTR("WinObjC") };
-    NSURL* testFileURL = __GetURLFromPathRelativeToCurrentDirectory(@"/data/WinObjC.ttf");
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
     EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
 

--- a/tests/unittests/UIKit/data/WinObjC-Bold.ttf
+++ b/tests/unittests/UIKit/data/WinObjC-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166411edb4e0334fcf288cb45302d0e25f90e649d4f9f387f815c603f53f224a
+size 1452

--- a/tests/unittests/UIKit/data/WinObjC-Italic.ttf
+++ b/tests/unittests/UIKit/data/WinObjC-Italic.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11df5ebba52a883ca67085ad8559bf9a430934091209b85ae2ff91bb0fe63106
+size 1476

--- a/tests/unittests/UIKit/data/WinObjC.ttf
+++ b/tests/unittests/UIKit/data/WinObjC.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02f3175200cdb9fa79594fe7c5a560a8c6744e716877617189b5f4ccd0d8a86
+size 1452


### PR DESCRIPTION
Adds support to register and unregister fonts in CTFontManager.  This allows apps to use custom fonts by either registering them programmatically or by including them in the app's info.plist

Fixes #1022
Fixes #1250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1454)
<!-- Reviewable:end -->
