### PR TITLE
Zero out memory for backing buffer of Context

### DIFF
--- a/Frameworks/include/CGIWICBitmap.h
+++ b/Frameworks/include/CGIWICBitmap.h
@@ -139,7 +139,7 @@ public:
         if (data) {
             m_dataBuffer = static_cast<BYTE*>(data);
         } else {
-            m_dataBuffer = new BYTE[m_height * m_bytesPerRow];
+            m_dataBuffer = new BYTE[m_height * m_bytesPerRow]();
             m_freeData = true;
         }
     }


### PR DESCRIPTION
#1472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1475)
<!-- Reviewable:end -->
