### PR TITLE
Handle missing font files more gracefully

### DIFF
--- a/Frameworks/CoreGraphics/CGDataProvider.mm
+++ b/Frameworks/CoreGraphics/CGDataProvider.mm
@@ -66,7 +66,9 @@ static const wchar_t* TAG = L"CGDataProvider";
 CGDataProviderRef CGDataProviderCreateWithURL(CFURLRef url) {
     NSString* path = [static_cast<NSURL*>(url) path];
     CGDataProvider* ret = [[CGDataProvider alloc] initWithContentsOfFile:path];
-    ret->filename = path;
+    if (ret) {
+        ret->filename = path;
+    }
 
     return ret;
 }

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -408,6 +408,8 @@ HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFon
     // Eg: Bold, Condensed, Light, Italic
     std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(name);
 
+    // Need to be able to load fonts from the app's bundle
+    // For now return a default font to avoid crashes in case of missing fonts
     if (!properties->familyName.get()) {
         name = CFSTR("Segoe UI");
         properties = _DWriteGetFontPropertiesFromName(name);

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -408,9 +408,6 @@ HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFon
     // Eg: Bold, Condensed, Light, Italic
     std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(name);
 
-    // TODO: #1250: Need to be able to load fonts from the app's bundle
-    // For now return a default font to avoid crashes in case of missing fonts
-    // When #1250 is completed, remove this
     if (!properties->familyName.get()) {
         name = CFSTR("Segoe UI");
         properties = _DWriteGetFontPropertiesFromName(name);
@@ -667,7 +664,7 @@ public:
         RETURN_HR_IF(E_ILLEGAL_METHOD_CALL, m_location < 0 || m_location > CFArrayGetCount(m_fontDatas.get()));
 
         if (0 <= m_location && m_location < m_previouslyCreatedFiles->size()) {
-            *fontFile = m_previouslyCreatedFiles->at(m_location).Get();
+            m_previouslyCreatedFiles->at(m_location).CopyTo(fontFile);
         } else {
             ComPtr<IDWriteFactory> dwriteFactory;
             RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -716,8 +716,9 @@ public:
         return S_OK;
     }
 
-    void AddDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
+    HRESULT AddDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
         CFMutableArrayRef outErrors = nil;
+        HRESULT ret = S_OK;
         if (errors) {
             outErrors = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
             *errors = outErrors;
@@ -729,6 +730,7 @@ public:
             if (data) {
                 if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
                     __AppendErrorIfExists(outErrors, kCTFontManagerErrorAlreadyRegistered);
+                    ret = S_FALSE;
                 } else {
                     CFArrayAppendValue(m_fontDatas.get(), data);
                     CFSetAddValue(m_fontDatasSet.get(), data);
@@ -736,12 +738,16 @@ public:
                 }
             } else {
                 __AppendErrorIfExists(outErrors, kCTFontManagerErrorInvalidFontData);
+                ret = S_FALSE;
             }
         }
+
+        return ret;
     }
 
-    void RemoveDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
+    HRESULT RemoveDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
         CFMutableArrayRef outErrors = nil;
+        HRESULT ret = S_OK;
         if (errors) {
             outErrors = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
             *errors = outErrors;
@@ -759,11 +765,15 @@ public:
                     __AppendNullptrIfExists(outErrors);
                 } else {
                     __AppendErrorIfExists(outErrors, kCTFontManagerErrorNotRegistered);
+                    ret = S_FALSE;
                 }
             } else {
                 __AppendErrorIfExists(outErrors, kCTFontManagerErrorInvalidFontData);
+                ret = S_FALSE;
             }
         }
+
+        return ret;
     }
 
     HRESULT STDMETHODCALLTYPE CreateEnumeratorFromKey(_In_ IDWriteFactory* factory,
@@ -802,7 +812,7 @@ private:
 };
 
 // TLambda is a member function of our FontCollectionLoader which updates the internal state of the loader
-// TLambda :: (DWriteFontCollectionLoader -> CFArrayRef -> CFArrayRef*) -> void
+// TLambda :: (DWriteFontCollectionLoader -> CFArrayRef -> CFArrayRef*) -> HRESULT
 template <typename TLambda>
 static HRESULT __DWriteUpdateUserCreatedFontCollection(CFArrayRef datas, CFArrayRef* errors, TLambda&& func) {
     ComPtr<IDWriteFactory> dwriteFactory;
@@ -820,21 +830,20 @@ static HRESULT __DWriteUpdateUserCreatedFontCollection(CFArrayRef datas, CFArray
     RETURN_IF_FAILED(createdLoader);
 
     // Call member function to update loader's font data
-    func(loader.Get(), datas, errors);
+    // Still want to update font collection with whatever fonts succeeded, so return ret at end
+    HRESULT ret = func(loader.Get(), datas, errors);
 
     // DWrite won't create a new font collection unless we provide a new key each time
     // So every time we modify the font collection increment the key
     static size_t collectionKey = 0;
-    ++collectionKey;
-
     std::lock_guard<std::mutex> guard(_userCreatedFontCollectionMutex);
     RETURN_IF_FAILED(
-        dwriteFactory->CreateCustomFontCollection(loader.Get(), &(collectionKey), sizeof(collectionKey), &_userCreatedFontCollection));
+        dwriteFactory->CreateCustomFontCollection(loader.Get(), &(++collectionKey), sizeof(collectionKey), &_userCreatedFontCollection));
 
     // Update s_userFontPropertiesMap with new values
     s_userFontPropertiesMap = __CreatePropertiesMapForFontCollection(_userCreatedFontCollection.Get());
 
-    return S_OK;
+    return ret;
 }
 
 // Registers user defined fonts to a collection so they can be created later

--- a/Frameworks/CoreText/CTFontManager.mm
+++ b/Frameworks/CoreText/CTFontManager.mm
@@ -59,12 +59,11 @@ static bool __CTFontManagerUpdateWithFonts(CFArrayRef fontURLs, CTFontManagerSco
     woc::unique_cf<CFMutableArrayRef> fontDatas{ CFArrayCreateMutable(nullptr, count, &kCFTypeArrayCallBacks) };
     for (size_t i = 0; i < count; ++i) {
         NSData* data = [NSData dataWithContentsOfURL:static_cast<NSURL*>(CFArrayGetValueAtIndex(fontURLs, i))];
-        if (data != nullptr) {
-            CFArrayAppendValue(fontDatas.get(), (CFDataRef)data);
-        }
+        CFArrayAppendValue(fontDatas.get(), (CFDataRef)data);
     }
 
-    return SUCCEEDED(func(fontDatas.get(), errors));
+    // S_FALSE represents partial failure so cannot use SUCCEEDED macro
+    return func(fontDatas.get(), errors) == S_OK;
 }
 
 // Gets CFData from CGFontRef if available, which are passed into DWriteWrapper methods
@@ -84,7 +83,9 @@ static bool __CTFontManagerUpdateWithGraphicsFont(CGFontRef font, CFErrorRef _Nu
 
     woc::unique_cf<CFArrayRef> fontDatas{ CFArrayCreate(nullptr, (const void**)&data, 1, &kCFTypeArrayCallBacks) };
     CFArrayRef errors = nil;
-    bool ret = SUCCEEDED(func(fontDatas.get(), &errors));
+
+    // S_FALSE represents partial failure so cannot use SUCCEEDED macro
+    bool ret = func(fontDatas.get(), &errors) == S_OK;
     if (error != nil && errors != nil && CFArrayGetCount(errors) > 0L) {
         *error = (CFErrorRef)CFRetain(CFArrayGetValueAtIndex(errors, 0));
     }

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -39,7 +39,8 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
     woc::unique_cf<CGFontRef> cgfont{ CGFontCreateWithFontName(fontName.get()) };
     EXPECT_NE(nullptr, cgfont);
 
-    StrongId<NSString> familyName = (NSString*)CTFontCopyFamilyName(font.get());
+    StrongId<NSString> familyName;
+    familyName.attach((NSString*)CTFontCopyFamilyName(font.get()));
     EXPECT_OBJCEQ(@"WinObjC", familyName);
 
     EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
@@ -69,7 +70,8 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
     woc::unique_cf<CGFontRef> cgfont{ CGFontCreateWithFontName(fontName.get()) };
     EXPECT_NE(nullptr, cgfont);
 
-    StrongId<NSString> familyName = (NSString*)CTFontCopyFullName(font.get());
+    StrongId<NSString> familyName;
+    familyName.attach((NSString*)CTFontCopyFullName(font.get()));
     EXPECT_OBJCEQ(@"WinObjC Italic", familyName);
 
     EXPECT_TRUE(CTFontManagerUnregisterGraphicsFont(graphicsFont.get(), &error));
@@ -112,7 +114,8 @@ TEST(CTFontManager, ShouldFailToRegisterSameFontTwice) {
     woc::unique_cf<CTFontRef> font{ CTFontCreateWithName(fontName.get(), 20, nullptr) };
     EXPECT_NE(nullptr, font);
 
-    StrongId<NSString> familyName = (NSString*)CTFontCopyFamilyName(font.get());
+    StrongId<NSString> familyName;
+    familyName.attach((NSString*)CTFontCopyFamilyName(font.get()));
     EXPECT_OBJCEQ(@"WinObjC", familyName);
 
     EXPECT_FALSE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
@@ -145,12 +148,14 @@ TEST(CTFontManager, ShouldRegisterMultipleFonts) {
 
     woc::unique_cf<CTFontRef> firstFont{ CTFontCreateWithName(firstFontName.get(), 20, nullptr) };
     EXPECT_NE(nullptr, firstFont);
-    StrongId<NSString> firstName = (NSString*)CTFontCopyFullName(firstFont.get());
+    StrongId<NSString> firstName;
+    firstName.attach((NSString*)CTFontCopyFullName(firstFont.get()));
     EXPECT_OBJCEQ(@"WinObjC", firstName);
 
     woc::unique_cf<CTFontRef> secondFont{ CTFontCreateWithName(secondFontName.get(), 20, nullptr) };
     EXPECT_NE(nullptr, secondFont);
-    StrongId<NSString> secondName = (NSString*)CTFontCopyFullName(secondFont.get());
+    StrongId<NSString> secondName;
+    secondName.attach((NSString*)CTFontCopyFullName(secondFont.get()));
     EXPECT_OBJCEQ(@"WinObjC Italic", secondName);
 
     EXPECT_TRUE(CTFontManagerUnregisterFontsForURLs((__bridge CFArrayRef)urls, kCTFontManagerScopeSession, &errors));

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -48,7 +48,7 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForURL) {
     woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(fontName.get(), 20, nullptr) };
     EXPECT_NE(nullptr, failedFont);
 
-    familyName = (NSString*)CTFontCopyFullName(failedFont.get());
+    familyName.attach((NSString*)CTFontCopyFullName(failedFont.get()));
     EXPECT_OBJCEQ(@"Segoe UI", familyName);
 }
 
@@ -125,7 +125,7 @@ TEST(CTFontManager, ShouldFailToRegisterSameFontTwice) {
     woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(fontName.get(), 20, nullptr) };
     EXPECT_NE(nullptr, failedFont);
 
-    familyName = (NSString*)CTFontCopyFullName(failedFont.get());
+    familyName.attach((NSString*)CTFontCopyFullName(failedFont.get()));
     EXPECT_OBJCEQ(@"Segoe UI", familyName);
 }
 
@@ -162,6 +162,6 @@ TEST(CTFontManager, ShouldRegisterMultipleFonts) {
     woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(secondFontName.get(), 20, nullptr) };
     EXPECT_NE(nullptr, failedFont);
 
-    secondName = (NSString*)CTFontCopyFullName(failedFont.get());
+    secondName.attach((NSString*)CTFontCopyFullName(failedFont.get()));
     EXPECT_OBJCEQ(@"Segoe UI", secondName);
 }

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -101,3 +101,67 @@ TEST(CTFontManager, ShouldFailToRegisterNonexistentFont) {
     EXPECT_NE(nullptr, error);
     EXPECT_EQ(kCTFontManagerErrorInvalidFontData, CFErrorGetCode(error));
 }
+
+TEST(CTFontManager, ShouldFailToRegisterSameFontTwice) {
+    woc::unique_cf<CFStringRef> fontName{ CFSTR("WinObjC") };
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf");
+    CFErrorRef error = nullptr;
+    EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
+
+    woc::unique_cf<CTFontRef> font{ CTFontCreateWithName(fontName.get(), 20, nullptr) };
+    EXPECT_NE(nullptr, font);
+
+    StrongId<NSString> familyName = (NSString*)CTFontCopyFamilyName(font.get());
+    EXPECT_OBJCEQ(@"WinObjC", familyName);
+
+    EXPECT_FALSE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_NE(nullptr, error);
+    EXPECT_EQ(kCTFontManagerErrorAlreadyRegistered, CFErrorGetCode(error));
+
+    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
+
+    woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(fontName.get(), 20, nullptr) };
+    EXPECT_NE(nullptr, failedFont);
+
+    familyName = (NSString*)CTFontCopyFullName(failedFont.get());
+    EXPECT_OBJCEQ(@"Segoe UI", familyName);
+}
+
+TEST(CTFontManager, ShouldRegisterMultipleFonts) {
+    woc::unique_cf<CFStringRef> firstFontName{ CFSTR("WinObjC") };
+    woc::unique_cf<CFStringRef> secondFontName{ CFSTR("WinObjC-Italic") };
+    NSArray* urls = @[
+        __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf"),
+        __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC-Italic.ttf")
+    ];
+    CFArrayRef errors = nullptr;
+    EXPECT_TRUE(CTFontManagerRegisterFontsForURLs((__bridge CFArrayRef)urls, kCTFontManagerScopeSession, &errors));
+    EXPECT_NE(nullptr, errors);
+    EXPECT_EQ(nullptr, CFArrayGetValueAtIndex(errors, 0));
+    EXPECT_EQ(nullptr, CFArrayGetValueAtIndex(errors, 1));
+    CFRelease(errors);
+
+    woc::unique_cf<CTFontRef> firstFont{ CTFontCreateWithName(firstFontName.get(), 20, nullptr) };
+    EXPECT_NE(nullptr, firstFont);
+    StrongId<NSString> firstName = (NSString*)CTFontCopyFullName(firstFont.get());
+    EXPECT_OBJCEQ(@"WinObjC", firstName);
+
+    woc::unique_cf<CTFontRef> secondFont{ CTFontCreateWithName(secondFontName.get(), 20, nullptr) };
+    EXPECT_NE(nullptr, secondFont);
+    StrongId<NSString> secondName = (NSString*)CTFontCopyFullName(secondFont.get());
+    EXPECT_OBJCEQ(@"WinObjC Italic", secondName);
+
+    EXPECT_TRUE(CTFontManagerUnregisterFontsForURLs((__bridge CFArrayRef)urls, kCTFontManagerScopeSession, &errors));
+    EXPECT_NE(nullptr, errors);
+    EXPECT_EQ(nullptr, CFArrayGetValueAtIndex(errors, 0));
+    EXPECT_EQ(nullptr, CFArrayGetValueAtIndex(errors, 1));
+    CFRelease(errors);
+
+    woc::unique_cf<CTFontRef> failedFont{ CTFontCreateWithName(secondFontName.get(), 20, nullptr) };
+    EXPECT_NE(nullptr, failedFont);
+
+    secondName = (NSString*)CTFontCopyFullName(failedFont.get());
+    EXPECT_OBJCEQ(@"Segoe UI", secondName);
+}

--- a/tests/unittests/CoreText/CTFontManagerTests.mm
+++ b/tests/unittests/CoreText/CTFontManagerTests.mm
@@ -85,7 +85,19 @@ TEST(CTFontManager, ShouldBeAbleToRegisterFontsForGraphicsFont) {
 TEST(CTFontManager, ShouldFailToUnregisterNonregisteredFonts) {
     NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf");
     CFErrorRef error = nullptr;
-    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_FALSE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
     EXPECT_NE(nullptr, error);
     EXPECT_EQ(kCTFontManagerErrorNotRegistered, CFErrorGetCode(error));
+}
+
+TEST(CTFontManager, ShouldFailToRegisterNonexistentFont) {
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/BlatantlyNonexistentFont.ttf");
+    CFErrorRef error = nullptr;
+    EXPECT_FALSE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_NE(nullptr, error);
+    EXPECT_EQ(kCTFontManagerErrorInvalidFontData, CFErrorGetCode(error));
+
+    EXPECT_FALSE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_NE(nullptr, error);
+    EXPECT_EQ(kCTFontManagerErrorInvalidFontData, CFErrorGetCode(error));
 }


### PR DESCRIPTION
Missing font files or otherwise incorrect font file data would cause a crash without producing a CFError or returning false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1486)
<!-- Reviewable:end -->
