### PR TITLE
objc2winmd binary update: Added support for marshaling NSURL

### DIFF
--- a/bin/objc2winmd.exe
+++ b/bin/objc2winmd.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aeb8737aec32067b182dc779c5044dd4d95a6d6a1f034a154f04063b0db91f1
-size 548352
+oid sha256:32091d9de0af52237d8f2b5ec793165759d64b88d365a6d2e52890b20a4581ab
+size 553472


### PR DESCRIPTION
NSURL will now be marshalled as StorageFile or Uri or both depending on the type of annotations provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1480)
<!-- Reviewable:end -->
