### PR TITLE
Added a dummy modulemap for include/objc

### DIFF
--- a/include/objc/module.modulemap
+++ b/include/objc/module.modulemap
@@ -1,0 +1,5 @@
+module ObjC [extern_c] {
+    umbrella header "objc.h"
+    exclude header "*.h"
+    export *
+}


### PR DESCRIPTION
This is a fix for issue#1397.
This module excludes all headers so its just a dummy to prevent other modules from adding symbols from objc to their own module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1515)
<!-- Reviewable:end -->
