### PR TITLE
Fix leak of some associated properties in AutoLayout.mm

### DIFF
--- a/Frameworks/AutoLayout/AutoLayout.mm
+++ b/Frameworks/AutoLayout/AutoLayout.mm
@@ -141,7 +141,9 @@ public:
 }
 
 - (void)autoLayoutAlloc {
-    objc_setAssociatedObject(self, @selector(_constraintStorage), [_NSLayoutConstraintStorage new], OBJC_ASSOCIATION_RETAIN);
+    _NSLayoutConstraintStorage* storage = [_NSLayoutConstraintStorage new];
+    objc_setAssociatedObject(self, @selector(_constraintStorage), storage, OBJC_ASSOCIATION_RETAIN);
+    [storage release];
 }
 
 - (void)autoLayoutConstraintAddedToView:(UIView*)view {
@@ -312,7 +314,9 @@ public:
 @implementation UILayoutGuide (AutoLayout)
 
 - (void)autoLayoutAlloc {
-    objc_setAssociatedObject(self, @selector(_autoLayoutProperties), [_AutoLayoutStorage new], OBJC_ASSOCIATION_RETAIN);
+    _AutoLayoutStorage* storage = [_AutoLayoutStorage new];
+    objc_setAssociatedObject(self, @selector(_autoLayoutProperties), storage, OBJC_ASSOCIATION_RETAIN);
+    [storage release];
 }
 
 - (CGRect)autoLayoutGetRect {
@@ -355,7 +359,9 @@ public:
 }
 
 - (void)autoLayoutAlloc {
-    objc_setAssociatedObject(self, @selector(_autoLayoutProperties), [_AutoLayoutStorage new], OBJC_ASSOCIATION_RETAIN);
+    _AutoLayoutStorage* storage = [_AutoLayoutStorage new];
+    objc_setAssociatedObject(self, @selector(_autoLayoutProperties), storage, OBJC_ASSOCIATION_RETAIN);
+    [storage release];
 }
 
 - (void)autoLayoutSetFrameToView:(UIView*)toView fromView:(UIView*)fromView {


### PR DESCRIPTION
Missing some releases.

Note: original pull also included calls to explicitly break the associations (by calling  objc_setAssociatedObject with nil on autoLayoutDealloc), citing this page 
https://web.archive.org/web/20120818164935/http://developer.apple.com/library/ios/#/web/20120820002100/http://developer.apple.com/library/ios/documentation/cocoa/conceptual/objectivec/Chapters/ocAssociativeReferences.html

However, as verified here https://github.com/Microsoft/WinObjC/blob/812d6636036a8d2eaeaaf7b92aa0c7b76252e190/tests/unittests/Starboard/objcrt_assoc.mm#L146 (and by manual testing) it's not necessary to manually nil out the associated objects with an objc_setAssociatedObject call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1461)
<!-- Reviewable:end -->
