### PR TITLE
Fix issue in UIButton that we are not fallback to value of normal state when setting value of other states to be nil

### DIFF
--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -262,13 +262,19 @@ Microsoft Extension
 */
 - (void)setImage:(UIImage*)image forState:(UIControlState)state {
     _states[state].image = image;
+
+    // NOTE: check if image is nil before creating inspetableImage
+    // ConvertUIImageToWUXMImageBrush:nil creates a valid imageBrush with null comObj
+    // which isn't what we want
     if (image) {
         WUXMImageBrush* imageBrush = ConvertUIImageToWUXMImageBrush(image);
         if (imageBrush) {
             _states[state].inspectableImage = [imageBrush comObj];
         }
     } else {
-        _states[state].inspectableImage = nil;
+        // this enforces the fallback of using Image of normalState
+        // when a image for other states does not exis
+        _states[state].inspectableImage = nullptr;
     }
 
     // Update the Xaml elements immediately, so the proxies reflect reality
@@ -486,7 +492,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 - (void)setTitle:(NSString*)title forState:(UIControlState)state {
     _states[state].title.attach([title copy]);
 
-    // NOTE: check if title is nil before creating inspetableTitle
+    // NOTE: check if title is nil before creating inspectableTitle
     // createString:nil creates a valid rtString with null comObj
     // which isn't what we want
     if (title) {
@@ -497,7 +503,7 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
     } else {
         // this enforces the fallback of using title of normalState
         // when a title for other states does not exist
-        _states[state].inspectableTitle = nil;
+        _states[state].inspectableTitle = nullptr;
     }
 
     // Update the Xaml elements immediately, so the proxies reflect reality
@@ -532,7 +538,9 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 - (void)setTitleColor:(UIColor*)color forState:(UIControlState)state {
     _states[state].textColor = color;
 
-    // NOTE: check if color is nil before creating convertedColor
+    // NOTE: check if image is nil before creating convertedColor
+    // ConvertUIColorToWUColor:nil creates a valid WUColor with null comObj
+    // which isn't what we want
     if (color) {
         WUColor* convertedColor = ConvertUIColorToWUColor(color);
         WUXMSolidColorBrush* titleColorBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
@@ -540,7 +548,9 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
             _states[state].inspectableTitleColor = [titleColorBrush comObj];
         }
     } else {
-        _states[state].inspectableTitleColor = nil;
+        // this enforces the fallback of using titleColor of normalState
+        // when a titleColor for other states does not exist
+        _states[state].inspectableTitleColor = nullptr;
     }
 
     // Update the Xaml elements immediately, so the proxies reflect reality

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -262,9 +262,13 @@ Microsoft Extension
 */
 - (void)setImage:(UIImage*)image forState:(UIControlState)state {
     _states[state].image = image;
-    WUXMImageBrush* imageBrush = ConvertUIImageToWUXMImageBrush(image);
-    if (imageBrush) {
-        _states[state].inspectableImage = [imageBrush comObj];
+    if (image) {
+        WUXMImageBrush* imageBrush = ConvertUIImageToWUXMImageBrush(image);
+        if (imageBrush) {
+            _states[state].inspectableImage = [imageBrush comObj];
+        }
+    } else {
+        _states[state].inspectableImage = nil;
     }
 
     // Update the Xaml elements immediately, so the proxies reflect reality
@@ -481,9 +485,19 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 */
 - (void)setTitle:(NSString*)title forState:(UIControlState)state {
     _states[state].title.attach([title copy]);
-    RTObject* rtString = [WFPropertyValue createString:title];
-    if (rtString) {
-        _states[state].inspectableTitle = [rtString comObj];
+
+    // NOTE: check if title is nil before creating inspetableTitle
+    // createString:nil creates a valid rtString with null comObj
+    // which isn't what we want
+    if (title) {
+        RTObject* rtString = [WFPropertyValue createString:title];
+        if (rtString) {
+            _states[state].inspectableTitle = [rtString comObj];
+        }
+    } else {
+        // this enforces the fallback of using title of normalState
+        // when a title for other states does not exist
+        _states[state].inspectableTitle = nil;
     }
 
     // Update the Xaml elements immediately, so the proxies reflect reality
@@ -517,10 +531,16 @@ static CGRect calculateContentRect(UIButton* self, CGSize size, CGRect contentRe
 */
 - (void)setTitleColor:(UIColor*)color forState:(UIControlState)state {
     _states[state].textColor = color;
-    WUColor* convertedColor = ConvertUIColorToWUColor(color);
-    WUXMSolidColorBrush* titleColorBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
-    if (titleColorBrush) {
-        _states[state].inspectableTitleColor = [titleColorBrush comObj];
+
+    // NOTE: check if color is nil before creating convertedColor
+    if (color) {
+        WUColor* convertedColor = ConvertUIColorToWUColor(color);
+        WUXMSolidColorBrush* titleColorBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
+        if (titleColorBrush) {
+            _states[state].inspectableTitleColor = [titleColorBrush comObj];
+        }
+    } else {
+        _states[state].inspectableTitleColor = nil;
     }
 
     // Update the Xaml elements immediately, so the proxies reflect reality

--- a/samples/XAMLCatalog/XAMLCatalog/UIButtonViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UIButtonViewController.m
@@ -271,7 +271,8 @@
 
         CGSize imageSize = [button.imageView sizeThatFits:CGSizeZero];
 
-        [button setTitle:[NSString stringWithFormat:@"W (%d) H (%d)", (int)imageSize.width, (int)imageSize.height] forState:UIControlStateNormal];
+        [button setTitle:[NSString stringWithFormat:@"W (%d) H (%d)", (int)imageSize.width, (int)imageSize.height]
+                forState:UIControlStateNormal];
 
         // Call to an unsupported API, should show up in Output window
         [button.imageView sizeToFit];
@@ -281,50 +282,50 @@
     } else if (indexPath.row == 14) {
         UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop, _labelWidth, _labelHeight)];
         label.text = @"UIButton, Selected=true, Title=Blue";
-        
+
         UIButton* button =
-        [[UIButton alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop + _labelHeight, _defaultWidth, _defaultHeight)];
+            [[UIButton alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop + _labelHeight, _defaultWidth, _defaultHeight)];
         button.selected = true;
         [button setTitleColor:[UIColor blueColor] forState:UIControlStateSelected];
         [button setTitleColor:[UIColor blueColor] forState:UIControlStateNormal];
-        
+
         [button setBackgroundImage:[UIImage imageNamed:@"blue_background.jpg"] forState:UIControlStateSelected];
         [button setBackgroundImage:[UIImage imageNamed:@"yellow_background.jpg"] forState:UIControlStateNormal];
-        
+
         [button setTitle:@"Selected Button" forState:UIControlStateSelected];
         [button setTitle:@"Selected Button" forState:UIControlStateNormal];
-        
+
         [cell addSubview:label];
         [cell addSubview:button];
     } else if (indexPath.row == 15) {
         UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop, _labelWidth, _labelHeight)];
-        label.text = @"UIButton, Highlighted state text/color/image is the same as normal state";
-        
-        UIButton* button =
-        [[UIButton alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop + _labelHeight, _defaultWidth, _defaultHeight)];
+        label.text = @"UIButton, when in Highlighted (pressed) state, text/color/image is the same as normal state";
 
-        // intentionally set nil color for UIControlStateHighlighted
+        UIButton* button =
+            [[UIButton alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop + _labelHeight, _defaultWidth, _defaultHeight)];
+
+        // intentionally set nil titleColor for UIControlStateHighlighted
         // make sure color used for UIControlStateNormal is also used
         // in highlighted state
         [button setTitleColor:nil forState:UIControlStateHighlighted];
         [button setTitleColor:[UIColor blueColor] forState:UIControlStateNormal];
-        
-        // intentionally set nil color for UIControlStateHighlighted
+
+        // intentionally set nil on title for UIControlStateHighlighted
         // make sure title used for UIControlStateNormal is also used
         // in highlighted state
         [button setTitle:nil forState:UIControlStateHighlighted];
-        [button setTitle:@"Selected Button" forState:UIControlStateNormal];
+        [button setTitle:@"Hightlighted Button" forState:UIControlStateNormal];
 
-        // intentionally set nil color for UIControlStateHighlighted
+        // intentionally set nil on Image for UIControlStateHighlighted
         // make sure image used for UIControlStateNormal is also used
         // in highlighted state
         [button setImage:nil forState:UIControlStateHighlighted];
         [button setImage:[UIButtonViewController scaledTestImage] forState:UIControlStateNormal];
-        
+
         [cell addSubview:label];
         [cell addSubview:button];
     }
-    
+
     return cell;
 }
 

--- a/samples/XAMLCatalog/XAMLCatalog/UIButtonViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UIButtonViewController.m
@@ -73,7 +73,7 @@
 }
 
 - (NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection:(NSInteger)section {
-    return 15;
+    return 16;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -293,6 +293,33 @@
         
         [button setTitle:@"Selected Button" forState:UIControlStateSelected];
         [button setTitle:@"Selected Button" forState:UIControlStateNormal];
+        
+        [cell addSubview:label];
+        [cell addSubview:button];
+    } else if (indexPath.row == 15) {
+        UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop, _labelWidth, _labelHeight)];
+        label.text = @"UIButton, Highlighted state text/color/image is the same as normal state";
+        
+        UIButton* button =
+        [[UIButton alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop + _labelHeight, _defaultWidth, _defaultHeight)];
+
+        // intentionally set nil color for UIControlStateHighlighted
+        // make sure color used for UIControlStateNormal is also used
+        // in highlighted state
+        [button setTitleColor:nil forState:UIControlStateHighlighted];
+        [button setTitleColor:[UIColor blueColor] forState:UIControlStateNormal];
+        
+        // intentionally set nil color for UIControlStateHighlighted
+        // make sure title used for UIControlStateNormal is also used
+        // in highlighted state
+        [button setTitle:nil forState:UIControlStateHighlighted];
+        [button setTitle:@"Selected Button" forState:UIControlStateNormal];
+
+        // intentionally set nil color for UIControlStateHighlighted
+        // make sure image used for UIControlStateNormal is also used
+        // in highlighted state
+        [button setImage:nil forState:UIControlStateHighlighted];
+        [button setImage:[UIButtonViewController scaledTestImage] forState:UIControlStateNormal];
         
         [cell addSubview:label];
         [cell addSubview:button];


### PR DESCRIPTION
UIButton can set different title/color/image for different state. if the value of a state, e.g., title for highlighted state is set to nil, then when button is lightlighted state, its value should fallback to normal state value. 

Currently when we set nil to title/color/image value for a state (e.g., highlighted), we are creating a non-nil inspectable object which in turns contains null comObj, so when button is in that state (e.g., highlighted state), we use this inspectable to retrieve their contained value (null) to update UIButton, which causes button text/image display incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1493)
<!-- Reviewable:end -->
