### PR TITLE
Fix for issue 1499: UIView: [UIView invalidateIntrinsicContentSize] does far more work than necessary

### DIFF
--- a/Frameworks/AutoLayout/AutoLayout.mm
+++ b/Frameworks/AutoLayout/AutoLayout.mm
@@ -533,19 +533,18 @@ public:
     }
 }
 
-- (void)autoLayoutInvalidateContentSize {
+- (BOOL)autoLayoutInvalidateContentSize {
     AutoLayoutProperties* layoutProperties = self._autoLayoutProperties;
 
     // We're already invalid; no more work is necessary
     if (!layoutProperties->_isContentSizeValid) {
-        return;
+        return NO;
     }
 
-    // Set ourselves to invalid, and trigger a re-layout pass.
+    // Set ourselves to invalid, and return that our state has changed so re-layout can
+    // be performed as needed.
     layoutProperties->_isContentSizeValid = false;
-
-    // The parent is always responsible for autolaying out its children
-    [self.superview setNeedsLayout];
+    return YES;
 }
 
 // Gets the top most view that autolayout is relative to.

--- a/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
@@ -59,19 +59,24 @@ extern "C" void RunApplicationMain(Platform::String^ principalClassName,
                                    float windowHeight,
                                    ActivationType activationType,
                                    Platform::Object^ activationArg) {
+    // Return from activation immediatly; push all subsequent app launch work to 
+    // be performed *after* initial app activation.
+    CoreWindow::GetForCurrentThread()->Dispatcher->RunAsync(
+        CoreDispatcherPriority::Normal, 
+        ref new DispatchedHandler([=]() {
+            // Perform initialization
+            InitializeApp();
 
-    // Perform initialization
-    InitializeApp();
-
-    // Kick off iOS application main startup
-    // Convert Object^ to IInspectable* so it can be passed into Objective C and there converted to its projection
-    ApplicationMainStart(
-            Strings::WideToNarrow(principalClassName->Data()).c_str(),
-            Strings::WideToNarrow(delegateClassName->Data()).c_str(),
-            windowWidth,
-            windowHeight,
-            activationType,
-            reinterpret_cast<IInspectable*>(activationArg));
+            // Kick off iOS application main startup
+            // Convert Object^ to IInspectable* so it can be passed into Objective C and there converted to its projection
+            ApplicationMainStart(
+                Strings::WideToNarrow(principalClassName->Data()).c_str(),
+                Strings::WideToNarrow(delegateClassName->Data()).c_str(),
+                windowWidth,
+                windowHeight,
+                activationType,
+                reinterpret_cast<IInspectable*>(activationArg));
+    }));
 }
 
 // clang-format off

--- a/Frameworks/UIKit/UILabel.mm
+++ b/Frameworks/UIKit/UILabel.mm
@@ -142,7 +142,7 @@
         if (font == nil) {
             font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
         }
-        [self setFont:font];
+        _font = font;
 
         _alignment = (UITextAlignment)[coder decodeInt32ForKey:@"UITextAlignment"];
         _adjustFontSize = [coder decodeInt32ForKey:@"UIAdjustsFontSizeToFit"];
@@ -160,6 +160,7 @@
         } else {
             _lineBreakMode = UILineBreakModeTailTruncation;
         }
+
         if ([coder containsValueForKey:@"UIShadowOffset"]) {
             id obj = [coder decodeObjectForKey:@"UIShadowOffset"];
             CGSize size = { 0 };
@@ -207,13 +208,11 @@
 
     _alignment = UITextAlignmentLeft;
     _lineBreakMode = UILineBreakModeTailTruncation;
-    [self setFont:[UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]]];
     _textColor = [UIColor blackColor];
     _shadowColor = _textColor;
     _minimumFontSize = 8.0f;
     _numberOfLines = 1;
     [self setOpaque:FALSE];
-    [self adjustTextLayerSize];
 }
 
 /**
@@ -226,6 +225,10 @@
         // TODO: Reevaluate whether or not this is the correct default mode for UILabels that are initialized via initWithFrame.
         //       Some of our test apps expect the initWithCoder path to default to UIViewContentModeScaleToFill (aka kCAGravityResize).
         [self setContentMode:UIViewContentModeRedraw];
+
+        _font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
+
+        [self adjustTextLayerSize];
     }
 
     return self;
@@ -241,6 +244,10 @@
         // TODO: Reevaluate whether or not this is the correct default mode for UILabels that are initialized via initWithFrame.
         //       Some of our test apps expect the initWithCoder path to default to UIViewContentModeScaleToFill (aka kCAGravityResize).
         [self setContentMode:UIViewContentModeRedraw];
+
+        _font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
+
+        [self adjustTextLayerSize];
     }
 
     return self;
@@ -282,9 +289,6 @@
  @Status Interoperable
 */
 - (UIFont*)font {
-    if (_font == nil) {
-        _font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
-    }
     return _font;
 }
 
@@ -556,13 +560,8 @@
     CGSize ret = { 0 };
 
     if (_text != nil) {
-        UIFont* measurementFont = nil;
-        if (_font == nil) {
-            [self setFont:[UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]]];
-        }
-
         //  Grab the font at the original point size set in setFont:
-        measurementFont = [_font fontWithSize:_originalFontSize];
+        UIFont* measurementFont = [_font fontWithSize:_originalFontSize];
 
         //  Measure the height of a single line of text of this font
         CGSize fontHeight = [@" " sizeWithFont:measurementFont];
@@ -654,10 +653,6 @@
     CGSize ret;
 
     if (_text != nil) {
-        if (_font == nil) {
-            [self setFont:[UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]]];
-        }
-
         ret = [_text sizeWithFont:_font];
 
         if (_numberOfLines == 1) {

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -719,10 +719,6 @@ static std::string _printViewhierarchy(UIView* leafView) {
     // Create the private backing object
     self->priv = new UIViewPrivateState(self);
 
-    // Since we piggyback on autoresize masks and layoutSubviews for autolayout, we need to
-    // edge-trigger intrinsic content size changes, or we stumble into layout loops
-    priv->_previousIntrinsicContentSize = { UIViewNoIntrinsicMetric, UIViewNoIntrinsicMetric };
-
     // Configure autolayout
     static bool isAutoLayoutInitialized = InitializeAutoLayout();
     [self autoLayoutAlloc];
@@ -2640,7 +2636,6 @@ static float doRound(float f) {
 */
 - (void)updateConstraints {
     priv->_constraintsNeedUpdate = NO;
-
     [self autoLayoutUpdateConstraints];
 }
 
@@ -3566,12 +3561,8 @@ static float doRound(float f) {
  @Status Interoperable
 */
 - (void)invalidateIntrinsicContentSize {
-    // The parent is always responsible for autolaying out its children
-    if (!CGSizeEqualToSize(priv->_previousIntrinsicContentSize, self.intrinsicContentSize)) {
-        priv->_previousIntrinsicContentSize = self.intrinsicContentSize;
-        [self autoLayoutInvalidateContentSize];
-        [self.superview setNeedsLayout];
-    }
+    // Call into our AutoLayout extension to invalidate; it will trigger a relayout if needed.
+    [self autoLayoutInvalidateContentSize]
 }
 
 /**

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -3562,7 +3562,7 @@ static float doRound(float f) {
 */
 - (void)invalidateIntrinsicContentSize {
     // Call into our AutoLayout extension to invalidate; it will trigger a relayout if needed.
-    [self autoLayoutInvalidateContentSize]
+    [self autoLayoutInvalidateContentSize];
 }
 
 /**

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -3561,8 +3561,11 @@ static float doRound(float f) {
  @Status Interoperable
 */
 - (void)invalidateIntrinsicContentSize {
-    // Call into our AutoLayout extension to invalidate; it will trigger a relayout if needed.
-    [self autoLayoutInvalidateContentSize];
+    // Only trigger a relayout if we're not already invalidated
+    if ([self autoLayoutInvalidateContentSize]) {
+        // The parent is always responsible for autolaying out its children
+        [self.superview setNeedsLayout];
+    }
 }
 
 /**

--- a/Frameworks/include/UIView+AutoLayout.h
+++ b/Frameworks/include/UIView+AutoLayout.h
@@ -18,7 +18,7 @@
 #import <AutoLayout.h>
 
 @interface UIView (AutoLayout) <AutoLayoutable>
-- (void)autoLayoutInvalidateContentSize;
+- (BOOL)autoLayoutInvalidateContentSize;
 - (void)autoLayoutLayoutSubviews;
 - (void)autoLayoutUpdateConstraints;
 @end

--- a/Frameworks/include/UIViewInternal.h
+++ b/Frameworks/include/UIViewInternal.h
@@ -55,7 +55,6 @@ public:
     UIViewAutoresizing autoresizingMask;
     CGSize _contentHuggingPriority;
     CGSize _contentCompressionResistancePriority;
-    CGSize _previousIntrinsicContentSize;
     BOOL autoresizesSubviews;
     BOOL translatesAutoresizingMaskIntoConstraints;
     CGRect _resizeRoundingError;


### PR DESCRIPTION
Moving to a lazy model for constraint recalculation allows IslandwoodNews to launch more reliably on phone, but additional perf investigation is ongoing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1506)
<!-- Reviewable:end -->
