### PR TITLE
Fix [GitHub Issue #1451] Canabalt [ARM-x86]: blocked at splash screen

### DIFF
--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -802,8 +802,6 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
         return;
     }
 
-    CALayer* oursuper = priv->superlayer;
-
     //  If our layer is visible, order all subviews out
     bool isVisible = false;
 
@@ -833,6 +831,8 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     [CATransaction _removeLayer:self];
 
     pSuper->priv->removeChild(self);
+
+    [pSuper setNeedsLayout];
     [self release];
 }
 

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -806,7 +806,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     bool isVisible = false;
 
     CALayer* curLayer = self;
-    CALayer* pSuper = (CALayer*)priv->superlayer;
+    CALayer* superLayer = (CALayer*)priv->superlayer;
     CALayer* nextSuper = curLayer->priv->superlayer;
     priv->superlayer = 0;
 
@@ -830,9 +830,9 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
 
     [CATransaction _removeLayer:self];
 
-    pSuper->priv->removeChild(self);
+    superLayer->priv->removeChild(self);
 
-    [pSuper setNeedsLayout];
+    [superLayer setNeedsLayout];
     [self release];
 }
 


### PR DESCRIPTION
The issue here is that when a sublayer is removed from super, we need call setNeedsLayout which will flush out corresponding transactions to update the view hierarchy.  

This is based on the observation from reference platform when removing layer. The following call sequence is happening. 

[subLayer removeFromSuper] triggers the following call sequence
[CALayer setNeedsLayout] -> [CALayer drawInContext] ->[UIView drawRect]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1471)
<!-- Reviewable:end -->
