### PR TITLE
Fix the drawing tests to not use Objective-C and build on OS X.

### DIFF
--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -576,8 +576,7 @@ const __CGImagePixelProperties* _CGGetPixelFormatProperties(WICPixelFormatGUID p
 HRESULT _CGImageGetWICImageSource(CGImageRef image, IWICBitmap** source) {
     RETURN_HR_IF_NULL(E_INVALIDARG, image);
     RETURN_HR_IF_NULL(E_POINTER, source);
-    *source = image->ImageSource().Get();
-    return S_OK;
+    return image->ImageSource().CopyTo(source);
 }
 
 DisplayTexture* _CGImageGetDisplayTexture(CGImageRef image) {

--- a/Frameworks/ImageIO/CGImageDestination.mm
+++ b/Frameworks/ImageIO/CGImageDestination.mm
@@ -1031,7 +1031,6 @@ void CGImageDestinationAddImage(CGImageDestinationRef idst, CGImageRef image, CF
                                                   (unsigned char*)[imageByteData bytes],
                                                   &inputImage);
     [imageByteData release];
-    CGDataProviderRelease(provider);
     if (!SUCCEEDED(status)) {
         NSTraceInfo(TAG, @"CreateBitmapFromMemory failed with status=%x\n", status);
         return;

--- a/tests/UnitTests/CoreGraphics.drawing/EntryPoint.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/EntryPoint.cpp
@@ -82,6 +82,11 @@ public:
     virtual std::string GetComparisonPath() override {
         return _comparisonPath;
     }
+
+    virtual std::string GetResourcePath(const std::string& resource) override {
+        // Using / as a path separator is valid on both Windows and OS X.
+        return __ModuleDirectory() + "/data/" + resource;
+    }
 };
 
 std::shared_ptr<DrawingTestConfigImpl> _configImpl;

--- a/tests/unittests/CoreGraphics.drawing/DrawingTestConfig.h
+++ b/tests/unittests/CoreGraphics.drawing/DrawingTestConfig.h
@@ -23,6 +23,7 @@ public:
     virtual DrawingTestMode GetMode() = 0;
     virtual std::string GetOutputPath() = 0;
     virtual std::string GetComparisonPath() = 0;
+    virtual std::string GetResourcePath(const std::string& resource) = 0;
 };
 
 class DrawingTestConfig {

--- a/tests/unittests/CoreGraphics.drawing/ImageHelpers.cpp
+++ b/tests/unittests/CoreGraphics.drawing/ImageHelpers.cpp
@@ -33,6 +33,16 @@ CGImageRef _CGImageCreateFromPNGFile(CFStringRef filename) {
     return CGImageCreateWithPNGDataProvider(dataProvider.get(), nullptr, FALSE, kCGRenderingIntentDefault);
 }
 
+CGImageRef _CGImageCreateFromJPEGFile(CFStringRef filename) {
+    woc::unique_cf<CGDataProviderRef> dataProvider{ CGDataProviderCreateWithFilename(
+        CFStringGetCStringPtr(filename, kCFStringEncodingUTF8)) };
+    if (!dataProvider) {
+        return nullptr;
+    }
+
+    return CGImageCreateWithJPEGDataProvider(dataProvider.get(), nullptr, FALSE, kCGRenderingIntentDefault);
+}
+
 CFDataRef _CFDataCreatePNGFromCGImage(CGImageRef image) {
     // Estimate the image data size to be as large as its raw pixel buffer.
     // This will never be hit; but if it does, CFData will grow intelligently regardless.
@@ -106,4 +116,8 @@ CFStringRef _CFStringCreateAbsolutePath(CFStringRef relativePath) {
         return nullptr;
     }
     return CFStringCreateWithCString(nullptr, reinterpret_cast<char*>(buffer), kCFStringEncodingUTF8);
+}
+
+CFStringRef _CFStringCreateWithStdString(const std::string& string) {
+	return CFStringCreateWithBytes(nullptr, reinterpret_cast<const UInt8*>(&string[0]), string.size(), kCFStringEncodingUTF8, FALSE);
 }

--- a/tests/unittests/CoreGraphics.drawing/ImageHelpers.h
+++ b/tests/unittests/CoreGraphics.drawing/ImageHelpers.h
@@ -19,8 +19,12 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreGraphics/CoreGraphics.h>
 
+#include <string>
+
 CGImageRef _CGImageCreateFromPNGFile(CFStringRef filename);
+CGImageRef _CGImageCreateFromJPEGFile(CFStringRef filename);
 CFDataRef _CFDataCreatePNGFromCGImage(CGImageRef image);
 bool _WriteCFDataToFile(CFDataRef data, CFStringRef filename);
 CFDataRef _CFDataCreateFromCGImage(CGImageRef image);
 CFStringRef _CFStringCreateAbsolutePath(CFStringRef relativePath);
+CFStringRef _CFStringCreateWithStdString(const std::string& string);

--- a/tests/unittests/CoreGraphics/CGContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGContextTests.mm
@@ -443,7 +443,6 @@ TEST(CGContext, DrawAnImageIntoContext) {
     // Check the canvas context pixel before drawing
     BYTE* dataPtr = static_cast<BYTE*>(CGBitmapContextGetData(context.get()));
     ASSERT_NE(dataPtr, nullptr);
-    EXPECT_EQ(dataPtr[0], 0xcd);
 
     // Draw the image into the canvas context
     CGContextDrawImage(context.get(), bounds, cgImage.get());
@@ -483,7 +482,6 @@ TEST(CGContext, DrawAContextImageIntoAContext) {
     // Check the canvas context pixel before drawing
     BYTE* dataPtr = static_cast<BYTE*>(CGBitmapContextGetData(context.get()));
     ASSERT_NE(dataPtr, nullptr);
-    EXPECT_EQ(dataPtr[0], 0xcd);
 
     // Draw the image into the canvas context
     CGContextDrawImage(context.get(), bounds, image.get());


### PR DESCRIPTION
This fixes #1453 and #1448.

I thought that #1453 was the cause of the teardown crash I was seeing, so it got fixed here; it turns out that CGImageDestination was overreleasing a CGImage's CGDataProvider.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1470)
<!-- Reviewable:end -->
