### PR TITLE
Refactor some DWriteWrapper code

### DIFF
--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.h
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.h
@@ -14,6 +14,8 @@
 //
 //******************************************************************************
 
+#pragma once
+
 #include <COMIncludes.h>
 #import <wrl/implements.h>
 #include <COMIncludes_End.h>

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.h
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.h
@@ -1,0 +1,62 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <COMIncludes.h>
+#import <wrl/implements.h>
+#include <COMIncludes_End.h>
+
+#import <Starboard.h>
+#import <CoreGraphics/DWriteWrapper.h>
+#import <CoreFoundation/CFArray.h>
+#import <CoreFoundation/CFData.h>
+
+#import <vector>
+
+/**
+ * Custom implementation of IDWriteFontCollectionLoader, which creates an IDWriteFontFileEnumerator to create font files
+ * Which are used to create a font collection.  This is expected to be a singleton.
+ */
+class DWriteFontBinaryDataCollectionLoader
+    : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::WinRtClassicComMix>,
+                                          IDWriteFontCollectionLoader> {
+protected:
+    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+
+public:
+    DWriteFontBinaryDataCollectionLoader() {
+    }
+
+    HRESULT RuntimeClassInitialize();
+
+    HRESULT STDMETHODCALLTYPE CreateEnumeratorFromKey(_In_ IDWriteFactory* factory,
+                                                      _In_ const void* collectionKey,
+                                                      _In_ UINT32 collectionKeySize,
+                                                      _Out_ IDWriteFontFileEnumerator** enumerator);
+
+    // Adds/removes an array of font data from this collection loader's internal storage
+    HRESULT AddDatas(CFArrayRef fontDatas, CFArrayRef* errors);
+    HRESULT RemoveDatas(CFArrayRef fontDatas, CFArrayRef* errors);
+
+private:
+    // Array of CFDataRef containing data of fonts, in order of being added
+    woc::unique_cf<CFMutableArrayRef> m_fontDatas;
+
+    // Set of CFDataRef containing data of fonts, used to simplify checking if font has been added
+    woc::unique_cf<CFMutableSetRef> m_fontDatasSet;
+
+    // Array of previously created font files, which saves us from having to read a file multiple times
+    std::vector<Microsoft::WRL::ComPtr<IDWriteFontFile>> m_previouslyCreatedFiles;
+};

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.mm
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.mm
@@ -1,0 +1,168 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "DWriteFontBinaryDataCollectionLoader.h"
+#import "DWriteFontBinaryDataLoader.h"
+
+#import <CoreFoundation/CFError.h>
+
+using namespace Microsoft::WRL;
+
+/**
+ * Private helpers to append a CFErrorRef or nullptr to the end of a CFMutableArray if it exists
+ */
+static inline void __AppendErrorIfExists(CFMutableArrayRef errors, CFIndex errorCode) {
+    if (errors) {
+        woc::unique_cf<CFErrorRef> error{ CFErrorCreate(nullptr, kCFErrorDomainCocoa, errorCode, nullptr) };
+        CFArrayAppendValue(errors, error.get());
+    }
+}
+
+static inline void __AppendNullptrIfExists(CFMutableArrayRef errors) {
+    if (errors) {
+        CFArrayAppendValue(errors, nullptr);
+    }
+}
+
+/**
+ * Private class.
+ * Custom implementation of IDWriteFontFileEnumerator, which enumerates over internal data and returns a font file
+ */
+class DWriteFontFileEnumerator : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontFileEnumerator> {
+protected:
+    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+
+public:
+    DWriteFontFileEnumerator() {
+    }
+
+    HRESULT RuntimeClassInitialize(CFArrayRef fontDatas, std::vector<ComPtr<IDWriteFontFile>>* previouslyCreatedFiles) {
+        CFRetain(fontDatas);
+        m_fontDatas.reset(fontDatas);
+        m_previouslyCreatedFiles = previouslyCreatedFiles;
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetCurrentFontFile(_Out_ IDWriteFontFile** fontFile) {
+        RETURN_HR_IF(E_ILLEGAL_METHOD_CALL, m_location < 0 || m_location > CFArrayGetCount(m_fontDatas.get()));
+
+        if (0 <= m_location && m_location < m_previouslyCreatedFiles->size()) {
+            m_previouslyCreatedFiles->at(m_location).CopyTo(fontFile);
+        } else {
+            ComPtr<IDWriteFactory> dwriteFactory;
+            RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
+
+            ComPtr<DWriteFontBinaryDataLoader> loader;
+            RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataLoader>(&loader,
+                                                                           static_cast<CFDataRef>(
+                                                                               CFArrayGetValueAtIndex(m_fontDatas.get(), m_location))));
+            RETURN_IF_FAILED(dwriteFactory->RegisterFontFileLoader(loader.Get()));
+
+            int unused;
+            RETURN_IF_FAILED(dwriteFactory->CreateCustomFontFileReference(&unused, sizeof(unused), loader.Get(), fontFile));
+            m_previouslyCreatedFiles->emplace_back(*fontFile);
+        }
+
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE MoveNext(_Out_ BOOL* hasCurrentFile) {
+        *hasCurrentFile = ++m_location < CFArrayGetCount(m_fontDatas.get());
+        return S_OK;
+    }
+
+private:
+    int m_location = -1;
+
+    woc::unique_cf<CFArrayRef> m_fontDatas;
+    std::vector<ComPtr<IDWriteFontFile>>* m_previouslyCreatedFiles;
+};
+
+// DWriteFontBinaryDataCollectionLoader member functions
+
+HRESULT DWriteFontBinaryDataCollectionLoader::DWriteFontBinaryDataCollectionLoader::RuntimeClassInitialize() {
+    m_fontDatas.reset(CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks));
+    m_fontDatasSet.reset(CFSetCreateMutable(nullptr, 0, &kCFTypeSetCallBacks));
+    return S_OK;
+}
+
+HRESULT STDMETHODCALLTYPE DWriteFontBinaryDataCollectionLoader::CreateEnumeratorFromKey(_In_ IDWriteFactory* factory,
+                                                                                        _In_ const void* collectionKey,
+                                                                                        _In_ UINT32 collectionKeySize,
+                                                                                        _Out_ IDWriteFontFileEnumerator** enumerator) {
+    MakeAndInitialize<DWriteFontFileEnumerator>(enumerator, m_fontDatas.get(), &m_previouslyCreatedFiles);
+    return S_OK;
+}
+
+HRESULT DWriteFontBinaryDataCollectionLoader::AddDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
+    CFMutableArrayRef outErrors = nil;
+    HRESULT ret = S_OK;
+    if (errors) {
+        outErrors = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
+        *errors = outErrors;
+    }
+
+    CFIndex count = CFArrayGetCount(fontDatas);
+    for (CFIndex i = 0; i < count; ++i) {
+        CFDataRef data = static_cast<CFDataRef>(CFArrayGetValueAtIndex(fontDatas, i));
+        if (data) {
+            if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
+                __AppendErrorIfExists(outErrors, kCTFontManagerErrorAlreadyRegistered);
+                ret = S_FALSE;
+            } else {
+                CFArrayAppendValue(m_fontDatas.get(), data);
+                CFSetAddValue(m_fontDatasSet.get(), data);
+                __AppendNullptrIfExists(outErrors);
+            }
+        } else {
+            __AppendErrorIfExists(outErrors, kCTFontManagerErrorInvalidFontData);
+            ret = S_FALSE;
+        }
+    }
+
+    return ret;
+}
+
+HRESULT DWriteFontBinaryDataCollectionLoader::RemoveDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
+    CFMutableArrayRef outErrors = nil;
+    HRESULT ret = S_OK;
+    if (errors) {
+        outErrors = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
+        *errors = outErrors;
+    }
+
+    CFIndex count = CFArrayGetCount(fontDatas);
+    for (CFIndex i = 0; i < count; ++i) {
+        CFDataRef data = static_cast<CFDataRef>(CFArrayGetValueAtIndex(fontDatas, i));
+        if (data) {
+            if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
+                CFSetRemoveValue(m_fontDatasSet.get(), data);
+                CFIndex index = CFArrayGetFirstIndexOfValue(m_fontDatas.get(), { 0, CFArrayGetCount(m_fontDatas.get()) }, data);
+                CFArrayRemoveValueAtIndex(m_fontDatas.get(), index);
+                m_previouslyCreatedFiles.erase(m_previouslyCreatedFiles.begin() + index);
+                __AppendNullptrIfExists(outErrors);
+            } else {
+                __AppendErrorIfExists(outErrors, kCTFontManagerErrorNotRegistered);
+                ret = S_FALSE;
+            }
+        } else {
+            __AppendErrorIfExists(outErrors, kCTFontManagerErrorInvalidFontData);
+            ret = S_FALSE;
+        }
+    }
+
+    return ret;
+}

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.mm
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.mm
@@ -57,6 +57,7 @@ public:
     }
 
     HRESULT STDMETHODCALLTYPE GetCurrentFontFile(_Out_ IDWriteFontFile** fontFile) {
+        RETURN_HR_IF_NULL(E_POINTER, fontFile);
         RETURN_HR_IF(E_ILLEGAL_METHOD_CALL, m_location < 0 || m_location > CFArrayGetCount(m_fontDatas.get()));
 
         if (0 <= m_location && m_location < m_previouslyCreatedFiles->size()) {
@@ -80,6 +81,7 @@ public:
     }
 
     HRESULT STDMETHODCALLTYPE MoveNext(_Out_ BOOL* hasCurrentFile) {
+        RETURN_HR_IF_NULL(E_POINTER, hasCurrentFile);
         *hasCurrentFile = ++m_location < CFArrayGetCount(m_fontDatas.get());
         return S_OK;
     }

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.h
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.h
@@ -1,0 +1,43 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <COMIncludes.h>
+#import <wrl/implements.h>
+#include <COMIncludes_End.h>
+
+#import <Starboard.h>
+#import <CoreGraphics/DWriteWrapper.h>
+#import <CoreFoundation/CFData.h>
+
+/**
+ * Custom implementation of IDWriteFontFileLoader that loads a CFDataRef as its font file
+ */
+class DWriteFontBinaryDataLoader
+    : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::WinRtClassicComMix>, IDWriteFontFileLoader> {
+protected:
+    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+
+public:
+    DWriteFontBinaryDataLoader();
+    HRESULT RuntimeClassInitialize(CFDataRef data);
+
+    HRESULT STDMETHODCALLTYPE CreateStreamFromKey(_In_ const void* fontFileReferenceKey,
+                                                  uint32_t fontFileReferenceKeySize,
+                                                  _Out_ IDWriteFontFileStream** fontFileStream);
+
+private:
+    woc::unique_cf<CFDataRef> m_data;
+};

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.h
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.h
@@ -30,10 +30,12 @@
 class DWriteFontBinaryDataLoader
     : public Microsoft::WRL::RuntimeClass<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::WinRtClassicComMix>, IDWriteFontFileLoader> {
 protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+    InspectableClass(L"Windows.Bridge.DirectWrite.DWriteFontBinaryDataLoader", TrustLevel::BaseTrust);
 
 public:
-    DWriteFontBinaryDataLoader();
+    DWriteFontBinaryDataLoader() {
+    }
+
     HRESULT RuntimeClassInitialize(CFDataRef data);
 
     HRESULT STDMETHODCALLTYPE CreateStreamFromKey(_In_ const void* fontFileReferenceKey,

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.h
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.h
@@ -14,6 +14,8 @@
 //
 //******************************************************************************
 
+#pragma once
+
 #include <COMIncludes.h>
 #import <wrl/implements.h>
 #include <COMIncludes_End.h>

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.mm
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.mm
@@ -28,13 +28,10 @@ using namespace Microsoft::WRL;
  */
 class DWriteFontBinaryDataStream : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontFileStream> {
 protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+    InspectableClass(L"Windows.Bridge.DirectWrite.DWriteFontBinaryDataStream", TrustLevel::BaseTrust);
 
 public:
-    DWriteFontBinaryDataStream() {
-    }
-
-    HRESULT RuntimeClassInitialize(CFDataRef data) {
+    DWriteFontBinaryDataStream(CFDataRef data) {
         CFRetain(data);
         m_data.reset(data);
 
@@ -46,6 +43,9 @@ public:
         m_lastWriteTime = 0;
         m_lastWriteTime |= static_cast<uint64_t>(fileTime.dwLowDateTime);
         m_lastWriteTime |= static_cast<uint64_t>(fileTime.dwHighDateTime) << 32;
+    }
+
+    HRESULT RuntimeClassInitialize() {
         return S_OK;
     }
 
@@ -94,10 +94,6 @@ private:
 
 // DWriteFontBinaryDataLoader member functions
 
-DWriteFontBinaryDataLoader::DWriteFontBinaryDataLoader() {
-    // Deliberate no-op
-}
-
 HRESULT DWriteFontBinaryDataLoader::RuntimeClassInitialize(CFDataRef data) {
     RETURN_HR_IF_NULL(E_INVALIDARG, data);
 
@@ -113,8 +109,8 @@ HRESULT STDMETHODCALLTYPE DWriteFontBinaryDataLoader::CreateStreamFromKey(_In_ c
                                                                           _Out_ IDWriteFontFileStream** fontFileStream) {
     RETURN_HR_IF_NULL(E_POINTER, fontFileStream);
 
-    ComPtr<DWriteFontBinaryDataStream> ret;
-    RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataStream>(&ret, m_data.get()));
+    ComPtr<DWriteFontBinaryDataStream> ret = Make<DWriteFontBinaryDataStream>(m_data.get());
 
-    return ret.CopyTo(fontFileStream);
+    *fontFileStream = ret.Detach();
+    return S_OK;
 }

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.mm
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.mm
@@ -45,10 +45,6 @@ public:
         m_lastWriteTime |= static_cast<uint64_t>(fileTime.dwHighDateTime) << 32;
     }
 
-    HRESULT RuntimeClassInitialize() {
-        return S_OK;
-    }
-
     HRESULT STDMETHODCALLTYPE GetFileSize(_Out_ uint64_t* fileSize) {
         RETURN_HR_IF_NULL(E_POINTER, fileSize);
         *fileSize = CFDataGetLength(m_data.get());

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.mm
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataLoader.mm
@@ -1,0 +1,119 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "DWriteFontBinaryDataLoader.h"
+
+using namespace Microsoft::WRL;
+
+/**
+ * Private class.
+ * Custom implementation of IDWriteFontFileStream that implements Read in terms of an underlying CFDataRef
+ *
+ * While IDWriteFontFileStream normally frees its underlying data bit by bit through ReleaseFileFragment(),
+ * for WinObjC purposes, it is easier to rely on existing mechanisms for CFData's destruction.
+ * Thus, this class releases its CFData all at once, at the time of its destruction.
+ */
+class DWriteFontBinaryDataStream : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontFileStream> {
+protected:
+    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+
+public:
+    DWriteFontBinaryDataStream() {
+    }
+
+    HRESULT RuntimeClassInitialize(CFDataRef data) {
+        CFRetain(data);
+        m_data.reset(data);
+
+        // Just use current time for m_lastWriteTime
+        FILETIME fileTime;
+        GetSystemTimeAsFileTime(&fileTime);
+
+        // Concat filetime into a single uint64_t
+        m_lastWriteTime = 0;
+        m_lastWriteTime |= static_cast<uint64_t>(fileTime.dwLowDateTime);
+        m_lastWriteTime |= static_cast<uint64_t>(fileTime.dwHighDateTime) << 32;
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetFileSize(_Out_ uint64_t* fileSize) {
+        RETURN_HR_IF_NULL(E_INVALIDARG, fileSize);
+        *fileSize = CFDataGetLength(m_data.get());
+        return S_OK;
+    };
+
+    HRESULT STDMETHODCALLTYPE GetLastWriteTime(_Out_ uint64_t* lastWriteTime) {
+        RETURN_HR_IF_NULL(E_INVALIDARG, lastWriteTime);
+        *lastWriteTime = m_lastWriteTime;
+        return S_OK;
+    };
+
+    HRESULT STDMETHODCALLTYPE ReadFileFragment(_Out_ const void** fragmentStart,
+                                               uint64_t fileOffset,
+                                               uint64_t fragmentSize,
+                                               _Out_ void** fragmentContext) {
+        if (fileOffset + fragmentSize > CFDataGetLength(m_data.get())) {
+            return E_INVALIDARG;
+        }
+
+        if (fragmentStart) {
+            const uint8_t* underlyingBuffer = CFDataGetBytePtr(m_data.get());
+            *fragmentStart = reinterpret_cast<const void*>(&(underlyingBuffer[fileOffset]));
+        }
+
+        if (fragmentContext) {
+            // Deliberately unused: this is meant to be passed to ReleaseFileFragment() below to free part of the data,
+            // but this stream frees all the underlying CFData at once
+            *fragmentContext = nullptr;
+        }
+
+        return S_OK;
+    };
+
+    void STDMETHODCALLTYPE ReleaseFileFragment(void* fragmentContext){
+        // Deliberate no-op: data is released alongside the m_data member with the destruction of this object
+    };
+
+private:
+    woc::unique_cf<CFDataRef> m_data;
+    uint64_t m_lastWriteTime;
+};
+
+// DWriteFontBinaryDataLoader member functions
+
+DWriteFontBinaryDataLoader::DWriteFontBinaryDataLoader() {
+    // Deliberate no-op
+}
+
+HRESULT DWriteFontBinaryDataLoader::RuntimeClassInitialize(CFDataRef data) {
+    CFRetain(data);
+    m_data.reset(data);
+    return S_OK;
+}
+
+// Ignores first two params, just return the same kind of stream always
+// Stream returned is dictated by dataProvider passed in at initialization time
+HRESULT STDMETHODCALLTYPE DWriteFontBinaryDataLoader::CreateStreamFromKey(_In_ const void* fontFileReferenceKey,
+                                                                          uint32_t fontFileReferenceKeySize,
+                                                                          _Out_ IDWriteFontFileStream** fontFileStream) {
+    RETURN_HR_IF_NULL(E_INVALIDARG, fontFileStream);
+
+    ComPtr<DWriteFontBinaryDataStream> ret;
+    RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataStream>(&ret, m_data.get()));
+
+    *fontFileStream = ret.Detach();
+    return S_OK;
+}

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
@@ -18,6 +18,7 @@
 
 #import <CoreGraphics/DWriteWrapper.h>
 
+#import <mutex>
 #import <unordered_map>
 
 /**
@@ -42,6 +43,8 @@ using _DWriteFontPropertiesMap =
  * by means of an internal cache.
  *
  * Concrete implementations must implement _GetFontCollection(), which is expected to return an IDWriteFontCollection to work on.
+ *
+ * Thread-safe.
  */
 class DWriteFontCollectionHelper {
 public:
@@ -51,12 +54,13 @@ public:
     CFMutableArrayRef CopyFontFamilyNames();
     CFMutableArrayRef CopyFontNamesForFamilyName(CFStringRef familyName);
     std::shared_ptr<_DWriteFontProperties> GetFontPropertiesFromUppercaseFontName(const woc::unique_cf<CFStringRef>& upperFontName);
-    HRESULT CreateFontFamilyWithName(_In_ const wchar_t* unicharFamilyName, _Outptr_ IDWriteFontFamily** outFontFamily);
+    HRESULT CreateFontFamilyWithName(const wchar_t* unicharFamilyName, IDWriteFontFamily** outFontFamily);
 
 protected:
     virtual Microsoft::WRL::ComPtr<IDWriteFontCollection> _GetFontCollection() = 0;
-    HRESULT _GetFontListForFamilyName(CFStringRef familyName, _Outptr_ IDWriteFontList** outFontList);
+    HRESULT _GetFontListForFamilyName(CFStringRef familyName, IDWriteFontList** outFontList);
 
     void _InitializePropertiesMap();
     std::shared_ptr<_DWriteFontPropertiesMap> m_propertiesMap;
+    std::recursive_mutex m_lock;
 };

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
@@ -1,0 +1,60 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <CoreGraphics/DWriteWrapper.h>
+
+#import <unordered_map>
+
+/**
+ * Struct that exposes CFHash and CFEqual to an STL container
+ */
+struct __CFStringHashEqual {
+    std::size_t operator()(const woc::unique_cf<CFStringRef>& item) const {
+        return CFHash(item.get());
+    }
+
+    bool operator()(const woc::unique_cf<CFStringRef>& item1, const woc::unique_cf<CFStringRef>& item2) const {
+        return CFEqual(item1.get(), item2.get());
+    }
+};
+
+using _DWriteFontPropertiesMap =
+    std::unordered_map<woc::unique_cf<CFStringRef>, std::shared_ptr<_DWriteFontProperties>, __CFStringHashEqual, __CFStringHashEqual>;
+
+/**
+ * A wrapper around an IDWriteFontCollection that provides mappings not directly available from the IDWriteFontCollection interface,
+ * such as font name -> family name, postscript name -> font name, font name -> font weight, style,
+ * by means of an internal cache.
+ *
+ * Concrete implementations must implement _GetFontCollection(), which is expected to return an IDWriteFontCollection to work on.
+ */
+class DWriteFontCollectionHelper {
+public:
+    DWriteFontCollectionHelper() {
+    }
+
+    CFMutableArrayRef CopyFontFamilyNames();
+    CFMutableArrayRef CopyFontNamesForFamilyName(CFStringRef familyName);
+    std::shared_ptr<_DWriteFontProperties> GetFontPropertiesFromUppercaseFontName(const woc::unique_cf<CFStringRef>& upperFontName);
+    HRESULT CreateFontFamilyWithName(_In_ const wchar_t* unicharFamilyName, _Out_ IDWriteFontFamily** outFontFamily);
+
+protected:
+    virtual Microsoft::WRL::ComPtr<IDWriteFontCollection> _GetFontCollection() = 0;
+    HRESULT _GetFontListForFamilyName(CFStringRef familyName, _Out_ IDWriteFontList** outFontList);
+
+    void _InitializePropertiesMap();
+    std::shared_ptr<_DWriteFontPropertiesMap> m_propertiesMap;
+};

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
@@ -14,6 +14,8 @@
 //
 //******************************************************************************
 
+#pragma once
+
 #import <CoreGraphics/DWriteWrapper.h>
 
 #import <unordered_map>
@@ -49,11 +51,11 @@ public:
     CFMutableArrayRef CopyFontFamilyNames();
     CFMutableArrayRef CopyFontNamesForFamilyName(CFStringRef familyName);
     std::shared_ptr<_DWriteFontProperties> GetFontPropertiesFromUppercaseFontName(const woc::unique_cf<CFStringRef>& upperFontName);
-    HRESULT CreateFontFamilyWithName(_In_ const wchar_t* unicharFamilyName, _Out_ IDWriteFontFamily** outFontFamily);
+    HRESULT CreateFontFamilyWithName(_In_ const wchar_t* unicharFamilyName, _Outptr_ IDWriteFontFamily** outFontFamily);
 
 protected:
     virtual Microsoft::WRL::ComPtr<IDWriteFontCollection> _GetFontCollection() = 0;
-    HRESULT _GetFontListForFamilyName(CFStringRef familyName, _Out_ IDWriteFontList** outFontList);
+    HRESULT _GetFontListForFamilyName(CFStringRef familyName, _Outptr_ IDWriteFontList** outFontList);
 
     void _InitializePropertiesMap();
     std::shared_ptr<_DWriteFontPropertiesMap> m_propertiesMap;

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
@@ -35,7 +35,7 @@ struct __CFStringHashEqual {
 };
 
 using _DWriteFontPropertiesMap =
-    std::unordered_map<woc::unique_cf<CFStringRef>, std::shared_ptr<_DWriteFontProperties>, __CFStringHashEqual, __CFStringHashEqual>;
+    std::unordered_map<woc::unique_cf<CFStringRef>, std::shared_ptr<const _DWriteFontProperties>, __CFStringHashEqual, __CFStringHashEqual>;
 
 /**
  * A wrapper around an IDWriteFontCollection that provides mappings not directly available from the IDWriteFontCollection interface,
@@ -53,7 +53,7 @@ public:
 
     CFMutableArrayRef CopyFontFamilyNames();
     CFMutableArrayRef CopyFontNamesForFamilyName(CFStringRef familyName);
-    std::shared_ptr<_DWriteFontProperties> GetFontPropertiesFromUppercaseFontName(const woc::unique_cf<CFStringRef>& upperFontName);
+    std::shared_ptr<const _DWriteFontProperties> GetFontPropertiesFromUppercaseFontName(const woc::unique_cf<CFStringRef>& upperFontName);
     HRESULT CreateFontFamilyWithName(const wchar_t* unicharFamilyName, IDWriteFontFamily** outFontFamily);
     virtual Microsoft::WRL::ComPtr<IDWriteFontCollection> GetFontCollection() = 0;
 

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.h
@@ -42,7 +42,7 @@ using _DWriteFontPropertiesMap =
  * such as font name -> family name, postscript name -> font name, font name -> font weight, style,
  * by means of an internal cache.
  *
- * Concrete implementations must implement _GetFontCollection(), which is expected to return an IDWriteFontCollection to work on.
+ * Concrete implementations must implement GetFontCollection(), which is expected to return an IDWriteFontCollection to work on.
  *
  * Thread-safe.
  */
@@ -55,9 +55,9 @@ public:
     CFMutableArrayRef CopyFontNamesForFamilyName(CFStringRef familyName);
     std::shared_ptr<_DWriteFontProperties> GetFontPropertiesFromUppercaseFontName(const woc::unique_cf<CFStringRef>& upperFontName);
     HRESULT CreateFontFamilyWithName(const wchar_t* unicharFamilyName, IDWriteFontFamily** outFontFamily);
+    virtual Microsoft::WRL::ComPtr<IDWriteFontCollection> GetFontCollection() = 0;
 
 protected:
-    virtual Microsoft::WRL::ComPtr<IDWriteFontCollection> _GetFontCollection() = 0;
     HRESULT _GetFontListForFamilyName(CFStringRef familyName, IDWriteFontList** outFontList);
 
     void _InitializePropertiesMap();

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
@@ -94,7 +94,7 @@ CFMutableArrayRef DWriteFontCollectionHelper::CopyFontNamesForFamilyName(CFStrin
     return ret;
 }
 
-std::shared_ptr<_DWriteFontProperties> DWriteFontCollectionHelper::GetFontPropertiesFromUppercaseFontName(
+std::shared_ptr<const _DWriteFontProperties> DWriteFontCollectionHelper::GetFontPropertiesFromUppercaseFontName(
     const woc::unique_cf<CFStringRef>& upperFontName) {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
@@ -27,7 +27,7 @@ static const wchar_t* TAG = L"_DWriteFontCollectionHelper";
 CFMutableArrayRef DWriteFontCollectionHelper::CopyFontFamilyNames() {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
-    ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
+    ComPtr<IDWriteFontCollection> fontCollection = GetFontCollection();
     if (!fontCollection) {
         // Return empty array for an empty font collection
         return CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
@@ -113,7 +113,7 @@ std::shared_ptr<_DWriteFontProperties> DWriteFontCollectionHelper::GetFontProper
 HRESULT DWriteFontCollectionHelper::CreateFontFamilyWithName(const wchar_t* unicharFamilyName, IDWriteFontFamily** outFontFamily) {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
-    ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
+    ComPtr<IDWriteFontCollection> fontCollection = GetFontCollection();
 
     // If no/empty font collection, say that the font family couldn't be found
     // Use S_FALSE to represent 'not found'
@@ -133,7 +133,7 @@ HRESULT DWriteFontCollectionHelper::CreateFontFamilyWithName(const wchar_t* unic
 HRESULT DWriteFontCollectionHelper::_GetFontListForFamilyName(CFStringRef familyName, IDWriteFontList** outFontList) {
     std::lock_guard<std::recursive_mutex> lock(m_lock);
 
-    ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
+    ComPtr<IDWriteFontCollection> fontCollection = GetFontCollection();
 
     // If no/empty font collection, fail to return a font list
     // Use of E_FAIL rather than a more nuanced HRESULT is permissable due to this being a private function only used in

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
@@ -105,12 +105,12 @@ std::shared_ptr<_DWriteFontProperties> DWriteFontCollectionHelper::GetFontProper
 }
 
 HRESULT DWriteFontCollectionHelper::CreateFontFamilyWithName(_In_ const wchar_t* unicharFamilyName,
-                                                             _Out_ IDWriteFontFamily** outFontFamily) {
+                                                             _Outptr_ IDWriteFontFamily** outFontFamily) {
     ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
 
     // If no/empty font collection, say that the font family couldn't be found
     // Use S_FALSE to represent 'not found'
-    RETURN_HR_IF(S_FALSE, !fontCollection);
+    RETURN_HR_IF_NULL(S_FALSE, fontCollection);
 
     size_t fontFamilyIndex;
     BOOL fontFamilyExists;
@@ -123,13 +123,13 @@ HRESULT DWriteFontCollectionHelper::CreateFontFamilyWithName(_In_ const wchar_t*
     return S_FALSE;
 }
 
-HRESULT DWriteFontCollectionHelper::_GetFontListForFamilyName(CFStringRef familyName, _Out_ IDWriteFontList** outFontList) {
+HRESULT DWriteFontCollectionHelper::_GetFontListForFamilyName(CFStringRef familyName, _Outptr_ IDWriteFontList** outFontList) {
     ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
 
     // If no/empty font collection, fail to return a font list
     // Use of E_FAIL rather than a more nuanced HRESULT is permissable due to this being a private function only used in
     // _InitializePropertiesMap()
-    RETURN_HR_IF(E_FAIL, !fontCollection);
+    RETURN_HR_IF_NULL(E_FAIL, fontCollection);
 
     ComPtr<IDWriteFactory> dwriteFactory;
     RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));

--- a/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
+++ b/Frameworks/CoreGraphics/DWriteFontCollectionHelper.mm
@@ -1,0 +1,207 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "DWriteFontCollectionHelper.h"
+
+#import <vector>
+
+#import <StringHelpers.h>
+
+using namespace Microsoft::WRL;
+
+static const wchar_t* TAG = L"_DWriteFontCollectionHelper";
+
+CFMutableArrayRef DWriteFontCollectionHelper::CopyFontFamilyNames() {
+    ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
+    if (!fontCollection) {
+        // Return empty array for an empty font collection
+        return CFArrayCreateMutable(kCFAllocatorSystemDefault, 0, &kCFTypeArrayCallBacks);
+    }
+
+    // Get the number of font families in the collection.
+    uint32_t count = fontCollection->GetFontFamilyCount();
+    CFMutableArrayRef ret = CFArrayCreateMutable(kCFAllocatorSystemDefault, count, &kCFTypeArrayCallBacks);
+    for (uint32_t i = 0; i < count; ++i) {
+        // Get the font family.
+        ComPtr<IDWriteFontFamily> fontFamily;
+        RETURN_NULL_IF_FAILED(fontCollection->GetFontFamily(i, &fontFamily));
+
+        // Get a list of localized strings for the family name.
+        ComPtr<IDWriteLocalizedStrings> familyNames;
+        RETURN_NULL_IF_FAILED(fontFamily->GetFamilyNames(&familyNames));
+
+        CFStringRef name = _CFStringFromLocalizedString(familyNames.Get());
+        if (CFStringGetLength(name) == 0) {
+            TraceError(TAG, L"Failed to convert the localized string to wide string.");
+            continue;
+        }
+
+        CFArrayAppendValue(ret, name);
+    }
+
+    return ret;
+}
+
+CFMutableArrayRef DWriteFontCollectionHelper::CopyFontNamesForFamilyName(CFStringRef familyName) {
+    CFMutableArrayRef ret = CFArrayCreateMutable(kCFAllocatorSystemDefault, 0, &kCFTypeArrayCallBacks);
+
+    ComPtr<IDWriteFontList> fontList;
+    if (FAILED(_GetFontListForFamilyName(familyName, &fontList))) {
+        return ret;
+    }
+
+    size_t fontCount = fontList->GetFontCount();
+    for (size_t i = 0; i < fontCount; i++) {
+        ComPtr<IDWriteFont> font;
+        if (FAILED(fontList->GetFont(i, &font))) {
+            continue;
+        }
+
+        ComPtr<IDWriteLocalizedStrings> fullName;
+        BOOL exist = FALSE;
+        if (FAILED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_FULL_NAME, &fullName, &exist))) {
+            continue;
+        }
+
+        if (exist) {
+            CFStringRef name = _CFStringFromLocalizedString(fullName.Get());
+            if (CFStringGetLength(name) == 0) {
+                TraceError(TAG, L"Failed to convert the localized string to wide string.");
+                continue;
+            }
+
+            CFArrayAppendValue(ret, name);
+        }
+    }
+
+    return ret;
+}
+
+std::shared_ptr<_DWriteFontProperties> DWriteFontCollectionHelper::GetFontPropertiesFromUppercaseFontName(
+    const woc::unique_cf<CFStringRef>& upperFontName) {
+    if (!m_propertiesMap) {
+        _InitializePropertiesMap();
+    }
+
+    const auto& info = m_propertiesMap->find(upperFontName);
+    if (info != m_propertiesMap->end()) {
+        return info->second;
+    }
+
+    return nullptr;
+}
+
+HRESULT DWriteFontCollectionHelper::CreateFontFamilyWithName(_In_ const wchar_t* unicharFamilyName,
+                                                             _Out_ IDWriteFontFamily** outFontFamily) {
+    ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
+
+    // If no/empty font collection, say that the font family couldn't be found
+    // Use S_FALSE to represent 'not found'
+    RETURN_HR_IF(S_FALSE, !fontCollection);
+
+    size_t fontFamilyIndex;
+    BOOL fontFamilyExists;
+
+    RETURN_IF_FAILED(fontCollection->FindFamilyName(unicharFamilyName, &fontFamilyIndex, &fontFamilyExists));
+    if (fontFamilyExists) {
+        return fontCollection->GetFontFamily(fontFamilyIndex, outFontFamily);
+    }
+
+    return S_FALSE;
+}
+
+HRESULT DWriteFontCollectionHelper::_GetFontListForFamilyName(CFStringRef familyName, _Out_ IDWriteFontList** outFontList) {
+    ComPtr<IDWriteFontCollection> fontCollection = _GetFontCollection();
+
+    // If no/empty font collection, fail to return a font list
+    // Use of E_FAIL rather than a more nuanced HRESULT is permissable due to this being a private function only used in
+    // _InitializePropertiesMap()
+    RETURN_HR_IF(E_FAIL, !fontCollection);
+
+    ComPtr<IDWriteFactory> dwriteFactory;
+    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
+
+    size_t index = 0;
+    BOOL exists = FALSE;
+
+    const auto& unicharFamilyName = Strings::VectorFromCFString(familyName);
+    const wchar_t* data = reinterpret_cast<const wchar_t*>(unicharFamilyName.data());
+    RETURN_IF_FAILED(fontCollection->FindFamilyName(data, &index, &exists));
+
+    // Trying to create with a nonexistent font
+    RETURN_HR_IF(E_INVALIDARG, !exists);
+
+    ComPtr<IDWriteFontFamily> fontFamily;
+    RETURN_IF_FAILED(fontCollection->GetFontFamily(index, &fontFamily));
+
+    RETURN_IF_FAILED(
+        fontFamily->GetMatchingFonts(DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, outFontList));
+
+    return S_OK;
+}
+
+void DWriteFontCollectionHelper::_InitializePropertiesMap() {
+    // Initialize m_propertiesMap
+    if (!m_propertiesMap) {
+        m_propertiesMap = std::make_shared<_DWriteFontPropertiesMap>();
+    }
+
+    woc::unique_cf<CFArrayRef> familyNames{ CopyFontFamilyNames() };
+
+    // Iterate over all the font families
+    CFIndex familyCount = CFArrayGetCount(familyNames.get());
+    for (size_t i = 0; i < familyCount; ++i) {
+        CFStringRef familyName = static_cast<CFStringRef>(CFArrayGetValueAtIndex(familyNames.get(), i));
+
+        ComPtr<IDWriteFontList> fontList;
+        if (FAILED(_GetFontListForFamilyName(familyName, &fontList))) {
+            continue;
+        }
+
+        // Iterate over each font in this family
+        size_t fontCount = fontList->GetFontCount();
+        for (size_t j = 0; j < fontCount; j++) {
+            ComPtr<IDWriteFont> font;
+            if (FAILED(fontList->GetFont(j, &font))) {
+                continue;
+            }
+
+            // For each font, fill out a _DWriteFontProperties
+            auto info = std::make_shared<_DWriteFontProperties>();
+            ComPtr<IDWriteLocalizedStrings> displayName;
+            ComPtr<IDWriteLocalizedStrings> postScriptName;
+            BOOL exist;
+
+            if (SUCCEEDED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_FULL_NAME, &displayName, &exist)) && exist) {
+                info->displayName.reset(_CFStringCreateUppercaseCopy(_CFStringFromLocalizedString(displayName.Get())));
+                woc::unique_cf<CFStringRef> uppercaseNameKey(CFStringCreateCopy(kCFAllocatorDefault, info->displayName.get()));
+                m_propertiesMap->emplace(std::move(uppercaseNameKey), info);
+            }
+
+            if (SUCCEEDED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, &postScriptName, &exist)) && exist) {
+                info->postScriptName.reset(static_cast<CFStringRef>(CFRetain(_CFStringFromLocalizedString(postScriptName.Get()))));
+                woc::unique_cf<CFStringRef> uppercaseNameKey(_CFStringCreateUppercaseCopy(info->postScriptName.get()));
+                m_propertiesMap->emplace(std::move(uppercaseNameKey), info);
+            }
+
+            info->familyName.reset(CFStringCreateCopy(nullptr, familyName));
+
+            info->weight = font->GetWeight();
+            info->stretch = font->GetStretch();
+            info->style = font->GetStyle();
+        }
+    }
+}

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -20,178 +20,98 @@
 #include <COMIncludes_End.h>
 
 #import <CoreGraphics/DWriteWrapper.h>
+#import <StringHelpers.h>
 
-#import <unordered_map>
-#import <vector>
 #import <functional>
 #import <mutex>
+#import <vector>
 #import <type_traits>
 
-using namespace std;
+#import "DWriteFontBinaryDataLoader.h"
+#import "DWriteFontCollectionHelper.h"
+#import "DWriteFontBinaryDataCollectionLoader.h"
+
 using namespace Microsoft::WRL;
 
 static const wchar_t* TAG = L"_DWriteWrapper";
 static const wchar_t* c_defaultUserLanguage = L"en-us";
 
-// Static collection which holds all fonts registered by user programatically, through plist, etc.
-static ComPtr<IDWriteFontCollection> _userCreatedFontCollection;
-static std::mutex _userCreatedFontCollectionMutex;
-
 /**
- * Private helper method to return the user set default locale string.
- *
- * @return use set locale string as wstring.
+ * Private concrete implementation of DWriteFontCollectionHelper.
+ * Wraps around the system font collection.
+ * Intended as a singleton.
  */
-static wstring __GetUserDefaultLocaleName() {
-    wchar_t localeName[LOCALE_NAME_MAX_LENGTH];
-    int defaultLocaleSuccess = GetUserDefaultLocaleName(localeName, LOCALE_NAME_MAX_LENGTH);
+class SystemFontCollectionHelper : public DWriteFontCollectionHelper {
+protected:
+    ComPtr<IDWriteFontCollection> _GetFontCollection() {
+        // Seems okay to fail-fast in this case - hard to continue without any system font collection
+        ComPtr<IDWriteFactory> dwriteFactory;
+        THROW_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
 
-    // If the default locale is returned, find that locale name, otherwise use "en-us".
-    return wstring(defaultLocaleSuccess ? localeName : c_defaultUserLanguage);
-}
+        ComPtr<IDWriteFontCollection> fontCollection;
+        THROW_IF_FAILED(dwriteFactory->GetSystemFontCollection(&fontCollection));
 
-/**
- * Private helper that creates an uppercase copy of a CFString
- */
-static CFStringRef __CFStringCreateUppercaseCopy(CFStringRef string, CFLocaleRef locale) {
-    CFMutableStringRef ret = CFStringCreateMutableCopy(nullptr, CFStringGetLength(string), string);
-    CFStringUppercase(ret, locale);
-    return ret;
-}
-
-/**
- * Private helper that creates an array of CFString family names from a font collection
- */
-CFArrayRef __DWriteCopyFontFamilyNamesFromCollection(IDWriteFontCollection* fontCollection) {
-    // Get the number of font families in the collection.
-    uint32_t count = fontCollection->GetFontFamilyCount();
-    woc::unique_cf<CFMutableArrayRef> fontFamilyNames(CFArrayCreateMutable(kCFAllocatorSystemDefault, count, &kCFTypeArrayCallBacks));
-    for (uint32_t i = 0; i < count; ++i) {
-        // Get the font family.
-        ComPtr<IDWriteFontFamily> fontFamily;
-        RETURN_NULL_IF_FAILED(fontCollection->GetFontFamily(i, &fontFamily));
-
-        // Get a list of localized strings for the family name.
-        ComPtr<IDWriteLocalizedStrings> familyNames;
-        RETURN_NULL_IF_FAILED(fontFamily->GetFamilyNames(&familyNames));
-
-        CFStringRef name = _CFStringFromLocalizedString(familyNames.Get());
-        if (CFStringGetLength(name) == 0) {
-            TraceError(TAG, L"Failed to convert the localized string to wide string.");
-            continue;
-        }
-
-        CFArrayAppendValue(fontFamilyNames.get(), name);
-    }
-
-    return fontFamilyNames.release();
-}
-
-/**
- * Private helper that creates the IDWriteFontList for a given font family name
- */
-HRESULT __DWriteGetFontListForFamilyName(CFStringRef familyName, IDWriteFontCollection* fontCollection, IDWriteFontList** outFontList) {
-    ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
-
-    // Get the font family.
-    CFIndex familyNameLength = CFStringGetLength(familyName);
-    std::vector<UniChar> unicharFamilyName(familyNameLength + 1);
-    CFStringGetCharacters(familyName, CFRangeMake(0, familyNameLength), unicharFamilyName.data());
-
-    size_t index = 0;
-    BOOL exists = FALSE;
-
-    RETURN_IF_FAILED(fontCollection->FindFamilyName(reinterpret_cast<wchar_t*>(unicharFamilyName.data()), &index, &exists));
-
-    // Trying to create with a nonexistent font
-    RETURN_HR_IF(E_INVALIDARG, !exists);
-
-    ComPtr<IDWriteFontFamily> fontFamily;
-    RETURN_IF_FAILED(fontCollection->GetFontFamily(index, &fontFamily));
-
-    RETURN_IF_FAILED(
-        fontFamily->GetMatchingFonts(DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL, outFontList));
-
-    return S_OK;
-}
-
-/**
- * Private struct that exposes CFHash and CFEqual to an STL container
- */
-struct __CFStringHashEqual {
-    std::size_t operator()(const woc::unique_cf<CFStringRef>& item) const {
-        return CFHash(item.get());
-    }
-
-    bool operator()(const woc::unique_cf<CFStringRef>& item1, const woc::unique_cf<CFStringRef>& item2) const {
-        return CFEqual(item1.get(), item2.get());
+        return fontCollection;
     }
 };
 
 /**
- * Local typedef for map from font name to font properties
+ * Private concrete implementation of DWriteFontCollectionHelper.
+ * Wraps around an in-memory font collection of fonts provided by the user.
+ * Intended as a singleton.
  */
-using __DWritePropertiesMap =
-    std::unordered_map<woc::unique_cf<CFStringRef>, std::shared_ptr<_DWriteFontProperties>, __CFStringHashEqual, __CFStringHashEqual>;
+class UserFontCollectionHelper : public DWriteFontCollectionHelper {
+public:
+    HRESULT UpdateCollection(const ComPtr<IDWriteFactory>& dwriteFactory, const ComPtr<DWriteFontBinaryDataCollectionLoader>& loader) {
+        // DWrite won't create a new font collection unless we provide a new key each time
+        // So every time we modify the font collection increment the key
+        static size_t collectionKey = 0;
 
-/**
- * Private helper to create a map of font names to properties for all fonts in a collection
- */
-static __DWritePropertiesMap __CreatePropertiesMapForFontCollection(IDWriteFontCollection* fontCollection) {
-    __DWritePropertiesMap ret;
-    woc::unique_cf<CFLocaleRef> locale(CFLocaleCopyCurrent());
-    woc::unique_cf<CFArrayRef> familyNames{ __DWriteCopyFontFamilyNamesFromCollection(fontCollection) };
-    CFIndex familyCount = CFArrayGetCount(familyNames.get());
-    for (size_t i = 0; i < familyCount; ++i) {
-        CFStringRef familyName = static_cast<CFStringRef>(CFArrayGetValueAtIndex(familyNames.get(), i));
-        ComPtr<IDWriteFontList> fontList;
+        RETURN_IF_FAILED(
+            dwriteFactory->CreateCustomFontCollection(loader.Get(), &(++collectionKey), sizeof(collectionKey), &m_fontCollection));
+        // TODO #1374: Can reduce this to only update new/remove old fonts,
+        // rather than leaving the whole map to regenerate
+        m_propertiesMap.reset();
 
-        if (FAILED(__DWriteGetFontListForFamilyName(familyName, fontCollection, &fontList))) {
-            continue;
-        }
-
-        size_t count = fontList->GetFontCount();
-
-        for (size_t j = 0; j < count; j++) {
-            ComPtr<IDWriteFont> font;
-            if (FAILED(fontList->GetFont(j, &font))) {
-                continue;
-            }
-
-            // For each font in that family, fill out a _DWriteFontProperties
-            auto info = std::make_shared<_DWriteFontProperties>();
-            ComPtr<IDWriteLocalizedStrings> displayName;
-            ComPtr<IDWriteLocalizedStrings> postScriptName;
-            BOOL exist;
-
-            if (SUCCEEDED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_FULL_NAME, &displayName, &exist)) && exist) {
-                info->displayName.reset(__CFStringCreateUppercaseCopy(_CFStringFromLocalizedString(displayName.Get()), locale.get()));
-                woc::unique_cf<CFStringRef> uppercaseNameKey(__CFStringCreateUppercaseCopy(info->displayName.get(), locale.get()));
-                ret.emplace(std::move(uppercaseNameKey), info);
-            }
-
-            if (SUCCEEDED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, &postScriptName, &exist)) && exist) {
-                info->postScriptName.reset(static_cast<CFStringRef>(CFRetain(_CFStringFromLocalizedString(postScriptName.Get()))));
-                woc::unique_cf<CFStringRef> uppercaseNameKey(__CFStringCreateUppercaseCopy(info->postScriptName.get(), locale.get()));
-                ret.emplace(std::move(uppercaseNameKey), info);
-            }
-
-            info->familyName.reset(CFStringCreateCopy(nullptr, familyName));
-
-            info->weight = font->GetWeight();
-            info->stretch = font->GetStretch();
-            info->style = font->GetStyle();
-        }
+        return S_OK;
     }
 
-    return ret;
+protected:
+    ComPtr<IDWriteFontCollection> _GetFontCollection() {
+        return m_fontCollection;
+    }
+    ComPtr<IDWriteFontCollection> m_fontCollection;
+};
+
+// Private helper which returns the singleton DWriteFontCollectionHelper for the system font collection.
+static std::shared_ptr<SystemFontCollectionHelper> __GetSystemFontCollectionHelper() {
+    // Function-local static for lazy initialization
+    static auto systemFontCollection = std::make_shared<SystemFontCollectionHelper>();
+    return systemFontCollection;
 }
 
+// Private helper which returns the singleton DWriteFontCollectionHelper for the user font collection.
+static std::shared_ptr<UserFontCollectionHelper> __GetUserFontCollectionHelper() {
+    // Function-local static for lazy initialization
+    static auto userFontCollection = std::make_shared<UserFontCollectionHelper>();
+    return userFontCollection;
+}
+
+// Lock controlling access to the user font collection helper
+static std::recursive_mutex s_userFontCollectionLock;
+
 /**
- * Private static map, that maps display name and postscript name to a _DWriteFontProperties struct for the corresponding user defined font.
+ * Helper method to return the user set default locale string.
+ *
+ * @return use set locale string as wstring.
  */
-static __DWritePropertiesMap s_userFontPropertiesMap;
+std::wstring _GetUserDefaultLocaleName() {
+    wchar_t localeName[LOCALE_NAME_MAX_LENGTH];
+    int defaultLocaleSuccess = GetUserDefaultLocaleName(localeName, LOCALE_NAME_MAX_LENGTH);
+
+    // If the default locale is returned, find that locale name, otherwise use "en-us".
+    return std::wstring(defaultLocaleSuccess ? localeName : c_defaultUserLanguage);
+}
 
 /**
  * Helper method to convert IDWriteLocalizedStrings object to CFString object.
@@ -207,7 +127,7 @@ CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedStrin
     }
 
     // Get the default locale for this user.
-    wstring localeName = __GetUserDefaultLocaleName();
+    std::wstring localeName = _GetUserDefaultLocaleName();
 
     uint32_t index = 0;
     BOOL exists = FALSE;
@@ -228,7 +148,7 @@ CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedStrin
     RETURN_NULL_IF_FAILED(localizedString->GetStringLength(index, &length));
 
     // Get the string.
-    vector<wchar_t> wcharString = std::vector<wchar_t>(length + 1, 0);
+    std::vector<wchar_t> wcharString = std::vector<wchar_t>(length + 1, 0);
     RETURN_NULL_IF_FAILED(localizedString->GetString(index, wcharString.data(), length + 1));
 
     // Strip out unnecessary null terminator
@@ -237,184 +157,92 @@ CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedStrin
 }
 
 /**
- * Helper method to retrieve font family names installed in the system.
- *
- * @return Immutable array of font family name strings that are installed in the system.
- */
-CFArrayRef _DWriteCopyFontFamilyNames() {
-    // Get the direct write factory instance
-    ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_NULL_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
-
-    // Get the system font collection.
-    ComPtr<IDWriteFontCollection> fontCollection;
-    RETURN_NULL_IF_FAILED(dwriteFactory->GetSystemFontCollection(&fontCollection));
-    woc::unique_cf<CFMutableArrayRef> systemFamilyNames{ (CFMutableArrayRef)__DWriteCopyFontFamilyNamesFromCollection(
-        fontCollection.Get()) };
-    std::lock_guard<std::mutex> guard(_userCreatedFontCollectionMutex);
-    if (_userCreatedFontCollection) {
-        woc::unique_cf<CFArrayRef> userFamilyNames{ __DWriteCopyFontFamilyNamesFromCollection(_userCreatedFontCollection.Get()) };
-        CFArrayAppendArray(systemFamilyNames.get(), userFamilyNames.get(), { 0, CFArrayGetCount(userFamilyNames.get()) });
-    }
-
-    return systemFamilyNames.release();
-}
-
-/**
- * Helper method to retrieve names of individual fonts under a font family.
- */
-CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName) {
-    woc::unique_cf<CFMutableArrayRef> fontNames(CFArrayCreateMutable(kCFAllocatorSystemDefault, 0, &kCFTypeArrayCallBacks));
-
-    ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_NULL_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
-    ComPtr<IDWriteFontCollection> systemFontCollection;
-    RETURN_NULL_IF_FAILED(dwriteFactory->GetSystemFontCollection(&systemFontCollection));
-
-    ComPtr<IDWriteFontList> fontList;
-    if (FAILED(__DWriteGetFontListForFamilyName(familyName, systemFontCollection.Get(), &fontList))) {
-        std::lock_guard<std::mutex> guard(_userCreatedFontCollectionMutex);
-        RETURN_NULL_IF_FAILED(__DWriteGetFontListForFamilyName(familyName, _userCreatedFontCollection.Get(), &fontList));
-    }
-
-    size_t count = fontList->GetFontCount();
-
-    for (size_t i = 0; i < count; i++) {
-        ComPtr<IDWriteFont> font;
-        RETURN_NULL_IF_FAILED(fontList->GetFont(i, &font));
-
-        ComPtr<IDWriteLocalizedStrings> fullName;
-        BOOL exist = FALSE;
-        RETURN_NULL_IF_FAILED(font->GetInformationalStrings(DWRITE_INFORMATIONAL_STRING_FULL_NAME, &fullName, &exist));
-
-        if (exist) {
-            CFStringRef name = _CFStringFromLocalizedString(fullName.Get());
-            if (CFStringGetLength(name) == 0) {
-                TraceError(TAG, L"Failed to convert the localized string to wide string.");
-                continue;
-            }
-
-            CFArrayAppendValue(fontNames.get(), name);
-        }
-    }
-
-    return fontNames.release();
-}
-
-/**
- * Helper method that maps a font name to the name of its family.
- *
- * Note: This function currently uses a cache, meaning that fonts installed during runtime will not be reflected
- */
-CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName) {
-    return _DWriteGetFontPropertiesFromName(fontName)->familyName.get();
-}
-
-/**
  * Helper that parses a font name, and returns appropriate weight, stretch, style, and family name values
  */
 std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName) {
-    woc::unique_cf<CFLocaleRef> locale(CFLocaleCopyCurrent());
-    woc::unique_cf<CFStringRef> upperFontName(__CFStringCreateUppercaseCopy(fontName, locale.get()));
+    woc::unique_cf<CFStringRef> upperFontName(_CFStringCreateUppercaseCopy(fontName));
 
-    static const __DWritePropertiesMap systemFontPropertiesMap = []() -> __DWritePropertiesMap {
-        ComPtr<IDWriteFactory> dwriteFactory;
-        if (SUCCEEDED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory))) {
-            // Get the system font collection.
-            ComPtr<IDWriteFontCollection> fontCollection;
-            if (SUCCEEDED(dwriteFactory->GetSystemFontCollection(&fontCollection))) {
-                return __CreatePropertiesMapForFontCollection(fontCollection.Get());
-            }
-        }
-
-        return {};
-    }();
-
-    const auto& info = systemFontPropertiesMap.find(upperFontName);
-    if (info != systemFontPropertiesMap.end()) {
-        return info->second;
+    const auto& info = __GetSystemFontCollectionHelper()->GetFontPropertiesFromUppercaseFontName(upperFontName);
+    if (info) {
+        return info;
     }
-    const auto& userFontInfo = s_userFontPropertiesMap.find(upperFontName);
-    if (userFontInfo != s_userFontPropertiesMap.end()) {
-        return userFontInfo->second;
+
+    std::lock_guard<std::recursive_mutex> guard(s_userFontCollectionLock);
+    const auto& userFontInfo = __GetUserFontCollectionHelper()->GetFontPropertiesFromUppercaseFontName(upperFontName);
+    if (userFontInfo) {
+        return userFontInfo;
     }
 
     return std::make_shared<_DWriteFontProperties>();
 }
 
 /**
- * Creates a DWrite text format object using the system font collection
+ * Helper method to retrieve font family names installed in the system.
+ *
+ * @return Array of font family name strings that are installed in the system.
  */
-HRESULT _DWriteCreateTextFormat(const wchar_t* fontFamilyName,
-                                DWRITE_FONT_WEIGHT weight,
-                                DWRITE_FONT_STYLE style,
-                                DWRITE_FONT_STRETCH stretch,
-                                float fontSize,
-                                IDWriteTextFormat** outTextFormat) {
-    // Get the direct write factory instance
-    ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
+CFArrayRef _DWriteCopyFontFamilyNames() {
+    CFMutableArrayRef ret = __GetSystemFontCollectionHelper()->CopyFontFamilyNames();
 
-    std::lock_guard<std::mutex> guard(_userCreatedFontCollectionMutex);
-    if (_userCreatedFontCollection) {
-        BOOL userCreatedFont = FALSE;
-        uint32_t unusedIndex;
-        RETURN_IF_FAILED(_userCreatedFontCollection->FindFamilyName(fontFamilyName, &unusedIndex, &userCreatedFont));
-        if (userCreatedFont) {
-            return dwriteFactory->CreateTextFormat(fontFamilyName,
-                                                   _userCreatedFontCollection.Get(),
-                                                   weight,
-                                                   style,
-                                                   stretch,
-                                                   fontSize,
-                                                   __GetUserDefaultLocaleName().data(),
-                                                   outTextFormat);
-        }
-    }
+    std::lock_guard<std::recursive_mutex> guard(s_userFontCollectionLock);
+    woc::unique_cf<CFArrayRef> userFamilyNames{ __GetUserFontCollectionHelper()->CopyFontFamilyNames() };
+    CFArrayAppendArray(ret, userFamilyNames.get(), { 0, CFArrayGetCount(userFamilyNames.get()) });
 
-    return dwriteFactory
-        ->CreateTextFormat(fontFamilyName, nullptr, weight, style, stretch, fontSize, __GetUserDefaultLocaleName().data(), outTextFormat);
+    return ret;
+}
+
+/**
+ * Helper method to retrieve names of individual fonts under a font family.
+ */
+CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName) {
+    CFMutableArrayRef ret = __GetSystemFontCollectionHelper()->CopyFontNamesForFamilyName(familyName);
+
+    std::lock_guard<std::recursive_mutex> guard(s_userFontCollectionLock);
+    woc::unique_cf<CFArrayRef> userFontNames{ __GetUserFontCollectionHelper()->CopyFontNamesForFamilyName(familyName) };
+    CFArrayAppendArray(ret, userFontNames.get(), { 0, CFArrayGetCount(userFontNames.get()) });
+    return ret;
+}
+
+/**
+ * Helper method that maps a font name to the name of its family.
+ *
+ * Note: This function currently uses a cache, meaning that fonts installed during runtime will not be reflected,
+ * unless registered to the user font collection
+ */
+CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName) {
+    return _DWriteGetFontPropertiesFromName(fontName)->familyName.get();
 }
 
 /**
  * Helper that creates a IDWriteFontFamily object for a given family name
  */
-HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily) {
-    ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
+HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, _Out_ IDWriteFontFamily** outFontFamily) {
+    const auto& familyNameUnichars = Strings::VectorFromCFString(familyName);
 
-    ComPtr<IDWriteFontCollection> systemFontCollection;
-    RETURN_IF_FAILED(dwriteFactory->GetSystemFontCollection(&systemFontCollection));
-
-    CFIndex familyNameLength = CFStringGetLength(familyName);
-    std::vector<UniChar> unicharFamilyName(familyNameLength + 1);
-    CFStringGetCharacters(familyName, CFRangeMake(0, familyNameLength), unicharFamilyName.data());
-
-    size_t fontFamilyIndex;
-    BOOL fontFamilyExists;
-
-    RETURN_IF_FAILED(systemFontCollection->FindFamilyName(reinterpret_cast<const wchar_t*>(unicharFamilyName.data()),
-                                                          &fontFamilyIndex,
-                                                          &fontFamilyExists));
-
-    if (fontFamilyExists) {
-        return systemFontCollection->GetFontFamily(fontFamilyIndex, outFontFamily);
+    HRESULT result =
+        __GetSystemFontCollectionHelper()->CreateFontFamilyWithName(reinterpret_cast<const wchar_t*>(familyNameUnichars.data()),
+                                                                    outFontFamily);
+    if (result != S_FALSE) {
+        return result;
     }
 
-    std::lock_guard<std::mutex> guard(_userCreatedFontCollectionMutex);
-    RETURN_HR_IF(E_INVALIDARG, !_userCreatedFontCollection);
-    RETURN_IF_FAILED(_userCreatedFontCollection->FindFamilyName(reinterpret_cast<const wchar_t*>(unicharFamilyName.data()),
-                                                                &fontFamilyIndex,
-                                                                &fontFamilyExists));
+    // S_FALSE represents 'not found'
+    // No unexpected failure occurred, just couldn't find in the system font collection
+    // Try the user font collection
+    result = __GetUserFontCollectionHelper()->CreateFontFamilyWithName(reinterpret_cast<const wchar_t*>(familyNameUnichars.data()),
+                                                                       outFontFamily);
+    if (result != S_FALSE) {
+        return result;
+    }
 
-    RETURN_HR_IF(E_INVALIDARG, !fontFamilyExists);
-    return _userCreatedFontCollection->GetFontFamily(fontFamilyIndex, outFontFamily);
+    // Family name could not be found
+    return E_INVALIDARG;
 }
 
 /**
  * Helper function that creates an IDWriteFontFace object for a given font name.
  */
-HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace) {
+HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, _Out_ IDWriteFontFace** outFontFace) {
     // Parse the font name for font weight, stretch, and style
     // Eg: Bold, Condensed, Light, Italic
     std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(name);
@@ -549,278 +377,6 @@ HRESULT _DWriteFontGetBoundingBoxesForGlyphs(
     return ret;
 }
 
-/**
- * Custom implementation of IDWriteFontFileStream that implements Read in terms of an underlying CFDataRef
- *
- * While IDWriteFontFileStream normally frees its underlying data bit by bit through ReleaseFileFragment(),
- * for WinObjC purposes, it is easier to rely on existing mechanisms for CFData's destruction.
- * Thus, this class releases its CFData all at once, at the time of its destruction.
- */
-class DWriteFontBinaryDataStream : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontFileStream> {
-protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
-
-public:
-    DWriteFontBinaryDataStream() {
-    }
-
-    HRESULT RuntimeClassInitialize(CFDataRef data) {
-        CFRetain(data);
-        _data.reset(data);
-
-        // Just use current time for _lastWriteTime
-        FILETIME fileTime;
-        GetSystemTimeAsFileTime(&fileTime);
-
-        // Concat filetime into a single uint64_t
-        _lastWriteTime = 0;
-        _lastWriteTime |= static_cast<uint64_t>(fileTime.dwLowDateTime);
-        _lastWriteTime |= static_cast<uint64_t>(fileTime.dwHighDateTime) << 32;
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE GetFileSize(_Out_ uint64_t* fileSize) {
-        RETURN_HR_IF_NULL(E_INVALIDARG, fileSize);
-        *fileSize = CFDataGetLength(_data.get());
-        return S_OK;
-    };
-
-    HRESULT STDMETHODCALLTYPE GetLastWriteTime(_Out_ uint64_t* lastWriteTime) {
-        RETURN_HR_IF_NULL(E_INVALIDARG, lastWriteTime);
-        *lastWriteTime = _lastWriteTime;
-        return S_OK;
-    };
-
-    HRESULT STDMETHODCALLTYPE ReadFileFragment(_Out_ const void** fragmentStart,
-                                               uint64_t fileOffset,
-                                               uint64_t fragmentSize,
-                                               _Out_ void** fragmentContext) {
-        if (fileOffset + fragmentSize > CFDataGetLength(_data.get())) {
-            return E_INVALIDARG;
-        }
-
-        if (fragmentStart) {
-            const uint8_t* underlyingBuffer = CFDataGetBytePtr(_data.get());
-            *fragmentStart = reinterpret_cast<const void*>(&(underlyingBuffer[fileOffset]));
-        }
-
-        if (fragmentContext) {
-            // Deliberately unused: this is meant to be passed to ReleaseFileFragment() below to free part of the data,
-            // but this stream frees all the underlying CFData at once
-            *fragmentContext = nullptr;
-        }
-
-        return S_OK;
-    };
-
-    void STDMETHODCALLTYPE ReleaseFileFragment(void* fragmentContext){
-        // Deliberate no-op: data is released alongside the _data member with the destruction of this object
-    };
-
-private:
-    woc::unique_cf<CFDataRef> _data;
-    uint64_t _lastWriteTime;
-};
-
-/**
- * Custom implementation of IDWriteFontFileLoader that loads a CGDataProviderRef as its font file
- */
-class DWriteFontBinaryDataLoader : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontFileLoader> {
-protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
-
-public:
-    DWriteFontBinaryDataLoader() {
-    }
-
-    HRESULT RuntimeClassInitialize(CFDataRef data) {
-        CFRetain(data);
-        _data.reset(data);
-        return S_OK;
-    }
-
-    // Ignores first two params, just return the same kind of stream always
-    // Stream returned is dictated by dataProvider passed in at initialization time
-    HRESULT STDMETHODCALLTYPE CreateStreamFromKey(_In_ const void* fontFileReferenceKey,
-                                                  uint32_t fontFileReferenceKeySize,
-                                                  _Out_ IDWriteFontFileStream** fontFileStream) {
-        RETURN_HR_IF_NULL(E_INVALIDARG, fontFileStream);
-
-        ComPtr<DWriteFontBinaryDataStream> ret;
-        RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataStream>(&ret, _data.get()));
-
-        *fontFileStream = ret.Detach();
-        return S_OK;
-    }
-
-private:
-    woc::unique_cf<CFDataRef> _data;
-};
-
-// Implementation of IDwriteFontFileEnumerator, which enumerates over internal data and returns a font file
-class DWriteFontFileEnumerator : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontFileEnumerator> {
-protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
-
-public:
-    DWriteFontFileEnumerator() {
-    }
-
-    HRESULT RuntimeClassInitialize(CFArrayRef fontDatas, std::vector<ComPtr<IDWriteFontFile>>* previouslyCreatedFiles) {
-        CFRetain(fontDatas);
-        m_fontDatas.reset(fontDatas);
-        m_previouslyCreatedFiles = previouslyCreatedFiles;
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE GetCurrentFontFile(_Out_ IDWriteFontFile** fontFile) {
-        RETURN_HR_IF(E_ILLEGAL_METHOD_CALL, m_location < 0 || m_location > CFArrayGetCount(m_fontDatas.get()));
-
-        if (0 <= m_location && m_location < m_previouslyCreatedFiles->size()) {
-            m_previouslyCreatedFiles->at(m_location).CopyTo(fontFile);
-        } else {
-            ComPtr<IDWriteFactory> dwriteFactory;
-            RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
-
-            ComPtr<DWriteFontBinaryDataLoader> loader;
-            RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataLoader>(&loader,
-                                                                           static_cast<CFDataRef>(
-                                                                               CFArrayGetValueAtIndex(m_fontDatas.get(), m_location))));
-            RETURN_IF_FAILED(dwriteFactory->RegisterFontFileLoader(loader.Get()));
-
-            int unused;
-            RETURN_IF_FAILED(dwriteFactory->CreateCustomFontFileReference(&unused, sizeof(unused), loader.Get(), fontFile));
-            m_previouslyCreatedFiles->emplace_back(*fontFile);
-        }
-
-        return S_OK;
-    }
-
-    HRESULT STDMETHODCALLTYPE MoveNext(_Out_ BOOL* hasCurrentFile) {
-        *hasCurrentFile = ++m_location < CFArrayGetCount(m_fontDatas.get());
-        return S_OK;
-    }
-
-private:
-    int m_location = -1;
-
-    woc::unique_cf<CFArrayRef> m_fontDatas;
-    std::vector<ComPtr<IDWriteFontFile>>* m_previouslyCreatedFiles;
-};
-
-/**
- * Implementation of IDWriteFontCollectionLoader, which creates an IDWriteFontFileEnumerator to create font files
- * Which are used to create a font collection.  This is expected to be a singleton
- */
-class DWriteFontCollectionLoader : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteFontCollectionLoader> {
-protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
-
-public:
-    DWriteFontCollectionLoader() {
-    }
-
-    HRESULT RuntimeClassInitialize() {
-        m_fontDatas.reset(CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks));
-        m_fontDatasSet.reset(CFSetCreateMutable(nullptr, 0, &kCFTypeSetCallBacks));
-        return S_OK;
-    }
-
-    HRESULT AddDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
-        CFMutableArrayRef outErrors = nil;
-        HRESULT ret = S_OK;
-        if (errors) {
-            outErrors = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
-            *errors = outErrors;
-        }
-
-        CFIndex count = CFArrayGetCount(fontDatas);
-        for (CFIndex i = 0; i < count; ++i) {
-            CFDataRef data = static_cast<CFDataRef>(CFArrayGetValueAtIndex(fontDatas, i));
-            if (data) {
-                if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
-                    __AppendErrorIfExists(outErrors, kCTFontManagerErrorAlreadyRegistered);
-                    ret = S_FALSE;
-                } else {
-                    CFArrayAppendValue(m_fontDatas.get(), data);
-                    CFSetAddValue(m_fontDatasSet.get(), data);
-                    __AppendNullptrIfExists(outErrors);
-                }
-            } else {
-                __AppendErrorIfExists(outErrors, kCTFontManagerErrorInvalidFontData);
-                ret = S_FALSE;
-            }
-        }
-
-        return ret;
-    }
-
-    HRESULT RemoveDatas(CFArrayRef fontDatas, CFArrayRef* errors) {
-        CFMutableArrayRef outErrors = nil;
-        HRESULT ret = S_OK;
-        if (errors) {
-            outErrors = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
-            *errors = outErrors;
-        }
-
-        CFIndex count = CFArrayGetCount(fontDatas);
-        for (CFIndex i = 0; i < count; ++i) {
-            CFDataRef data = static_cast<CFDataRef>(CFArrayGetValueAtIndex(fontDatas, i));
-            if (data) {
-                if (CFSetContainsValue(m_fontDatasSet.get(), data)) {
-                    CFSetRemoveValue(m_fontDatasSet.get(), data);
-                    CFIndex index = CFArrayGetFirstIndexOfValue(m_fontDatas.get(), { 0, CFArrayGetCount(m_fontDatas.get()) }, data);
-                    CFArrayRemoveValueAtIndex(m_fontDatas.get(), index);
-                    m_previouslyCreatedFiles.erase(m_previouslyCreatedFiles.begin() + index);
-                    __AppendNullptrIfExists(outErrors);
-                } else {
-                    __AppendErrorIfExists(outErrors, kCTFontManagerErrorNotRegistered);
-                    ret = S_FALSE;
-                }
-            } else {
-                __AppendErrorIfExists(outErrors, kCTFontManagerErrorInvalidFontData);
-                ret = S_FALSE;
-            }
-        }
-
-        return ret;
-    }
-
-    HRESULT STDMETHODCALLTYPE CreateEnumeratorFromKey(_In_ IDWriteFactory* factory,
-                                                      _In_ const void* collectionKey,
-                                                      _In_ UINT32 collectionKeySize,
-                                                      _Out_ IDWriteFontFileEnumerator** enumerator) {
-        MakeAndInitialize<DWriteFontFileEnumerator>(enumerator, m_fontDatas.get(), &m_previouslyCreatedFiles);
-        return S_OK;
-    }
-
-private:
-    // Array of CFDataRef containing data of fonts, in order of being added
-    woc::unique_cf<CFMutableArrayRef> m_fontDatas;
-
-    // Set of CFDataRef containing data of fonts, used to simplify checking if font has been added
-    woc::unique_cf<CFMutableSetRef> m_fontDatasSet;
-
-    // Array of previously created font files, which saves us from having to read a file multiple times
-    std::vector<ComPtr<IDWriteFontFile>> m_previouslyCreatedFiles;
-
-    /**
-     * Private helpers to append a CFErrorRef or nullptr to the end of a CFMutableArray if it exists
-     */
-    static void __AppendErrorIfExists(CFMutableArrayRef errors, CFIndex errorCode) {
-        if (errors) {
-            woc::unique_cf<CFErrorRef> error{ CFErrorCreate(nullptr, kCFErrorDomainCocoa, errorCode, nullptr) };
-            CFArrayAppendValue(errors, error.get());
-        }
-    }
-
-    static void __AppendNullptrIfExists(CFMutableArrayRef errors) {
-        if (errors) {
-            CFArrayAppendValue(errors, nullptr);
-        }
-    }
-};
-
 // TLambda is a member function of our FontCollectionLoader which updates the internal state of the loader
 // TLambda :: (DWriteFontCollectionLoader -> CFArrayRef -> CFArrayRef*) -> HRESULT
 template <typename TLambda>
@@ -829,11 +385,11 @@ static HRESULT __DWriteUpdateUserCreatedFontCollection(CFArrayRef datas, CFArray
     RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
 
     // Create singleton Font Collection loader, which will be shared for registering/unregistering fonts
-    static ComPtr<DWriteFontCollectionLoader> loader;
-    static HRESULT createdLoader = [](DWriteFontCollectionLoader** collectionLoader) {
+    static ComPtr<DWriteFontBinaryDataCollectionLoader> loader;
+    static HRESULT createdLoader = [](DWriteFontBinaryDataCollectionLoader** collectionLoader) {
         ComPtr<IDWriteFactory> dwriteFactory;
         RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
-        RETURN_IF_FAILED(MakeAndInitialize<DWriteFontCollectionLoader>(collectionLoader));
+        RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataCollectionLoader>(collectionLoader));
         RETURN_IF_FAILED(dwriteFactory->RegisterFontCollectionLoader(*collectionLoader));
         return S_OK;
     }(&loader);
@@ -843,15 +399,9 @@ static HRESULT __DWriteUpdateUserCreatedFontCollection(CFArrayRef datas, CFArray
     // Still want to update font collection with whatever fonts succeeded, so return ret at end
     HRESULT ret = func(loader.Get(), datas, errors);
 
-    // DWrite won't create a new font collection unless we provide a new key each time
-    // So every time we modify the font collection increment the key
-    static size_t collectionKey = 0;
-    std::lock_guard<std::mutex> guard(_userCreatedFontCollectionMutex);
-    RETURN_IF_FAILED(
-        dwriteFactory->CreateCustomFontCollection(loader.Get(), &(++collectionKey), sizeof(collectionKey), &_userCreatedFontCollection));
-
-    // Update s_userFontPropertiesMap with new values
-    s_userFontPropertiesMap = __CreatePropertiesMapForFontCollection(_userCreatedFontCollection.Get());
+    // Update the user font collection
+    std::lock_guard<std::recursive_mutex> guard(s_userFontCollectionLock);
+    RETURN_IF_FAILED(__GetUserFontCollectionHelper()->UpdateCollection(dwriteFactory, loader));
 
     return ret;
 }
@@ -859,17 +409,17 @@ static HRESULT __DWriteUpdateUserCreatedFontCollection(CFArrayRef datas, CFArray
 // Registers user defined fonts to a collection so they can be created later
 // Expects datas to be array of CFDataRefs, errors to be out pointer to array of CFErrorRef
 HRESULT _DWriteRegisterFontsWithDatas(CFArrayRef datas, CFArrayRef* errors) {
-    return __DWriteUpdateUserCreatedFontCollection(datas, errors, std::mem_fn(&DWriteFontCollectionLoader::AddDatas));
+    return __DWriteUpdateUserCreatedFontCollection(datas, errors, std::mem_fn(&DWriteFontBinaryDataCollectionLoader::AddDatas));
 }
 
 // Unregisters user defined fonts to a collection so they can be created later
 // Expects datas to be array of CFDataRefs, errors to be out pointer to array of CFErrorRef
 HRESULT _DWriteUnregisterFontsWithDatas(CFArrayRef datas, CFArrayRef* errors) {
-    return __DWriteUpdateUserCreatedFontCollection(datas, errors, std::mem_fn(&DWriteFontCollectionLoader::RemoveDatas));
+    return __DWriteUpdateUserCreatedFontCollection(datas, errors, std::mem_fn(&DWriteFontBinaryDataCollectionLoader::RemoveDatas));
 }
 
 /**
- * Creates an IDWriteFontFace by attempting to use a CGDataProviderRef as a font file
+ * Creates an IDWriteFontFace by attempting to use a CFDataRef as a font file
  */
 HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, IDWriteFontFace** outFontFace) {
     ComPtr<IDWriteFactory> dwriteFactory;

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -14,7 +14,6 @@
 //
 //******************************************************************************
 
-// #1207: Do not move this block, it has to come first for some reason
 #include <COMIncludes.h>
 #import <wrl/implements.h>
 #include <COMIncludes_End.h>
@@ -421,7 +420,7 @@ HRESULT _DWriteUnregisterFontsWithDatas(CFArrayRef datas, CFArrayRef* errors) {
 /**
  * Creates an IDWriteFontFace by attempting to use a CFDataRef as a font file
  */
-HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, IDWriteFontFace** outFontFace) {
+HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, _Out_ IDWriteFontFace** outFontFace) {
     ComPtr<IDWriteFactory> dwriteFactory;
     RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
 

--- a/Frameworks/CoreGraphics/DWriteWrapper.mm
+++ b/Frameworks/CoreGraphics/DWriteWrapper.mm
@@ -155,7 +155,7 @@ CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedStrin
 /**
  * Helper that parses a font name, and returns appropriate weight, stretch, style, and family name values
  */
-std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName) {
+std::shared_ptr<const _DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName) {
     woc::unique_cf<CFStringRef> upperFontName(_CFStringCreateUppercaseCopy(fontName));
 
     const auto& info = __GetSystemFontCollectionHelper()->GetFontPropertiesFromUppercaseFontName(upperFontName);
@@ -168,7 +168,7 @@ std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFString
         return userFontInfo;
     }
 
-    return std::make_shared<_DWriteFontProperties>();
+    return std::make_shared<const _DWriteFontProperties>();
 }
 
 /**
@@ -238,7 +238,7 @@ HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamil
 HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace) {
     // Parse the font name for font weight, stretch, and style
     // Eg: Bold, Condensed, Light, Italic
-    std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(name);
+    std::shared_ptr<const _DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(name);
 
     // Need to be able to load fonts from the app's bundle
     // For now return a default font to avoid crashes in case of missing fonts
@@ -269,11 +269,11 @@ HRESULT _DWriteCreateTextFormatWithFontNameAndSize(CFStringRef optionalFontName,
     RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
 
     ComPtr<IDWriteTextFormat> textFormat;
-    std::shared_ptr<_DWriteFontProperties> info;
-    std::shared_ptr<_DWriteFontProperties> userFontInfo;
+    std::shared_ptr<const _DWriteFontProperties> info;
+    std::shared_ptr<const _DWriteFontProperties> userFontInfo;
 
     if (!optionalFontName) {
-        info = std::make_shared<_DWriteFontProperties>();
+        info = std::make_shared<const _DWriteFontProperties>();
     } else {
         woc::unique_cf<CFStringRef> upperFontName(_CFStringCreateUppercaseCopy(optionalFontName));
         info = __GetSystemFontCollectionHelper()->GetFontPropertiesFromUppercaseFontName(upperFontName);

--- a/Frameworks/CoreText/CTTypesetter.mm
+++ b/Frameworks/CoreText/CTTypesetter.mm
@@ -84,6 +84,15 @@ CTLineRef CTTypesetterCreateLineWithOffset(CTTypesetterRef ts, CFRange range, do
     RETURN_NULL_IF(!frame);
     THROW_NS_IF_FALSE(E_UNEXPECTED, [frame->_lines count] == 1);
 
+    if ([frame->_lines count] != 1) {
+        TraceError(TAG,
+                   L"CTTypesetterCreateLineWithOffset - range {%f, %f} did not fit on a single line, instead used %u.",
+                   range.location,
+                   range.length,
+                   [frame->_lines count]);
+        return nullptr;
+    }
+
     return static_cast<CTLineRef>([[frame->_lines firstObject] retain]);
 }
 

--- a/Frameworks/CoreText/CTTypesetter.mm
+++ b/Frameworks/CoreText/CTTypesetter.mm
@@ -82,8 +82,6 @@ CTLineRef CTTypesetterCreateLineWithOffset(CTTypesetterRef ts, CFRange range, do
                                       CGRectMake(offset, 0, FLT_MAX, FLT_MAX));
 
     RETURN_NULL_IF(!frame);
-    THROW_NS_IF_FALSE(E_UNEXPECTED, [frame->_lines count] == 1);
-
     if ([frame->_lines count] != 1) {
         TraceError(TAG,
                    L"CTTypesetterCreateLineWithOffset - range {%f, %f} did not fit on a single line, instead used %u.",

--- a/Frameworks/CoreText/DWriteWrapper_CGPath.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CGPath.mm
@@ -41,7 +41,7 @@ static const wchar_t* TAG = L"_DWriteWrapper_CGPath";
  */
 class __CGPathGeometrySink : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteGeometrySink> {
 protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+    InspectableClass(L"Windows.Bridge.DirectWrite.__CGPathGeometrySink", TrustLevel::BaseTrust);
 
 public:
     __CGPathGeometrySink(const CGAffineTransform* transform) {

--- a/Frameworks/CoreText/DWriteWrapper_CGPath.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CGPath.mm
@@ -14,7 +14,6 @@
 //
 //******************************************************************************
 
-// #1207: Do not move this block, it has to come first for some reason
 #include <COMIncludes.h>
 #import <wrl/implements.h>
 #import <D2d1.h>

--- a/Frameworks/CoreText/DWriteWrapper_CGPath.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CGPath.mm
@@ -51,10 +51,6 @@ public:
         }
     }
 
-    HRESULT RuntimeClassInitialize() {
-        return S_OK;
-    }
-
     void STDMETHODCALLTYPE AddBeziers(_In_ const D2D1_BEZIER_SEGMENT* beziers, unsigned int beziersCount) {
         // Some background on Bezier curves:
         // A quadratic Bezier curve is specified by 3 points:     a start point, a control point, and an end point

--- a/Frameworks/CoreText/DWriteWrapper_CGPath.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CGPath.mm
@@ -1,0 +1,178 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+// #1207: Do not move this block, it has to come first for some reason
+#include <COMIncludes.h>
+#import <wrl/implements.h>
+#import <D2d1.h>
+#include <COMIncludes_End.h>
+
+#import <LoggingNative.h>
+
+#import "DWriteWrapper_CoreText.h"
+
+using namespace Microsoft::WRL;
+
+static const wchar_t* TAG = L"_DWriteWrapper_CGPath";
+
+/**
+ * Custom IDWriteGeometrySink class, built on top of a CGMutablePath,
+ * that translates callbacks from IDWriteFontFace::GetGlyphRunOutline to CGPath elements.
+ *
+ * Notes:
+ *
+ * DWrite provides negative values for y-coordinates, whereas CGPath expects positive ones
+ * As such, functions in this class will invert y-coordinates when passing points from DWrite to CG
+ *
+ * IDWriteFontFace::GetGlyphRunOutline uses this class in a single-threaded manner (dumping the draw instructions from the font linearly)
+ * As such, this class is deliberately left thread-unsafe.
+ */
+class __CGPathGeometrySink : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteGeometrySink> {
+protected:
+    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+
+public:
+    __CGPathGeometrySink(const CGAffineTransform* transform) {
+        m_cgPath.reset(CGPathCreateMutable());
+        if (transform) {
+            m_transform = std::make_unique<CGAffineTransform>(*transform);
+        }
+    }
+
+    HRESULT RuntimeClassInitialize() {
+        return S_OK;
+    }
+
+    void STDMETHODCALLTYPE AddBeziers(_In_ const D2D1_BEZIER_SEGMENT* beziers, unsigned int beziersCount) {
+        // Some background on Bezier curves:
+        // A quadratic Bezier curve is specified by 3 points:     a start point, a control point, and an end point
+        // A cubic Bezier curve is instead specified by 4 points: a start point, TWO control points, and an end point
+        // As a generalization, most "older" fonts specify quadratic curves, and "newer" ones can use cubic curves
+        // Eg: Times New Roman's curves are all quadratic
+
+        // CGPath has support for both orders of Bezier curve, (AddCurveToPoint for cubic, AddQuadCurveToPointFor quadratic)
+        // but DWrite's GeometrySink only supports cubic Bezier curves (AddBeziers),
+        // and approximates any quadratic curves in terms of a cubic curve
+        // Eg: Reference platform quadratic curve:  (previous endpoint),              (512, 632),              (480, 632)
+        //     DWrite approximate cubic curve:      (previous endpoint), (529, 632.666626), (501.333313, 632), (480, 632)
+
+        // Attempting to do an approximation from cubic back to quadratic would be clumsy and introduce further approximation error,
+        // So just pass all cubic Beziers through directly, including approximated ones
+        for (unsigned int i = 0; i < beziersCount; ++i) {
+            CGPathAddCurveToPoint(m_cgPath.get(),
+                                  m_transform.get(),
+                                  beziers[i].point1.x,
+                                  -beziers[i].point1.y,
+                                  beziers[i].point2.x,
+                                  -beziers[i].point2.y,
+                                  beziers[i].point3.x,
+                                  -beziers[i].point3.y);
+        }
+    }
+
+    void STDMETHODCALLTYPE AddLines(_In_ const D2D1_POINT_2F* points, unsigned int pointsCount) {
+        // Use individual CGPathAddLineToPoint() calls here, rather than CGPathAddLines
+        // CGPathAddLines does a CGPathMoveToPoint to the first point,
+        // which doesn't match what DWrite expects (draw a line from the previous point)
+        for (unsigned int i = 0; i < pointsCount; ++i) {
+            CGPathAddLineToPoint(m_cgPath.get(), m_transform.get(), points[i].x, -points[i].y);
+        }
+    }
+
+    void STDMETHODCALLTYPE BeginFigure(D2D1_POINT_2F startPoint, D2D1_FIGURE_BEGIN figureBegin) {
+        if (m_figureInProgress) {
+            TraceError(TAG,
+                       L"IDWriteGeometrySink::BeginFigure called while a figure was currently in progress. Placing object in error state - "
+                       L"future function calls will fail.");
+            m_invalidState = true;
+        }
+
+        if (!m_invalidState) {
+            // figureBegin is ignored for CGPath purposes -
+            // filled vs hollow maps to CGPathDrawingMode, and is specified to CGContextDrawPath directly
+            m_figureInProgress = true;
+            CGPathMoveToPoint(m_cgPath.get(), m_transform.get(), startPoint.x, -startPoint.y);
+        }
+    }
+
+    HRESULT STDMETHODCALLTYPE Close() {
+        if (m_figureInProgress) {
+            TraceError(TAG,
+                       L"IDWriteGeometrySink::Close called while a figure was currently in progress. Placing object in error state - "
+                       L"future function calls will fail.");
+            m_invalidState = true;
+        }
+
+        return m_invalidState ? E_UNEXPECTED : S_OK;
+    }
+
+    void STDMETHODCALLTYPE EndFigure(D2D1_FIGURE_END figureEnd) {
+        if (!m_figureInProgress) {
+            TraceError(TAG,
+                       L"IDWriteGeometrySink::EndFigure called while no figure was currently in progress. Placing object in error state - "
+                       L"future function calls will fail.");
+            m_invalidState = true;
+        }
+
+        if (!m_invalidState) {
+            // figureBegin is ignored for CGPath purposes -
+            // filled vs hollow maps to CGPathDrawingMode, and is specified to CGContextDrawPath directly
+            m_figureInProgress = false;
+
+            if (figureEnd) {
+                // D2D1_FIGURE_END_CLOSED  = 1, close the subpath
+                CGPathCloseSubpath(m_cgPath.get());
+            }
+            // D2D1_FIGURE_END_OPEN = 0, subpath is left open (no-op in terms of CGPath)
+        }
+    }
+
+    void STDMETHODCALLTYPE SetFillMode(D2D1_FILL_MODE fillMode) {
+        // No-op for CGPath purposes - CGPathDrawingMode is specified to CGContextDrawPath directly
+    }
+
+    void STDMETHODCALLTYPE SetSegmentFlags(D2D1_PATH_SEGMENT vertexFlags) {
+        // No-op for CGPath purposes - CGLineJoin is specified to CGContextStrokePath directly
+    }
+
+    // Releases the class's ownership of its path when all operations are finished, returning a +1 reference (from the path's Create)
+    CGPathRef ReleasePath() {
+        return m_cgPath.release();
+    }
+
+private:
+    woc::unique_cf<CGMutablePathRef> m_cgPath;
+    std::unique_ptr<CGAffineTransform> m_transform;
+    bool m_figureInProgress = false; // Keeps track of whether this class is currently between a BeginFigure and EndFigure call
+    bool m_invalidState = false; // If BeginFigure and EndFigure calls are imbalanced, invalidate all future operations
+};
+
+/**
+ * Returns a CGPathRef representing the specified glyph, using the specified font face, point size, and transformation matrix.
+ */
+CGPathRef _DWriteFontCreatePathForGlyph(const ComPtr<IDWriteFontFace>& fontFace,
+                                        CGFloat pointSize,
+                                        CGGlyph glyph,
+                                        const CGAffineTransform* transform) {
+    // Create an instance of a custom IDWriteGeometrySink backed by a CGMutablePathRef
+    ComPtr<__CGPathGeometrySink> geometrySink = Make<__CGPathGeometrySink>(transform);
+
+    // Call GetGlyphRunOutline using glyph as a C-style array of size 1
+    RETURN_NULL_IF_FAILED(fontFace->GetGlyphRunOutline(pointSize, &glyph, nullptr, nullptr, 1, false, false, geometrySink.Get()));
+
+    // Get the underlying CGMutablePathRef from the sink
+    return geometrySink->ReleasePath();
+}

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -181,7 +181,7 @@ CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num) {
  * Creates an IDWriteFontFace given the attributes of a CTFontDescriptor
  * Currently, font name, family name, kCTFontWeight/Slant/Width, and part of SymbolicTrait, are taken into account
  */
-HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Out_ IDWriteFontFace** fontFace) {
+HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Outptr_ IDWriteFontFace** fontFace) {
     woc::unique_cf<CFStringRef> fontName(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontNameAttribute)));
     woc::unique_cf<CFStringRef> familyName(
         static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontFamilyNameAttribute)));

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -216,8 +216,6 @@ static CFDictionaryRef _DWriteFontCreateTraitsDict(const ComPtr<IDWriteFontFace>
     // Get pointers for the additional FontFace interfaces
     ComPtr<IDWriteFontFace1> fontFace1;
     RETURN_NULL_IF_FAILED(fontFace.As(&fontFace1));
-    ComPtr<IDWriteFontFace2> fontFace2;
-    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace2));
     ComPtr<IDWriteFontFace3> fontFace3;
     RETURN_NULL_IF_FAILED(fontFace.As(&fontFace3));
 
@@ -256,24 +254,17 @@ static CFDictionaryRef _DWriteFontCreateTraitsDict(const ComPtr<IDWriteFontFace>
         symbolicTraits |= kCTFontVerticalTrait;
     }
 
-    if (fontFace2->IsColorFont()) {
+    if (fontFace3->IsColorFont()) {
         symbolicTraits |= kCTFontColorGlyphsTrait;
     }
 
     // TODO: The symbolic traits below are poorly documented/have no clear DWrite mapping
-    // if (fontFace->IsFoo()) {
-    //     symbolicTraits |= kCTFontUIOptimizedTrait;
-    // }
-    // if (fontFace->IsFoo()) {
-    //     symbolicTraits |= kCTFontCompositeTrait;
-    // }
+    // kCTFontUIOptimizedTrait
+    // kCTFontCompositeTrait
 
     // TODO: The upper 16 bits of symbolic traits describe stylistic aspects of a font, specifically its serifs,
     // such as modern, ornamental, or sans (no serifs)
     // DWrite has no such API for characterizing fonts
-    // if (fontFace->IsFoo()) {
-    //     symbolicTraits |= kCTFontOldStyleSerifsClass;
-    // }
 
     // Keys and values for the final trait dictionary
     CFTypeRef traitKeys[] = { kCTFontSymbolicTrait, kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait };

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -1,0 +1,368 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "DWriteWrapper_CoreText.h"
+
+#import <LoggingNative.h>
+
+using namespace Microsoft::WRL;
+
+static const wchar_t* TAG = L"_DWriteWrapper_CTFont";
+
+// Represents a mapping between multiple representations of the same font weight across DWrite and CoreText
+// DWRITE_FONT_WEIGHT_BOLD = kCTFontWeightBold
+struct __WeightMapping {
+    DWRITE_FONT_WEIGHT dwriteValue;
+    CGFloat ctValue;
+};
+
+// Mapping for weight
+// Some loss of precision here as CT presents fewer values than DWrite
+// Note also that Thin and Ultra/Extra-Light are in opposite order in DWrite and CoreText/UIKit constants
+// (However, "Thin" fonts on the reference platform have UIFontWeightUltraLight...)
+// clang-format off
+static const struct __WeightMapping c_weightMap[] = { { DWRITE_FONT_WEIGHT_THIN, kCTFontWeightUltraLight },
+                                                    { DWRITE_FONT_WEIGHT_EXTRA_LIGHT, kCTFontWeightThin },
+                                                    { DWRITE_FONT_WEIGHT_ULTRA_LIGHT, kCTFontWeightThin },
+                                                    { DWRITE_FONT_WEIGHT_LIGHT, kCTFontWeightLight },
+                                                    { DWRITE_FONT_WEIGHT_SEMI_LIGHT, kCTFontWeightLight },
+                                                    { DWRITE_FONT_WEIGHT_NORMAL, kCTFontWeightRegular },
+                                                    { DWRITE_FONT_WEIGHT_REGULAR, kCTFontWeightRegular },
+                                                    { DWRITE_FONT_WEIGHT_MEDIUM, kCTFontWeightMedium },
+                                                    { DWRITE_FONT_WEIGHT_DEMI_BOLD, kCTFontWeightSemibold },
+                                                    { DWRITE_FONT_WEIGHT_SEMI_BOLD, kCTFontWeightSemibold },
+                                                    { DWRITE_FONT_WEIGHT_BOLD, kCTFontWeightBold },
+                                                    { DWRITE_FONT_WEIGHT_EXTRA_BOLD, kCTFontWeightHeavy },
+                                                    { DWRITE_FONT_WEIGHT_ULTRA_BOLD, kCTFontWeightHeavy },
+                                                    { DWRITE_FONT_WEIGHT_BLACK, kCTFontWeightBlack },
+                                                    { DWRITE_FONT_WEIGHT_HEAVY, kCTFontWeightBlack },
+                                                    { DWRITE_FONT_WEIGHT_EXTRA_BLACK, kCTFontWeightBlack },
+                                                    { DWRITE_FONT_WEIGHT_ULTRA_BLACK, kCTFontWeightBlack } };
+// clang-format on
+
+/**
+ * Helper function that converts a DWRITE_FONT_WEIGHT into a float usable for kCTFontWeightTrait.
+ */
+static CGFloat __DWriteFontWeightToCT(DWRITE_FONT_WEIGHT weight) {
+    for (const auto& weightMapping : c_weightMap) {
+        if (weight == weightMapping.dwriteValue) {
+            return weightMapping.ctValue;
+        }
+    }
+
+    return kCTFontWeightRegular;
+}
+
+/**
+ * Helper function that converts a kCTFontWeightTrait-eligible CGFloat into a DWRITE_FONT_WEIGHT
+ */
+static DWRITE_FONT_WEIGHT __CTFontWeightToDWrite(CGFloat weight) {
+    for (const auto& weightMapping : c_weightMap) {
+        if (weight == weightMapping.ctValue) {
+            return weightMapping.dwriteValue;
+        }
+    }
+
+    return DWRITE_FONT_WEIGHT_NORMAL;
+}
+
+/**
+ * Helper function that converts a DWRITE_FONT_STRETCH into a float usable for kCTFontWidthTrait.
+ */
+static CGFloat __DWriteFontStretchToCT(DWRITE_FONT_STRETCH stretch) {
+    // kCTFontWidthTrait is documented to range from -1.0 to 1.0, centered at 0,
+    // with 'Condensed' fonts returning -0.2 on the reference platform
+    // DWrite stretch ranges from 0-9, centered at 5
+
+    // Reference platform lacks fonts with stretch besides 'normal' or 'condensed',
+    // and it is not yet clear how these values are used
+    // Do an approximate conversion for now
+    return (static_cast<float>(stretch) / 10.0f) - 0.5f;
+}
+
+/**
+ * Private helper that examines a traits dict, then returns a struct of DWRITE_FONT_WEIGHT, _STRETCH, _STYLE,
+ * derived from that traits dict.
+ *
+ * Note that the name fields in the _DWriteFontProperties are left as blank
+ */
+static _DWriteFontProperties __DWriteFontPropertiesFromTraits(CFDictionaryRef traits) {
+    if (!traits) {
+        return {};
+    }
+
+    _DWriteFontProperties ret = {};
+
+    // kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait take precedence over symbolic traits
+    CFNumberRef weightTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontWeightTrait));
+    CFNumberRef widthTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontWidthTrait));
+    CFNumberRef slantTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontSlantTrait));
+
+    CFNumberRef cfSymbolicTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontSymbolicTrait));
+    uint32_t symbolicTrait = cfSymbolicTrait ? _CTFontSymbolicTraitsFromCFNumber(cfSymbolicTrait) : 0;
+
+    // Check numeric weightTrait first, otherwise defer to symbolic traits, otherwise leave as _NORMAL
+    if (weightTrait) {
+        CGFloat weightFloat;
+        CFNumberGetValue(weightTrait, kCFNumberCGFloatType, &weightFloat);
+        ret.weight = __CTFontWeightToDWrite(weightFloat);
+    } else if (symbolicTrait & kCTFontBoldTrait) {
+        ret.weight = DWRITE_FONT_WEIGHT_BOLD;
+    }
+
+    // Check numeric widthTrait first, otherwise defer to symbolic traits, otherwise leave as _NORMAL
+    if (widthTrait) {
+        CGFloat widthFloat;
+        CFNumberGetValue(widthTrait, kCFNumberCGFloatType, &widthFloat);
+
+        // Treat above 0 as expanded, below 0 as condensed
+        if (widthFloat > 0) {
+            ret.stretch = DWRITE_FONT_STRETCH_EXPANDED;
+        } else if (widthFloat < 0) {
+            ret.stretch = DWRITE_FONT_STRETCH_CONDENSED;
+        }
+    } else if (symbolicTrait & kCTFontExpandedTrait) {
+        ret.stretch = DWRITE_FONT_STRETCH_EXPANDED;
+    } else if (symbolicTrait & kCTFontCondensedTrait) {
+        ret.stretch = DWRITE_FONT_STRETCH_CONDENSED;
+    }
+
+    // Check numeric slantTrait first, otherwise defer to symbolic traits, otherwise leave as _NORMAL
+    if (slantTrait) {
+        CGFloat slantFloat;
+        CFNumberGetValue(slantTrait, kCFNumberCGFloatType, &slantFloat);
+
+        // Treat anything above 0 as italic
+        if (slantFloat > 0) {
+            ret.style = DWRITE_FONT_STYLE_ITALIC;
+        }
+    } else if (symbolicTrait & kCTFontItalicTrait) {
+        ret.style = DWRITE_FONT_STYLE_ITALIC;
+    }
+
+    return ret;
+}
+
+/**
+ * Helper function to box a CTFontSymbolicTraits in a CFNumber
+ */
+CFNumberRef _CFNumberCreateFromSymbolicTraits(CTFontSymbolicTraits symbolicTraits) {
+    // symbolic traits are an unsigned 32-bit int
+    // CFNumber doesn't support unsigned ints
+    // get around this by storing in a signed 64-bit int
+    int64_t signedTraits = static_cast<int64_t>(symbolicTraits);
+    return CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &signedTraits);
+}
+
+/**
+ * Helper function to unbox a CTFontSymbolicTraits from a CFNumber
+ */
+CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num) {
+    // symbolic traits are an unsigned 32-bit int, but were stored in a signed 64-bit int
+    int64_t ret;
+    CFNumberGetValue(static_cast<CFNumberRef>(num), kCFNumberSInt64Type, &ret);
+    return static_cast<CTFontSymbolicTraits>(ret);
+}
+
+/**
+ * Creates an IDWriteFontFace given the attributes of a CTFontDescriptor
+ * Currently, font name, family name, kCTFontWeight/Slant/Width, and part of SymbolicTrait, are taken into account
+ */
+HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Out_ IDWriteFontFace** fontFace) {
+    woc::unique_cf<CFStringRef> fontName(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontNameAttribute)));
+    woc::unique_cf<CFStringRef> familyName(
+        static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontFamilyNameAttribute)));
+
+    // font name takes precedence
+    if (fontName.get()) {
+        if (familyName.get() && !CFEqual(familyName.get(), _DWriteGetFamilyNameForFontName(fontName.get()))) {
+            TraceError(TAG,
+                       L"Mismatched font name (kCTFontNameAttribute) and family name (kCTFontFamilyNameAttribute) in "
+                       L"_DWriteCreateFontFaceWithFontDescriptor");
+            return E_INVALIDARG;
+        }
+
+        // familyName is either valid for fontName, or unspecified
+        // just use fontName, then
+        return _DWriteCreateFontFaceWithName(fontName.get(), fontFace);
+    }
+
+    // otherwise, look at family name and other attributes
+    if (familyName.get()) {
+        ComPtr<IDWriteFontFamily> fontFamily;
+        RETURN_IF_FAILED(_DWriteCreateFontFamilyWithName(familyName.get(), &fontFamily));
+        RETURN_HR_IF_NULL(E_INVALIDARG, fontFamily);
+
+        // Look for traits that may specify weight, stretch, style
+        woc::unique_cf<CFDictionaryRef> traits(
+            static_cast<CFDictionaryRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontTraitsAttribute)));
+        _DWriteFontProperties properties = __DWriteFontPropertiesFromTraits(traits.get());
+
+        // Create a best matching font based on the family name and weight/stretch/style
+        ComPtr<IDWriteFont> font;
+        RETURN_IF_FAILED(fontFamily->GetFirstMatchingFont(properties.weight, properties.stretch, properties.style, &font));
+
+        return font->CreateFontFace(fontFace);
+    }
+
+    TraceError(TAG, L"Must specify either kCTFontFamilyNameAttribute or kCTFontNameAttribute in font descriptor");
+    return E_INVALIDARG;
+}
+
+/**
+ * Helper function that reads certain properties from a DWrite font face,
+ * then parses them into a dictionary suitable for kCTFontTraitsAttribute
+ */
+static CFDictionaryRef _DWriteFontCreateTraitsDict(const ComPtr<IDWriteFontFace>& fontFace) {
+    // Get pointers for the additional FontFace interfaces
+    ComPtr<IDWriteFontFace1> fontFace1;
+    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace1));
+    ComPtr<IDWriteFontFace2> fontFace2;
+    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace2));
+    ComPtr<IDWriteFontFace3> fontFace3;
+    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace3));
+
+    DWRITE_FONT_WEIGHT weight = fontFace3->GetWeight();
+    DWRITE_FONT_STRETCH stretch = fontFace3->GetStretch();
+    DWRITE_FONT_STYLE style = fontFace3->GetStyle();
+
+    CGFloat weightTrait = __DWriteFontWeightToCT(weight);
+    CGFloat widthTrait = __DWriteFontStretchToCT(stretch);
+
+    // kCTFontSlantTrait appears scaled to be 1.0 = 180 degrees, rather than = 30 degrees as documentation claims
+    CGFloat slantTrait = _DWriteFontGetSlantDegrees(fontFace) / -180.0f; // kCTFontSlantTrait is positive for negative angles
+
+    // symbolic traits are a bit mask - evaluate the trueness of each flag
+    CTFontSymbolicTraits symbolicTraits = 0;
+
+    if (style != DWRITE_FONT_STYLE_NORMAL) {
+        symbolicTraits |= kCTFontItalicTrait;
+    }
+
+    if (weight > DWRITE_FONT_WEIGHT_MEDIUM) {
+        symbolicTraits |= kCTFontBoldTrait;
+    }
+
+    if (stretch > DWRITE_FONT_STRETCH_MEDIUM) {
+        symbolicTraits |= kCTFontExpandedTrait;
+    } else if (stretch < DWRITE_FONT_STRETCH_NORMAL) {
+        symbolicTraits |= kCTFontCondensedTrait;
+    }
+
+    if (fontFace1->IsMonospacedFont()) {
+        symbolicTraits |= kCTFontMonoSpaceTrait;
+    }
+
+    if (fontFace1->HasVerticalGlyphVariants()) {
+        symbolicTraits |= kCTFontVerticalTrait;
+    }
+
+    if (fontFace2->IsColorFont()) {
+        symbolicTraits |= kCTFontColorGlyphsTrait;
+    }
+
+    // TODO: The symbolic traits below are poorly documented/have no clear DWrite mapping
+    // if (fontFace->IsFoo()) {
+    //     symbolicTraits |= kCTFontUIOptimizedTrait;
+    // }
+    // if (fontFace->IsFoo()) {
+    //     symbolicTraits |= kCTFontCompositeTrait;
+    // }
+
+    // TODO: The upper 16 bits of symbolic traits describe stylistic aspects of a font, specifically its serifs,
+    // such as modern, ornamental, or sans (no serifs)
+    // DWrite has no such API for characterizing fonts
+    // if (fontFace->IsFoo()) {
+    //     symbolicTraits |= kCTFontOldStyleSerifsClass;
+    // }
+
+    // Keys and values for the final trait dictionary
+    CFTypeRef traitKeys[] = { kCTFontSymbolicTrait, kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait };
+    CFTypeRef traitValues[] = { CFAutorelease(_CFNumberCreateFromSymbolicTraits(symbolicTraits)),
+                                CFAutorelease(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &weightTrait)),
+                                CFAutorelease(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &widthTrait)),
+                                CFAutorelease(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &slantTrait)) };
+
+    return CFDictionaryCreate(kCFAllocatorDefault,
+                              traitKeys,
+                              traitValues,
+                              4,
+                              &kCFTypeDictionaryKeyCallBacks,
+                              &kCFTypeDictionaryValueCallBacks);
+}
+
+/**
+ * Gets a name/informational string from a DWrite font face corresponding to a CTFont constant
+ */
+CFStringRef _DWriteFontCopyName(const ComPtr<IDWriteFontFace>& fontFace, CFStringRef nameKey) {
+    if (nameKey == nullptr || fontFace == nullptr) {
+        return nullptr;
+    }
+
+    DWRITE_INFORMATIONAL_STRING_ID informationalStringId;
+
+    if (CFEqual(nameKey, kCTFontCopyrightNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_COPYRIGHT_NOTICE;
+    } else if (CFEqual(nameKey, kCTFontFamilyNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_WIN32_FAMILY_NAMES;
+    } else if (CFEqual(nameKey, kCTFontSubFamilyNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_WIN32_SUBFAMILY_NAMES;
+    } else if (CFEqual(nameKey, kCTFontStyleNameKey)) {
+        ComPtr<IDWriteFontFace3> dwriteFontFace3;
+        RETURN_NULL_IF_FAILED(fontFace.As(&dwriteFontFace3));
+        ComPtr<IDWriteLocalizedStrings> name;
+        RETURN_NULL_IF_FAILED(dwriteFontFace3->GetFaceNames(&name));
+        return static_cast<CFStringRef>(CFRetain(_CFStringFromLocalizedString(name.Get())));
+
+    } else if (CFEqual(nameKey, kCTFontUniqueNameKey)) {
+        return CFStringCreateWithFormat(kCFAllocatorDefault,
+                                        nullptr,
+                                        CFSTR("%@ %@"),
+                                        CFAutorelease(_DWriteFontCopyName(fontFace, kCTFontFullNameKey)),
+                                        CFAutorelease(_DWriteFontCopyName(fontFace, kCTFontStyleNameKey)));
+
+    } else if (CFEqual(nameKey, kCTFontFullNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_FULL_NAME;
+    } else if (CFEqual(nameKey, kCTFontVersionNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_VERSION_STRINGS;
+    } else if (CFEqual(nameKey, kCTFontPostScriptNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME;
+    } else if (CFEqual(nameKey, kCTFontTrademarkNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_TRADEMARK;
+    } else if (CFEqual(nameKey, kCTFontManufacturerNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_MANUFACTURER;
+    } else if (CFEqual(nameKey, kCTFontDesignerNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_DESIGNER;
+    } else if (CFEqual(nameKey, kCTFontDescriptionNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_DESCRIPTION;
+    } else if (CFEqual(nameKey, kCTFontVendorURLNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_FONT_VENDOR_URL;
+    } else if (CFEqual(nameKey, kCTFontDesignerURLNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_DESIGNER_URL;
+    } else if (CFEqual(nameKey, kCTFontLicenseNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_LICENSE_DESCRIPTION;
+    } else if (CFEqual(nameKey, kCTFontLicenseURLNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_LICENSE_INFO_URL;
+    } else if (CFEqual(nameKey, kCTFontSampleTextNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_SAMPLE_TEXT;
+    } else if (CFEqual(nameKey, kCTFontPostScriptCIDNameKey)) {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_CID_NAME;
+    } else {
+        informationalStringId = DWRITE_INFORMATIONAL_STRING_NONE;
+    }
+
+    return _DWriteFontCopyInformationalString(fontFace, informationalStringId);
+}

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -23,35 +23,21 @@ using namespace Microsoft::WRL;
 static const wchar_t* TAG = L"_DWriteWrapper_CTFont";
 
 // Represents a mapping between multiple representations of the same font weight across DWrite and CoreText
-// DWRITE_FONT_WEIGHT_BOLD = kCTFontWeightBold
-struct __WeightMapping {
-    DWRITE_FONT_WEIGHT dwriteValue;
-    CGFloat ctValue;
-};
-
-// Mapping for weight
 // Some loss of precision here as CT presents fewer values than DWrite
 // Note also that Thin and Ultra/Extra-Light are in opposite order in DWrite and CoreText/UIKit constants
 // (However, "Thin" fonts on the reference platform have UIFontWeightUltraLight...)
-// clang-format off
-static const struct __WeightMapping c_weightMap[] = { { DWRITE_FONT_WEIGHT_THIN, kCTFontWeightUltraLight },
-                                                    { DWRITE_FONT_WEIGHT_EXTRA_LIGHT, kCTFontWeightThin },
-                                                    { DWRITE_FONT_WEIGHT_ULTRA_LIGHT, kCTFontWeightThin },
-                                                    { DWRITE_FONT_WEIGHT_LIGHT, kCTFontWeightLight },
-                                                    { DWRITE_FONT_WEIGHT_SEMI_LIGHT, kCTFontWeightLight },
-                                                    { DWRITE_FONT_WEIGHT_NORMAL, kCTFontWeightRegular },
-                                                    { DWRITE_FONT_WEIGHT_REGULAR, kCTFontWeightRegular },
-                                                    { DWRITE_FONT_WEIGHT_MEDIUM, kCTFontWeightMedium },
-                                                    { DWRITE_FONT_WEIGHT_DEMI_BOLD, kCTFontWeightSemibold },
-                                                    { DWRITE_FONT_WEIGHT_SEMI_BOLD, kCTFontWeightSemibold },
-                                                    { DWRITE_FONT_WEIGHT_BOLD, kCTFontWeightBold },
-                                                    { DWRITE_FONT_WEIGHT_EXTRA_BOLD, kCTFontWeightHeavy },
-                                                    { DWRITE_FONT_WEIGHT_ULTRA_BOLD, kCTFontWeightHeavy },
-                                                    { DWRITE_FONT_WEIGHT_BLACK, kCTFontWeightBlack },
-                                                    { DWRITE_FONT_WEIGHT_HEAVY, kCTFontWeightBlack },
-                                                    { DWRITE_FONT_WEIGHT_EXTRA_BLACK, kCTFontWeightBlack },
-                                                    { DWRITE_FONT_WEIGHT_ULTRA_BLACK, kCTFontWeightBlack } };
-// clang-format on
+static const struct {
+    DWRITE_FONT_WEIGHT dwriteValue;
+    CGFloat ctValue;
+} c_weightMap[] = { { DWRITE_FONT_WEIGHT_THIN, kCTFontWeightUltraLight },    { DWRITE_FONT_WEIGHT_EXTRA_LIGHT, kCTFontWeightThin },
+                    { DWRITE_FONT_WEIGHT_ULTRA_LIGHT, kCTFontWeightThin },   { DWRITE_FONT_WEIGHT_LIGHT, kCTFontWeightLight },
+                    { DWRITE_FONT_WEIGHT_SEMI_LIGHT, kCTFontWeightLight },   { DWRITE_FONT_WEIGHT_NORMAL, kCTFontWeightRegular },
+                    { DWRITE_FONT_WEIGHT_REGULAR, kCTFontWeightRegular },    { DWRITE_FONT_WEIGHT_MEDIUM, kCTFontWeightMedium },
+                    { DWRITE_FONT_WEIGHT_DEMI_BOLD, kCTFontWeightSemibold }, { DWRITE_FONT_WEIGHT_SEMI_BOLD, kCTFontWeightSemibold },
+                    { DWRITE_FONT_WEIGHT_BOLD, kCTFontWeightBold },          { DWRITE_FONT_WEIGHT_EXTRA_BOLD, kCTFontWeightHeavy },
+                    { DWRITE_FONT_WEIGHT_ULTRA_BOLD, kCTFontWeightHeavy },   { DWRITE_FONT_WEIGHT_BLACK, kCTFontWeightBlack },
+                    { DWRITE_FONT_WEIGHT_HEAVY, kCTFontWeightBlack },        { DWRITE_FONT_WEIGHT_EXTRA_BLACK, kCTFontWeightBlack },
+                    { DWRITE_FONT_WEIGHT_ULTRA_BLACK, kCTFontWeightBlack } };
 
 /**
  * Helper function that converts a DWRITE_FONT_WEIGHT into a float usable for kCTFontWeightTrait.
@@ -100,11 +86,11 @@ static CGFloat __DWriteFontStretchToCT(DWRITE_FONT_STRETCH stretch) {
  * Note that the name fields in the _DWriteFontProperties are left as blank
  */
 static _DWriteFontProperties __DWriteFontPropertiesFromTraits(CFDictionaryRef traits) {
-    if (!traits) {
-        return {};
-    }
-
     _DWriteFontProperties ret = {};
+
+    if (!traits) {
+        return ret;
+    }
 
     // kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait take precedence over symbolic traits
     CFNumberRef weightTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontWeightTrait));
@@ -181,7 +167,7 @@ CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num) {
  * Creates an IDWriteFontFace given the attributes of a CTFontDescriptor
  * Currently, font name, family name, kCTFontWeight/Slant/Width, and part of SymbolicTrait, are taken into account
  */
-HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Outptr_ IDWriteFontFace** fontFace) {
+HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, IDWriteFontFace** fontFace) {
     woc::unique_cf<CFStringRef> fontName(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontNameAttribute)));
     woc::unique_cf<CFStringRef> familyName(
         static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontFamilyNameAttribute)));

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -58,7 +58,7 @@ _CTLine* _DWriteGetLine(CFAttributedStringRef string);
 CFNumberRef _CFNumberCreateFromSymbolicTraits(CTFontSymbolicTraits symbolicTraits);
 CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num);
 
-HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Outptr_ IDWriteFontFace** fontFace);
+HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, IDWriteFontFace** fontFace);
 
 CFDictionaryRef _DWriteFontCreateTraitsDict(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace);
 CFStringRef _DWriteFontCopyName(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace, CFStringRef nameKey);

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -54,13 +54,16 @@ bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Out_ DWRITE_GLYPH_R
 _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CGRect frameSize);
 _CTLine* _DWriteGetLine(CFAttributedStringRef string);
 
-HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, IDWriteFontFace** outFontFace);
-
+// DWriteWrapper functions relating to CTFont, CTFontDescriptor
 CFNumberRef _CFNumberCreateFromSymbolicTraits(CTFontSymbolicTraits symbolicTraits);
 CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num);
 
+HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Out_ IDWriteFontFace** fontFace);
+
 CFDictionaryRef _DWriteFontCreateTraitsDict(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace);
 CFStringRef _DWriteFontCopyName(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace, CFStringRef nameKey);
+
+// DWriteWrapper functions relating to CGPath
 CGPathRef _DWriteFontCreatePathForGlyph(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace,
                                         CGFloat pointSize,
                                         CGGlyph glyph,

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -49,7 +49,7 @@ struct _DWriteGlyphRunDetails {
     std::vector<_DWriteGlyphRunDescription> _glyphRunDescriptions;
 };
 
-bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Out_ DWRITE_GLYPH_RUN* dest);
+bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Outptr_ DWRITE_GLYPH_RUN* dest);
 
 _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CGRect frameSize);
 _CTLine* _DWriteGetLine(CFAttributedStringRef string);
@@ -58,7 +58,7 @@ _CTLine* _DWriteGetLine(CFAttributedStringRef string);
 CFNumberRef _CFNumberCreateFromSymbolicTraits(CTFontSymbolicTraits symbolicTraits);
 CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num);
 
-HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Out_ IDWriteFontFace** fontFace);
+HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, _Outptr_ IDWriteFontFace** fontFace);
 
 CFDictionaryRef _DWriteFontCreateTraitsDict(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace);
 CFStringRef _DWriteFontCopyName(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace, CFStringRef nameKey);

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -145,7 +145,7 @@ static inline HRESULT __DWriteTextFormatApplyParagraphStyle(const ComPtr<IDWrite
  * Private helper that applies a CTFontRef to an IDWriteTextLayout within the specified range.
  */
 static inline HRESULT __DWriteTextLayoutApplyFont(const ComPtr<IDWriteTextLayout>& textLayout, CTFontRef font, DWRITE_TEXT_RANGE range) {
-    std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(CTFontCopyName(font, kCTFontFullNameKey));
+    std::shared_ptr<const _DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(CTFontCopyName(font, kCTFontFullNameKey));
     RETURN_IF_FAILED(textLayout->SetFontWeight(properties->weight, range));
     RETURN_IF_FAILED(textLayout->SetFontStretch(properties->stretch, range));
     RETURN_IF_FAILED(textLayout->SetFontStyle(properties->style, range));

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -189,7 +189,7 @@ static inline HRESULT __DWriteTextLayoutApplyExtraKerning(const ComPtr<IDWriteTe
  *
  * @return whether the creation was successful
  */
-static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange range, _Outptr_ IDWriteTextFormat** outTextFormat) {
+static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange range, IDWriteTextFormat** outTextFormat) {
     RETURN_HR_IF_NULL(E_POINTER, outTextFormat);
 
     std::shared_ptr<_DWriteFontProperties> properties;
@@ -229,7 +229,8 @@ static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange ra
         RETURN_IF_FAILED(__DWriteTextFormatApplyParagraphStyle(textFormat, settings));
     }
 
-    return textFormat.CopyTo(outTextFormat);
+    *outTextFormat = textFormat.Detach();
+    return S_OK;
 }
 
 /**
@@ -242,10 +243,7 @@ static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange ra
  *
  * @return whether the creation was successful
  */
-static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string,
-                                        CFRange range,
-                                        CGRect frameSize,
-                                        _Outptr_ IDWriteTextLayout** outTextLayout) {
+static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string, CFRange range, CGRect frameSize, IDWriteTextLayout** outTextLayout) {
     RETURN_HR_IF_NULL(E_POINTER, outTextLayout);
 
     ComPtr<IDWriteTextFormat> textFormat;
@@ -311,7 +309,8 @@ static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string,
         RETURN_NULL_IF_FAILED(textLayout->SetTypography(typography.Get(), dwriteRange));
     }
 
-    return textLayout.CopyTo(outTextLayout);
+    *outTextLayout = textLayout.Detach();
+    return S_OK;
 }
 
 /**
@@ -319,7 +318,7 @@ static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string,
  */
 class CustomDWriteTextRenderer : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteTextRenderer> {
 protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
+    InspectableClass(L"Windows.Bridge.DirectWrite.CustomDWriteTextRenderer", TrustLevel::BaseTrust);
 
 public:
     CustomDWriteTextRenderer() {

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -14,7 +14,6 @@
 //
 //******************************************************************************
 
-// #1207: Do not move this block, it has to come first for some reason
 #include <COMIncludes.h>
 #import <wrl/implements.h>
 #include <COMIncludes_End.h>
@@ -83,7 +82,7 @@ static bool __CloneArray(_In_reads_opt_(count) TElement const* source,
     return ret;
 }
 
-bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Out_ DWRITE_GLYPH_RUN* dest) {
+bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Outptr_ DWRITE_GLYPH_RUN* dest) {
     bool ret = true;
 
     if (src) {
@@ -190,8 +189,8 @@ static inline HRESULT __DWriteTextLayoutApplyExtraKerning(const ComPtr<IDWriteTe
  *
  * @return whether the creation was successful
  */
-static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange range, _Out_ IDWriteTextFormat** outTextFormat) {
-    RETURN_HR_IF(E_INVALIDARG, !outTextFormat);
+static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange range, _Outptr_ IDWriteTextFormat** outTextFormat) {
+    RETURN_HR_IF_NULL(E_POINTER, outTextFormat);
 
     std::shared_ptr<_DWriteFontProperties> properties;
     CGFloat fontSize;
@@ -230,8 +229,7 @@ static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange ra
         RETURN_IF_FAILED(__DWriteTextFormatApplyParagraphStyle(textFormat, settings));
     }
 
-    *outTextFormat = textFormat.Detach();
-    return S_OK;
+    return textFormat.CopyTo(outTextFormat);
 }
 
 /**
@@ -247,8 +245,8 @@ static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange ra
 static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string,
                                         CFRange range,
                                         CGRect frameSize,
-                                        _Out_ IDWriteTextLayout** outTextLayout) {
-    RETURN_HR_IF(E_INVALIDARG, !outTextLayout);
+                                        _Outptr_ IDWriteTextLayout** outTextLayout) {
+    RETURN_HR_IF_NULL(E_POINTER, outTextLayout);
 
     ComPtr<IDWriteTextFormat> textFormat;
     RETURN_IF_FAILED(__DWriteTextFormatCreate(string, range, &textFormat));
@@ -313,8 +311,7 @@ static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string,
         RETURN_NULL_IF_FAILED(textLayout->SetTypography(typography.Get(), dwriteRange));
     }
 
-    *outTextLayout = textLayout.Detach();
-    return S_OK;
+    return textLayout.CopyTo(outTextLayout);
 }
 
 /**

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -17,27 +17,22 @@
 // #1207: Do not move this block, it has to come first for some reason
 #include <COMIncludes.h>
 #import <wrl/implements.h>
-#import <D2d1.h>
 #include <COMIncludes_End.h>
 
 #import "DWriteWrapper_CoreText.h"
 #import "CoreTextInternal.h"
 
-#import <Starboard.h>
-
-#import <CoreFoundation/CFBase.h>
-
 #import <LoggingNative.h>
+#import <StringHelpers.h>
 #import <vector>
 #import <iterator>
-#import <numeric>
 
 using namespace std;
 using namespace Microsoft::WRL;
 
 static const wchar_t* TAG = L"_DWriteWrapper_CoreText";
 
-static DWRITE_TEXT_ALIGNMENT __CoreTextAlignmentToDwrite(CTTextAlignment alignment) {
+static DWRITE_TEXT_ALIGNMENT __CTAlignmentToDWrite(CTTextAlignment alignment) {
     switch (alignment) {
         case kCTRightTextAlignment:
             return DWRITE_TEXT_ALIGNMENT_TRAILING;
@@ -52,10 +47,26 @@ static DWRITE_TEXT_ALIGNMENT __CoreTextAlignmentToDwrite(CTTextAlignment alignme
     }
 }
 
+static DWRITE_WORD_WRAPPING __CTLineBreakModeToDWrite(CTLineBreakMode lineBreakMode) {
+    switch (lineBreakMode) {
+        // TODO 1121:: DWrite does not support line breaking by truncation, so just use clipping for now
+        case kCTLineBreakByTruncatingHead:
+        case kCTLineBreakByTruncatingTail:
+        case kCTLineBreakByTruncatingMiddle:
+        case kCTLineBreakByClipping:
+            return DWRITE_WORD_WRAPPING_NO_WRAP;
+        case kCTLineBreakByCharWrapping:
+            return DWRITE_WORD_WRAPPING_CHARACTER;
+        case kCTLineBreakByWordWrapping:
+        default:
+            return DWRITE_WORD_WRAPPING_WRAP;
+    }
+}
+
 template <typename TElement>
-bool __CloneArray(_In_reads_opt_(count) TElement const* source,
-                  _In_ size_t count,
-                  _Outptr_result_buffer_all_maybenull_(count) TElement const** result) {
+static bool __CloneArray(_In_reads_opt_(count) TElement const* source,
+                         _In_ size_t count,
+                         _Outptr_result_buffer_all_maybenull_(count) TElement const** result) {
     bool ret = true;
 
     *result = nullptr;
@@ -97,97 +108,130 @@ bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Out_ DWRITE_GLYPH_R
 }
 
 /**
+ * Private helper that applies a CTParagraphStyleRef to an IDWriteTextFormat
+ */
+static inline HRESULT __DWriteTextFormatApplyParagraphStyle(const ComPtr<IDWriteTextFormat>& textFormat, CTParagraphStyleRef settings) {
+    CTTextAlignment alignment = kCTNaturalTextAlignment;
+    if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &alignment)) {
+        RETURN_IF_FAILED(textFormat->SetTextAlignment(__CTAlignmentToDWrite(alignment)));
+    }
+
+    CTWritingDirection direction;
+    if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(direction), &direction)) {
+        DWRITE_READING_DIRECTION dwriteDirection = DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
+        if (direction == kCTWritingDirectionRightToLeft) {
+            dwriteDirection = DWRITE_READING_DIRECTION_RIGHT_TO_LEFT;
+
+            // DWrite alignment is based upon reading direction whereas CoreText alignment is constant
+            // so we have to flip the writing direction
+            if (alignment == kCTRightTextAlignment || alignment == kCTNaturalTextAlignment) {
+                RETURN_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING));
+            } else if (alignment == kCTLeftTextAlignment) {
+                RETURN_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING));
+            }
+        }
+
+        RETURN_IF_FAILED(textFormat->SetReadingDirection(dwriteDirection));
+    }
+
+    CTLineBreakMode lineBreakMode;
+    if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierLineBreakMode, sizeof(lineBreakMode), &lineBreakMode)) {
+        RETURN_IF_FAILED(textFormat->SetWordWrapping(__CTLineBreakModeToDWrite(lineBreakMode)));
+    }
+
+    return S_OK;
+}
+
+/**
+ * Private helper that applies a CTFontRef to an IDWriteTextLayout within the specified range.
+ */
+static inline HRESULT __DWriteTextLayoutApplyFont(const ComPtr<IDWriteTextLayout>& textLayout, CTFontRef font, DWRITE_TEXT_RANGE range) {
+    std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(CTFontCopyName(font, kCTFontFullNameKey));
+    RETURN_IF_FAILED(textLayout->SetFontWeight(properties->weight, range));
+    RETURN_IF_FAILED(textLayout->SetFontStretch(properties->stretch, range));
+    RETURN_IF_FAILED(textLayout->SetFontStyle(properties->style, range));
+
+    RETURN_IF_FAILED(textLayout->SetFontSize(CTFontGetSize(font), range));
+    RETURN_IF_FAILED(
+        textLayout->SetFontFamilyName(reinterpret_cast<wchar_t*>(Strings::VectorFromCFString(properties->familyName.get()).data()), range));
+
+    return S_OK;
+}
+
+/**
+ * Private helper that applies extra kerning to an IDWriteTextLayout within the specified range.
+ */
+static inline HRESULT __DWriteTextLayoutApplyExtraKerning(const ComPtr<IDWriteTextLayout>& textLayout,
+                                                          const ComPtr<IDWriteTypography>& typography,
+                                                          CFNumberRef extraKerningRef,
+                                                          DWRITE_TEXT_RANGE range) {
+    ComPtr<IDWriteTextLayout1> textLayout1;
+    RETURN_IF_FAILED(textLayout.As(&textLayout1));
+
+    CGFloat extraKerning;
+    CFNumberGetValue(extraKerningRef, kCFNumberFloatType, &extraKerning);
+
+    CGFloat leadingSpacing, trailingSpacing, minimumAdvanceWidth;
+    RETURN_IF_FAILED(textLayout1->GetCharacterSpacing(range.startPosition, &leadingSpacing, &trailingSpacing, &minimumAdvanceWidth));
+    RETURN_IF_FAILED(textLayout1->SetCharacterSpacing(leadingSpacing, trailingSpacing + extraKerning, minimumAdvanceWidth, range));
+
+    // Setting kern disables default kerning
+    RETURN_IF_FAILED(typography->AddFontFeature({ DWRITE_FONT_FEATURE_TAG_KERNING, 0 }));
+
+    return S_OK;
+}
+
+/**
  * Helper method to create a IDWriteTextFormat object given _CTTypesetter object and string range.
  *
  * @parameter ts _CTTypesetter object.
  * @parameter range string range to consider for rendering.
+ * @parameter outTextFormat outpointer for creating the text format
  *
- * @return the created IDWriteTextFormat object.
+ * @return whether the creation was successful
  */
-static ComPtr<IDWriteTextFormat> __CreateDWriteTextFormat(CFAttributedStringRef string, CFRange range) {
-    // TODO::
-    // Note here we only look at attribute value at first index of the specified range as we can get a default faont size to use here.
-    // Per string range attribute handling will be done in _CreateDWriteTextLayout.
-
-    NSDictionary* attribs = [static_cast<NSAttributedString*>(string) attributesAtIndex:range.location effectiveRange:NULL];
-
-    CGFloat fontSize = kCTFontSystemFontSize;
-    CTFontRef font = static_cast<CTFontRef>([attribs objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
-    std::vector<wchar_t> familyName;
+static HRESULT __DWriteTextFormatCreate(CFAttributedStringRef string, CFRange range, _Out_ IDWriteTextFormat** outTextFormat) {
+    RETURN_HR_IF(E_INVALIDARG, !outTextFormat);
 
     std::shared_ptr<_DWriteFontProperties> properties;
+    CGFloat fontSize;
+
+    // TODO::
+    // Note here we only look at attribute value at first index of the specified range as we can get a default font size to use here.
+    // Per string range attribute handling will be done in _CreateDWriteTextLayout.
+    CTFontRef font = static_cast<CTFontRef>(CFAttributedStringGetAttribute(string, range.location, kCTFontAttributeName, nullptr));
 
     if (font) {
+        woc::unique_cf<CFStringRef> fontFullName(CTFontCopyName(font, kCTFontFullNameKey));
+        properties = _DWriteGetFontPropertiesFromName(fontFullName.get());
         fontSize = CTFontGetSize(font);
-        CFStringRef fontFullName = CTFontCopyName(font, kCTFontFullNameKey);
-        CFAutorelease(fontFullName);
-        properties = _DWriteGetFontPropertiesFromName(fontFullName);
     } else {
         properties = std::make_shared<_DWriteFontProperties>();
+        fontSize = kCTFontSystemFontSize;
     }
 
-    familyName.resize(CFStringGetLength(properties->familyName.get()) + 1, 0);
-    CFStringGetCharacters(properties->familyName.get(), CFRangeMake(0, familyName.size()), reinterpret_cast<UniChar*>(familyName.data()));
-
+    ComPtr<IDWriteFactory> dwriteFactory;
+    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
     ComPtr<IDWriteTextFormat> textFormat;
-    RETURN_NULL_IF_FAILED(
-        _DWriteCreateTextFormat(familyName.data(), properties->weight, properties->style, properties->stretch, fontSize, &textFormat));
+    RETURN_IF_FAILED(
+        dwriteFactory->CreateTextFormat(reinterpret_cast<wchar_t*>(Strings::VectorFromCFString(properties->familyName.get()).data()),
+                                        nullptr,
+                                        properties->weight,
+                                        properties->style,
+                                        properties->stretch,
+                                        fontSize,
+                                        _GetUserDefaultLocaleName().data(),
+                                        &textFormat));
 
+    // Apply paragraph style if one exists in the attributed string
     CTParagraphStyleRef settings =
-        static_cast<CTParagraphStyleRef>([attribs valueForKey:static_cast<NSString*>(kCTParagraphStyleAttributeName)]);
+        static_cast<CTParagraphStyleRef>(CFAttributedStringGetAttribute(string, range.location, kCTParagraphStyleAttributeName, nullptr));
     if (settings) {
-        CTTextAlignment alignment = kCTNaturalTextAlignment;
-        if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &alignment)) {
-            DWRITE_TEXT_ALIGNMENT dwriteAlignment = __CoreTextAlignmentToDwrite(alignment);
-            RETURN_NULL_IF_FAILED(textFormat->SetTextAlignment(dwriteAlignment));
-        }
-
-        CTWritingDirection direction;
-        if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(direction), &direction)) {
-            DWRITE_READING_DIRECTION dwriteDirection = DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
-            if (direction == kCTWritingDirectionRightToLeft) {
-                dwriteDirection = DWRITE_READING_DIRECTION_RIGHT_TO_LEFT;
-
-                // DWrite alignment is based upon reading direction whereas CoreText alignment is constant
-                // so we have to flip the writing direction
-                if (alignment == kCTRightTextAlignment || alignment == kCTNaturalTextAlignment) {
-                    RETURN_NULL_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING));
-                } else if (alignment == kCTLeftTextAlignment) {
-                    RETURN_NULL_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING));
-                }
-            }
-
-            RETURN_NULL_IF_FAILED(textFormat->SetReadingDirection(dwriteDirection));
-        }
-
-        CTLineBreakMode lineBreakMode;
-        if (CTParagraphStyleGetValueForSpecifier(settings,
-                                                 kCTParagraphStyleSpecifierLineBreakMode,
-                                                 sizeof(lineBreakMode),
-                                                 &lineBreakMode)) {
-            DWRITE_WORD_WRAPPING wrapping;
-            switch (lineBreakMode) {
-                // TODO 1121:: DWrite does not support line breaking by truncation, so just use clipping for now
-                case kCTLineBreakByTruncatingHead:
-                case kCTLineBreakByTruncatingTail:
-                case kCTLineBreakByTruncatingMiddle:
-                case kCTLineBreakByClipping:
-                    wrapping = DWRITE_WORD_WRAPPING_NO_WRAP;
-                    break;
-                case kCTLineBreakByCharWrapping:
-                    wrapping = DWRITE_WORD_WRAPPING_CHARACTER;
-                    break;
-                case kCTLineBreakByWordWrapping:
-                default:
-                    wrapping = DWRITE_WORD_WRAPPING_WRAP;
-                    break;
-            }
-
-            THROW_IF_FAILED(textFormat->SetWordWrapping(wrapping));
-        }
+        RETURN_IF_FAILED(__DWriteTextFormatApplyParagraphStyle(textFormat, settings));
     }
 
-    return textFormat;
+    *outTextFormat = textFormat.Detach();
+    return S_OK;
 }
 
 /**
@@ -196,15 +240,18 @@ static ComPtr<IDWriteTextFormat> __CreateDWriteTextFormat(CFAttributedStringRef 
  * @parameter CFAttributedStringRef string with text and attributes
  * @parameter range string range to consider for rendering.
  * @parameter frameSize frame constrains to render the text on.
+ * @parameter outTextLayout outpointer for creating the text layout
  *
- * @return the created IDWriteTextLayout object.
+ * @return whether the creation was successful
  */
-static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(CFAttributedStringRef string, CFRange range, CGRect frameSize) {
-    ComPtr<IDWriteTextFormat> textFormat = __CreateDWriteTextFormat(string, range);
+static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string,
+                                        CFRange range,
+                                        CGRect frameSize,
+                                        _Out_ IDWriteTextLayout** outTextLayout) {
+    RETURN_HR_IF(E_INVALIDARG, !outTextLayout);
 
-    NSRange curRange = NSMakeRangeFromCF(range);
-    NSString* subString = [static_cast<NSString*>(CFAttributedStringGetString(string)) substringWithRange:curRange];
-    wchar_t* wcharString = reinterpret_cast<wchar_t*>(const_cast<char*>([subString cStringUsingEncoding:NSUTF16StringEncoding]));
+    ComPtr<IDWriteTextFormat> textFormat;
+    RETURN_IF_FAILED(__DWriteTextFormatCreate(string, range, &textFormat));
 
     // TODO::
     // We need too support widthFunc semantic to be able to support NSLayout*. We could either change the API signature of this API or
@@ -214,68 +261,48 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(CFAttributedStringRef 
 
     // Get the direct write factory instance
     ComPtr<IDWriteFactory> dwriteFactory;
-    RETURN_NULL_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
+    RETURN_IF_FAILED(DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory), &dwriteFactory));
 
+    woc::unique_cf<CFStringRef> substring(CFStringCreateWithSubstring(kCFAllocatorDefault, CFAttributedStringGetString(string), range));
     ComPtr<IDWriteTextLayout> textLayout;
-    RETURN_NULL_IF_FAILED(dwriteFactory->CreateTextLayout(
-        wcharString, [subString length], textFormat.Get(), frameSize.size.width, frameSize.size.height, &textLayout));
+    RETURN_IF_FAILED(dwriteFactory->CreateTextLayout(reinterpret_cast<wchar_t*>(Strings::VectorFromCFString(substring.get()).data()),
+                                                     CFStringGetLength(substring.get()),
+                                                     textFormat.Get(),
+                                                     frameSize.size.width,
+                                                     frameSize.size.height,
+                                                     &textLayout));
 
     // TODO::
     // Iterate through all attributed string ranges and identify attributes so they can be used to -
     //  - set indentation
     //  - etc.
     //  These can be done using the DWrite IDWriteTextFormat range property methods.
+    CFIndex rangeEnd = range.location + range.length;
 
     // Used to separate runs for attributes which DWrite does not handle until drawing (e.g. Foreground Color)
     uint32_t incompatibleAttributeFlag = 0;
+    CFRange attributeRange;
 
-    NSRange attributeRange;
-    for (size_t i = 0; i < [subString length]; i += attributeRange.length) {
-        NSDictionary* attribs = [static_cast<NSAttributedString*>(string) attributesAtIndex:i + range.location
-                                                                      longestEffectiveRange:&attributeRange
-                                                                                    inRange:{ i + range.location, [subString length] }];
+    for (CFIndex currentIndex = range.location; currentIndex < rangeEnd; currentIndex += attributeRange.length) {
+        CTFontRef font =
+            static_cast<CTFontRef>(CFAttributedStringGetAttribute(string, currentIndex, kCTFontAttributeName, &attributeRange));
 
+        // attributeRange is properly populated even if this attribute is not found
         const DWRITE_TEXT_RANGE dwriteRange = { attributeRange.location, attributeRange.length };
-
-        CTFontRef font = static_cast<CTFontRef>([attribs objectForKey:static_cast<NSString*>(kCTFontAttributeName)]);
-        CGFloat fontSize = kCTFontSystemFontSize;
-        if (font != nil) {
-            fontSize = CTFontGetSize(font);
-            std::shared_ptr<_DWriteFontProperties> properties = _DWriteGetFontPropertiesFromName(CTFontCopyName(font, kCTFontFullNameKey));
-            std::vector<wchar_t> familyName(CFStringGetLength(properties->familyName.get()) + 1);
-            CFStringGetCharacters(properties->familyName.get(),
-                                  CFRangeMake(0, familyName.size()),
-                                  reinterpret_cast<UniChar*>(familyName.data()));
-
-            RETURN_NULL_IF_FAILED(textLayout->SetFontSize(fontSize, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontWeight(properties->weight, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontStretch(properties->stretch, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontStyle(properties->style, dwriteRange));
-            RETURN_NULL_IF_FAILED(textLayout->SetFontFamilyName(familyName.data(), dwriteRange));
+        if (font) {
+            RETURN_IF_FAILED(__DWriteTextLayoutApplyFont(textLayout, font, dwriteRange));
         }
 
         ComPtr<IDWriteTypography> typography;
-        RETURN_NULL_IF_FAILED(textLayout->GetTypography(dwriteRange.startPosition, &typography));
+        RETURN_IF_FAILED(textLayout->GetTypography(dwriteRange.startPosition, &typography));
         if (!typography.Get()) {
-            RETURN_NULL_IF_FAILED(dwriteFactory->CreateTypography(&typography));
+            RETURN_IF_FAILED(dwriteFactory->CreateTypography(&typography));
         }
 
-        CFNumberRef extraKerningRef = static_cast<CFNumberRef>([attribs objectForKey:static_cast<NSString*>(kCTKernAttributeName)]);
+        CFNumberRef extraKerningRef =
+            static_cast<CFNumberRef>(CFAttributedStringGetAttribute(string, currentIndex, kCTKernAttributeName, nullptr));
         if (extraKerningRef) {
-            ComPtr<IDWriteTextLayout1> textLayout1;
-            RETURN_NULL_IF_FAILED(textLayout.As(&textLayout1));
-            CGFloat leadingSpacing, trailingSpacing, minimumAdvanceWidth;
-            RETURN_NULL_IF_FAILED(
-                textLayout1->GetCharacterSpacing(dwriteRange.startPosition, &leadingSpacing, &trailingSpacing, &minimumAdvanceWidth));
-
-            CGFloat extraKerning;
-            CFNumberGetValue(extraKerningRef, kCFNumberFloatType, &extraKerning);
-            trailingSpacing += extraKerning;
-
-            RETURN_NULL_IF_FAILED(textLayout1->SetCharacterSpacing(leadingSpacing, trailingSpacing, minimumAdvanceWidth, dwriteRange));
-
-            // Setting kern disables default kerning
-            RETURN_NULL_IF_FAILED(typography->AddFontFeature({ DWRITE_FONT_FEATURE_TAG_KERNING, 0 }));
+            RETURN_IF_FAILED(__DWriteTextLayoutApplyExtraKerning(textLayout, typography, extraKerningRef, dwriteRange));
         } else {
             // Otherwise set kerning to true, as it will default to no kerning and this can be used to signify noncompatible features
             // Forces run breaks without interfering with any layout features
@@ -286,7 +313,8 @@ static ComPtr<IDWriteTextLayout> __CreateDWriteTextLayout(CFAttributedStringRef 
         RETURN_NULL_IF_FAILED(textLayout->SetTypography(typography.Get(), dwriteRange));
     }
 
-    return textLayout;
+    *outTextLayout = textLayout.Detach();
+    return S_OK;
 }
 
 /**
@@ -297,9 +325,12 @@ protected:
     InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
 
 public:
-    CustomDWriteTextRenderer();
+    CustomDWriteTextRenderer() {
+    }
 
-    HRESULT RuntimeClassInitialize();
+    HRESULT RuntimeClassInitialize() {
+        return S_OK;
+    }
 
     HRESULT STDMETHODCALLTYPE DrawGlyphRun(_In_ void* clientDrawingContext,
                                            _In_ float baselineOriginX,
@@ -370,13 +401,6 @@ public:
     };
 };
 
-CustomDWriteTextRenderer::CustomDWriteTextRenderer() {
-}
-
-HRESULT CustomDWriteTextRenderer::RuntimeClassInitialize() {
-    return S_OK;
-}
-
 /**
  * Helper method to create _CTLine object given a CFAttributedStringRef
  *
@@ -411,8 +435,10 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
         return frame;
     }
 
+    ComPtr<IDWriteTextLayout> textLayout;
+    RETURN_NULL_IF_FAILED(__DWriteTextLayoutCreate(string, range, frameSize, &textLayout));
+
     // Call custom renderer to get all glyph run details
-    ComPtr<IDWriteTextLayout> textLayout = __CreateDWriteTextLayout(string, range, frameSize);
     ComPtr<CustomDWriteTextRenderer> textRenderer = Make<CustomDWriteTextRenderer>();
     _DWriteGlyphRunDetails glyphRunDetails = {};
     textLayout->Draw(&glyphRunDetails, textRenderer.Get(), 0, 0);
@@ -429,11 +455,11 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
     int i = 0;
     int j = 0;
 
-    // Relative offsets for each run and line that will be used by CTLineDraw and CTRunDRaw methods to render.
+    // Relative offsets for each run and line that will be used by CTLineDraw and CTRunDraw methods to render.
     float prevXPosForDraw = 0;
     float prevYPosForDraw = 0;
 
-    while (j < numOfGlyphRuns) {
+    while (i < numOfGlyphRuns) {
         _CTLine* line = [[_CTLine new] autorelease];
         NSMutableArray<_CTRun*>* runs = [NSMutableArray array];
         uint32_t stringRange = 0;
@@ -449,23 +475,23 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
         line->_leading = -FLT_MAX;
 
         // Glyph runs that have the same _baselineOriginY value are part of the the same Line.
-        while ((j < numOfGlyphRuns) && (glyphRunDetails._baselineOriginY[i] == glyphRunDetails._baselineOriginY[j])) {
-            j++;
-        }
-        while (i < j) {
+        float baselineOriginYForCurrentLine = glyphRunDetails._baselineOriginY[i];
+
+        // Iterate through runs on the current line
+        for (j = i; (j < numOfGlyphRuns) && (glyphRunDetails._baselineOriginY[j] == baselineOriginYForCurrentLine); ++j) {
             // Create _CTRun objects and make them part of _CTLine
             _CTRun* run = [[_CTRun new] autorelease];
-            run->_range.location = glyphRunDetails._glyphRunDescriptions[i]._textPosition;
-            run->_range.length = glyphRunDetails._glyphRunDescriptions[i]._stringLength;
+            run->_range.location = glyphRunDetails._glyphRunDescriptions[j]._textPosition;
+            run->_range.length = glyphRunDetails._glyphRunDescriptions[j]._stringLength;
             run->_stringFragment = [static_cast<NSString*>(CFAttributedStringGetString(string))
                 substringWithRange:NSMakeRange(range.location + run->_range.location, run->_range.length)];
-            run->_dwriteGlyphRun = move(glyphRunDetails._dwriteGlyphRun[i]);
-            run->_stringIndices = move(glyphRunDetails._glyphRunDescriptions[i]._clusterMap);
+            run->_dwriteGlyphRun = move(glyphRunDetails._dwriteGlyphRun[j]);
+            run->_stringIndices = move(glyphRunDetails._glyphRunDescriptions[j]._clusterMap);
             run->_attributes =
                 [static_cast<NSAttributedString*>(string) attributesAtIndex:(range.location + run->_range.location) effectiveRange:NULL];
 
-            xPos = glyphRunDetails._baselineOriginX[i];
-            yPos = glyphRunDetails._baselineOriginY[i];
+            xPos = glyphRunDetails._baselineOriginX[j];
+            yPos = glyphRunDetails._baselineOriginY[j];
 
             // Calculate the relative offset of each glyph run and store it. This will be useful while drawing individual glpyh runs or
             // lines.
@@ -475,18 +501,20 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
 
             // TODO::
             // This is a temp workaround until we can have actual glyph origins
-            for (int index = 0; index < glyphRunDetails._dwriteGlyphRun[i].glyphCount; index++) {
+            for (int index = 0; index < glyphRunDetails._dwriteGlyphRun[j].glyphCount; index++) {
                 run->_glyphOrigins.emplace_back(CGPoint{ xPos, yPos });
-                run->_glyphAdvances.emplace_back(CGSize{ glyphRunDetails._dwriteGlyphRun[i].glyphAdvances[index], 0.0f });
-                xPos += glyphRunDetails._dwriteGlyphRun[i].glyphAdvances[index];
-                line->_width += glyphRunDetails._dwriteGlyphRun[i].glyphAdvances[index];
+                run->_glyphAdvances.emplace_back(CGSize{ glyphRunDetails._dwriteGlyphRun[j].glyphAdvances[index], 0.0f });
+                xPos += glyphRunDetails._dwriteGlyphRun[j].glyphAdvances[index];
+                line->_width += glyphRunDetails._dwriteGlyphRun[j].glyphAdvances[index];
             }
 
             [runs addObject:run];
             stringRange += run->_range.length;
-            glyphCount += glyphRunDetails._dwriteGlyphRun[i].glyphCount;
-            i++;
+            glyphCount += glyphRunDetails._dwriteGlyphRun[j].glyphCount;
         }
+
+        // Fast-forward i to start on the next line
+        i = j;
 
         if ([runs count] > 0) {
             prevYPosForDraw = yPos;
@@ -509,476 +537,4 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
     }
 
     return frame;
-}
-
-// Represents a mapping between multiple representations of the same font weight across DWrite and CoreText
-// DWRITE_FONT_WEIGHT_BOLD = kCTFontWeightBold
-struct WeightMapping {
-    DWRITE_FONT_WEIGHT dwriteValue;
-    CGFloat ctValue;
-};
-
-// Mapping for weight
-// Some loss of precision here as CT presents fewer values than DWrite
-// Note also that Thin and Ultra/Extra-Light are in opposite order in DWrite and CoreText/UIKit constants
-// (However, "Thin" fonts on the reference platform have UIFontWeightUltraLight...)
-// clang-format off
-static const struct WeightMapping c_weightMap[] = { { DWRITE_FONT_WEIGHT_THIN, kCTFontWeightUltraLight },
-                                                    { DWRITE_FONT_WEIGHT_EXTRA_LIGHT, kCTFontWeightThin },
-                                                    { DWRITE_FONT_WEIGHT_ULTRA_LIGHT, kCTFontWeightThin },
-                                                    { DWRITE_FONT_WEIGHT_LIGHT, kCTFontWeightLight },
-                                                    { DWRITE_FONT_WEIGHT_SEMI_LIGHT, kCTFontWeightLight },
-                                                    { DWRITE_FONT_WEIGHT_NORMAL, kCTFontWeightRegular },
-                                                    { DWRITE_FONT_WEIGHT_REGULAR, kCTFontWeightRegular },
-                                                    { DWRITE_FONT_WEIGHT_MEDIUM, kCTFontWeightMedium },
-                                                    { DWRITE_FONT_WEIGHT_DEMI_BOLD, kCTFontWeightSemibold },
-                                                    { DWRITE_FONT_WEIGHT_SEMI_BOLD, kCTFontWeightSemibold },
-                                                    { DWRITE_FONT_WEIGHT_BOLD, kCTFontWeightBold },
-                                                    { DWRITE_FONT_WEIGHT_EXTRA_BOLD, kCTFontWeightHeavy },
-                                                    { DWRITE_FONT_WEIGHT_ULTRA_BOLD, kCTFontWeightHeavy },
-                                                    { DWRITE_FONT_WEIGHT_BLACK, kCTFontWeightBlack },
-                                                    { DWRITE_FONT_WEIGHT_HEAVY, kCTFontWeightBlack },
-                                                    { DWRITE_FONT_WEIGHT_EXTRA_BLACK, kCTFontWeightBlack },
-                                                    { DWRITE_FONT_WEIGHT_ULTRA_BLACK, kCTFontWeightBlack } };
-// clang-format on
-
-/**
- * Creates an IDWriteFontFace given the attributes of a CTFontDescriptor
- * Currently, font name, family name, kCTFontWeight/Slant/Width, and part of SymbolicTrait, are taken into account
- */
-HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescriptor, IDWriteFontFace** outFontFace) {
-    CFStringRef fontName = static_cast<CFStringRef>(CFAutorelease(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontNameAttribute)));
-    CFStringRef familyName =
-        static_cast<CFStringRef>(CFAutorelease(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontFamilyNameAttribute)));
-
-    // font name takes precedence
-    if (fontName) {
-        if (familyName && !CFEqual(familyName, _DWriteGetFamilyNameForFontName(fontName))) {
-            TraceError(TAG,
-                       L"Mismatched font name \"%hs\" and family name \"%hs\"",
-                       [static_cast<NSString*>(fontName) UTF8String],
-                       [static_cast<NSString*>(familyName) UTF8String]);
-            return E_INVALIDARG;
-        }
-
-        // familyName is either valid for fontName, or unspecified
-        // just use fontName, then
-        return _DWriteCreateFontFaceWithName(fontName, outFontFace);
-    }
-
-    // otherwise, look at family name and other attributes
-    if (familyName) {
-        DWRITE_FONT_WEIGHT weight = DWRITE_FONT_WEIGHT_NORMAL;
-        DWRITE_FONT_STRETCH stretch = DWRITE_FONT_STRETCH_NORMAL;
-        DWRITE_FONT_STYLE style = DWRITE_FONT_STYLE_NORMAL;
-
-        // Look for traits that may specify weight, stretch, style
-        CFDictionaryRef traits =
-            static_cast<CFDictionaryRef>(CFAutorelease(CTFontDescriptorCopyAttribute(fontDescriptor, kCTFontTraitsAttribute)));
-
-        if (traits) {
-            // kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait take precedence over symbolic traits
-            CFNumberRef weightTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontWeightTrait));
-            CFNumberRef widthTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontWidthTrait));
-            CFNumberRef slantTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontSlantTrait));
-
-            CFNumberRef cfSymbolicTrait = static_cast<CFNumberRef>(CFDictionaryGetValue(traits, kCTFontSymbolicTrait));
-            uint32_t symbolicTrait = cfSymbolicTrait ? _CTFontSymbolicTraitsFromCFNumber(cfSymbolicTrait) : 0;
-
-            if (weightTrait) {
-                CGFloat weightFloat;
-                CFNumberGetValue(weightTrait, kCFNumberCGFloatType, &weightFloat);
-
-                // Consult c_weightMap
-                for (const auto& weightMapping : c_weightMap) {
-                    if (weightFloat == weightMapping.ctValue) {
-                        weight = weightMapping.dwriteValue;
-                        break;
-                    }
-                }
-            } else if (symbolicTrait & kCTFontBoldTrait) {
-                weight = DWRITE_FONT_WEIGHT_BOLD;
-            }
-
-            if (widthTrait) {
-                CGFloat widthFloat;
-                CFNumberGetValue(widthTrait, kCFNumberCGFloatType, &widthFloat);
-
-                // Treat above 0 as expanded, below 0 as condensed
-                if (widthFloat > 0) {
-                    stretch = DWRITE_FONT_STRETCH_EXPANDED;
-                } else if (widthFloat < 0) {
-                    stretch = DWRITE_FONT_STRETCH_CONDENSED;
-                }
-            } else if (symbolicTrait & kCTFontExpandedTrait) {
-                stretch = DWRITE_FONT_STRETCH_EXPANDED;
-            } else if (symbolicTrait & kCTFontCondensedTrait) {
-                stretch = DWRITE_FONT_STRETCH_CONDENSED;
-            }
-
-            if (slantTrait) {
-                CGFloat slantFloat;
-                CFNumberGetValue(slantTrait, kCFNumberCGFloatType, &slantFloat);
-
-                // Treat anything above 0 as italic
-                if (slantFloat > 0) {
-                    style = DWRITE_FONT_STYLE_ITALIC;
-                }
-            } else if (symbolicTrait & kCTFontItalicTrait) {
-                style = DWRITE_FONT_STYLE_ITALIC;
-            }
-        }
-
-        // Create a best matching font based on the family name and weight/stretch/style
-        ComPtr<IDWriteFontFamily> fontFamily;
-        RETURN_IF_FAILED(_DWriteCreateFontFamilyWithName(familyName, &fontFamily));
-        RETURN_HR_IF_NULL(E_INVALIDARG, fontFamily);
-
-        ComPtr<IDWriteFont> font;
-        RETURN_IF_FAILED(fontFamily->GetFirstMatchingFont(weight, stretch, style, &font));
-
-        return font->CreateFontFace(outFontFace);
-    }
-
-    TraceError(TAG, L"Must specify either kCTFontFamilyNameAttribute or kCTFontNameAttribute in font descriptor");
-    return E_INVALIDARG;
-}
-
-/**
- * Helper function to box a CTFontSymbolicTraits in a CFNumber
- */
-CFNumberRef _CFNumberCreateFromSymbolicTraits(CTFontSymbolicTraits symbolicTraits) {
-    // symbolic traits are an unsigned 32-bit int
-    // CFNumber doesn't support unsigned ints
-    // get around this by storing in a signed 64-bit int
-    int64_t signedTraits = static_cast<int64_t>(symbolicTraits);
-    return CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &signedTraits);
-}
-
-/**
- * Helper function to unbox a CTFontSymbolicTraits from a CFNumber
- */
-CTFontSymbolicTraits _CTFontSymbolicTraitsFromCFNumber(CFNumberRef num) {
-    // symbolic traits are an unsigned 32-bit int, but were stored in a signed 64-bit int
-    int64_t ret;
-    CFNumberGetValue(static_cast<CFNumberRef>(num), kCFNumberSInt64Type, &ret);
-    return static_cast<CTFontSymbolicTraits>(ret);
-}
-
-/**
- * Helper function that converts a DWRITE_FONT_WEIGHT into a float usable for kCTFontWeightTrait.
- */
-CGFloat __DWriteGetCTFontWeight(DWRITE_FONT_WEIGHT weight) {
-    for (const auto& weightMapping : c_weightMap) {
-        if (weight == weightMapping.dwriteValue) {
-            return weightMapping.ctValue;
-        }
-    }
-
-    return kCTFontWeightRegular;
-}
-
-/**
- * Helper function that converts a DWRITE_FONT_STRETCH into a float usable for kCTFontWidthTrait.
- */
-CGFloat __DWriteGetCTFontWidth(DWRITE_FONT_STRETCH stretch) {
-    // kCTFontWidthTrait is documented to range from -1.0 to 1.0, centered at 0,
-    // with 'Condensed' fonts returning -0.2 on the reference platform
-    // DWrite stretch ranges from 0-9, centered at 5
-
-    // Reference platform lacks fonts with stretch besides 'normal' or 'condensed',
-    // and it is not yet clear how these values are used
-    // Do an approximate conversion for now
-    return (static_cast<float>(stretch) / 10.0f) - 0.5f;
-}
-
-/**
- * Helper function that reads certain properties from a DWrite font face,
- * then parses them into a dictionary suitable for kCTFontTraitsAttribute
- */
-static CFDictionaryRef _DWriteFontCreateTraitsDict(const ComPtr<IDWriteFontFace>& fontFace) {
-    // Get pointers for the additional FontFace interfaces
-    ComPtr<IDWriteFontFace1> fontFace1;
-    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace1));
-    ComPtr<IDWriteFontFace2> fontFace2;
-    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace2));
-    ComPtr<IDWriteFontFace3> fontFace3;
-    RETURN_NULL_IF_FAILED(fontFace.As(&fontFace3));
-
-    DWRITE_FONT_WEIGHT weight = fontFace3->GetWeight();
-    DWRITE_FONT_STRETCH stretch = fontFace3->GetStretch();
-    DWRITE_FONT_STYLE style = fontFace3->GetStyle();
-
-    CGFloat weightTrait = __DWriteGetCTFontWeight(weight);
-    CGFloat widthTrait = __DWriteGetCTFontWidth(stretch);
-
-    // kCTFontSlantTrait appears scaled to be 1.0 = 180 degrees, rather than = 30 degrees as documentation claims
-    CGFloat slantTrait = _DWriteFontGetSlantDegrees(fontFace) / -180.0f; // kCTFontSlantTrait is positive for negative angles
-
-    // symbolic traits are a bit mask - evaluate the trueness of each flag
-    CTFontSymbolicTraits symbolicTraits = 0;
-
-    if (style != DWRITE_FONT_STYLE_NORMAL) {
-        symbolicTraits |= kCTFontItalicTrait;
-    }
-
-    if (weight > DWRITE_FONT_WEIGHT_MEDIUM) {
-        symbolicTraits |= kCTFontBoldTrait;
-    }
-
-    if (stretch > DWRITE_FONT_STRETCH_MEDIUM) {
-        symbolicTraits |= kCTFontExpandedTrait;
-    } else if (stretch < DWRITE_FONT_STRETCH_NORMAL) {
-        symbolicTraits |= kCTFontCondensedTrait;
-    }
-
-    if (fontFace1->IsMonospacedFont()) {
-        symbolicTraits |= kCTFontMonoSpaceTrait;
-    }
-
-    if (fontFace1->HasVerticalGlyphVariants()) {
-        symbolicTraits |= kCTFontVerticalTrait;
-    }
-
-    if (fontFace2->IsColorFont()) {
-        symbolicTraits |= kCTFontColorGlyphsTrait;
-    }
-
-    // TODO: The symbolic traits below are poorly documented/have no clear DWrite mapping
-    // if (fontFace->IsFoo()) {
-    //     symbolicTraits |= kCTFontUIOptimizedTrait;
-    // }
-    // if (fontFace->IsFoo()) {
-    //     symbolicTraits |= kCTFontCompositeTrait;
-    // }
-
-    // TODO: The upper 16 bits of symbolic traits describe stylistic aspects of a font, specifically its serifs,
-    // such as modern, ornamental, or sans (no serifs)
-    // DWrite has no such API for characterizing fonts
-    // if (fontFace->IsFoo()) {
-    //     symbolicTraits |= kCTFontOldStyleSerifsClass;
-    // }
-
-    // Keys and values for the final trait dictionary
-    CFTypeRef traitKeys[] = { kCTFontSymbolicTrait, kCTFontWeightTrait, kCTFontWidthTrait, kCTFontSlantTrait };
-    CFTypeRef traitValues[] = { CFAutorelease(_CFNumberCreateFromSymbolicTraits(symbolicTraits)),
-                                CFAutorelease(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &weightTrait)),
-                                CFAutorelease(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &widthTrait)),
-                                CFAutorelease(CFNumberCreate(kCFAllocatorDefault, kCFNumberCGFloatType, &slantTrait)) };
-
-    return CFDictionaryCreate(kCFAllocatorDefault,
-                              traitKeys,
-                              traitValues,
-                              4,
-                              &kCFTypeDictionaryKeyCallBacks,
-                              &kCFTypeDictionaryValueCallBacks);
-}
-
-/**
- * Gets a name/informational string from a DWrite font face corresponding to a CTFont constant
- */
-CFStringRef _DWriteFontCopyName(const ComPtr<IDWriteFontFace>& fontFace, CFStringRef nameKey) {
-    if (nameKey == nullptr || fontFace == nullptr) {
-        return nullptr;
-    }
-
-    DWRITE_INFORMATIONAL_STRING_ID informationalStringId;
-
-    if (CFEqual(nameKey, kCTFontCopyrightNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_COPYRIGHT_NOTICE;
-    } else if (CFEqual(nameKey, kCTFontFamilyNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_WIN32_FAMILY_NAMES;
-    } else if (CFEqual(nameKey, kCTFontSubFamilyNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_WIN32_SUBFAMILY_NAMES;
-    } else if (CFEqual(nameKey, kCTFontStyleNameKey)) {
-        ComPtr<IDWriteFontFace3> dwriteFontFace3;
-        RETURN_NULL_IF_FAILED(fontFace.As(&dwriteFontFace3));
-        ComPtr<IDWriteLocalizedStrings> name;
-        RETURN_NULL_IF_FAILED(dwriteFontFace3->GetFaceNames(&name));
-        return static_cast<CFStringRef>(CFRetain(_CFStringFromLocalizedString(name.Get())));
-
-    } else if (CFEqual(nameKey, kCTFontUniqueNameKey)) {
-        return CFStringCreateWithFormat(kCFAllocatorDefault,
-                                        nullptr,
-                                        CFSTR("%@ %@"),
-                                        CFAutorelease(_DWriteFontCopyName(fontFace, kCTFontFullNameKey)),
-                                        CFAutorelease(_DWriteFontCopyName(fontFace, kCTFontStyleNameKey)));
-
-    } else if (CFEqual(nameKey, kCTFontFullNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_FULL_NAME;
-    } else if (CFEqual(nameKey, kCTFontVersionNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_VERSION_STRINGS;
-    } else if (CFEqual(nameKey, kCTFontPostScriptNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME;
-    } else if (CFEqual(nameKey, kCTFontTrademarkNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_TRADEMARK;
-    } else if (CFEqual(nameKey, kCTFontManufacturerNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_MANUFACTURER;
-    } else if (CFEqual(nameKey, kCTFontDesignerNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_DESIGNER;
-    } else if (CFEqual(nameKey, kCTFontDescriptionNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_DESCRIPTION;
-    } else if (CFEqual(nameKey, kCTFontVendorURLNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_FONT_VENDOR_URL;
-    } else if (CFEqual(nameKey, kCTFontDesignerURLNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_DESIGNER_URL;
-    } else if (CFEqual(nameKey, kCTFontLicenseNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_LICENSE_DESCRIPTION;
-    } else if (CFEqual(nameKey, kCTFontLicenseURLNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_LICENSE_INFO_URL;
-    } else if (CFEqual(nameKey, kCTFontSampleTextNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_SAMPLE_TEXT;
-    } else if (CFEqual(nameKey, kCTFontPostScriptCIDNameKey)) {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_CID_NAME;
-    } else {
-        informationalStringId = DWRITE_INFORMATIONAL_STRING_NONE;
-    }
-
-    return _DWriteFontCopyInformationalString(fontFace, informationalStringId);
-}
-
-/**
- * Custom IDWriteGeometrySink class, built on top of a CGMutablePath,
- * that translates callbacks from IDWriteFontFace::GetGlyphRunOutline to CGPath elements.
- *
- * Notes:
- *
- * DWrite provides negative values for y-coordinates, whereas CGPath expects positive ones
- * As such, functions in this class will invert y-coordinates when passing points from DWrite to CG
- *
- * IDWriteFontFace::GetGlyphRunOutline uses this class in a single-threaded manner (dumping the draw instructions from the font linearly)
- * As such, this class is deliberately left thread-unsafe.
- */
-class __CGPathGeometrySink : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, IDWriteGeometrySink> {
-protected:
-    InspectableClass(L"Windows.Bridge.DirectWrite", TrustLevel::BaseTrust);
-
-public:
-    __CGPathGeometrySink(const CGAffineTransform* transform) {
-        _cgPath.reset(CGPathCreateMutable());
-        if (transform) {
-            _transform = std::make_unique<CGAffineTransform>(*transform);
-        }
-    }
-
-    HRESULT RuntimeClassInitialize() {
-        return S_OK;
-    }
-
-    void STDMETHODCALLTYPE AddBeziers(_In_ const D2D1_BEZIER_SEGMENT* beziers, unsigned int beziersCount) {
-        // Some background on Bezier curves:
-        // A quadratic Bezier curve is specified by 3 points:     a start point, a control point, and an end point
-        // A cubic Bezier curve is instead specified by 4 points: a start point, TWO control points, and an end point
-        // As a generalization, most "older" fonts specify quadratic curves, and "newer" ones can use cubic curves
-        // Eg: Times New Roman's curves are all quadratic
-
-        // CGPath has support for both orders of Bezier curve, (AddCurveToPoint for cubic, AddQuadCurveToPointFor quadratic)
-        // but DWrite's GeometrySink only supports cubic Bezier curves (AddBeziers),
-        // and approximates any quadratic curves in terms of a cubic curve
-        // Eg: Reference platform quadratic curve:  (previous endpoint),              (512, 632),              (480, 632)
-        //     DWrite approximate cubic curve:      (previous endpoint), (529, 632.666626), (501.333313, 632), (480, 632)
-
-        // Attempting to do an approximation from cubic back to quadratic would be clumsy and introduce further approximation error,
-        // So just pass all cubic Beziers through directly, including approximated ones
-        for (unsigned int i = 0; i < beziersCount; ++i) {
-            CGPathAddCurveToPoint(_cgPath.get(),
-                                  _transform.get(),
-                                  beziers[i].point1.x,
-                                  -beziers[i].point1.y,
-                                  beziers[i].point2.x,
-                                  -beziers[i].point2.y,
-                                  beziers[i].point3.x,
-                                  -beziers[i].point3.y);
-        }
-    }
-
-    void STDMETHODCALLTYPE AddLines(_In_ const D2D1_POINT_2F* points, unsigned int pointsCount) {
-        // Use individual CGPathAddLineToPoint() calls here, rather than CGPathAddLines
-        // CGPathAddLines does a CGPathMoveToPoint to the first point,
-        // which doesn't match what DWrite expects (draw a line from the previous point)
-        for (unsigned int i = 0; i < pointsCount; ++i) {
-            CGPathAddLineToPoint(_cgPath.get(), _transform.get(), points[i].x, -points[i].y);
-        }
-    }
-
-    void STDMETHODCALLTYPE BeginFigure(D2D1_POINT_2F startPoint, D2D1_FIGURE_BEGIN figureBegin) {
-        if (_figureInProgress) {
-            TraceError(TAG,
-                       L"IDWriteGeometrySink::BeginFigure called while a figure was currently in progress. Placing object in error state - "
-                       L"future function calls will fail.");
-            _invalidState = true;
-        }
-
-        if (!_invalidState) {
-            // figureBegin is ignored for CGPath purposes -
-            // filled vs hollow maps to CGPathDrawingMode, and is specified to CGContextDrawPath directly
-            _figureInProgress = true;
-            CGPathMoveToPoint(_cgPath.get(), _transform.get(), startPoint.x, -startPoint.y);
-        }
-    }
-
-    HRESULT STDMETHODCALLTYPE Close() {
-        if (_figureInProgress) {
-            TraceError(TAG,
-                       L"IDWriteGeometrySink::Close called while a figure was currently in progress. Placing object in error state - "
-                       L"future function calls will fail.");
-            _invalidState = true;
-        }
-
-        return _invalidState ? E_UNEXPECTED : S_OK;
-    }
-
-    void STDMETHODCALLTYPE EndFigure(D2D1_FIGURE_END figureEnd) {
-        if (!_figureInProgress) {
-            TraceError(TAG,
-                       L"IDWriteGeometrySink::EndFigure called while no figure was currently in progress. Placing object in error state - "
-                       L"future function calls will fail.");
-            _invalidState = true;
-        }
-
-        if (!_invalidState) {
-            // figureBegin is ignored for CGPath purposes -
-            // filled vs hollow maps to CGPathDrawingMode, and is specified to CGContextDrawPath directly
-            _figureInProgress = false;
-
-            if (figureEnd) {
-                // D2D1_FIGURE_END_CLOSED  = 1, close the subpath
-                CGPathCloseSubpath(_cgPath.get());
-            }
-            // D2D1_FIGURE_END_OPEN = 0, subpath is left open (no-op in terms of CGPath)
-        }
-    }
-
-    void STDMETHODCALLTYPE SetFillMode(D2D1_FILL_MODE fillMode) {
-        // No-op for CGPath purposes - CGPathDrawingMode is specified to CGContextDrawPath directly
-    }
-
-    void STDMETHODCALLTYPE SetSegmentFlags(D2D1_PATH_SEGMENT vertexFlags) {
-        // No-op for CGPath purposes - CGLineJoin is specified to CGContextStrokePath directly
-    }
-
-    // Releases the class's ownership of its path when all operations are finished, returning a +1 reference (from the path's Create)
-    CGPathRef ReleasePath() {
-        return _cgPath.release();
-    }
-
-private:
-    woc::unique_cf<CGMutablePathRef> _cgPath;
-    std::unique_ptr<CGAffineTransform> _transform;
-    bool _figureInProgress = false; // Keeps track of whether this class is currently between a BeginFigure and EndFigure call
-    bool _invalidState = false; // If BeginFigure and EndFigure calls are imbalanced, invalidate all future operations
-};
-
-CGPathRef _DWriteFontCreatePathForGlyph(const ComPtr<IDWriteFontFace>& fontFace,
-                                        CGFloat pointSize,
-                                        CGGlyph glyph,
-                                        const CGAffineTransform* transform) {
-    // Create an instance of a custom IDWriteGeometrySink backed by a CGMutablePathRef
-    ComPtr<__CGPathGeometrySink> geometrySink = Make<__CGPathGeometrySink>(transform);
-
-    // Call GetGlyphRunOutline using glyph as a C-style array of size 1
-    RETURN_NULL_IF_FAILED(fontFace->GetGlyphRunOutline(pointSize, &glyph, nullptr, nullptr, 1, false, false, geometrySink.Get()));
-
-    // Get the underlying CGMutablePathRef from the sink
-    return geometrySink->ReleasePath();
 }

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -53,7 +53,7 @@ struct _DWriteFontProperties {
 
 // Font name <-> font family, font properties
 #ifdef __cplusplus
-extern "C++" std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName);
+extern "C++" std::shared_ptr<const _DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName);
 #endif
 
 COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontFamilyNames();

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -63,6 +63,9 @@ COREGRAPHICS_EXPORT CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef font
 // Creation of DWrite font face/family objects
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily);
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateTextFormatWithFontNameAndSize(CFStringRef optionalFontName,
+                                                                       CGFloat fontSize,
+                                                                       IDWriteTextFormat** outTextFormat);
 
 // DWriteFont getters that convert to a CF/CG object or struct
 COREGRAPHICS_EXPORT CFStringRef _DWriteFontCopyInformationalString(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace,

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -29,12 +29,17 @@
 #import <memory>
 
 // General DWrite helpers
-COREGRAPHICS_EXPORT CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedString);
+#ifdef __cplusplus
+extern "C++" std::wstring _GetUserDefaultLocaleName();
+#endif
 
-// Font name <-> font family
-COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontFamilyNames();
-COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName);
-COREGRAPHICS_EXPORT CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName);
+static inline CFStringRef _CFStringCreateUppercaseCopy(CFStringRef string) {
+    CFMutableStringRef ret = CFStringCreateMutableCopy(nullptr, CFStringGetLength(string), string);
+    CFStringUppercase(ret, nullptr);
+    return ret;
+}
+
+COREGRAPHICS_EXPORT CFStringRef _CFStringFromLocalizedString(IDWriteLocalizedStrings* localizedString);
 
 struct _DWriteFontProperties {
     DWRITE_FONT_WEIGHT weight = DWRITE_FONT_WEIGHT_NORMAL;
@@ -46,22 +51,18 @@ struct _DWriteFontProperties {
     woc::unique_cf<CFStringRef> familyName;
 };
 
-// Create DWrite objects
+// Font name <-> font family, font properties
 #ifdef __cplusplus
 extern "C++" std::shared_ptr<_DWriteFontProperties> _DWriteGetFontPropertiesFromName(CFStringRef fontName);
 #endif
 
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateTextFormat(const wchar_t* fontFamilyName,
-                                                    DWRITE_FONT_WEIGHT weight,
-                                                    DWRITE_FONT_STYLE style,
-                                                    DWRITE_FONT_STRETCH stretch,
-                                                    float fontSize,
-                                                    IDWriteTextFormat** outTextFormat);
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily);
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace);
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, IDWriteFontFace** outFontFace);
-COREGRAPHICS_EXPORT HRESULT _DWriteRegisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
-COREGRAPHICS_EXPORT HRESULT _DWriteUnregisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
+COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontFamilyNames();
+COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName);
+COREGRAPHICS_EXPORT CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName);
+
+// Creation of DWrite font face/family objects
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, _Out_ IDWriteFontFamily** outFontFamily);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, _Out_ IDWriteFontFace** outFontFace);
 
 // DWriteFont getters that convert to a CF/CG object or struct
 COREGRAPHICS_EXPORT CFStringRef _DWriteFontCopyInformationalString(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace,
@@ -71,3 +72,8 @@ COREGRAPHICS_EXPORT CGFloat _DWriteFontGetSlantDegrees(const Microsoft::WRL::Com
 COREGRAPHICS_EXPORT CGRect _DWriteFontGetBoundingBox(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace);
 COREGRAPHICS_EXPORT HRESULT _DWriteFontGetBoundingBoxesForGlyphs(
     const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace, const CGGlyph* glyphs, CGRect* boundingRects, size_t count, bool isSideways);
+
+// DWrite functions relating to font binary data
+COREGRAPHICS_EXPORT HRESULT _DWriteRegisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
+COREGRAPHICS_EXPORT HRESULT _DWriteUnregisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, _Out_ IDWriteFontFace** outFontFace);

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -61,8 +61,8 @@ COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef fam
 COREGRAPHICS_EXPORT CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName);
 
 // Creation of DWrite font face/family objects
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, _Out_ IDWriteFontFamily** outFontFamily);
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, _Out_ IDWriteFontFace** outFontFace);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithName(CFStringRef name, IDWriteFontFace** outFontFace);
 
 // DWriteFont getters that convert to a CF/CG object or struct
 COREGRAPHICS_EXPORT CFStringRef _DWriteFontCopyInformationalString(const Microsoft::WRL::ComPtr<IDWriteFontFace>& fontFace,
@@ -76,4 +76,4 @@ COREGRAPHICS_EXPORT HRESULT _DWriteFontGetBoundingBoxesForGlyphs(
 // DWrite functions relating to font binary data
 COREGRAPHICS_EXPORT HRESULT _DWriteRegisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
 COREGRAPHICS_EXPORT HRESULT _DWriteUnregisterFontsWithDatas(CFArrayRef fontDatas, CFArrayRef* errors);
-COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, _Out_ IDWriteFontFace** outFontFace);
+COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFaceWithData(CFDataRef data, IDWriteFontFace** outFontFace);

--- a/Frameworks/include/StringHelpers.h
+++ b/Frameworks/include/StringHelpers.h
@@ -19,6 +19,7 @@
 #include "Starboard.h"
 
 #ifdef __OBJC__
+#import <CoreFoundation/CFString.h>
 #import <Foundation/NSString.h>
 #import <NSStringInternal.h>
 #include <COMIncludes.h>
@@ -242,7 +243,7 @@ struct StringTraits<HSTRING> {
 template <unsigned int Count>
 struct StringTraits<const wchar_t[Count]> {
     // Returns a const pointer to the start of the buffer
-    static const wchar_t* Data(const wchar_t(&string)[Count]) {
+    static const wchar_t* Data(const wchar_t (&string)[Count]) {
         static_assert(Count > 0, "StringTraits<wchar_t[]> does not support empty arrays.");
         return &string[0];
     }
@@ -252,7 +253,7 @@ struct StringTraits<const wchar_t[Count]> {
 template <unsigned int Count>
 struct StringTraits<wchar_t[Count]> {
     // Returns a const pointer to the start of the buffer
-    static const wchar_t* Data(const wchar_t(&string)[Count]) {
+    static const wchar_t* Data(const wchar_t (&string)[Count]) {
         static_assert(Count > 0, "StringTraits<wchar_t[]> does not support empty arrays.");
         return &string[0];
     }
@@ -300,7 +301,7 @@ struct StringTraits<const char*> {
 template <unsigned int Count>
 struct StringTraits<char[Count]> {
     // Returns a const pointer to the start of the buffer
-    static const char* Data(const char(&string)[Count]) {
+    static const char* Data(const char (&string)[Count]) {
         static_assert(Count > 0, "StringTraits<char[]> does not support empty arrays.");
         return &string[0];
     }
@@ -465,9 +466,22 @@ inline TSource ContainerFromDelimitedString(_In_ const std::wstring& delimitedSt
     return result;
 }
 
-// Returns a a vector from a delmited string
+// Returns a vector from a delmited string
 inline std::vector<std::wstring> VectorFromDelimitedString(_In_ const std::wstring& delimitedString, wchar_t delimiter) {
     return ContainerFromDelimitedString<std::vector<std::wstring>>(delimitedString, delimiter);
 }
+
+#ifdef __OBJC__
+
+// Returns a vector from a CFString
+inline std::vector<UniChar> VectorFromCFString(CFStringRef string) {
+    CFIndex length = CFStringGetLength(string);
+    std::vector<UniChar> ret(length + 1);
+    CFStringGetCharacters(string, CFRangeMake(0, length), ret.data());
+
+    return ret;
+}
+
+#endif
 
 } // Strings

--- a/Frameworks/include/StringHelpers.h
+++ b/Frameworks/include/StringHelpers.h
@@ -18,8 +18,11 @@
 
 #include "Starboard.h"
 
-#ifdef __OBJC__
+#ifdef __clang__
 #import <CoreFoundation/CFString.h>
+#endif
+
+#ifdef __OBJC__
 #import <Foundation/NSString.h>
 #import <NSStringInternal.h>
 #include <COMIncludes.h>
@@ -471,7 +474,7 @@ inline std::vector<std::wstring> VectorFromDelimitedString(_In_ const std::wstri
     return ContainerFromDelimitedString<std::vector<std::wstring>>(delimitedString, delimiter);
 }
 
-#ifdef __OBJC__
+#ifdef __clang__
 
 // Returns a vector from a CFString
 inline std::vector<UniChar> VectorFromCFString(CFStringRef string) {

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -37,12 +37,12 @@ LIBRARY CoreGraphics
         CGBitmapContextGetImage
 
         ; DWriteWrapper Additions
+        _GetUserDefaultLocaleName
         _CFStringFromLocalizedString
         _DWriteCopyFontFamilyNames
         _DWriteCopyFontNamesForFamilyName
         _DWriteGetFamilyNameForFontName
         _DWriteGetFontPropertiesFromName
-        _DWriteCreateTextFormat
         _DWriteCreateFontFamilyWithName
         _DWriteCreateFontFaceWithName
         _DWriteCreateFontFaceWithData

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -45,6 +45,7 @@ LIBRARY CoreGraphics
         _DWriteGetFontPropertiesFromName
         _DWriteCreateFontFamilyWithName
         _DWriteCreateFontFaceWithName
+        _DWriteCreateTextFormatWithFontNameAndSize
         _DWriteCreateFontFaceWithData
         _DWriteFontCopyInformationalString
         _DWriteFontCopyTable

--- a/build/CoreGraphics/lib/CoreGraphicsLib.vcxproj
+++ b/build/CoreGraphics/lib/CoreGraphicsLib.vcxproj
@@ -55,9 +55,15 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\CGPDFStream.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\CGPDFString.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\CGShading.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\DWriteFontBinaryDataLoader.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\DWriteFontBinaryDataCollectionLoader.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\DWriteFontCollectionHelper.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreGraphics\DWriteWrapper.mm" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CoreGraphics\DWriteFontBinaryDataLoader.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CoreGraphics\DWriteFontBinaryDataCollectionLoader.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CoreGraphics\DWriteFontCollectionHelper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\include\CoreGraphics\DWriteWrapper.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/build/CoreText/lib/CoreTextLib.vcxproj
+++ b/build/CoreText/lib/CoreTextLib.vcxproj
@@ -34,6 +34,8 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreText\CTTextTab.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreText\CTTypesetter.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreText\CTUtilities.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreText\DWriteWrapper_CGPath.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreText\DWriteWrapper_CTFont.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\CoreText\DWriteWrapper_CoreText.mm" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Split DWriteWrapper, DWriteWrapper_CoreText among more files
  - DWriteFontBinaryDataLoader is now in its own .h + .mm along with BinaryDataStream
  - DWriteFontCollectionLoader is now in its own .h + .mm along with FileEnumerator
    - Renamed to DWriteFontBinaryDataCollectionLoader to get the name farther from the interface name (IDWriteFontCollectionLoader)
  - Implementation for _DWriteFontCreatePathForGlyph(), and the __CGPathGeometrySink class,
    which was only used in this function, are now in a separate .mm file
  - Implementation for DWriteFont_CoreText functions relating to CTFont, CTFontDescriptor are now in a separate .mm file
  - Refactored _userFontCollection, s_userFontPropertiesMap, systemFontPropertiesMap to be behind an abstraction layer,
    DWriteFontCollectionHelper, which wraps around either a user or system IDWriteFontCollection and provides
    font name -> other name/family name, properties mappings.
    - This is in its own .h + .mm file
    - As a result, many _DWrite functions now reduce cleanly to
      __GetSystemFontCollectionHelper()->Foo(), lock, __GetUserFontCollectionHelper()->Foo()

- Refactored __CreateDWriteTextFormat(), __CreateDWriteTextLayout()
  - Removed export of _DWriteCreateTextFormat(), this is now done directly in DWriteWrapper_CoreText.mm
  - Now return HRESULT instead of ComPtr, now create through out-pointers, changed naming convention
    - As a result, __CreateDWriteTextFormat no longer always returns a nullptr if an error occurs -
      this should not impact anything, as this was an internal function, and return values were never checked for nullptr anyway
  - Use CFAttributedStringGetAttribute directly instead of copying to a dictionary first,
    this should save some time on redundant copies/copies of unused attributes
  - Parts of these functions were moved into separate inline functions for easier reading

- Reversed order of i, j in _DWriteGetFrame(), such that i is on the outside and j on the inside
  - Replaced the inner two while loops, with a single for loop

- Exported _GetDefaultUserLocaleName()
- Broke parts of _DWriteCreateFontFaceWithFontDescriptor() into separate functions for easier readability (less nesting)
- Moved CustomDWriteTextRenderer member functions bodies to inside the class body
- _CFStringCreateUppercaseCopy now uses a nullptr CFLocale (faster, font names are not localized anyway)
  - Removed a redundant call to CFStringCreateUppercaseCopy() in the initialization of a font property map

- Changed most remaining instances where CFAutorelease was used to use woc::unique_cf instead
- Standardized naming convention of functions that translate a DWrite constant to CT/CG, or vice-versa
- Changed members of most C++ classes to use the m_ naming convention
- Standardized most file-private functions to be static
- Standardized most instances of loops that call functions that return HRESULTs to call continue on failure
- Changed CTTypesetterCreateLineWithOffset() to log and return null instead of throw
- Added a bunch of SAL annotations
- Added a string helper for copying a CFString to a vector, this was a pattern that occurred multiple times
- Added comments in various places

Fixes #1212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1504)
<!-- Reviewable:end -->
