### PR TITLE
Update objc2winmd binary: 

### DIFF
--- a/bin/objc2winmd.exe
+++ b/bin/objc2winmd.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:18a788b27d81e82bcafd2c64b9e5610886d5a84b911d0d16fe5572d4301cfb79
-size 589312
+oid sha256:6f373225ed425dd20145b83a9b3f69f4ff85c7c62eb2e3cfb6664a3bd542f6a8
+size 590336


### PR DESCRIPTION
Changed the annotation used for heterogeneous containers.
Heterogeneous containers are now annotated as:
ContainerType<type1, type2, type3[,...]>
This change maintains backward compatibility, so the previous annotation:
ContainerType<type1>:ContainerType<type2>:ContainerType<type3> 
is still valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1514)
<!-- Reviewable:end -->
