### PR TITLE
Implement CG and CTFont text drawing using DWrite

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -118,28 +118,28 @@ void CGContextShowTextAtPoint(CGContextRef pContext, CGFloat x, CGFloat y, const
  @Status Interoperable
 */
 void CGContextShowGlyphsAtPoint(CGContextRef ctx, CGFloat x, CGFloat y, const CGGlyph* glyphs, unsigned count) {
-    ctx->Backing()->CGContextShowGlyphsAtPoint(x, y, (WORD*)glyphs, count);
+    ctx->Backing()->CGContextShowGlyphsAtPoint(x, y, glyphs, count);
 }
 
 /**
  @Status Interoperable
 */
-void CGContextShowGlyphsWithAdvances(CGContextRef ctx, const CGGlyph* glyphs, CGSize* advances, unsigned count) {
-    ctx->Backing()->CGContextShowGlyphsWithAdvances((WORD*)glyphs, advances, count);
+void CGContextShowGlyphsWithAdvances(CGContextRef ctx, const CGGlyph* glyphs, const CGSize* advances, unsigned count) {
+    ctx->Backing()->CGContextShowGlyphsWithAdvances(glyphs, advances, count);
 }
 
 /**
  @Status Interoperable
 */
 void CGContextShowGlyphs(CGContextRef ctx, const CGGlyph* glyphs, unsigned count) {
-    ctx->Backing()->CGContextShowGlyphs((WORD*)glyphs, count);
+    ctx->Backing()->CGContextShowGlyphs(glyphs, count);
 }
 
 /**
  @Status Interoperable
 */
 void CGContextSetFont(CGContextRef ctx, CGFontRef font) {
-    ctx->Backing()->CGContextSetFont((id)font);
+    ctx->Backing()->CGContextSetFont(font);
 }
 
 /**
@@ -1178,14 +1178,6 @@ void CGContextSetStrokePattern(CGContextRef c, CGPatternRef pattern, const CGFlo
  @Notes
 */
 void CGContextShowGlyphsAtPositions(CGContextRef c, const CGGlyph* glyphs, const CGPoint* Lpositions, size_t count) {
-    UNIMPLEMENTED();
-}
-
-/**
- @Status Stub
- @Notes
-*/
-void CGContextShowGlyphsWithAdvances(CGContextRef c, const CGGlyph* glyphs, const CGSize* advances, size_t count) {
     UNIMPLEMENTED();
 }
 

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -504,7 +504,7 @@ void CGContextCairo::CGContextShowGlyphsWithAdvances(const CGGlyph* glyphs, cons
     FAIL_FAST_IF_FAILED(_CGFontGetDWriteFontFace(font, &fontFace));
     std::vector<DWRITE_GLYPH_OFFSET> positions(count);
     CGPoint delta = CGPointZero;
-    std::transform(advances, advances + count, positions.begin(), [&delta](CGSize size) {
+    std::transform(advances, advances + count, positions.begin(), [&delta](const CGSize& size) {
         DWRITE_GLYPH_OFFSET ret = { delta.x, delta.y };
         delta.x += size.width;
         delta.y += size.height;
@@ -512,7 +512,7 @@ void CGContextCairo::CGContextShowGlyphsWithAdvances(const CGGlyph* glyphs, cons
     });
 
     // Give array of advances of zero so it will use positions correctly
-    std::vector<FLOAT> dwriteAdvances(count);
+    std::vector<FLOAT> dwriteAdvances(count, 0);
 
     DWRITE_GLYPH_RUN run = { fontFace.Get(), curState->fontSize, count, glyphs, dwriteAdvances.data(), positions.data(), FALSE, 0 };
     CGContextDrawGlyphRun(&run);

--- a/Frameworks/CoreGraphics/CGContextCairo.mm
+++ b/Frameworks/CoreGraphics/CGContextCairo.mm
@@ -30,6 +30,7 @@
 #import "CGGradientInternal.h"
 #import "CGImageInternal.h"
 #import "CGPathInternal.h"
+#import "CoreGraphics/CGFontInternal.h"
 #import "CGPatternInternal.h"
 #import "UIColorInternal.h"
 #import "CGSurfaceInfoInternal.h"
@@ -50,6 +51,9 @@ extern "C" {
 
 #include "LoggingNative.h"
 #import <StubReturn.h>
+
+#import <vector>
+#import <algorithm>
 
 using namespace Microsoft::WRL;
 
@@ -448,16 +452,31 @@ CGBlendMode CGContextCairo::CGContextGetBlendMode() {
     return curState->curBlendMode;
 }
 
-void CGContextCairo::CGContextShowTextAtPoint(float x, float y, const char* str, DWORD length) {
-    // TODO #924: Implement this with DWrite
-    UNIMPLEMENTED();
+void CGContextCairo::CGContextShowTextAtPoint(float x, float y, const char* str, size_t length) {
+    CGFontRef font = curState->getCurFont();
+    std::vector<CGGlyph> glyphs(length);
+    if (_CGFontGetGlyphsForCharacters(font, str, length, glyphs.data())) {
+        CGContextShowGlyphsAtPoint(x, y, glyphs.data(), length);
+    }
 }
 
-void CGContextCairo::CGContextShowGlyphsAtPoint(float x, float y, WORD* glyphs, int count) {
-    CGSize size;
+void CGContextCairo::CGContextShowGlyphsAtPoint(float x, float y, const CGGlyph* glyphs, size_t count) {
+    CGSize size = CGSizeZero;
 
     _isDirty = true;
 
+    std::vector<int> designUnitAdvances(count);
+    CGFontRef font = curState->getCurFont();
+    CGFontGetGlyphAdvances(font, glyphs, count, designUnitAdvances.data());
+    std::vector<CGSize> advances(count);
+    std::transform(designUnitAdvances.cbegin(),
+                   designUnitAdvances.cend(),
+                   advances.begin(),
+                   [ scale = curState->fontSize / CGFontGetUnitsPerEm(font), &size ](int unscaledAdvance) {
+                       CGFloat advanceWidth = scale * unscaledAdvance;
+                       size.width += advanceWidth;
+                       return CGSize{ advanceWidth, 0 };
+                   });
     switch (curState->textDrawingMode) {
         case kCGTextFill:
         case kCGTextStroke:
@@ -465,37 +484,46 @@ void CGContextCairo::CGContextShowGlyphsAtPoint(float x, float y, WORD* glyphs, 
         case kCGTextFillClip:
         case kCGTextStrokeClip:
         case kCGTextFillStrokeClip:
-            size = CGFontDrawGlyphsToContext(glyphs, count, x, y);
+            curState->curTextPosition = { x, y };
+            CGContextShowGlyphsWithAdvances(glyphs, advances.data(), count);
             break;
 
         case kCGTextClip:
         case kCGTextInvisible:
-            // TODO #924: Update the text position in this case
-            UNIMPLEMENTED();
+            // Do nothing, set text position at end
             break;
     }
 
-    curState->curTextPosition.x = x + size.width;
-    curState->curTextPosition.y = y;
+    curState->curTextPosition = { x + size.width, y };
 }
 
-void CGContextCairo::CGContextShowGlyphsWithAdvances(WORD* glyphs, CGSize* advances, int count) {
-    CGPoint curPos = { curState->curTextPosition.x, curState->curTextPosition.y };
+void CGContextCairo::CGContextShowGlyphsWithAdvances(const CGGlyph* glyphs, const CGSize* advances, size_t count) {
     _isDirty = true;
+    CGPoint curPos = curState->curTextPosition;
+    CGFontRef font = curState->getCurFont();
+    ComPtr<IDWriteFontFace> fontFace;
+    if (SUCCEEDED(_CGFontGetDWriteFontFace(font, &fontFace))) {
+        std::vector<DWRITE_GLYPH_OFFSET> positions(count);
+        CGPoint delta = CGPointZero;
+        std::transform(advances, advances + count, positions.begin(), [&delta](CGSize size) {
+            DWRITE_GLYPH_OFFSET ret = { delta.x, delta.y };
+            delta.x += size.width;
+            delta.y += size.height;
+            return ret;
+        });
+        std::vector<FLOAT> dwriteAdvances(count);
 
-    for (int i = 0; i < count; i++) {
-        CGFontDrawGlyphsToContext(&glyphs[i], 1, curPos.x, curPos.y);
-        curPos.x += advances[i].width;
-        curPos.y += advances[i].height;
+        DWRITE_GLYPH_RUN run = { fontFace.Get(), curState->fontSize, count, glyphs, dwriteAdvances.data(), positions.data(), FALSE, 0 };
+        CGContextDrawGlyphRun(&run);
+        curState->curTextPosition = { curPos.x + delta.x, curPos.y + delta.y };
     }
-    curState->curTextPosition = curPos;
 }
 
-void CGContextCairo::CGContextShowGlyphs(WORD* glyphs, int count) {
+void CGContextCairo::CGContextShowGlyphs(const CGGlyph* glyphs, size_t count) {
     CGContextShowGlyphsAtPoint(curState->curTextPosition.x, curState->curTextPosition.y, glyphs, count);
 }
 
-void CGContextCairo::CGContextSetFont(id font) {
+void CGContextCairo::CGContextSetFont(CGFontRef font) {
     curState->setCurFont(font);
 }
 
@@ -1775,12 +1803,6 @@ void CGContextCairo::CGContextSetRGBStrokeColor(float r, float g, float b, float
     curState->curStrokeColor.a = a;
 }
 
-CGSize CGContextCairo::CGFontDrawGlyphsToContext(WORD* glyphs, DWORD length, float x, float y) {
-    // TODO #924: Implement this with DWrite
-    UNIMPLEMENTED();
-    return StubReturn();
-}
-
 bool CGContextCairo::CGContextIsPointInPath(bool eoFill, float x, float y) {
     ObtainLock();
     LOCK_CAIRO();
@@ -1851,14 +1873,10 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     //     1. Scaling - to handle scaling once text has been scaled, apply translation to the scaled height
     //     2. Rotation - CoreText rotates text anti-clockwise but DWrite performs clockwise rotation
 
-    // Apply the text transformation (text position, text matrix) in text space rather than user space
     // This means flipping the coordinate system,
     // Apply text position, where it will be translated to correct position given text matrix value
-    CGAffineTransform textTransform =
-        CGAffineTransformTranslate(curState->curTextMatrix, curState->curTextPosition.x, curState->curTextPosition.y);
-
     // Undo assumed inversion about Y axis
-    textTransform = CGAffineTransformConcat(CGAffineTransformMake(1, 0, 0, -1, 0, 0), textTransform);
+    CGAffineTransform textTransform = CGAffineTransformConcat(curState->curTextMatrix, CGAffineTransformMake(1, 0, 0, -1, 0, 0));
 
     // Find transform that user created by multiplying given transform by necessary transforms to draw with CoreText
     // First multiply by inverse scale to get properly scaled values
@@ -1868,6 +1886,9 @@ void CGContextCairo::CGContextDrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun) {
     float height = _imgDest->Backing()->Height();
     CGAffineTransform userTransform =
         CGAffineTransformConcat(curState->curTransform, CGAffineTransformMake(1.0f / _scale, 0, 0, -1.0f / _scale, 0, height / _scale));
+
+    // Apply the text position in user space, not in text space
+    userTransform = CGAffineTransformTranslate(userTransform, curState->curTextPosition.x, curState->curTextPosition.y);
 
     // Apply the two transforms giving us the final result
     CGAffineTransform transform = CGAffineTransformConcat(textTransform, userTransform);

--- a/Frameworks/CoreGraphics/CGContextImpl.mm
+++ b/Frameworks/CoreGraphics/CGContextImpl.mm
@@ -41,15 +41,15 @@ static const wchar_t* TAG = L"CGContextImpl";
 
 static IWLazyClassLookup _LazyUIFont("UIFont");
 
-id CGContextState::getCurFont() {
-    if (curFont == nil) {
-        curFont = [_LazyUIFont defaultFont];
+CGFontRef CGContextState::getCurFont() {
+    if (curFont == nullptr) {
+        curFont = CGFontCreateWithFontName(CFSTR("Segoe UI"));
     }
 
     return curFont;
 }
 
-void CGContextState::setCurFont(id font) {
+void CGContextState::setCurFont(CGFontRef font) {
     curFont = font;
 }
 
@@ -140,54 +140,23 @@ CGBlendMode CGContextImpl::CGContextGetBlendMode() {
     return curState->curBlendMode;
 }
 
-void CGContextImpl::CGContextShowTextAtPoint(float x, float y, const char* str, DWORD length) {
-    // TODO #924: Implement this with DWrite
+void CGContextImpl::CGContextShowTextAtPoint(float x, float y, const char* str, size_t length) {
     UNIMPLEMENTED();
 }
 
-void CGContextImpl::CGContextShowGlyphsAtPoint(float x, float y, WORD* glyphs, int count) {
-    CGSize size;
-
-    _isDirty = true;
-
-    switch (curState->textDrawingMode) {
-        case kCGTextFill:
-        case kCGTextStroke:
-        case kCGTextFillStroke:
-        case kCGTextFillClip:
-        case kCGTextStrokeClip:
-        case kCGTextFillStrokeClip:
-            size = CGFontDrawGlyphsToContext(glyphs, count, x, y);
-            break;
-
-        case kCGTextClip:
-        case kCGTextInvisible:
-            // TODO #924: Update the text position in this case
-            UNIMPLEMENTED();
-            break;
-    }
-
-    curState->curTextPosition.x = x + size.width;
-    curState->curTextPosition.y = y;
+void CGContextImpl::CGContextShowGlyphsAtPoint(float x, float y, const CGGlyph* glyphs, size_t count) {
+    UNIMPLEMENTED();
 }
 
-void CGContextImpl::CGContextShowGlyphsWithAdvances(WORD* glyphs, CGSize* advances, int count) {
-    CGPoint curPos = { curState->curTextPosition.x, curState->curTextPosition.y };
-    _isDirty = true;
-
-    for (int i = 0; i < count; i++) {
-        CGFontDrawGlyphsToContext(&glyphs[i], 1, curPos.x, curPos.y);
-        curPos.x += advances[i].width;
-        curPos.y += advances[i].height;
-    }
-    curState->curTextPosition = curPos;
+void CGContextImpl::CGContextShowGlyphsWithAdvances(const CGGlyph* glyphs, const CGSize* advances, size_t count) {
+    UNIMPLEMENTED();
 }
 
-void CGContextImpl::CGContextShowGlyphs(WORD* glyphs, int count) {
+void CGContextImpl::CGContextShowGlyphs(const CGGlyph* glyphs, size_t count) {
     CGContextShowGlyphsAtPoint(curState->curTextPosition.x, curState->curTextPosition.y, glyphs, count);
 }
 
-void CGContextImpl::CGContextSetFont(id font) {
+void CGContextImpl::CGContextSetFont(CGFontRef font) {
     curState->setCurFont(font);
 }
 
@@ -731,12 +700,6 @@ void CGContextImpl::CGContextSetRGBStrokeColor(float r, float g, float b, float 
     curState->curStrokeColor.g = g;
     curState->curStrokeColor.b = b;
     curState->curStrokeColor.a = a;
-}
-
-CGSize CGContextImpl::CGFontDrawGlyphsToContext(WORD* glyphs, DWORD length, float x, float y) {
-    CGSize ret = { 0, 0 };
-
-    return ret;
 }
 
 void CGContextImpl::CGContextSetShadowWithColor(CGSize offset, float blur, CGColorRef color) {

--- a/Frameworks/CoreGraphics/CGFont.mm
+++ b/Frameworks/CoreGraphics/CGFont.mm
@@ -28,6 +28,8 @@
 
 #import "LoggingNative.h"
 
+#import <vector>
+
 const CFStringRef kCGFontVariationAxisName = static_cast<CFStringRef>(@"kCGFontVariationAxisName");
 const CFStringRef kCGFontVariationAxisMinValue = static_cast<CFStringRef>(@"kCGFontVariationAxisMinValue");
 const CFStringRef kCGFontVariationAxisMaxValue = static_cast<CFStringRef>(@"kCGFontVariationAxisMaxValue");
@@ -379,4 +381,17 @@ CFTypeID CGFontGetTypeID() {
 // So to prevent potentially copying multiple times, save a reference to the data
 CFDataRef _CGFontGetData(CGFontRef font) {
     return font ? font->_data.get() : nullptr;
+}
+
+bool _CGFontGetGlyphsForCharacters(CGFontRef font, const char* characters, size_t count, CGGlyph* glyphs) {
+    if (!font || !characters || !glyphs || count == 0) {
+        return false;
+    }
+
+    std::vector<uint32_t> chars(characters, characters + count);
+    return SUCCEEDED(font->_dwriteFontFace->GetGlyphIndices(chars.data(), count, glyphs));
+}
+
+HRESULT _CGFontGetDWriteFontFace(CGFontRef font, IDWriteFontFace** outFace) {
+    return font ? font->_dwriteFontFace.CopyTo(outFace) : E_POINTER;
 }

--- a/Frameworks/CoreGraphics/CGFont.mm
+++ b/Frameworks/CoreGraphics/CGFont.mm
@@ -384,14 +384,12 @@ CFDataRef _CGFontGetData(CGFontRef font) {
 }
 
 bool _CGFontGetGlyphsForCharacters(CGFontRef font, const char* characters, size_t count, CGGlyph* glyphs) {
-    if (!font || !characters || !glyphs || count == 0) {
-        return false;
-    }
-
+    RETURN_FALSE_IF(!font || !characters || !glyphs || count == 0);
     std::vector<uint32_t> chars(characters, characters + count);
     return SUCCEEDED(font->_dwriteFontFace->GetGlyphIndices(chars.data(), count, glyphs));
 }
 
 HRESULT _CGFontGetDWriteFontFace(CGFontRef font, IDWriteFontFace** outFace) {
-    return font ? font->_dwriteFontFace.CopyTo(outFace) : E_POINTER;
+    RETURN_HR_IF(E_POINTER, font == nullptr || outFace == nullptr);
+    return font->_dwriteFontFace.CopyTo(outFace);
 }

--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -860,10 +860,10 @@ bool CTFontGetGlyphsForCharacters(CTFontRef fontRef, const UniChar characters[],
 void CTFontDrawGlyphs(CTFontRef font, const CGGlyph glyphs[], const CGPoint positions[], size_t count, CGContextRef context) {
     if (font && glyphs && positions && count != 0 && context) {
         std::vector<DWRITE_GLYPH_OFFSET> offsets(count);
-        std::transform(positions, positions + count, offsets.begin(), [](CGPoint point) {
+        std::transform(positions, positions + count, offsets.begin(), [](const CGPoint& point) {
             return DWRITE_GLYPH_OFFSET{ point.x, point.y };
         });
-        std::vector<FLOAT> advances(count);
+        std::vector<FLOAT> advances(count, 0);
 
         DWRITE_GLYPH_RUN run = { font->_dwriteFontFace.Get(), font->_pointSize, count, glyphs, advances.data(), offsets.data(), FALSE, 0 };
         CGContextSetTextPosition(context, 0, 0);

--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -117,14 +117,14 @@ void CTFrameDraw(CTFrameRef frameRef, CGContextRef ctx) {
         _CGPathGetBoundingBoxInternal(frame->_path.get(), &boundingRect);
         CGContextTranslateCTM(ctx, 0, boundingRect.size.height);
 
-        // Invert Text Matrix so glyphs are drawn in correct orientation
+        // Invert Text Matrix and CTM so glyphs are drawn in correct orientation and correct position
         CGAffineTransform textMatrix = CGContextGetTextMatrix(ctx);
         CGContextSetTextMatrix(ctx, CGAffineTransformScale(textMatrix, 1.0f, -1.0f));
         CGContextScaleCTM(ctx, 1.0f, -1.0f);
 
         for (size_t i = 0; i < frame->_lineOrigins.size() && (frame->_lineOrigins[i].y < frame->_frameRect.size.height); ++i) {
             _CTLine* line = static_cast<_CTLine*>([frame->_lines objectAtIndex:i]);
-            CGContextSetTextPosition(ctx, frame->_lineOrigins[i].x, -frame->_lineOrigins[i].y);
+            CGContextSetTextPosition(ctx, frame->_lineOrigins[i].x, frame->_lineOrigins[i].y);
             CTLineDraw(static_cast<CTLineRef>(line), ctx);
         }
 

--- a/Frameworks/UIKit/NSLayoutManager.mm
+++ b/Frameworks/UIKit/NSLayoutManager.mm
@@ -243,7 +243,7 @@ static bool __lineHasGlyphsAfterIndex(CTLineRef line, CFIndex index) {
     for (int curLine = 0; curLine < count; curLine++) {
         CTLineRef line = (CTLineRef)_ctLines[curLine];
         CGContextSaveGState(curCtx);
-        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, -_lineOrigins[curLine].y);
+        CGContextSetTextPosition(curCtx, _lineOrigins[curLine].x, _lineOrigins[curLine].y);
         CTLineDraw(line, curCtx);
         CGContextRestoreGState(curCtx);
     }

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -91,8 +91,7 @@ static void drawString(UIFont* font,
     CTFrameGetLineOrigins(frame, {}, origins.data());
     for (size_t i = 0; i < origins.size(); ++i) {
         // Need to set text position so each line will be drawn in the correct position relative to each other
-        // Y positions will be negative because we are drawing with the coordinate system flipped to what CoreText is expecting
-        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, -(rect.origin.y + origins[i].y));
+        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, rect.origin.y + origins[i].y);
         CTLineDraw(static_cast<CTLineRef>(lines[i]), context);
     }
 

--- a/Frameworks/include/CGContextCairo.h
+++ b/Frameworks/include/CGContextCairo.h
@@ -56,11 +56,11 @@ public:
 
     virtual void CGContextSetBlendMode(CGBlendMode mode);
     virtual CGBlendMode CGContextGetBlendMode();
-    virtual void CGContextShowTextAtPoint(float x, float y, const char* str, DWORD length);
-    virtual void CGContextShowGlyphsAtPoint(float x, float y, WORD* glyphs, int count);
-    virtual void CGContextShowGlyphsWithAdvances(WORD* glyphs, CGSize* advances, int count);
-    virtual void CGContextShowGlyphs(WORD* glyphs, int count);
-    virtual void CGContextSetFont(id font);
+    virtual void CGContextShowTextAtPoint(float x, float y, const char* str, size_t length);
+    virtual void CGContextShowGlyphsAtPoint(float x, float y, const CGGlyph* glyphs, size_t count);
+    virtual void CGContextShowGlyphsWithAdvances(const CGGlyph* glyphs, const CGSize* advances, size_t count);
+    virtual void CGContextShowGlyphs(const CGGlyph* glyphs, size_t count);
+    virtual void CGContextSetFont(CGFontRef font);
     virtual void CGContextSetFontSize(float ptSize);
     virtual void CGContextSetTextMatrix(CGAffineTransform matrix);
     virtual void CGContextGetTextMatrix(CGAffineTransform* ret);
@@ -134,7 +134,6 @@ public:
     virtual void CGContextSetRGBFillColor(float r, float g, float b, float a);
     virtual void CGContextSetRGBStrokeColor(float r, float g, float b, float a);
 
-    virtual CGSize CGFontDrawGlyphsToContext(WORD* glyphs, DWORD length, float x, float y);
     virtual bool CGContextIsPointInPath(bool eoFill, float x, float y);
     virtual CGPathRef CGContextCopyPath(void);
 

--- a/Frameworks/include/CGContextImpl.h
+++ b/Frameworks/include/CGContextImpl.h
@@ -49,11 +49,11 @@ typedef struct {
     float shadowBlur;
     CGColorRef shadowColor;
 
-    id getCurFont();
-    void setCurFont(id font);
+    CGFontRef getCurFont();
+    void setCurFont(CGFontRef font);
 
 private:
-    id curFont;
+    CGFontRef curFont;
 } CGContextState;
 
 #define MAX_CG_STATES 16
@@ -90,11 +90,11 @@ public:
 
     virtual void CGContextSetBlendMode(CGBlendMode mode);
     virtual CGBlendMode CGContextGetBlendMode();
-    virtual void CGContextShowTextAtPoint(float x, float y, const char* str, DWORD length);
-    virtual void CGContextShowGlyphsAtPoint(float x, float y, WORD* glyphs, int count);
-    virtual void CGContextShowGlyphsWithAdvances(WORD* glyphs, CGSize* advances, int count);
-    virtual void CGContextShowGlyphs(WORD* glyphs, int count);
-    virtual void CGContextSetFont(id font);
+    virtual void CGContextShowTextAtPoint(float x, float y, const char* str, size_t length);
+    virtual void CGContextShowGlyphsAtPoint(float x, float y, const CGGlyph* glyphs, size_t count);
+    virtual void CGContextShowGlyphsWithAdvances(const CGGlyph* glyphs, const CGSize* advances, size_t count);
+    virtual void CGContextShowGlyphs(const CGGlyph* glyphs, size_t count);
+    virtual void CGContextSetFont(CGFontRef font);
     virtual void CGContextSetFontSize(float ptSize);
     virtual void CGContextSetTextMatrix(CGAffineTransform matrix);
     virtual void CGContextGetTextMatrix(CGAffineTransform* ret);
@@ -171,8 +171,6 @@ public:
     virtual void CGContextSetAlpha(float a);
     virtual void CGContextSetRGBFillColor(float r, float g, float b, float a);
     virtual void CGContextSetRGBStrokeColor(float r, float g, float b, float a);
-
-    virtual CGSize CGFontDrawGlyphsToContext(WORD* glyphs, DWORD length, float x, float y);
 
     virtual void CGContextSetShadowWithColor(CGSize offset, float blur, CGColorRef color);
     virtual void CGContextSetShadow(CGSize offset, float blur);

--- a/Frameworks/include/CoreGraphics/CGFontInternal.h
+++ b/Frameworks/include/CoreGraphics/CGFontInternal.h
@@ -15,6 +15,12 @@
 //******************************************************************************
 #pragma once
 
-#include <CoreGraphics/CGFont.h>
+#import <CoreGraphics/CGFont.h>
+#include <COMIncludes.h>
+#import <DWrite_3.h>
+#import <wrl/client.h>
+#include <COMIncludes_End.h>
 
 COREGRAPHICS_EXPORT CFDataRef _CGFontGetData(CGFontRef font);
+bool _CGFontGetGlyphsForCharacters(CGFontRef font, const char* chars, size_t count, CGGlyph* glyphs);
+HRESULT _CGFontGetDWriteFontFace(CGFontRef font, IDWriteFontFace** outFace);

--- a/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
@@ -240,6 +240,7 @@
     </ClangCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics.drawing\CGTextDrawing.cpp" />
     <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics.drawing\CTDrawingTests.cpp" />
     <ClCompile Include="$(StarboardBasePath)\tests\unittests\Framework\Framework.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\EntryPoint.cpp" />

--- a/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
@@ -240,12 +240,12 @@
     </ClangCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics.drawing\CGTextDrawing.cpp" />
-    <ClangCompile Include="..\..\..\..\tests\unittests\CoreGraphics.drawing\CTDrawingTests.cpp" />
     <ClCompile Include="$(StarboardBasePath)\tests\unittests\Framework\Framework.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\EntryPoint.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\CGTextDrawing.cpp" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\CTDrawingTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextBlendModeTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawingTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawing_FillTests.cpp" />

--- a/include/CoreText/CTFont.h
+++ b/include/CoreText/CTFont.h
@@ -241,8 +241,8 @@ CORETEXT_EXPORT CFDictionaryRef CTFontCopyVariation(CTFontRef font) STUB_METHOD;
 CORETEXT_EXPORT CFArrayRef CTFontCopyFeatures(CTFontRef font) STUB_METHOD;
 CORETEXT_EXPORT CFArrayRef CTFontCopyFeatureSettings(CTFontRef font) STUB_METHOD;
 CORETEXT_EXPORT bool CTFontGetGlyphsForCharacters(CTFontRef font, const UniChar characters[], CGGlyph glyphs[], CFIndex count);
-CORETEXT_EXPORT void CTFontDrawGlyphs(CTFontRef font, const CGGlyph glyphs[], const CGPoint positions[], size_t count, CGContextRef context)
-    STUB_METHOD;
+CORETEXT_EXPORT void CTFontDrawGlyphs(
+    CTFontRef font, const CGGlyph glyphs[], const CGPoint positions[], size_t count, CGContextRef context);
 CORETEXT_EXPORT CFIndex CTFontGetLigatureCaretPositions(CTFontRef font, CGGlyph glyph, CGFloat* positions, CFIndex maxPositions)
     STUB_METHOD;
 CORETEXT_EXPORT CGFontRef CTFontCopyGraphicsFont(CTFontRef font, CTFontDescriptorRef _Nullable* attributes);

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
@@ -91,8 +91,7 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
     // Draws the text in the frame
     CTFrameDraw(frame, context);
 
-    UniChar characters[6];
-    [@"Glyphs" getCharacters:characters range:NSMakeRange(0, 6)];
+    UniChar characters[6]{ 'G', 'l', 'y', 'p', 'h', 's' };
     CGGlyph glyphs[6];
     CTFontGetGlyphsForCharacters(_font, characters, glyphs, 6);
     CGPoint positions[6] = { { 0, 0 }, { 10, 10 }, { 20, 20 }, { 30, 20 }, { 40, 10 }, { 50, 0 } };
@@ -254,8 +253,7 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
     [_rows addObject:createTextCell(@"CTFontGetDescent", [NSString stringWithFormat:@"%f", CTFontGetDescent(_font)], width / 2)];
     [_rows addObject:createTextCell(@"CTFontGetSize", [NSString stringWithFormat:@"%f", CTFontGetSize(_font)], width / 2)];
 
-    UniChar characters[6];
-    [@"Glyphs" getCharacters:characters range:NSMakeRange(0, 6)];
+    UniChar characters[6]{ 'G', 'l', 'y', 'p', 'h', 's' };
     CGGlyph glyphs[6];
     CTFontGetGlyphsForCharacters(_font, characters, glyphs, 6);
     [_rows addObject:createTextCell(

--- a/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
+++ b/tests/testapps/CTCatalog/CTCatalog/Tests/CTCFontTestViewController.mm
@@ -91,6 +91,13 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
     // Draws the text in the frame
     CTFrameDraw(frame, context);
 
+    UniChar characters[6];
+    [@"Glyphs" getCharacters:characters range:NSMakeRange(0, 6)];
+    CGGlyph glyphs[6];
+    CTFontGetGlyphsForCharacters(_font, characters, glyphs, 6);
+    CGPoint positions[6] = { { 0, 0 }, { 10, 10 }, { 20, 20 }, { 30, 20 }, { 40, 10 }, { 50, 0 } };
+    CTFontDrawGlyphs(_font, glyphs, positions, 6, context);
+
     // Creates outline
     CGContextSetLineWidth(context, 2.0);
     CGContextSetStrokeColorWithColor(context, color.CGColor);
@@ -292,7 +299,6 @@ static UITableViewCell* createButtonCell(NSString* title, id target, SEL action)
     ADD_UNIMPLEMENTED(_rows, @"CTFontCreatePathForGlyph", width / 2);
     ADD_UNIMPLEMENTED(_rows, @"CTFontCreateUIFontForLanguage", width / 2);
     ADD_UNIMPLEMENTED(_rows, @"CTFontCreateWithNameAndOptions", width / 2);
-    ADD_UNIMPLEMENTED(_rows, @"CTFontDrawGlyphs", width / 2);
     ADD_UNIMPLEMENTED(_rows, @"CTFontGetBoundingBox", width / 2);
     ADD_UNIMPLEMENTED(_rows, @"CTFontGetBoundingRectsForGlyphs", width / 2);
     ADD_UNIMPLEMENTED(_rows, @"CTFontGetCapHeight", width / 2);

--- a/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
@@ -18,58 +18,41 @@
 #include <CoreText/CoreText.h>
 #include <Starboard/SmartTypes.h>
 
-DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest) {
-    CGContextRef context = GetDrawingContext();
-    CGRect bounds = GetDrawingBounds();
-
-    // Creates path with current rectangle
-    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
-    CGPathAddRect(path.get(), nullptr, bounds);
+void __CreateGlyphs(CGGlyph glyphs[4]) {
+    UniChar chars[4] = { 'T', 'E', 'S', 'T' };
     woc::unique_cf<CTFontRef> ctfont{ CTFontCreateWithName(CFSTR("Arial"), 144, nullptr) };
-    woc::unique_cf<CFStringRef> text{ CFSTR("TEST") };
-    UniChar chars[4];
-    CFStringGetCharacters(text.get(), { 0, 4 }, chars);
-    CGGlyph glyphs[4];
     CTFontGetGlyphsForCharacters(ctfont.get(), chars, glyphs, 4);
+}
+
+void __SetFontForContext(CGContextRef context) {
     woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
     CGContextSetFont(context, font.get());
     CGContextSetFontSize(context, 144);
+}
+
+DISABLED_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest) {
+    CGContextRef context = GetDrawingContext();
+    CGGlyph glyphs[4];
+    __CreateGlyphs(glyphs);
+    __SetFontForContext(context);
     CGContextSetTextPosition(context, 25, 50);
     CGContextShowGlyphs(context, glyphs, 4);
 }
 
-DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
-    CGRect bounds = GetDrawingBounds();
-
-    // Creates path with current rectangle
-    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
-    CGPathAddRect(path.get(), nullptr, bounds);
-    woc::unique_cf<CTFontRef> ctfont{ CTFontCreateWithName(CFSTR("Arial"), 144, nullptr) };
-    woc::unique_cf<CFStringRef> text{ CFSTR("TEST") };
-    UniChar chars[4];
-    CFStringGetCharacters(text.get(), { 0, 4 }, chars);
     CGGlyph glyphs[4];
-    CTFontGetGlyphsForCharacters(ctfont.get(), chars, glyphs, 4);
-    woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
-    CGContextSetFont(context, font.get());
-    CGContextSetFontSize(context, 144);
+    __CreateGlyphs(glyphs);
+    __SetFontForContext(context);
     CGContextShowGlyphsAtPoint(context, 25, 50, glyphs, 4);
 }
 
 // On reference platform, CGContextShowText* can only be used with CGContextSelectFont
 // Which we do not currently support.
 #ifdef WINOBJC
-DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
-    CGRect bounds = GetDrawingBounds();
-
-    // Creates path with current rectangle
-    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
-    CGPathAddRect(path.get(), nullptr, bounds);
-    woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
-    CGContextSetFont(context, font.get());
-    CGContextSetFontSize(context, 144);
+    __SetFontForContext(context);
     CGContextShowTextAtPoint(context, 25, 50, "TEST", 4);
 }
 #endif // WINOBJC

--- a/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
@@ -18,13 +18,15 @@
 #include <CoreText/CoreText.h>
 #include <Starboard/SmartTypes.h>
 
-void __CreateGlyphs(CGGlyph glyphs[4]) {
+static std::vector<CGGlyph> __CreateGlyphs() {
     UniChar chars[4] = { 'T', 'E', 'S', 'T' };
+    std::vector<CGGlyph> glyphs(4);
     woc::unique_cf<CTFontRef> ctfont{ CTFontCreateWithName(CFSTR("Arial"), 144, nullptr) };
-    CTFontGetGlyphsForCharacters(ctfont.get(), chars, glyphs, 4);
+    CTFontGetGlyphsForCharacters(ctfont.get(), chars, glyphs.data(), 4);
+    return glyphs;
 }
 
-void __SetFontForContext(CGContextRef context) {
+static void __SetFontForContext(CGContextRef context) {
     woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
     CGContextSetFont(context, font.get());
     CGContextSetFontSize(context, 144);
@@ -32,19 +34,17 @@ void __SetFontForContext(CGContextRef context) {
 
 DISABLED_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
-    CGGlyph glyphs[4];
-    __CreateGlyphs(glyphs);
+    std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
     CGContextSetTextPosition(context, 25, 50);
-    CGContextShowGlyphs(context, glyphs, 4);
+    CGContextShowGlyphs(context, glyphs.data(), glyphs.size());
 }
 
 DISABLED_DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
-    CGGlyph glyphs[4];
-    __CreateGlyphs(glyphs);
+    std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
-    CGContextShowGlyphsAtPoint(context, 25, 50, glyphs, 4);
+    CGContextShowGlyphsAtPoint(context, 25, 50, glyphs.data(), glyphs.size());
 }
 
 // On reference platform, CGContextShowText* can only be used with CGContextSelectFont

--- a/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
@@ -1,0 +1,75 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include "DrawingTest.h"
+#include <CoreText/CoreText.h>
+#include <Starboard/SmartTypes.h>
+
+DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    // Creates path with current rectangle
+    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
+    CGPathAddRect(path.get(), nullptr, bounds);
+    woc::unique_cf<CTFontRef> ctfont{ CTFontCreateWithName(CFSTR("Arial"), 144, nullptr) };
+    woc::unique_cf<CFStringRef> text{ CFSTR("TEST") };
+    UniChar chars[4];
+    CFStringGetCharacters(text.get(), { 0, 4 }, chars);
+    CGGlyph glyphs[4];
+    CTFontGetGlyphsForCharacters(ctfont.get(), chars, glyphs, 4);
+    woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
+    CGContextSetFont(context, font.get());
+    CGContextSetFontSize(context, 144);
+    CGContextSetTextPosition(context, 25, 50);
+    CGContextShowGlyphs(context, glyphs, 4);
+}
+
+DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    // Creates path with current rectangle
+    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
+    CGPathAddRect(path.get(), nullptr, bounds);
+    woc::unique_cf<CTFontRef> ctfont{ CTFontCreateWithName(CFSTR("Arial"), 144, nullptr) };
+    woc::unique_cf<CFStringRef> text{ CFSTR("TEST") };
+    UniChar chars[4];
+    CFStringGetCharacters(text.get(), { 0, 4 }, chars);
+    CGGlyph glyphs[4];
+    CTFontGetGlyphsForCharacters(ctfont.get(), chars, glyphs, 4);
+    woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
+    CGContextSetFont(context, font.get());
+    CGContextSetFontSize(context, 144);
+    CGContextShowGlyphsAtPoint(context, 25, 50, glyphs, 4);
+}
+
+// On reference platform, CGContextShowText* can only be used with CGContextSelectFont
+// Which we do not currently support.
+#ifdef WINOBJC
+DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    // Creates path with current rectangle
+    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
+    CGPathAddRect(path.get(), nullptr, bounds);
+    woc::unique_cf<CGFontRef> font{ CGFontCreateWithFontName(CFSTR("Arial")) };
+    CGContextSetFont(context, font.get());
+    CGContextSetFontSize(context, 144);
+    CGContextShowTextAtPoint(context, 25, 50, "TEST", 4);
+}
+#endif // WINOBJC

--- a/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
@@ -18,11 +18,13 @@
 #include <CoreText/CoreText.h>
 #include <Starboard/SmartTypes.h>
 
+#ifdef WINOBJC
 static NSURL* __GetURLFromPathRelativeToModuleDirectory(NSString* relativePath) {
     static char fullPath[_MAX_PATH];
     static int unused = [](char* path) { return GetModuleFileNameA(NULL, path, _MAX_PATH); }(fullPath);
     return [NSURL fileURLWithPath:[[@(fullPath) stringByDeletingLastPathComponent] stringByAppendingPathComponent:relativePath]];
 }
+#endif // WINOBJC
 
 DISABLED_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
@@ -440,6 +442,7 @@ DISABLED_DRAW_TEST_P(Fonts, TestFonts) {
 static CFStringRef c_fontNames[] = { CFSTR("Arial"), CFSTR("Times New Roman"), CFSTR("Wingdings"), CFSTR("Segoe UI") };
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInFonts, Fonts, ::testing::ValuesIn(c_fontNames));
 
+#ifdef WINOBJC
 DISABLED_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
@@ -463,5 +466,43 @@ DISABLED_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest) {
     CFStringRef keys[2] = { kCTFontAttributeName, kCTParagraphStyleAttributeName };
     CFTypeRef values[2] = { myCFFont.get(), paragraphStyle.get() };
 
-    __DrawLoremIpsum(context, path.get(), keys, values);
+    woc::unique_cf<CFDictionaryRef> dict{ CFDictionaryCreate(nullptr,
+                                                             (const void**)keys,
+                                                             (const void**)values,
+                                                             std::extent<decltype(keys)>::value,
+                                                             &kCFTypeDictionaryKeyCallBacks,
+                                                             &kCFTypeDictionaryValueCallBacks) };
+
+    woc::unique_cf<CFAttributedStringRef> attrString{
+        CFAttributedStringCreate(nullptr,
+                                 CFSTR("GUR DHVPX OEBJA SBK WHZCF BIRE GUR YNML QBT. gur dhvpx oebja qbt whzcf bire gur ynml sbk."),
+                                 dict.get())
+    };
+
+    woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString(attrString.get()) };
+
+    // Creates frame for framesetter with current attributed string
+    woc::unique_cf<CTFrameRef> frame{ CTFramesetterCreateFrame(framesetter.get(), CFRangeMake(0, 0), path.get(), NULL) };
+
+    // Draws the text in the frame
+    CTFrameDraw(frame.get(), context);
+    CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, nullptr);
+}
+#endif // WINOBJC
+
+DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    // Creates path with current rectangle
+    woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
+    CGPathAddRect(path.get(), nullptr, bounds);
+    woc::unique_cf<CTFontRef> font{ CTFontCreateWithName(CFSTR("Segoe UI"), 20, nullptr) };
+    woc::unique_cf<CFStringRef> text{ CFSTR("TEST") };
+    UniChar chars[4];
+    CFStringGetCharacters(text.get(), { 0, 4 }, chars);
+    CGGlyph glyphs[4];
+    CTFontGetGlyphsForCharacters(font.get(), chars, glyphs, 4);
+    CGPoint positions[4] = { { 0, 0 }, { 10, 10 }, { 25, 25 }, { 65, 15 } };
+    CTFontDrawGlyphs(font.get(), glyphs, positions, 4, context);
 }

--- a/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
@@ -490,7 +490,7 @@ DISABLED_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest) {
 }
 #endif // WINOBJC
 
-DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -498,9 +498,7 @@ DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest) {
     woc::unique_cf<CGMutablePathRef> path{ CGPathCreateMutable() };
     CGPathAddRect(path.get(), nullptr, bounds);
     woc::unique_cf<CTFontRef> font{ CTFontCreateWithName(CFSTR("Segoe UI"), 20, nullptr) };
-    woc::unique_cf<CFStringRef> text{ CFSTR("TEST") };
-    UniChar chars[4];
-    CFStringGetCharacters(text.get(), { 0, 4 }, chars);
+    UniChar chars[4] = { 'T', 'E', 'S', 'T' };
     CGGlyph glyphs[4];
     CTFontGetGlyphsForCharacters(font.get(), chars, glyphs, 4);
     CGPoint positions[4] = { { 0, 0 }, { 10, 10 }, { 25, 25 }, { 65, 15 } };

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ShowGlyphs.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ShowGlyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23211c75d1da28f24f1598ff7a2cfdf7bda8b98a1a4c5ebd04c157e192f1e9f9
+size 5383

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ShowGlyphsAtPoint.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ShowGlyphsAtPoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23211c75d1da28f24f1598ff7a2cfdf7bda8b98a1a4c5ebd04c157e192f1e9f9
+size 5383

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ShowTextAtPoint.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ShowTextAtPoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23211c75d1da28f24f1598ff7a2cfdf7bda8b98a1a4c5ebd04c157e192f1e9f9
+size 5383

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CTFont.DrawGlyphs.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CTFont.DrawGlyphs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22a0bc304e0c298ca1b6ac34ec832fbbda56d5ef3b002705591695c596f6cc8d
+size 1741


### PR DESCRIPTION
Implement CGContextShowTextAtPoint, CGContextShowGlyphsAtPoint, CGContextShowGlyphsWithAdvances, and CTFontDrawGlyphs using DWrite.  To do this changed CGContextCairo to use a CGFont and fixed our text position to apply to User Space, not Text Space.  Added private functions to access CGFont internals in CGContextCairo.  With this change drawing text into UIKit owned contexts will not need to have a negative Y text position.

Fixes #924

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1516)
<!-- Reviewable:end -->
