### PR TITLE
remove export of internal function  _CGImageGetWICImageSource

### DIFF
--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -117,7 +117,7 @@ COREGRAPHICS_EXPORT NSData* _CGImageRepresentation(CGImageRef image, REFGUID gui
 
 COREGRAPHICS_EXPORT CGImageRef _CGImageCreateWithWICBitmap(IWICBitmap* bitmap);
 
-COREGRAPHICS_EXPORT HRESULT _CGImageGetWICImageSource(CGImageRef image, IWICBitmap** source);
+HRESULT _CGImageGetWICImageSource(CGImageRef image, IWICBitmap** source);
 
 // Obtain a direct pointer to the data.
 COREGRAPHICS_EXPORT void* _CGImageGetRawBytes(CGImageRef image);

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -362,7 +362,6 @@ LIBRARY CoreGraphics
         _CGImageCreateCopyWithPixelFormat
         _CGImageGetRawBytes
         _CGImageGetDisplayTexture
-        _CGImageGetWICImageSource
 
         ; private exports below
         CGImageAddDestructionListener


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1458)
<!-- Reviewable:end -->
