### PR TITLE
presentViewController/dismissViewController fixups

### DIFF
--- a/Frameworks/UIKit/UIPopoverPresentationController.mm
+++ b/Frameworks/UIKit/UIPopoverPresentationController.mm
@@ -80,7 +80,6 @@
     StrongId<UIView*> _sourceView;
     CGRect _sourceRect;
     StrongId<dispatch_block_t> _dismissCompletion;
-    BOOL _isManagingPresentation;
 }
 
 /**
@@ -98,24 +97,13 @@
     return self;
 }
 
-- (BOOL)_isManagingPresentation {
-    return _isManagingPresentation;
-}
+- (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion dismissCompletion:(dispatch_block_t)dismissCompletion {
+    _popoverControllerInternal->_presentCompletion.attach([presentCompletion copy]);
+    _dismissCompletion.attach([dismissCompletion copy]);
 
-- (void)_prepareForPresentation {
     if ([[_delegateInternal delegate] respondsToSelector:@selector(prepareForPopoverPresentation:)]) {
         [[_delegateInternal delegate] prepareForPopoverPresentation:self];
     }
-}
-
-- (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion dismissCompletion:(dispatch_block_t)dismissCompletion {
-    _popoverControllerInternal->_presentCompletion.attach([presentCompletion copy]);
-
-    _dismissCompletion.attach([dismissCompletion copy]);
-
-    // WYPopoverController internally manages the presentation of the content
-    // view controller (and the invoking of the viewWillAppear: et al. appearance events).
-    _isManagingPresentation = YES;
 
     if (_barButtonItem) {
         [_popoverControllerInternal presentPopoverFromBarButtonItem:_barButtonItem
@@ -141,8 +129,6 @@
 
     _dismissCompletion();
     _dismissCompletion = nil;
-
-    _isManagingPresentation = NO;
 }
 
 /**

--- a/Frameworks/UIKit/UIViewController.mm
+++ b/Frameworks/UIKit/UIViewController.mm
@@ -478,14 +478,20 @@ NSMutableDictionary* _pageMappings;
 
 - (BOOL)_hidesParent {
     UIModalPresentationStyle style = [self modalPresentationStyle];
-    if ((style == UIModalPresentationFormSheet || style == UIModalPresentationPopover) && DisplayProperties::IsTablet()) {
+
+    if (style == UIModalPresentationPopover) {
+        // Popovers (which don't hide their parent) are always shown regardless of tablet mode.
+        return NO;
+    } else if (style == UIModalPresentationFormSheet && DisplayProperties::IsTablet()) {
+        // FormSheet modals (which don't hide their parent) are only presented with tablet mode enabled.
         return NO;
     }
+
     return YES;
 }
 
 - (void)_setResizeToScreen:(BOOL)resize {
-    priv->_resizeToScreen = TRUE;
+    priv->_resizeToScreen = YES;
 }
 
 - (void)setOrientationInternal:(UIInterfaceOrientation)orientation animated:(BOOL)animated {
@@ -989,7 +995,7 @@ NSMutableDictionary* _pageMappings;
  @Status Interoperable
 */
 - (UIViewController*)modalViewController {
-    return priv->_modalViewController;
+    return priv->_presentedViewController;
 }
 
 /**
@@ -1126,22 +1132,12 @@ NSMutableDictionary* _pageMappings;
  @Status Interoperable
 */
 - (void)presentViewController:(UIViewController*)controller animated:(BOOL)animated completion:(void (^)(void))completion {
-    bool shouldShow = false;
-    UIViewController* curController = self;
-    while (curController != nil) {
-        if (curController->priv->_visibility != controllerNotVisible) {
-            shouldShow = true;
-        }
-        curController = [curController parentViewController];
-    }
-    if (!shouldShow) {
-        TraceWarning(TAG, L"Controller is not visible!");
+    if (!controller) {
+        TraceWarning(TAG, L"presentViewController with nil controller");
         return;
     }
 
-    UIViewController* oldViewController = self;
-    if (priv->_modalViewController != nil) {
-        oldViewController = priv->_modalViewController;
+    if (priv->_presentedViewController) {
         TraceWarning(TAG,
                      L"Can't present view controller %08x (%hs) - view controller %08x (%hs) already has a presented controller!",
                      controller,
@@ -1151,27 +1147,64 @@ NSMutableDictionary* _pageMappings;
         return;
     }
 
-    if (controller != nil) {
-        [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
+    // Allow presentation if an ancestor is not not visible. TODO: Dubious logic; consider disallowing presentation if self not visible.
+    UIViewController *visibleParent = self;
+    BOOL shouldShow = NO;
+    do {
+        shouldShow = visibleParent->priv->_visibility != controllerNotVisible;
+        visibleParent = [visibleParent parentViewController];
+    } while (!shouldShow && visibleParent);
+
+    if (!shouldShow) {
+        TraceWarning(TAG, L"No visible view controller - disallowing presentation");
+        return;
     }
+
+    if (visibleParent != self) {
+        TraceWarning(TAG,
+                     L"View controller %hs not visible but ancestor %hs is. Continuing presentation anyway.",
+                     object_getClassName(self),
+                     object_getClassName(visibleParent));
+    }
+
+    [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
 
     if ([controller _hidesParent]) {
         [self _notifyViewWillDisappear:animated];
     }
 
-    priv->_modalViewController = controller;
     priv->_presentedViewController = controller;
-    if (controller != nil) {
-        [controller view];
-        controller->priv->_parentViewController = self;
-        controller->priv->_presentingViewController = self;
+    [controller view];
+    controller->priv->_parentViewController = self;
+    controller->priv->_presentingViewController = self;
+
+    if ([controller modalPresentationStyle] == UIModalPresentationPopover) {
+        controller->priv->_popoverPresentationController.attach([[UIPopoverPresentationController alloc] initWithPresentedViewController:controller presentingViewController:self]);
+
+        dispatch_block_t popoverPresent = ^{
+            [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+
+            if (completion) {
+                completion();
+            }
+        };
+
+        __unsafe_unretained __block UIViewController* weakSelf = self;
+
+        dispatch_block_t popoverDismiss = ^{
+            StrongId<UIViewController> strongSelf = weakSelf;
+            [strongSelf _childDismissCleanup];
+        };
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Dispatch the presentation asynchronously so users have the opportunity to configure the
+            // popoverPresentationController after presentViewController but before the actual popover is presented.
+
+            [controller->priv->_popoverPresentationController _presentAnimated:animated presentCompletion:popoverPresent dismissCompletion:popoverDismiss];
+        });
+    } else {
         controller->priv->_presentCompletionBlock.attach([completion copy]);
-
-        if ([controller modalPresentationStyle] == UIModalPresentationPopover) {
-            controller->priv->_popoverPresentationController.attach([[UIPopoverPresentationController alloc] initWithPresentedViewController:controller presentingViewController:self]);
-        }
-
-        [controller performSelectorOnMainThread:@selector(_addToTop:) withObject:[NSNumber numberWithInt:animated] waitUntilDone:NO];
+        [controller performSelectorOnMainThread:@selector(_addToTop:) withObject:[NSNumber numberWithBool:animated] waitUntilDone:NO];
     }
 }
 
@@ -1211,57 +1244,80 @@ NSMutableDictionary* _pageMappings;
     [[UIApplication sharedApplication] endIgnoringInteractionEvents];
 }
 
+- (void)_childDismissCleanup {
+    priv->_presentedViewController->priv->_parentViewController = nil;
+    priv->_presentedViewController->priv->_presentingViewController = nil;
+    priv->_presentedViewController->priv->_popoverPresentationController = nil;
+    priv->_presentedViewController = nil;
+}
+
 /**
  @Status Interoperable
 */
 - (void)dismissViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion {
-    if (priv->_modalViewController == nil) {
-        if ([self parentViewController] != nil) {
+    if (![self presentedViewController]) {
+        // Calling dismiss on a view controller that hasn't presented additional view controllers itself should result in the parent handling the dismissal.
+
+        if ([self parentViewController]) {
             [[self parentViewController] dismissViewControllerAnimated:animated completion:completion];
-            return;
+        } else {
+            TraceWarning(TAG, L"dismissViewController invalid - nothing to dismiss");
         }
 
-        TraceWarning(TAG, L"dismissModalViewController invalid!");
         return;
     }
 
-    UIViewController* curController = priv->_modalViewController;
+    UIViewController* presented = [self presentedViewController];
 
-    [curController retain];
-    [curController autorelease];
+    UIViewController* grandChild = [presented presentedViewController];
+    while (UIViewController* next = [grandChild presentedViewController]) {
+        grandChild = next;
+    }
 
-    // We maintain a popoverPresentationController instance whenever UIModalPresentationPopover is specified.
-    // However, in non-tablet operation mode, UIModalPresentationPopover should result in the presentation of
-    // a full screen modal instead. We check here if an actual popover has been presented to handle the
-    // dismiss (of a genuine popover or alternately a full screen modal) appropriately.
-    BOOL realPopoverPresented = [[curController popoverPresentationController] _isManagingPresentation];
+    if (grandChild) {
+        // Dismiss the youngest first with specified animation
+        __unsafe_unretained __block UIViewController* parent = [grandChild parentViewController];
+        [parent dismissViewControllerAnimated:animated completion:^{
+            // Dismiss the remaining with no animation
+            do {
+                parent = [parent parentViewController];
+                // We rely on dismissViewControllerAnimated:NO blocking until child dismissal
+                [parent dismissViewControllerAnimated:NO completion:nil];
+            } while (parent != self);
 
-    if (!realPopoverPresented && curController->priv->_modalViewController) {
-        [curController dismissViewControllerAnimated:animated completion:completion];
+            if (completion) {
+                completion();
+            }
+        }];
+
+        return;
+    }
+
+    dispatch_block_t cleanupCompletion = ^{
+        [self _childDismissCleanup];
+
+        // Completion must happen after full tear-down, otherwise attempts to present a new
+        // view controller from the parent of the just dismissed controller, in this completion,
+        // will fail on the stale presentingViewController/presentedViewController relationship.
+        if (completion) {
+            completion();
+        }
+    };
+
+    UIPopoverPresentationController* popover = [presented popoverPresentationController];
+    if (popover) {
+        [popover _dismissAnimated:animated completion:cleanupCompletion];
+        return;
     }
 
     [self _notifyViewWillAppear:animated];
 
-    priv->_modalViewController = nil;
-    priv->_presentedViewController = nil;
-
-    if (curController->priv->_parentViewController) {
-        curController->priv->_parentViewController->priv->_presentedViewController = nil;
-        curController->priv->_parentViewController->priv->_modalViewController = nil;
-    }
-
-    curController->priv->_parentViewController = nil;
-    curController->priv->_presentingViewController = nil;
-    curController->priv->_popoverPresentationController = nil;
-
-    UIView* curView = [curController view];
+    UIView* curView = [presented view];
 
     UIView* myView = [self view];
-    [myView setHidden:FALSE];
+    [myView setHidden:NO];
 
-    if (realPopoverPresented) {
-        [[curController popoverPresentationController] _dismissAnimated:animated completion:completion];
-    } else if (animated) {
+    if (animated) {
         CGPoint curPos;
         id layer = [curView layer];
 
@@ -1292,12 +1348,12 @@ NSMutableDictionary* _pageMappings;
         [animation setRemovedOnCompletion:FALSE];
         [layer addAnimation:animation forKey:@"ModalDismiss"];
 
-        priv->_dismissCompletionBlock.attach([completion copy]);
+        priv->_dismissCompletionBlock.attach([cleanupCompletion copy]);
 
-        priv->_dismissController = curController;
-        [curController _notifyViewWillDisappear:TRUE];
+        priv->_dismissController = presented;
+        [presented _notifyViewWillDisappear:YES];
     } else {
-        [curController _notifyViewWillDisappear:animated];
+        [presented _notifyViewWillDisappear:animated];
         [curView removeFromSuperview];
 
         if ([[self view] superview] == nil) {
@@ -1305,16 +1361,10 @@ NSMutableDictionary* _pageMappings;
             [[[self view] superview] bringSubviewToFront:[self view]];
         }
 
-        [curController _notifyViewDidDisappear:FALSE];
+        [presented _notifyViewDidDisappear:NO];
         [self _notifyViewDidAppear:animated];
 
-        TraceVerbose(TAG, L"Preparing completion");
-
-        if (completion) {
-            completion();
-        }
-
-        TraceVerbose(TAG, L"Done completion");
+        cleanupCompletion();
     }
 }
 
@@ -1341,116 +1391,95 @@ NSMutableDictionary* _pageMappings;
 }
 
 - (void)_addToTop:(NSNumber*)animatedValue {
-    BOOL animated = [animatedValue intValue];
 
-    priv->_isRootView = true;
+    if (![self parentViewController]) {
+        TraceError(TAG, L"Modal controller doesn't have a parent!");
+        [[UIApplication sharedApplication] endIgnoringInteractionEvents];
+        return;
+    }
 
-    BOOL displayPopover = NO;
+    BOOL animated = [animatedValue boolValue];
 
-    if ([self parentViewController] != nil) {
-        if ([self modalPresentationStyle] == UIModalPresentationPopover) {
-            [[self popoverPresentationController] _prepareForPresentation];
+    priv->_isRootView = YES;
 
-            displayPopover = ![self _hidesParent];
+    float endY = 0;
 
-            if (displayPopover) {
-                __unsafe_unretained __block UIViewController* me = self;
+    UIView* view = [self view];
+    UIWindow* parentWindow = [[[self parentViewController] view] window];
 
-                dispatch_block_t cleanup = ^{
-                    me->priv->_parentViewController->priv->_presentedViewController = nil;
-                    me->priv->_parentViewController->priv->_modalViewController = nil;
-                    me->priv->_popoverPresentationController = nil;
-                };
+    if (animated) {
+        g_presentingAnimated = YES;
+        [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
+        [self _notifyViewWillAppear:YES];
+    } else if ([self _hidesParent]) {
+        [[[self parentViewController] view] setHidden:YES];
+    }
 
-                [[self popoverPresentationController] _presentAnimated:animated presentCompletion:priv->_presentCompletionBlock dismissCompletion:cleanup];
-                priv->_presentCompletionBlock = nil;
-            }
-        }
-
-        if (!displayPopover) {
-            float endY = 0;
-
-            UIView* view = [self view];
-            UIWindow* parentWindow = [[[self parentViewController] view] window];
-
-            if (animated) {
-                g_presentingAnimated = TRUE;
-                [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
-                [self _notifyViewWillAppear:TRUE];
-            } else if ([self _hidesParent]) {
-                [[[self parentViewController] view] setHidden:TRUE];
-            }
-
-            if (parentWindow != nil) {
-                [parentWindow addSubview:view];
-            } else {
-                /*
-                    This is a workaround for VSO 5794762.
-                    Right now, every application has a popup window at level 100000. If we
-                    naively try to present into it, we'll bifurcate the application UI across
-                    two different stacked windows and break touch event handling.
-
-                    Mitigate that by avoiding the application's popup window when looking for the
-                    topmost window.
-                */
-                UIWindow* applicationPopupWindow = [[UIApplication sharedApplication] _popupWindow];
-                NSArray* windows = [[UIApplication sharedApplication] windows];
-                NSUInteger index = [windows count] - 1;
-                UIWindow* window = nil;
-                do {
-                    window = [windows objectAtIndex:index];
-                    index--;
-                } while (window == applicationPopupWindow);
-
-                [window addSubview:view];
-            }
-
-            if (animated) {
-                CGPoint curPos;
-                CALayer* layer = [view layer];
-
-                curPos = [layer position];
-
-                int orientation = findOrientation(self);
-                if (orientation == UIInterfaceOrientationPortrait) {
-                    curPos.y += DisplayProperties::ScreenHeight();
-                } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
-                    curPos.y -= DisplayProperties::ScreenHeight();
-                } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
-                    curPos.x += DisplayProperties::ScreenWidth();
-                } else {
-                    curPos.x -= DisplayProperties::ScreenWidth();
-                }
-
-                CABasicAnimation* animation = [CABasicAnimation animationWithKeyPath:@"position"];
-                [animation setFromValue:[NSValue valueWithCGPoint:curPos]];
-
-                if (orientation == UIInterfaceOrientationPortrait) {
-                    curPos.y -= DisplayProperties::ScreenHeight();
-                } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
-                    curPos.y += DisplayProperties::ScreenHeight();
-                } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
-                    curPos.x -= DisplayProperties::ScreenWidth();
-                } else {
-                    curPos.x += DisplayProperties::ScreenWidth();
-                }
-
-                [animation setToValue:[NSValue valueWithCGPoint:curPos]];
-                [animation setDuration:0.2f];
-                [animation setBeginTime:CACurrentMediaTime()];
-                [animation setTimingFunction:[CAMediaTimingFunction functionWithName:@"kCAMediaTimingFunctionEaseInEaseOut"]];
-                [animation setDelegate:[_TransitionNotifier _transitionTrampoline:self withSelector:@selector(_transitionStopped:)]];
-                [layer addAnimation:animation forKey:@"ModalPresent"];
-                g_presentingAnimated = FALSE;
-            }
-
-            if ([self _hidesParent]) {
-                [[self parentViewController] _notifyViewDidDisappear:animated];
-            }
-        }
-
+    if (parentWindow != nil) {
+        [parentWindow addSubview:view];
     } else {
-        TraceVerbose(TAG, L"Modal controller doesn't have a parent!");
+        /*
+            This is a workaround for VSO 5794762.
+            Right now, every application has a popup window at level 100000. If we
+            naively try to present into it, we'll bifurcate the application UI across
+            two different stacked windows and break touch event handling.
+
+            Mitigate that by avoiding the application's popup window when looking for the
+            topmost window.
+        */
+        UIWindow* applicationPopupWindow = [[UIApplication sharedApplication] _popupWindow];
+        NSArray* windows = [[UIApplication sharedApplication] windows];
+        NSUInteger index = [windows count] - 1;
+        UIWindow* window = nil;
+        do {
+            window = [windows objectAtIndex:index];
+            index--;
+        } while (window == applicationPopupWindow);
+
+        [window addSubview:view];
+    }
+
+    if (animated) {
+        CGPoint curPos;
+        CALayer* layer = [view layer];
+
+        curPos = [layer position];
+
+        int orientation = findOrientation(self);
+        if (orientation == UIInterfaceOrientationPortrait) {
+            curPos.y += DisplayProperties::ScreenHeight();
+        } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
+            curPos.y -= DisplayProperties::ScreenHeight();
+        } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
+            curPos.x += DisplayProperties::ScreenWidth();
+        } else {
+            curPos.x -= DisplayProperties::ScreenWidth();
+        }
+
+        CABasicAnimation* animation = [CABasicAnimation animationWithKeyPath:@"position"];
+        [animation setFromValue:[NSValue valueWithCGPoint:curPos]];
+
+        if (orientation == UIInterfaceOrientationPortrait) {
+            curPos.y -= DisplayProperties::ScreenHeight();
+        } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
+            curPos.y += DisplayProperties::ScreenHeight();
+        } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
+            curPos.x -= DisplayProperties::ScreenWidth();
+        } else {
+            curPos.x += DisplayProperties::ScreenWidth();
+        }
+
+        [animation setToValue:[NSValue valueWithCGPoint:curPos]];
+        [animation setDuration:0.2f];
+        [animation setBeginTime:CACurrentMediaTime()];
+        [animation setTimingFunction:[CAMediaTimingFunction functionWithName:@"kCAMediaTimingFunctionEaseInEaseOut"]];
+        [animation setDelegate:[_TransitionNotifier _transitionTrampoline:self withSelector:@selector(_transitionStopped:)]];
+        [layer addAnimation:animation forKey:@"ModalPresent"];
+        g_presentingAnimated = NO;
+    }
+
+    if ([self _hidesParent]) {
+        [[self parentViewController] _notifyViewDidDisappear:animated];
     }
 
     [[UIApplication sharedApplication] endIgnoringInteractionEvents];
@@ -1520,7 +1549,7 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
                 priv->_visibility = controllerWillAppear;
             }
 
-            if (![[self popoverPresentationController] _isManagingPresentation]) {
+            if (![self popoverPresentationController]) {
                 [self viewWillAppear:isAnimated];
             }
         } break;
@@ -1548,7 +1577,9 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
 
 - (void)_doNotifyViewDidAppear:(BOOL)isAnimated {
     priv->_visibility = controllerVisible;
-    if (![[self popoverPresentationController] _isManagingPresentation]) {
+    if (![self popoverPresentationController]) {
+        // UIPopoverPresentationController internally manages viewDidAppear et al. appearance events (via WYPopoverController).
+
         [self viewDidAppear:isAnimated];
         if (priv->_presentCompletionBlock) {
             priv->_presentCompletionBlock();
@@ -1604,7 +1635,7 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
             } else {
                 priv->_visibility = controllerWillDisappearAnimated;
             }
-            if (![[self popoverPresentationController] _isManagingPresentation]) {
+            if (![self popoverPresentationController]) {
                 [self viewWillDisappear:isAnimated];
             }
             break;
@@ -1629,7 +1660,7 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
         case controllerWillDisappear:
             if (isAnimated == FALSE) {
                 priv->_visibility = controllerNotVisible;
-                if (![[self popoverPresentationController] _isManagingPresentation]) {
+                if (![self popoverPresentationController]) {
                     [self viewDidDisappear:isAnimated];
                 }
             } else {
@@ -1640,7 +1671,7 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
         case controllerWillDisappearAnimated:
             if (isAnimated) {
                 priv->_visibility = controllerNotVisible;
-                if (![[self popoverPresentationController] _isManagingPresentation]) {
+                if (![self popoverPresentationController]) {
                     [self viewDidDisappear:isAnimated];
                 }
             }
@@ -1649,7 +1680,7 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
         case controllerVisible:
             TraceWarning(TAG, L"Warning: Didn't notify view will disappear");
             priv->_visibility = controllerNotVisible;
-            if (![[self popoverPresentationController] _isManagingPresentation]) {
+            if (![self popoverPresentationController]) {
                 [self viewDidDisappear:isAnimated];
             }
             break;
@@ -2202,13 +2233,7 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
  @Status Interoperable
 */
 - (UIViewController*)presentedViewController {
-    if (priv->_presentedViewController) {
-        return priv->_presentedViewController;
-    } else if ([priv->_parentViewController presentedViewController] != self) {
-        return [priv->_parentViewController presentedViewController];
-    }
-
-    return nil;
+    return priv->_presentedViewController;
 }
 
 /**
@@ -2231,10 +2256,9 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
     priv->toolbarItems = nil;
     priv->editButtonItem = nil;
     priv->navigationController = nil;
-    if (priv->_modalViewController) {
-        ((UIViewController*)priv->_modalViewController)->priv->_parentViewController = nil;
+    if (priv->_presentedViewController) {
+        priv->_presentedViewController->priv->_parentViewController = nil;
     }
-    priv->_modalViewController = nil;
     priv->_parentViewController = nil;
     priv->nibName = nil;
     priv->nibBundle = nil;

--- a/Frameworks/include/UIPopoverPresentationControllerInternal.h
+++ b/Frameworks/include/UIPopoverPresentationControllerInternal.h
@@ -18,8 +18,6 @@
 
 @interface UIPopoverPresentationController ()
 
-- (BOOL)_isManagingPresentation;
-- (void)_prepareForPresentation;
 - (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion dismissCompletion:(dispatch_block_t)dismissCompletion;
 - (void)_dismissAnimated:(BOOL)animated completion:(dispatch_block_t)dismissCompletion;
 

--- a/Frameworks/include/UIViewControllerInternal.h
+++ b/Frameworks/include/UIViewControllerInternal.h
@@ -34,14 +34,13 @@ struct UIViewControllerPriv {
     idretaintype(NSArray) toolbarItems;
     idretaintype(UIBarButtonItem) editButtonItem;
     idretaintype(UINavigationController) navigationController;
-    idretaintype(UIViewController) _modalViewController;
     idretaintype(UISearchDisplayController) _searchDisplayController;
-    __unsafe_unretained UIViewController* _presentingViewController;
-    __unsafe_unretained UIViewController* _presentedViewController;
+    StrongId<UIViewController> _presentedViewController;
     StrongId<UIPopoverPresentationController> _popoverPresentationController;
     StrongId<UIPresentationController> _presentationController;
     idretaintype(NSDictionary) _externalObjects;
     __unsafe_unretained UIViewController* _parentViewController;
+    __unsafe_unretained UIViewController* _presentingViewController;
     idretaintype(NSString) nibName;
     idretaintype(NSBundle) nibBundle;
     idretaintype(NSString) _title;


### PR DESCRIPTION
-fix too early popover deallocation when programmatically dismissing via dismissViewController
-stop requiring tablet mode to display popovers, allowing simplifications to popover presentation
-fix/implement proper handling of multiple children dismissal via dismissViewController (example added to WOCCatalog)
-kill _modalViewController
-more sane handling of _presentedViewController memory management (existing approach with __unsafe_unretained ivar and retain/autorelease gymnastics on dismiss not proper)
-general cleanups

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1511)
<!-- Reviewable:end -->

note: the crash on dismiss of popover via dismissViewController existed prior to #1464
