### PR TITLE
Copying the entire test directory to the device.

### DIFF
--- a/tests/Run-UnitTests.ps1
+++ b/tests/Run-UnitTests.ps1
@@ -83,20 +83,8 @@ function DeployTests($testList)
               # This is awkward.
           }
 
-          putd -recurse $testDirectory\*.gif $testOutputDirectory
-          putd -recurse $testDirectory\*.tif $testOutputDirectory
-          putd -recurse $testDirectory\*.tiff $testOutputDirectory
-          putd -recurse $testDirectory\*.bmp $testOutputDirectory
-          putd -recurse $testDirectory\*.ico $testOutputDirectory
-          putd -recurse $testDirectory\*.png $testOutputDirectory
-          putd -recurse $testDirectory\*.jpg $testOutputDirectory
-          putd -recurse $testDirectory\*.dll $testOutputDirectory
-          putd -recurse $testDirectory\*.exe $testOutputDirectory
-          putd -recurse $testDirectory\*.txt $testOutputDirectory
-          putd -recurse $testDirectory\*.bitmap $testOutputDirectory
-          putd -recurse $testDirectory\*.mapping $testOutputDirectory
-          putd -recurse $testDirectory\*.data $testOutputDirectory
-          putd -recurse $testDirectory\*.plist $testOutputDirectory
+          write-host "Copying $testDirectory to $testOutputDirectory"
+          putd -recurse $testDirectory $testOutputDirectory
         }
     }
     else


### PR DESCRIPTION
ARM Unit tests that are trying to load a font are failing because the run-unittests.ps1 script doesn't copy the fonts to the device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1489)
<!-- Reviewable:end -->
