### PR TITLE
Move functional tests to use TAEF directly. This removes the need for…

### DIFF
--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -281,6 +281,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURLStorageFileTests.mm">
       <ObjectiveCARC>true</ObjectiveCARC>
     </ClangCompile>
+    <ClangCompile Include="$(WINOBJC_SDK_ROOT)\tests\unittests\CoreText\CTRunTests.mm" />
   </ItemGroup>
   <ItemGroup>
     <Xml Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\Default.AppxManifest.xml" />

--- a/tests/frameworks/gtest/include/gtest/gtest.h
+++ b/tests/frameworks/gtest/include/gtest/gtest.h
@@ -174,6 +174,7 @@ class Test;
 class TestCase;
 class TestInfo;
 class UnitTest;
+class TestRunner;
 
 // A class for indicating whether an assertion was successful.  When
 // the assertion wasn't successful, the AssertionResult object
@@ -372,6 +373,7 @@ GTEST_API_ AssertionResult AssertionFailure(const Message& msg);
 class GTEST_API_ Test {
  public:
   friend class TestInfo;
+  friend class TestRunner;
 
   // Defines types for pointers to functions that set up and tear down
   // a test case.
@@ -476,6 +478,23 @@ class GTEST_API_ Test {
 
   // We disallow copying Tests.
   GTEST_DISALLOW_COPY_AND_ASSIGN_(Test);
+};
+
+// Helper TestRunner class used to indirect from a TAEF test class which is named with a Prefix to a single
+// class that TEST_P can friend. TODO: move to a impl file to not violate ODR (doesn't matter since all defs are the same though)
+class TestRunner {
+public:
+    static void SetUp(Test* test) {
+        test->SetUp();
+    }
+
+    static void TestBody(Test* test) {
+        test->TestBody();
+    }
+
+    static void TearDown(Test* test) {
+        test->TearDown();
+    }
 };
 
 typedef internal::TimeInMillis TimeInMillis;

--- a/tests/frameworks/gtest/include/gtest/internal/gtest-param-util.h
+++ b/tests/frameworks/gtest/include/gtest/internal/gtest-param-util.h
@@ -1,3 +1,4 @@
+// clang-format off
 // Copyright 2008 Google Inc.
 // All Rights Reserved.
 //
@@ -598,6 +599,16 @@ class ParameterizedTestCaseInfo : public ParameterizedTestCaseInfoBase {
     }  // for test_it
   }  // RegisterTests
 
+  std::vector<TestMetaFactoryBase<typename TestCase::ParamType>*> GetTestMetaFactories() {
+    std::vector<TestMetaFactoryBase<typename TestCase::ParamType>*> toReturn;
+    for (typename TestInfoContainer::iterator test_it = tests_.begin(); test_it != tests_.end(); ++test_it) {
+      linked_ptr<TestInfo> test_info = *test_it;
+      toReturn.push_back(test_info->test_meta_factory.get());
+    }
+
+    return toReturn;
+  }
+
  private:
   // LocalTestInfo structure keeps information about a single test registered
   // with TEST_P macro.
@@ -729,3 +740,5 @@ class ParameterizedTestCaseRegistry {
 #endif  //  GTEST_HAS_PARAM_TEST
 
 #endif  // GTEST_INCLUDE_GTEST_INTERNAL_GTEST_PARAM_UTIL_H_
+
+// clang-format on

--- a/tests/functionaltests/Tests/AssetsLibraryTests/AssetsLibraryTests.mm
+++ b/tests/functionaltests/Tests/AssetsLibraryTests/AssetsLibraryTests.mm
@@ -23,85 +23,208 @@
 #import <Starboard/SmartTypes.h>
 #import <UWP/WindowsStorage.h>
 
-TEST(AssetsLibrary, GetVideoAsset) {
-    __block BOOL success = YES;
-    __block StrongId<NSString> message = @"";
-    __block unsigned int knownFileSize = 635445;
-    __block StrongId<NSString> fileName = @"AssetsLibraryTestVideo.mp4";
-    __block StrongId<NSURL> assetRepresentationUrl = nil;
+//
+// AssetsLibrary Tests
+//
 
-    StrongId<NSURL> relativeURLToVideo = [NSURL URLWithString:@"assets-library://Pictures/AssetsLibraryTestVideo.mp4"];
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "FunctionalTestHelpers.h"
+#import <Starboard/SmartTypes.h>
+#import <TestFramework.h>
+#import <UWP/WindowsStorage.h>
+
+static bool copyFileToPicturesLibrary(NSString* fullPathToFile, NSString* fileName) {
+    __block bool success = YES;
 
     dispatch_group_t group = dispatch_group_create();
     dispatch_group_enter(group);
 
-    ALAssetsLibrary* assetsLibrary = [[[ALAssetsLibrary alloc] init] autorelease];
+    void (^onFailure)(NSError*) = ^(NSError* error) {
+        LOG_ERROR([[error description] UTF8String]);
+        success = NO;
+        dispatch_group_leave(group);
+    };
 
-    [assetsLibrary assetForURL:relativeURLToVideo
-        resultBlock:^(ALAsset* asset) {
-            if (asset == nil) {
-                success = NO;
-                message = @"FAILED: Invalid Asset.";
-                dispatch_group_leave(group);
-                return;
-            }
-
-            ALAssetRepresentation* _assetRepresentation = [asset defaultRepresentation];
-            if (_assetRepresentation == nil) {
-                success = NO;
-                message = @"FAILED: Invalid Asset Representation.";
-                dispatch_group_leave(group);
-                return;
-            }
-
-            // Check this NSURL after assetForURL completes
-            assetRepresentationUrl = [_assetRepresentation url];
-
-            NSUInteger size = (NSUInteger)_assetRepresentation.size;
-            if (size != knownFileSize) {
-                success = NO;
-                message = @"FAILED: Size of Asset Representation does not equal its file size.";
-                dispatch_group_leave(group);
-                return;
-            }
-
-            StrongId<NSMutableData> data = [NSMutableData dataWithLength:size];
-            NSError* error = nil;
-            NSUInteger length = [_assetRepresentation getBytes:(uint8_t*)[data mutableBytes] fromOffset:0 length:size error:&error];
-            if (error != nil) {
-                success = NO;
-                message = [@"FAILED: Could not get bytes from asset representation - " stringByAppendingString:[error description]];
-                dispatch_group_leave(group);
-                return;
-            }
-            if (size != length) {
-                success = NO;
-                message = @"FAILED: Bytes received does not equal size of Asset.";
-                dispatch_group_leave(group);
-                return;
-            }
-
-            StrongId<NSString*> testFileFullPath = appendPathRelativeToFTModule([@"data" stringByAppendingPathComponent:fileName]);
-            NSData* localFile = [[[NSData alloc] initWithContentsOfFile:testFileFullPath] autorelease];
-            if (![data isEqualToData:localFile]) {
-                success = NO;
-                message = @"FAILED: Bytes recieved does not equal original file.";
-                dispatch_group_leave(group);
-                return;
-            }
-
-            dispatch_group_leave(group);
-        }
-        failureBlock:^(NSError* assetsLibError) {
-            success = NO;
-            message = [@"FAILED: Could not get asset - " stringByAppendingString:[assetsLibError description]];
-            dispatch_group_leave(group);
-        }];
+    // Get StorageFile reference for file in local folder
+    [WSStorageFile
+        getFileFromPathAsync:fullPathToFile
+                     success:^void(WSStorageFile* storageFile) {
+                         // Get StorageFolder for Picture Library known folder
+                         [WSStorageLibrary
+                             getLibraryAsync:WSKnownLibraryIdPictures
+                                     success:^void(WSStorageLibrary* picturesLibrary) {
+                                         [picturesLibrary.saveFolder
+                                             tryGetItemAsync:fileName
+                                                     success:^void(RTObject<WSIStorageItem>* storageItem) {
+                                                         if (storageItem == nil) {
+                                                             [storageFile
+                                                                 copyOverloadDefaultNameAndOptions:picturesLibrary.saveFolder
+                                                                                           success:^void(WSStorageFile* storageFile) {
+                                                                                               dispatch_group_leave(group);
+                                                                                           }
+                                                                                           failure:onFailure];
+                                                         } else {
+                                                             dispatch_group_leave(group);
+                                                         }
+                                                     }
+                                                     failure:onFailure];
+                                     }
+                                     failure:onFailure];
+                     }
+                     failure:onFailure];
 
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     dispatch_release(group);
 
-    ASSERT_TRUE_MSG([assetRepresentationUrl isEqual:relativeURLToVideo], @"FAILED: NSURL of ALAssetRepresentation incorrect.");
-
-    ASSERT_TRUE_MSG(success, message);
+    return success;
 }
+
+class AssetsLibrary {
+public:
+    BEGIN_TEST_CLASS(AssetsLibrary)
+    TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"AssetsLibrary.AppxManifest.xml")
+    END_TEST_CLASS()
+
+    TEST_CLASS_SETUP(AssetsLibraryClassSetup) {
+        const char* fileNameTemp = "AssetsLibraryTestVideo.mp4";
+        StrongId<NSString> fileName = [NSString stringWithUTF8String:fileNameTemp];
+        StrongId<NSString> testFileFullPath = appendPathRelativeToFTModule([@"data" stringByAppendingPathComponent:fileName]);
+        return (copyFileToPicturesLibrary(testFileFullPath, fileName) &
+                SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize)));
+    }
+
+    TEST_CLASS_CLEANUP(AssetsLibraryClassCleanup) {
+        const char* fileNameTemp = "AssetsLibraryTestVideo.mp4";
+        __block bool success = YES;
+        NSString* fileName = [NSString stringWithUTF8String:fileNameTemp];
+
+        dispatch_group_t group = dispatch_group_create();
+        dispatch_group_enter(group);
+
+        void (^onFailure)(NSError*) = ^(NSError* error) {
+            LOG_ERROR([[error description] UTF8String]);
+            success = NO;
+            dispatch_group_leave(group);
+        };
+
+        [WSStorageLibrary getLibraryAsync:WSKnownLibraryIdPictures
+                                  success:^void(WSStorageLibrary* picturesLibrary) {
+                                      [picturesLibrary.saveFolder getFileAsync:fileName
+                                                                       success:^void(WSStorageFile* storageFile) {
+                                                                           // Delete permantently so the Recycle Bin doesn't get filled up
+                                                                           [storageFile deleteAsync:WSStorageDeleteOptionPermanentDelete];
+                                                                           dispatch_group_leave(group);
+                                                                       }
+                                                                       failure:onFailure];
+                                  }
+                                  failure:onFailure];
+
+        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+        dispatch_release(group);
+
+        return success;
+    }
+
+    TEST_METHOD_CLEANUP(AssetsLibraryCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(GetVideoAsset) {
+        __block BOOL success = YES;
+        __block StrongId<NSString> message = @"";
+        __block unsigned int knownFileSize = 635445;
+        __block StrongId<NSString> fileName = @"AssetsLibraryTestVideo.mp4";
+        __block StrongId<NSURL> assetRepresentationUrl = nil;
+
+        StrongId<NSURL> relativeURLToVideo = [NSURL URLWithString:@"assets-library://Pictures/AssetsLibraryTestVideo.mp4"];
+
+        dispatch_group_t group = dispatch_group_create();
+        dispatch_group_enter(group);
+
+        ALAssetsLibrary* assetsLibrary = [[[ALAssetsLibrary alloc] init] autorelease];
+
+        [assetsLibrary assetForURL:relativeURLToVideo
+            resultBlock:^(ALAsset* asset) {
+                if (asset == nil) {
+                    success = NO;
+                    message = @"FAILED: Invalid Asset.";
+                    dispatch_group_leave(group);
+                    return;
+                }
+
+                ALAssetRepresentation* _assetRepresentation = [asset defaultRepresentation];
+                if (_assetRepresentation == nil) {
+                    success = NO;
+                    message = @"FAILED: Invalid Asset Representation.";
+                    dispatch_group_leave(group);
+                    return;
+                }
+
+                // Check this NSURL after assetForURL completes
+                assetRepresentationUrl = [_assetRepresentation url];
+
+                NSUInteger size = (NSUInteger)_assetRepresentation.size;
+                if (size != knownFileSize) {
+                    success = NO;
+                    message = @"FAILED: Size of Asset Representation does not equal its file size.";
+                    dispatch_group_leave(group);
+                    return;
+                }
+
+                StrongId<NSMutableData> data = [NSMutableData dataWithLength:size];
+                NSError* error = nil;
+                NSUInteger length = [_assetRepresentation getBytes:(uint8_t*)[data mutableBytes] fromOffset:0 length:size error:&error];
+                if (error != nil) {
+                    success = NO;
+                    message = [@"FAILED: Could not get bytes from asset representation - " stringByAppendingString:[error description]];
+                    dispatch_group_leave(group);
+                    return;
+                }
+                if (size != length) {
+                    success = NO;
+                    message = @"FAILED: Bytes received does not equal size of Asset.";
+                    dispatch_group_leave(group);
+                    return;
+                }
+
+                StrongId<NSString*> testFileFullPath = appendPathRelativeToFTModule([@"data" stringByAppendingPathComponent:fileName]);
+                NSData* localFile = [[[NSData alloc] initWithContentsOfFile:testFileFullPath] autorelease];
+                if (![data isEqualToData:localFile]) {
+                    success = NO;
+                    message = @"FAILED: Bytes recieved does not equal original file.";
+                    dispatch_group_leave(group);
+                    return;
+                }
+
+                dispatch_group_leave(group);
+            }
+            failureBlock:^(NSError* assetsLibError) {
+                success = NO;
+                message = [@"FAILED: Could not get asset - " stringByAppendingString:[assetsLibError description]];
+                dispatch_group_leave(group);
+            }];
+
+        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+        dispatch_release(group);
+
+        ASSERT_TRUE_MSG([assetRepresentationUrl isEqual:relativeURLToVideo], @"FAILED: NSURL of ALAssetRepresentation incorrect.");
+
+        ASSERT_TRUE_MSG(success, message);
+    }
+};

--- a/tests/functionaltests/Tests/CoreAnimationTests/CALayerAppearanceTests.mm
+++ b/tests/functionaltests/Tests/CoreAnimationTests/CALayerAppearanceTests.mm
@@ -61,116 +61,134 @@ static const NSTimeInterval c_testTimeoutInSec = 5;
 }
 @end
 
-//
-// Validate that the CALayer opacity property change invokes a property change in the backing XAML element
-//
-TEST(CALayerAppearance, OpacityChanged) {
-    __block CALayerViewController* caLayerVC;
-    __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
-    __block WXUIElement* backingElement = nil;
+class CoreAnimationTests {
+public:
+    BEGIN_TEST_CLASS(CoreAnimationTests)
+    END_TEST_CLASS()
 
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        LOG_INFO("Creating CALayerViewController on the UI thread explicitly");
-        caLayerVC = [[CALayerViewController alloc] init];
+    TEST_CLASS_SETUP(CoreAnimationTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-        // TODO: Remove this line once we hook up to the root view controller which will trigger the view method
-        [caLayerVC view];
+    TEST_METHOD_CLEANUP(CoreAnimationTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-        // We have to artificially ref the element since the block needs to keep it around
-        backingElement = [caLayerVC.layer _xamlElement];
-        [backingElement retain];
+    //
+    // Validate that the CALayer opacity property change invokes a property change in the backing XAML element
+    //
+    TEST_METHOD(OpacityChanged) {
+        __block CALayerViewController* caLayerVC;
+        __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
+        __block WXUIElement* backingElement = nil;
 
-        // Register callback and wait for the property changed event to trigger
-        int64_t callbackToken = [backingElement
-            registerPropertyChangedCallback:[WXUIElement opacityProperty]
-                                   callback:^(WXDependencyObject* sender, WXDependencyProperty* dp) {
-                LOG_INFO("Backing XAML element opacity: %f", backingElement.opacity);
-                LOG_INFO("CALayer.opacity: %f", caLayerVC.layer.opacity);
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            LOG_INFO("Creating CALayerViewController on the UI thread explicitly");
+            caLayerVC = [[CALayerViewController alloc] init];
 
-                // Verification
-                EXPECT_EQ_MSG(backingElement.opacity, caLayerVC.layer.opacity, "Failed to match opacity");
-                EXPECT_EQ_MSG(backingElement.opacity, 0.5f, "Failed to match opacity with expected value");
+            // TODO: Remove this line once we hook up to the root view controller which will trigger the view method
+            [caLayerVC view];
 
-                // Unregister the callback
-                [backingElement unregisterPropertyChangedCallback:[WXUIElement opacityProperty] token:callbackToken];
+            // We have to artificially ref the element since the block needs to keep it around
+            backingElement = [caLayerVC.layer _xamlElement];
+            [backingElement retain];
 
-                [condition lock];
-                [condition signal];
-                [condition unlock];
-            }];
+            // Register callback and wait for the property changed event to trigger
+            int64_t callbackToken = [backingElement
+                registerPropertyChangedCallback:[WXUIElement opacityProperty]
+                                       callback:^(WXDependencyObject* sender, WXDependencyProperty* dp) {
+                                           LOG_INFO("Backing XAML element opacity: %f", backingElement.opacity);
+                                           LOG_INFO("CALayer.opacity: %f", caLayerVC.layer.opacity);
 
-        // Action
-        caLayerVC.layer.opacity = 0.5f;
-    });
+                                           // Verification
+                                           EXPECT_EQ_MSG(backingElement.opacity, caLayerVC.layer.opacity, "Failed to match opacity");
+                                           EXPECT_EQ_MSG(backingElement.opacity, 0.5f, "Failed to match opacity with expected value");
 
-    [condition lock];
-    ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
-        "FAILED: Waiting for property changed event timed out!");
-    [condition unlock];
+                                           // Unregister the callback
+                                           [backingElement unregisterPropertyChangedCallback:[WXUIElement opacityProperty]
+                                                                                       token:callbackToken];
 
-    // Don't leak
-    [backingElement release];
-    [caLayerVC release];
-}
+                                           [condition lock];
+                                           [condition signal];
+                                           [condition unlock];
+                                       }];
 
-//
-// Validate that the CALayer background property change invokes a property change in the backing XAML element
-//
-TEST(CALayerAppearance, BackgroundColorChanged) {
-    __block CALayerViewController* caLayerVC;
-    __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
-    __block WXUIElement* backingElement = nil;
+            // Action
+            caLayerVC.layer.opacity = 0.5f;
+        });
 
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        LOG_INFO("Creating CALayerViewController on the UI thread explicitly");
-        caLayerVC = [[CALayerViewController alloc] init];
-        [caLayerVC view];
+        [condition lock];
+        ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for property changed event timed out!");
+        [condition unlock];
 
-        // We have to artificially ref the element since the block needs to keep it around
-        backingElement = [caLayerVC.layer _xamlElement];
-        [backingElement retain];
+        // Don't leak
+        [backingElement release];
+        [caLayerVC release];
+    }
 
-        // Register callback and wait for the property changed event to trigger
-        int64_t callbackToken = [backingElement
-            registerPropertyChangedCallback:[WXCPanel backgroundProperty]
-                                   callback:^(WXDependencyObject* sender, WXDependencyProperty* dp) {
-                WUXMSolidColorBrush* solidBrush = rt_dynamic_cast([WUXMSolidColorBrush class], [sender getValue:dp]);
-                ASSERT_TRUE(solidBrush);
+    //
+    // Validate that the CALayer background property change invokes a property change in the backing XAML element
+    //
+    TEST_METHOD(BackgroundColorChanged) {
+        __block CALayerViewController* caLayerVC;
+        __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
+        __block WXUIElement* backingElement = nil;
 
-                LOG_INFO("Backing XAML element backgroundColor (rgba): %d,%d,%d,%d",
-                        [solidBrush.color r],
-                        [solidBrush.color g],
-                        [solidBrush.color b],
-                        [solidBrush.color a]);
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            LOG_INFO("Creating CALayerViewController on the UI thread explicitly");
+            caLayerVC = [[CALayerViewController alloc] init];
+            [caLayerVC view];
 
-                CGFloat red, green, blue, alpha;
-                [caLayerVC.layer.backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha];
-                LOG_INFO("CALayer.backgroundColor (rgba): %.2f,%.2f,%.2f,%.2f", red, green, blue, alpha);
+            // We have to artificially ref the element since the block needs to keep it around
+            backingElement = [caLayerVC.layer _xamlElement];
+            [backingElement retain];
 
-                // Validate that the change is reflected on the backing XAML control
-                EXPECT_EQ_MSG(solidBrush.color.r, (int)(red * 255), @"Failed to match red component");
-                EXPECT_EQ_MSG(solidBrush.color.g, (int)(green * 255), @"Failed to match green component");
-                EXPECT_EQ_MSG(solidBrush.color.b, (int)(blue * 255), @"Failed to match blue component");
-                EXPECT_EQ_MSG(solidBrush.color.a, (int)(alpha * 255), @"Failed to match alpha component");
+            // Register callback and wait for the property changed event to trigger
+            int64_t callbackToken = [backingElement
+                registerPropertyChangedCallback:[WXCPanel backgroundProperty]
+                                       callback:^(WXDependencyObject* sender, WXDependencyProperty* dp) {
+                                           WUXMSolidColorBrush* solidBrush =
+                                               rt_dynamic_cast([WUXMSolidColorBrush class], [sender getValue:dp]);
+                                           ASSERT_TRUE(solidBrush);
 
-                // Unregister the callback
-                [backingElement unregisterPropertyChangedCallback:[WXCPanel backgroundProperty] token:callbackToken];
+                                           LOG_INFO("Backing XAML element backgroundColor (rgba): %d,%d,%d,%d",
+                                                    [solidBrush.color r],
+                                                    [solidBrush.color g],
+                                                    [solidBrush.color b],
+                                                    [solidBrush.color a]);
 
-                [condition lock];
-                [condition signal];
-                [condition unlock];
-        }];
+                                           CGFloat red, green, blue, alpha;
+                                           [caLayerVC.layer.backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha];
+                                           LOG_INFO("CALayer.backgroundColor (rgba): %.2f,%.2f,%.2f,%.2f", red, green, blue, alpha);
 
-        // Action
-        caLayerVC.layer.backgroundColor = [UIColor redColor].CGColor;
-    });
+                                           // Validate that the change is reflected on the backing XAML control
+                                           EXPECT_EQ_MSG(solidBrush.color.r, (int)(red * 255), @"Failed to match red component");
+                                           EXPECT_EQ_MSG(solidBrush.color.g, (int)(green * 255), @"Failed to match green component");
+                                           EXPECT_EQ_MSG(solidBrush.color.b, (int)(blue * 255), @"Failed to match blue component");
+                                           EXPECT_EQ_MSG(solidBrush.color.a, (int)(alpha * 255), @"Failed to match alpha component");
 
-    [condition lock];
-    ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
-        "FAILED: Waiting for property changed event timed out!");
-    [condition unlock];
+                                           // Unregister the callback
+                                           [backingElement unregisterPropertyChangedCallback:[WXCPanel backgroundProperty]
+                                                                                       token:callbackToken];
 
-    // Don't leak
-    [backingElement release];
-    [caLayerVC release];
-}
+                                           [condition lock];
+                                           [condition signal];
+                                           [condition unlock];
+                                       }];
+
+            // Action
+            caLayerVC.layer.backgroundColor = [UIColor redColor].CGColor;
+        });
+
+        [condition lock];
+        ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for property changed event timed out!");
+        [condition unlock];
+
+        // Don't leak
+        [backingElement release];
+        [caLayerVC release];
+    }
+};

--- a/tests/functionaltests/Tests/CortanaTests.mm
+++ b/tests/functionaltests/Tests/CortanaTests.mm
@@ -198,93 +198,124 @@ MOCK_CLASS(MockProtocolActivatedEventArgs,
     return;
 }
 @end
-// Creates test method which we call in TEST_CLASS_SETUP to activate app
-TEST(CortanaTest, VoiceCommandForegroundActivation) {
-    LOG_INFO("CortanaTest Voice Command Foreground Activation Test: ");
 
-    // Create mocked data to pass into application
-    auto fakeSpeechRecognitionResult = Make<MockSpeechRecognitionResult>();
-    fakeSpeechRecognitionResult->Setget_Text([](HSTRING* text) {
-        Wrappers::HString value;
-        value.Set(L"CORTANA_TEST");
-        *text = value.Detach();
-        return S_OK;
-    });
+//
+// Cortana Activation Tests
+//
+class CortanaVoiceCommandForegroundActivation {
+public:
+    BEGIN_TEST_CLASS(CortanaVoiceCommandForegroundActivation)
+    END_TEST_CLASS()
 
-    auto fakeVoiceCommandActivatedEventArgs = Make<MockVoiceCommandActivatedEventArgs>();
-    fakeVoiceCommandActivatedEventArgs->Setget_Result([&fakeSpeechRecognitionResult](ISpeechRecognitionResult** result) {
-        fakeSpeechRecognitionResult.CopyTo(result);
-        return S_OK;
-    });
+    TEST_CLASS_SETUP(CortanaVoiceCommandForegroundTestClassSetup) {
+        // The class setup allows us to activate the app in our test method, but can only be done once per class
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread([]() {
+            LOG_INFO("CortanaTest Voice Command Foreground Activation Test: ");
 
-    fakeVoiceCommandActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
-        *kind = ActivationKind_VoiceCommand;
-        return S_OK;
-    });
+            // Create mocked data to pass into application
+            auto fakeSpeechRecognitionResult = Make<MockSpeechRecognitionResult>();
+            fakeSpeechRecognitionResult->Setget_Text([](HSTRING* text) {
+                Wrappers::HString value;
+                value.Set(L"CORTANA_TEST");
+                *text = value.Detach();
+                return S_OK;
+            });
 
-    fakeVoiceCommandActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
-        *state = ApplicationExecutionState_NotRunning;
-        return S_OK;
-    });
+            auto fakeVoiceCommandActivatedEventArgs = Make<MockVoiceCommandActivatedEventArgs>();
+            fakeVoiceCommandActivatedEventArgs->Setget_Result([&fakeSpeechRecognitionResult](ISpeechRecognitionResult** result) {
+                fakeSpeechRecognitionResult.CopyTo(result);
+                return S_OK;
+            });
 
-    // Pass activation argument to method which activates the app
-    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeVoiceCommandActivatedEventArgs.Get()),
-                                NSStringFromClass([CortanaVoiceCommandForegroundTestDelegate class]));
-}
+            fakeVoiceCommandActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
+                *kind = ActivationKind_VoiceCommand;
+                return S_OK;
+            });
 
-TEST(CortanaTest, VoiceCommandForegroundActivationDelegateMethodsCalled) {
-    CortanaVoiceCommandForegroundTestDelegate* testDelegate = [[UIApplication sharedApplication] delegate];
-    NSDictionary* methodsCalled = [testDelegate methodsCalled];
-    EXPECT_TRUE(methodsCalled);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:willFinishLaunchingWithOptions:"]);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didFinishLaunchingWithOptions:"]);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveVoiceCommand:"]);
-}
+            fakeVoiceCommandActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
+                *state = ApplicationExecutionState_NotRunning;
+                return S_OK;
+            });
 
-// Creates test method which we call in TEST_CLASS_SETUP to activate app
-TEST(CortanaTest, ProtocolForegroundActivation) {
-    LOG_INFO("CortanaTest Protocol Foreground Activation Test: ");
+            // Pass activation argument to method which activates the app
+            UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeVoiceCommandActivatedEventArgs.Get()),
+                                        NSStringFromClass([CortanaVoiceCommandForegroundTestDelegate class]));
+        }));
+    }
 
-    // Create mocked data to pass into application
-    auto fakeUri = Make<MockUri>();
-    fakeUri->SetToString([](HSTRING* text) {
-        Wrappers::HString value;
-        value.Set(L"CORTANA_TEST");
-        *text = value.Detach();
-        return S_OK;
-    });
+    TEST_METHOD_CLEANUP(CortanaVoiceCommandForegroundCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    auto fakeProtocolActivatedEventArgs = Make<MockProtocolActivatedEventArgs>();
-    fakeProtocolActivatedEventArgs->Setget_Uri([&fakeUri](IUriRuntimeClass** uri) {
-        fakeUri.CopyTo(uri);
-        return S_OK;
-    });
+    TEST_METHOD(VoiceCommandForegroundActivationDelegateMethodsCalled) {
+        CortanaVoiceCommandForegroundTestDelegate* testDelegate = [[UIApplication sharedApplication] delegate];
+        NSDictionary* methodsCalled = [testDelegate methodsCalled];
+        EXPECT_TRUE(methodsCalled);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:willFinishLaunchingWithOptions:"]);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didFinishLaunchingWithOptions:"]);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveVoiceCommand:"]);
+    }
 
-    fakeProtocolActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
-        *kind = ActivationKind_Protocol;
-        return S_OK;
-    });
+}; /* class CortanaVoiceCommandForegroundActivation */
 
-    fakeProtocolActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
-        *state = ApplicationExecutionState_NotRunning;
-        return S_OK;
-    });
+class CortanaProtocolForegroundActivation {
+public:
+    BEGIN_TEST_CLASS(CortanaProtocolForegroundActivation)
+    END_TEST_CLASS()
 
-    fakeProtocolActivatedEventArgs->Setget_CallerPackageFamilyName([](HSTRING* name) {
-        Wrappers::HStringReference testName(L"TestPackageFamilyName");
-        return testName.CopyTo(name);
-    });
+    TEST_CLASS_SETUP(CortanaProtocolForegroundTestClassSetup) {
+        // The class setup allows us to activate the app in our test method, but can only be done once per class
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread([]() {
+            LOG_INFO("CortanaTest Protocol Foreground Activation Test: ");
 
-    // Pass activation argument to method which activates the app
-    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeProtocolActivatedEventArgs.Get()),
-                                NSStringFromClass([CortanaProtocolForegroundTestDelegate class]));
-}
+            // Create mocked data to pass into application
+            auto fakeUri = Make<MockUri>();
+            fakeUri->SetToString([](HSTRING* text) {
+                Wrappers::HString value;
+                value.Set(L"CORTANA_TEST");
+                *text = value.Detach();
+                return S_OK;
+            });
 
-TEST(CortanaTest, ProtocolForegroundActivationDelegateMethodsCalled) {
-    CortanaProtocolForegroundTestDelegate* testDelegate = [[UIApplication sharedApplication] delegate];
-    NSDictionary* methodsCalled = [testDelegate methodsCalled];
-    EXPECT_TRUE(methodsCalled);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:willFinishLaunchingWithOptions:"]);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didFinishLaunchingWithOptions:"]);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveProtocol:"]);
-}
+            auto fakeProtocolActivatedEventArgs = Make<MockProtocolActivatedEventArgs>();
+            fakeProtocolActivatedEventArgs->Setget_Uri([&fakeUri](IUriRuntimeClass** uri) {
+                fakeUri.CopyTo(uri);
+                return S_OK;
+            });
+
+            fakeProtocolActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
+                *kind = ActivationKind_Protocol;
+                return S_OK;
+            });
+
+            fakeProtocolActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
+                *state = ApplicationExecutionState_NotRunning;
+                return S_OK;
+            });
+
+            fakeProtocolActivatedEventArgs->Setget_CallerPackageFamilyName([](HSTRING* name) {
+                Wrappers::HStringReference testName(L"TestPackageFamilyName");
+                return testName.CopyTo(name);
+            });
+
+            // Pass activation argument to method which activates the app
+            UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeProtocolActivatedEventArgs.Get()),
+                                        NSStringFromClass([CortanaProtocolForegroundTestDelegate class]));
+        }));
+    }
+
+    TEST_METHOD_CLEANUP(CortanaProtocolForegroundCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(ProtocolForegroundActivationDelegateMethodsCalled) {
+        CortanaProtocolForegroundTestDelegate* testDelegate = [[UIApplication sharedApplication] delegate];
+        NSDictionary* methodsCalled = [testDelegate methodsCalled];
+        EXPECT_TRUE(methodsCalled);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:willFinishLaunchingWithOptions:"]);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didFinishLaunchingWithOptions:"]);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveProtocol:"]);
+    }
+};

--- a/tests/functionaltests/Tests/NSBundleTests.mm
+++ b/tests/functionaltests/Tests/NSBundleTests.mm
@@ -19,39 +19,54 @@
 #import <UWP/WindowsFoundation.h>
 #import <UWP/WindowsStorage.h>
 
-TEST(NSBundle, MSAppxURL) {
-    LOG_INFO("MSAppxURL test: ");
+class NSBundleTests {
+public:
+    BEGIN_TEST_CLASS(NSBundleTests)
+    END_TEST_CLASS()
 
-    NSURL* resourceURL = [[NSBundle mainBundle] URLForResource:@"FunctionalTests" withExtension:@"dll"];
-    NSURL* msAppxURL = [[NSBundle mainBundle] _msAppxURLForResourceWithURL:resourceURL];
-    ASSERT_OBJCEQ([NSURL URLWithString:[@"ms-appx:///" stringByAppendingString:[resourceURL lastPathComponent]]], msAppxURL);
+    TEST_CLASS_SETUP(NSURLClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    WFUri* msAppxURI = [WFUri makeUri:msAppxURL.absoluteString];
+    TEST_METHOD_CLEANUP(NSBundleCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    // Verify that the file can be accessed
-    __block BOOL success = NO;
-    __block BOOL signaled = NO;
-    __block NSCondition* condition = [[NSCondition new] autorelease];
+    TEST_METHOD(MSAppxURL) {
+        LOG_INFO("MSAppxURL test: ");
 
-    [WSStorageFile getFileFromApplicationUriAsync:msAppxURI
-        success:^void(WSStorageFile* file) {
-            [condition lock];
-            success = YES;
-            signaled = YES;
-            [condition signal];
-            [condition unlock];
-        }
-        failure:^void(NSError* error) {
-            LOG_ERROR([[error description] UTF8String]);
-            [condition lock];
-            signaled = YES;
-            [condition signal];
-            [condition unlock];
-        }];
+        NSURL* resourceURL = [[NSBundle mainBundle] URLForResource:@"FunctionalTests" withExtension:@"dll"];
+        NSURL* msAppxURL = [[NSBundle mainBundle] _msAppxURLForResourceWithURL:resourceURL];
+        ASSERT_OBJCEQ([NSURL URLWithString:[@"ms-appx:///" stringByAppendingString:[resourceURL lastPathComponent]]], msAppxURL);
 
-    [condition lock];
-    ASSERT_TRUE (signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]]);
-    [condition unlock];
+        WFUri* msAppxURI = [WFUri makeUri:msAppxURL.absoluteString];
 
-    ASSERT_EQ(YES, success);
-}
+        // Verify that the file can be accessed
+        __block BOOL success = NO;
+        __block BOOL signaled = NO;
+        __block NSCondition* condition = [[NSCondition new] autorelease];
+
+        [WSStorageFile getFileFromApplicationUriAsync:msAppxURI
+            success:^void(WSStorageFile* file) {
+                [condition lock];
+                success = YES;
+                signaled = YES;
+                [condition signal];
+                [condition unlock];
+            }
+            failure:^void(NSError* error) {
+                LOG_ERROR([[error description] UTF8String]);
+                [condition lock];
+                signaled = YES;
+                [condition signal];
+                [condition unlock];
+            }];
+
+        [condition lock];
+        ASSERT_TRUE(signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]]);
+        [condition unlock];
+
+        ASSERT_EQ(YES, success);
+    }
+};

--- a/tests/functionaltests/Tests/NSLayoutConstraintTests.mm
+++ b/tests/functionaltests/Tests/NSLayoutConstraintTests.mm
@@ -30,174 +30,212 @@
     return os;
 }
 
-TEST(NSLayoutConstraint, VisualFormatLanguage) {
-    UIView* topLevelView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
-    UIView* leftView = [UIView new];
-    UIView* rightView = [UIView new];
+class NSLayoutConstraintTests {
+public:
+    BEGIN_TEST_CLASS(NSLayoutConstraintTests)
+    END_TEST_CLASS()
 
-    [topLevelView addSubview:leftView];
-    [topLevelView addSubview:rightView];
+    TEST_CLASS_SETUP(NSLayoutConstraintTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    NSDictionary* metrics = @{ @"metric1" : @750, @"metric2" : @20 };
+    TEST_METHOD_CLEANUP(NSLayoutConstraintTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    NSArray* layoutConstraints =
-        [NSLayoutConstraint constraintsWithVisualFormat:@"|-(>=10@metric1)-[leftView(rightView@1000)][rightView(metric2)]|"
-                                                options:0
-                                                metrics:metrics
-                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+    TEST_METHOD(VisualFormatLanguage) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* topLevelView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+            UIView* leftView = [UIView new];
+            UIView* rightView = [UIView new];
 
-    // Parse should be successful, and return a correct number of constraints.
-    ASSERT_TRUE_MSG(layoutConstraints, "constraintsWithVisualFormat returned nil!");
-    ASSERT_EQ_MSG(5, [layoutConstraints count], "constraintsWithVisualFormat returned incorrect number of constraints; returned constraints");
+            [topLevelView addSubview:leftView];
+            [topLevelView addSubview:rightView];
 
-    // Constraints should be returned in the order that they appear.
-    NSLayoutConstraint* constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:0];
-    ASSERT_EQ_MSG(750, constraint.priority, "Constraints out of order.");
-    constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:1];
-    ASSERT_EQ_MSG(NSLayoutAttributeWidth, constraint.firstAttribute, "Constraints out of order.");
-    constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:2];
-    ASSERT_EQ_MSG(constraint.firstItem, leftView, "Constraints out of order.");
-    ASSERT_EQ_MSG(constraint.secondItem, rightView, "Constraints out of order.");
-    constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:3];
-    ASSERT_EQ_MSG(20, constraint.constant, "Constraints out of order.");
-    constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:4];
-    ASSERT_EQ_MSG(0, constraint.constant, "Constraints out of order.");
+            NSDictionary* metrics = @{ @"metric1" : @750, @"metric2" : @20 };
 
-    // There are a few more modes of operation that aren't tested, since their operation is quite simple:
-    //   * Vertical layout
-    //   * NSLayoutFormat options
-    //   * Metrics (though used in the test already)
-}
+            NSArray* layoutConstraints =
+                [NSLayoutConstraint constraintsWithVisualFormat:@"|-(>=10@metric1)-[leftView(rightView@1000)][rightView(metric2)]|"
+                                                        options:0
+                                                        metrics:metrics
+                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-TEST(NSLayoutConstraint, VisualFormatLanguageSyntax) {
-    UIView* topLevelView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
-    UIView* leftView = [UIView new];
-    UIView* rightView = [UIView new];
-    UIView* danglingView = [UIView new];
+            // Parse should be successful, and return a correct number of constraints.
+            ASSERT_TRUE_MSG(layoutConstraints, "constraintsWithVisualFormat returned nil!");
+            ASSERT_EQ_MSG(5,
+                          [layoutConstraints count],
+                          "constraintsWithVisualFormat returned incorrect number of constraints; returned constraints");
 
-    [topLevelView addSubview:leftView];
-    [topLevelView addSubview:rightView];
+            // Constraints should be returned in the order that they appear.
+            NSLayoutConstraint* constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:0];
+            ASSERT_EQ_MSG(750, constraint.priority, "Constraints out of order.");
+            constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:1];
+            ASSERT_EQ_MSG(NSLayoutAttributeWidth, constraint.firstAttribute, "Constraints out of order.");
+            constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:2];
+            ASSERT_EQ_MSG(constraint.firstItem, leftView, "Constraints out of order.");
+            ASSERT_EQ_MSG(constraint.secondItem, rightView, "Constraints out of order.");
+            constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:3];
+            ASSERT_EQ_MSG(20, constraint.constant, "Constraints out of order.");
+            constraint = (NSLayoutConstraint*)[layoutConstraints objectAtIndex:4];
+            ASSERT_EQ_MSG(0, constraint.constant, "Constraints out of order.");
 
-    NSDictionary* metrics = @{ @"metric" : @1 };
+            // There are a few more modes of operation that aren't tested, since their operation is quite simple:
+            //   * Vertical layout
+            //   * NSLayoutFormat options
+            //   * Metrics (though used in the test already)
+        });
+    }
 
-    // Dangling view to (nonexistant) superview
-    NSArray* layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[danglingView]-|"
-                                                                         options:0
-                                                                         metrics:nil
-                                                                           views:NSDictionaryOfVariableBindings(danglingView)];
+    TEST_METHOD(VisualFormatLanguageSyntax) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* topLevelView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+            UIView* leftView = [UIView new];
+            UIView* rightView = [UIView new];
+            UIView* danglingView = [UIView new];
 
-    EXPECT_FALSE_MSG(layoutConstraints, "View with no superview; constraintWithVisualFormat shouldn't return constraints! Returned");
+            [topLevelView addSubview:leftView];
+            [topLevelView addSubview:rightView];
 
-    // Missing item in views
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[noView(20)]"
-                                                                options:0
-                                                                metrics:nil
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            NSDictionary* metrics = @{ @"metric" : @1 };
 
-    EXPECT_FALSE_MSG(layoutConstraints, "View missing from views; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Dangling view to (nonexistant) superview
+            NSArray* layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[danglingView]-|"
+                                                                                 options:0
+                                                                                 metrics:nil
+                                                                                   views:NSDictionaryOfVariableBindings(danglingView)];
 
-    // Missing item in views, but in metrics
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[metric(20)]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "View with no superview; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "View missing from views, but in metrics; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Missing item in views
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[noView(20)]"
+                                                                        options:0
+                                                                        metrics:nil
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    // Missing item in metrics, but in views
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20@rightView)]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "View missing from views; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "View missing from metrics, but in views; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Missing item in views, but in metrics
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[metric(20)]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    // Dangling constraint
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20)]-"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "View missing from views, but in metrics; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Constraint left dangling; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Missing item in metrics, but in views
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20@rightView)]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    // Extra parens
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView((20))]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "View missing from metrics, but in views; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Extra parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Dangling constraint
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20)]-"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView()(20)]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Constraint left dangling; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Extra parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Extra parens
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView((20))]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20)]()"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Extra parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Extra parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView()(20)]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    // Missing parens
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Extra parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Missing parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20)]()"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    // Priority out of bounds
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20@1001)]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Extra parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Priority out of bounds; constraintWithVisualFormat shouldn't return constraints! Returned");
+            // Missing parens
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20@-1)]"
-                                                                options:0
-                                                                metrics:metrics
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Missing parens in format; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    EXPECT_FALSE_MSG(layoutConstraints, "Priority out of bounds; constraintWithVisualFormat shouldn't return constraints! Returned");
-}
+            // Priority out of bounds
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20@1001)]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-TEST(NSLayoutConstraint, AddConstraints) {
-    UIView* topLevelView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
-    UIView* leftView = [UIView new];
-    UIView* rightView = [UIView new];
-    UIView* danglingView = [UIView new];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Priority out of bounds; constraintWithVisualFormat shouldn't return constraints! Returned");
 
-    [topLevelView addSubview:leftView];
-    [topLevelView addSubview:rightView];
+            layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[leftView(20@-1)]"
+                                                                        options:0
+                                                                        metrics:metrics
+                                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    NSArray* layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"|[leftView(rightView@1000)]-[rightView(10)]|"
-                                                                         options:0
-                                                                         metrics:nil
-                                                                           views:NSDictionaryOfVariableBindings(leftView, rightView)];
+            EXPECT_FALSE_MSG(layoutConstraints,
+                             "Priority out of bounds; constraintWithVisualFormat shouldn't return constraints! Returned");
+        });
+    }
 
-    ASSERT_TRUE_MSG(layoutConstraints, "constraintsWithVisualFormat returned nil!");
+    TEST_METHOD(AddConstraints) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* topLevelView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+            UIView* leftView = [UIView new];
+            UIView* rightView = [UIView new];
+            UIView* danglingView = [UIView new];
 
-    int numConstraints = [topLevelView.constraints count];
+            [topLevelView addSubview:leftView];
+            [topLevelView addSubview:rightView];
 
-    [topLevelView addConstraints:layoutConstraints];
+            NSArray* layoutConstraints =
+                [NSLayoutConstraint constraintsWithVisualFormat:@"|[leftView(rightView@1000)]-[rightView(10)]|"
+                                                        options:0
+                                                        metrics:nil
+                                                          views:NSDictionaryOfVariableBindings(leftView, rightView)];
 
-    EXPECT_EQ_MSG(numConstraints + [layoutConstraints count], [topLevelView.constraints count], "Not all constraints added to view");
+            ASSERT_TRUE_MSG(layoutConstraints, "constraintsWithVisualFormat returned nil!");
 
-    layoutConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"[rightView][danglingView]"
-                                                                options:0
-                                                                metrics:nil
-                                                                  views:NSDictionaryOfVariableBindings(leftView, rightView, danglingView)];
+            int numConstraints = [topLevelView.constraints count];
 
-    ASSERT_TRUE_MSG(layoutConstraints, "constraintsWithVisualFormat returned nil!");
+            [topLevelView addConstraints:layoutConstraints];
 
-    numConstraints = [topLevelView.constraints count];
+            EXPECT_EQ_MSG(numConstraints + [layoutConstraints count],
+                          [topLevelView.constraints count],
+                          "Not all constraints added to view");
 
-    [topLevelView addConstraints:layoutConstraints];
+            layoutConstraints =
+                [NSLayoutConstraint constraintsWithVisualFormat:@"[rightView][danglingView]"
+                                                        options:0
+                                                        metrics:nil
+                                                          views:NSDictionaryOfVariableBindings(leftView, rightView, danglingView)];
 
-    EXPECT_EQ_MSG(numConstraints, [topLevelView.constraints count], "Unrelated constraints added to view");
-}
+            ASSERT_TRUE_MSG(layoutConstraints, "constraintsWithVisualFormat returned nil!");
+
+            numConstraints = [topLevelView.constraints count];
+
+            [topLevelView addConstraints:layoutConstraints];
+
+            EXPECT_EQ_MSG(numConstraints, [topLevelView.constraints count], "Unrelated constraints added to view");
+        });
+    }
+};

--- a/tests/functionaltests/Tests/NSURLConnection.mm
+++ b/tests/functionaltests/Tests/NSURLConnection.mm
@@ -56,10 +56,9 @@ typedef NS_ENUM(NSInteger, NSURLConnectionDelegateType) {
 }
 
 - (void)connection:(NSURLConnection*)connection didReceiveResponse:(NSURLResponse*)response {
-    dispatch_sync(self.queue,
-                  ^{
-                      [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLConnectionDelegateDidReceiveResponse]];
-                  });
+    dispatch_sync(self.queue, ^{
+        [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLConnectionDelegateDidReceiveResponse]];
+    });
     [self.condition lock];
     self.response = response;
     [self.condition signal];
@@ -67,10 +66,9 @@ typedef NS_ENUM(NSInteger, NSURLConnectionDelegateType) {
 }
 
 - (void)connection:(NSURLConnection*)connection didReceiveData:(nonnull NSData*)data {
-    dispatch_sync(self.queue,
-                  ^{
-                      [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLConnectionDelegateDidReceiveData]];
-                  });
+    dispatch_sync(self.queue, ^{
+        [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLConnectionDelegateDidReceiveData]];
+    });
 
     [self.condition lock];
     self.data = data;
@@ -79,10 +77,9 @@ typedef NS_ENUM(NSInteger, NSURLConnectionDelegateType) {
 }
 
 - (void)connection:(NSURLConnection*)connection didFailWithError:(NSError*)e {
-    dispatch_sync(self.queue,
-                  ^{
-                      [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLConnectionDelegateDidFailWithError]];
-                  });
+    dispatch_sync(self.queue, ^{
+        [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLConnectionDelegateDidFailWithError]];
+    });
 
     [self.condition lock];
     self.error = e;
@@ -92,84 +89,100 @@ typedef NS_ENUM(NSInteger, NSURLConnectionDelegateType) {
 
 @end
 
-/**
- * Test to verify a request can be successfully made and a valid response and data is received.
- */
-TEST(NSURLConnection, RequestWithURL) {
-    NSURLConnectionTestHelper* connectionTestHelper = [[NSURLConnectionTestHelper alloc] init];
-    NSString* urlString = @"https://httpbin.org/cookies/set?winobjc=awesome";
-    LOG_INFO("Establishing download task with url %@", urlString);
-    NSURLConnection* connection = [connectionTestHelper createConnectionWithRequest:urlString];
-    [connection start];
+class NSURLConnectionTests {
+public:
+    BEGIN_TEST_CLASS(NSURLConnectionTests)
+    TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"NSURL.AppxManifest.xml")
+    END_TEST_CLASS()
 
-    // Wait for data.
-    [connectionTestHelper.condition lock];
-    for (int i = 0; (i < 5) && ([connectionTestHelper.delegateCallOrder count] != 2); i++) {
-        [connectionTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+    TEST_CLASS_SETUP(NSURLClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
-    ASSERT_EQ_MSG(2, [connectionTestHelper.delegateCallOrder count], "FAILED: We should have received two delegates call by now!");
-    [connectionTestHelper.condition unlock];
 
-    // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didReceiveResponse should be the first delegate to be called!");
-    ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
-    NSURLResponse* response = connectionTestHelper.response;
-    if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-        ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+    TEST_METHOD_CLEANUP(NSURLCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-    LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
-    ASSERT_EQ_MSG(200, [httpResponse statusCode], "FAILED: HTTP status 200 expected!");
-    LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
 
-    // Make sure we received data.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveData,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: didReceiveData should be the first delegate to be called!");
-    ASSERT_TRUE_MSG((connectionTestHelper.data != nil), "FAILED: We should have received some data!");
-    LOG_INFO("Received data: %@", [[NSString alloc] initWithData:connectionTestHelper.data encoding:NSUTF8StringEncoding]);
+    /**
+     * Test to verify a request can be successfully made and a valid response and data is received.
+     */
+    TEST_METHOD(RequestWithURL) {
+        NSURLConnectionTestHelper* connectionTestHelper = [[NSURLConnectionTestHelper alloc] init];
+        NSString* urlString = @"https://httpbin.org/cookies/set?winobjc=awesome";
+        LOG_INFO("Establishing download task with url %@", urlString);
+        NSURLConnection* connection = [connectionTestHelper createConnectionWithRequest:urlString];
+        [connection start];
 
-    // Make sure there was no error.
-    ASSERT_TRUE_MSG((connectionTestHelper.error == nil), "FAILED: Connection returned error %@!", connectionTestHelper.error);
-}
+        // Wait for data.
+        [connectionTestHelper.condition lock];
+        for (int i = 0; (i < 5) && ([connectionTestHelper.delegateCallOrder count] != 2); i++) {
+            [connectionTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        ASSERT_EQ_MSG(2, [connectionTestHelper.delegateCallOrder count], "FAILED: We should have received two delegates call by now!");
+        [connectionTestHelper.condition unlock];
 
-/**
- * Test to verify a request can be successfully made but no data was received and a valid response error code was received.
- */
-TEST(NSURLConnection, RequestWithURL_Failure) {
-    NSURLConnectionTestHelper* connectionTestHelper = [[NSURLConnectionTestHelper alloc] init];
-    NSString* urlString = @"https://httpbin.org/status/404";
-    LOG_INFO("Establishing download task with url %@", urlString);
-    NSURLConnection* connection = [connectionTestHelper createConnectionWithRequest:urlString];
-    [connection start];
+        // Make sure we received a response.
+        ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
+                      [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: didReceiveResponse should be the first delegate to be called!");
+        ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
+        NSURLResponse* response = connectionTestHelper.response;
+        if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+            ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+        }
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+        LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
+        ASSERT_EQ_MSG(200, [httpResponse statusCode], "FAILED: HTTP status 200 expected!");
+        LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
 
-    // Wait for a response.
-    [connectionTestHelper.condition lock];
+        // Make sure we received data.
+        ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveData,
+                      [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
+                      "FAILED: didReceiveData should be the first delegate to be called!");
+        ASSERT_TRUE_MSG((connectionTestHelper.data != nil), "FAILED: We should have received some data!");
+        LOG_INFO("Received data: %@", [[NSString alloc] initWithData:connectionTestHelper.data encoding:NSUTF8StringEncoding]);
 
-    for (int i = 0; (i < 5) && ([connectionTestHelper.delegateCallOrder count] != 1); i++) {
-        [connectionTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        // Make sure there was no error.
+        ASSERT_TRUE_MSG((connectionTestHelper.error == nil), "FAILED: Connection returned error %@!", connectionTestHelper.error);
     }
-    ASSERT_EQ_MSG(1, [connectionTestHelper.delegateCallOrder count], "FAILED: We should have received one delegate call by now!");
-    [connectionTestHelper.condition unlock];
 
-    // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didReceiveResponse should be the first delegate to be called!");
-    ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
-    NSURLResponse* response = connectionTestHelper.response;
-    if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-        ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+    /**
+     * Test to verify a request can be successfully made but no data was received and a valid response error code was received.
+     */
+    TEST_METHOD(RequestWithURL_Failure) {
+        NSURLConnectionTestHelper* connectionTestHelper = [[NSURLConnectionTestHelper alloc] init];
+        NSString* urlString = @"https://httpbin.org/status/404";
+        LOG_INFO("Establishing download task with url %@", urlString);
+        NSURLConnection* connection = [connectionTestHelper createConnectionWithRequest:urlString];
+        [connection start];
+
+        // Wait for a response.
+        [connectionTestHelper.condition lock];
+
+        for (int i = 0; (i < 5) && ([connectionTestHelper.delegateCallOrder count] != 1); i++) {
+            [connectionTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        ASSERT_EQ_MSG(1, [connectionTestHelper.delegateCallOrder count], "FAILED: We should have received one delegate call by now!");
+        [connectionTestHelper.condition unlock];
+
+        // Make sure we received a response.
+        ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
+                      [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: didReceiveResponse should be the first delegate to be called!");
+        ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
+        NSURLResponse* response = connectionTestHelper.response;
+        if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+            ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+        }
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+        LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
+        ASSERT_EQ_MSG(404, [httpResponse statusCode], "FAILED: HTTP status 404 was expected!");
+
+        // Make sure we did not receive any data.
+        ASSERT_TRUE_MSG((connectionTestHelper.data == nil), "FAILED: We should not have received any data!");
+
+        // Make sure there was no error.
+        ASSERT_TRUE_MSG((connectionTestHelper.error == nil), "FAILED: Connection returned error %@!", connectionTestHelper.error);
     }
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-    LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
-    ASSERT_EQ_MSG(404, [httpResponse statusCode], "FAILED: HTTP status 404 was expected!");
-
-    // Make sure we did not receive any data.
-    ASSERT_TRUE_MSG((connectionTestHelper.data == nil), "FAILED: We should not have received any data!");
-
-    // Make sure there was no error.
-    ASSERT_TRUE_MSG((connectionTestHelper.error == nil), "FAILED: Connection returned error %@!", connectionTestHelper.error);
-}
+};

--- a/tests/functionaltests/Tests/NSURLSession.mm
+++ b/tests/functionaltests/Tests/NSURLSession.mm
@@ -143,223 +143,6 @@ typedef NS_ENUM(NSInteger, NSURLSessionAllDelegateType) {
 
 @end
 
-/**
- * Test to verify a that two tasks do not have the same identifier.
- */
-TEST(NSURLSession, TaskIdentifiers) {
-    NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
-    NSURLSession* session = [dataTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"https://httpbin.org/cookies/set?Hello=World"];
-
-    NSURLSessionTask* dataTask = [session dataTaskWithURL:url];
-    NSURLSessionTask* downloadTask = [session downloadTaskWithURL:url];
-
-    ASSERT_NE(dataTask.taskIdentifier, downloadTask.taskIdentifier);
-}
-
-/**
- * Test to verify a data task call can be successfully made and a valid data is received without a completion handler
- */
-TEST(NSURLSession, DataTaskWithURL) {
-    NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
-    NSURLSession* session = [dataTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"https://httpbin.org/cookies/set?Hello=World"];
-    LOG_INFO("Establishing data task with url %@", url);
-    NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url];
-    [dataTask resume];
-
-    // Wait for data.
-    [dataTaskTestHelper.condition lock];
-    for (int i = 0; (i < 5) && ([dataTaskTestHelper.delegateCallOrder count] != 4); i++) {
-        [dataTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
-    }
-    [dataTaskTestHelper.condition unlock];
-    ASSERT_EQ_MSG(4, [dataTaskTestHelper.delegateCallOrder count], "FAILED: We should have received all four delegates call by now!");
-
-    // Make sure willPerformHTTPRedirection delegate was first called.
-    ASSERT_EQ_MSG(NSURLSessionDelegateWillPerformHTTPRedirection,
-                  [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: willPerformHTTPRedirection should be the first delegate to be called!");
-
-    // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLSessionDataDelegateDidReceiveResponse,
-                  [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: didReceiveResponse should be the second delegate to be called!");
-    ASSERT_TRUE_MSG((dataTaskTestHelper.response != nil), "FAILED: Response cannot be empty!");
-    NSURLResponse* response = dataTaskTestHelper.response;
-    if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-        ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
-    }
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-    LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
-    ASSERT_EQ_MSG(200, [httpResponse statusCode], "FAILED: HTTP status 200 expected!");
-    LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
-
-    // Make sure we received data.
-    ASSERT_EQ_MSG(NSURLSessionDataDelegateDidReceiveData,
-                  [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:2] integerValue],
-                  "FAILED: didReceiveData should be the third delegate to be called!");
-    ASSERT_TRUE_MSG((dataTaskTestHelper.data != nil), "FAILED: We should have received some data!");
-    LOG_INFO("Received data: %@", [[NSString alloc] initWithData:dataTaskTestHelper.data encoding:NSUTF8StringEncoding]);
-
-    // Make sure didCompleteWithError delegate was called last.
-    ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
-                  [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:3] integerValue],
-                  "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
-    // Make sure there was no error.
-    ASSERT_TRUE_MSG((dataTaskTestHelper.completedWithError == nil),
-                    "FAILED: Data task returned error %@!",
-                    dataTaskTestHelper.completedWithError);
-}
-
-/**
- * Test to verify a data task call can be successfully made without a completion handler but no data was received but a valid response
- * error code was received.
- */
-TEST(NSURLSession, DataTaskWithURL_Failure) {
-    NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
-    NSURLSession* session = [dataTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"https://httpbin.org/status/500"];
-    LOG_INFO("Establishing data task with url %@", url);
-    NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url];
-    [dataTask resume];
-
-    // Wait for data.
-    [dataTaskTestHelper.condition lock];
-    for (int i = 0; (i < 5) && ([dataTaskTestHelper.delegateCallOrder count] != 2); i++) {
-        [dataTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
-    }
-    [dataTaskTestHelper.condition unlock];
-
-    ASSERT_EQ_MSG(2, [dataTaskTestHelper.delegateCallOrder count], "FAILED: We should have received all two delegates call by now!");
-
-    // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLSessionDataDelegateDidReceiveResponse,
-                  [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didReceiveResponse should be the second delegate to be called!");
-    ASSERT_TRUE_MSG((dataTaskTestHelper.response != nil), "FAILED: Response cannot be empty!");
-    NSURLResponse* response = dataTaskTestHelper.response;
-    if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-        ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
-    }
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-    LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
-    ASSERT_EQ_MSG(500, [httpResponse statusCode], "FAILED: HTTP status 500 expected!");
-
-    // Make sure we did not receive any data.
-    ASSERT_TRUE_MSG((dataTaskTestHelper.data == nil), "FAILED: We should have not received any data!");
-
-    // Make sure didCompleteWithError delegate was called last.
-    ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
-                  [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
-    // Make sure there was no error.
-    ASSERT_TRUE_MSG((dataTaskTestHelper.completedWithError == nil),
-                    "FAILED: Data task returned error %@!",
-                    dataTaskTestHelper.completedWithError);
-}
-
-/**
- * Test to verify a data task call can be successfully made and a valid data is received with a completion handler
- */
-TEST(NSURLSession, DataTaskWithURL_WithCompletionHandler) {
-    __block NSCondition* condition = [[NSCondition alloc] init];
-    __block NSURLResponse* taskResponse;
-    __block NSData* taskData;
-    __block NSError* taskError;
-
-    NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
-    NSURLSession* session = [dataTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"https://httpbin.org/cookies/set?You=There"];
-    LOG_INFO("Establishing data task with url %@", url);
-    NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url
-                                            completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-                                                [condition lock];
-                                                taskResponse = response;
-                                                taskData = data;
-                                                taskError = error;
-                                                [condition signal];
-                                                [condition unlock];
-                                            }];
-    [dataTask resume];
-
-    // Wait for data.
-    [condition lock];
-    ASSERT_TRUE_MSG((taskResponse || taskData || taskError) ||
-                        [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
-                    "FAILED: Waiting for connection timed out!");
-    [condition unlock];
-
-    // Make sure we received a response.
-    ASSERT_TRUE_MSG((taskResponse != nil), "FAILED: Response cannot be empty!");
-    if (![taskResponse isKindOfClass:[NSHTTPURLResponse class]]) {
-        ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
-    }
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)taskResponse;
-    LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
-    ASSERT_EQ_MSG(200, [httpResponse statusCode], "FAILED: HTTP status 200 expected!");
-    LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
-
-    // Make sure we received data.
-    ASSERT_TRUE_MSG((taskData != nil), "FAILED: We should have received some data!");
-    LOG_INFO("Received data: %@", [[NSString alloc] initWithData:taskData encoding:NSUTF8StringEncoding]);
-
-    // Make sure there was no error.
-    ASSERT_EQ_MSG(nil, taskError, "FAILED: Task returned error!");
-}
-
-/**
- * Test to verify a data task call can be successfully made with a completion handler but no data was received but a valid response
- * error code was received.
- */
-TEST(NSURLSession, DataTaskWithURL_WithCompletionHandler_Failure) {
-    __block NSCondition* condition = [[NSCondition alloc] init];
-    __block NSURLResponse* taskResponse;
-    __block NSData* taskData;
-    __block NSError* taskError;
-
-    NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
-    NSURLSession* session = [dataTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"https://httpbin.org/status/403"];
-    LOG_INFO("Establishing data task with url %@", url);
-    NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url
-                                            completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-                                                [condition lock];
-                                                taskResponse = response;
-                                                taskData = data;
-                                                taskError = error;
-                                                [condition signal];
-                                                [condition unlock];
-                                            }];
-    [dataTask resume];
-
-    // Wait for data.
-    [condition lock];
-    ASSERT_TRUE_MSG((taskResponse || taskData || taskError) ||
-                        [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
-                    "FAILED: Waiting for connection timed out!");
-    [condition unlock];
-
-    // Make sure we received a response.
-    ASSERT_TRUE_MSG((taskResponse != nil), "FAILED: Response cannot be empty!");
-    if (![taskResponse isKindOfClass:[NSHTTPURLResponse class]]) {
-        ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
-    }
-    NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)taskResponse;
-    LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
-    ASSERT_EQ_MSG(403, [httpResponse statusCode], "FAILED: HTTP status 403 expected!");
-
-    // Make sure we did not receive any data.
-    ASSERT_TRUE_MSG((taskData == nil), "FAILED: We should not have received any data!");
-
-    // Make sure there was no error.
-    ASSERT_EQ_MSG(nil, taskError, "FAILED: Connection returned error!");
-}
-
-//
-// NSURLSessionDownloadTask tests
-//
-
 @interface NSURLSessionDownloadTaskTestHelper : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate> {
     dispatch_queue_t _queue;
     NSOperationQueue* _delegateQueue;
@@ -398,29 +181,33 @@ TEST(NSURLSession, DataTaskWithURL_WithCompletionHandler_Failure) {
 //
 // NSURLSessionDelegate
 //
-- (void)URLSession:(NSURLSession*)session didBecomeInvalidWithError:(NSError*)error {
-    // TODO::
-    // todo-nithishm-03312016 - Have tests for these.
-}
-
 - (void)URLSession:(NSURLSession*)session
-    didReceiveChallenge:(NSURLAuthenticationChallenge*)challenge
-      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential* credential))completionHandler {
-    // TODO::
-    // todo-nithishm-03312016 - Have tests for these.
-}
+                           didBecomeInvalidWithError:(NSError*)error{
+                               // TODO::
+                               // todo-nithishm-03312016 - Have tests for these.
+                           }
 
-- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession*)session {
-}
+                                                     - (void)
+                                          URLSession:(NSURLSession*)session
+                                 didReceiveChallenge:(NSURLAuthenticationChallenge*)challenge
+                                   completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
+                                                               NSURLCredential* credential))completionHandler{
+                                       // TODO::
+                                       // todo-nithishm-03312016 - Have tests for these.
+                                   }
 
-//
-// NSURLSessionTaskDelegate
-//
-- (void)URLSession:(NSURLSession*)session
-                          task:(NSURLSessionTask*)task
-    willPerformHTTPRedirection:(NSHTTPURLResponse*)response
-                    newRequest:(NSURLRequest*)request
-             completionHandler:(void (^)(NSURLRequest*))completionHandler {
+                                                     - (void)
+    URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession*)session{}
+
+                                                     //
+                                                     // NSURLSessionTaskDelegate
+                                                     //
+                                                     - (void)
+                                          URLSession:(NSURLSession*)session
+                                                task:(NSURLSessionTask*)task
+                          willPerformHTTPRedirection:(NSHTTPURLResponse*)response
+                                          newRequest:(NSURLRequest*)request
+                                   completionHandler:(void (^)(NSURLRequest*))completionHandler {
     [self.condition lock];
     dispatch_sync(_queue, ^{
         [self.delegateCallOrder addObject:[NSNumber numberWithInteger:NSURLSessionDelegateWillPerformHTTPRedirection]];
@@ -491,224 +278,476 @@ TEST(NSURLSession, DataTaskWithURL_WithCompletionHandler_Failure) {
 
 @end
 
-/**
- * Test to verify a download task call can be successfully made without a completion handler
- */
-TEST(NSURLSession, DownloadTaskWithURL) {
-    NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
-    NSURLSession* session = [downloadTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"http://speedtest.sea01.softlayer.com/downloads/test10.zip"];
-    LOG_INFO("Establishing download task with url %@", url);
-    NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url];
-    [downloadTask resume];
+class NSURLSessionTests {
+public:
+    BEGIN_TEST_CLASS(NSURLSessionTests)
+    TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"NSURL.AppxManifest.xml")
+    END_TEST_CLASS()
 
-    // Wait for download to complete.
-    [downloadTaskTestHelper.condition lock];
-    for (int i = 0; (i < 5) && ([downloadTaskTestHelper.delegateCallOrder count] != 3); i++) {
-        [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+    TEST_CLASS_SETUP(NSURLClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
-    [downloadTaskTestHelper.condition unlock];
-    ASSERT_EQ_MSG(3, [downloadTaskTestHelper.delegateCallOrder count], "FAILED: We should have received all three delegates call by now!");
 
-    // Make sure the download started.
-    ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidWriteData,
-                  [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didWriteData should be the first delegate to be called!");
-    double fileSizeInMB = (double)downloadTaskTestHelper.totalBytesExpectedToWrite / 1024 / 1024;
-    LOG_INFO("Downloaded file size is %fMB", fileSizeInMB);
-    ASSERT_EQ_MSG(11, std::lround(fileSizeInMB), "FAILED: Expected download file size does not match!");
-
-    // Make sure the didFinishDownloadingToURL got called.
-    ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidFinishDownloadingToURL,
-                  [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: didFinishDownloadingToURL should be the second delegate to be called!");
-
-    // Make sure didCompleteWithError delegate was called last.
-    ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
-                  [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:2] integerValue],
-                  "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
-    // Make sure there was no error.
-    ASSERT_TRUE_MSG((downloadTaskTestHelper.completedWithError == nil),
-                    "FAILED: Data task returned error %@!",
-                    downloadTaskTestHelper.completedWithError);
-}
-
-/**
- * Test to verify a download task call can be made without a completion handler
- */
-TEST(NSURLSession, DownloadTaskWithURL_Failure) {
-    NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
-    NSURLSession* session = [downloadTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"https://httpbin.org/status/401"];
-    LOG_INFO("Establishing download task with url %@", url);
-    NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url];
-    [downloadTask resume];
-
-    // Wait for download to complete.
-    [downloadTaskTestHelper.condition lock];
-    for (int i = 0; (i < 5) && ([downloadTaskTestHelper.delegateCallOrder count] != 2); i++) {
-        [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+    TEST_METHOD_CLEANUP(NSURLCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
-    [downloadTaskTestHelper.condition unlock];
-    ASSERT_EQ_MSG(2, [downloadTaskTestHelper.delegateCallOrder count], "FAILED: We should have received all two delegates call by now!");
 
-    ASSERT_EQ_MSG(0, downloadTaskTestHelper.totalBytesExpectedToWrite, "FAILED: Expected download file size to be ZERO!");
+    /**
+     * Test to verify a that two tasks do not have the same identifier.
+     */
+    TEST_METHOD(TaskIdentifiers) {
+        NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
+        NSURLSession* session = [dataTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"https://httpbin.org/cookies/set?Hello=World"];
 
-    // Make sure the didFinishDownloadingToURL got called first. We would never get didWriteData delegate called as the download URL we
-    // have passed in invalid.
-    ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidFinishDownloadingToURL,
-                  [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didFinishDownloadingToURL should be the second delegate to be called!");
+        NSURLSessionTask* dataTask = [session dataTaskWithURL:url];
+        NSURLSessionTask* downloadTask = [session downloadTaskWithURL:url];
 
-    // Make sure didCompleteWithError delegate was called last.
-    ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
-                  [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
-    // Make sure there was no error.
-    ASSERT_TRUE_MSG((downloadTaskTestHelper.completedWithError == nil),
-                    "FAILED: Download task returned error %@!",
-                    downloadTaskTestHelper.completedWithError);
-}
-
-/**
- * Test to verify a download task call can be successfully made with a completion handler
- */
-TEST(NSURLSession, DownloadTaskWithURL_WithCompletionHandler) {
-    __block NSCondition* condition = [[NSCondition alloc] init];
-    __block NSURLResponse* downloadResponse;
-    __block NSURL* downloadLocation;
-    __block NSError* downloadError;
-
-    NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
-    NSURLSession* session = [downloadTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"http://speedtest.sea01.softlayer.com/downloads/test10.zip"];
-    LOG_INFO("Establishing download task with url %@", url);
-    NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url
-                                                        completionHandler:^(NSURL* location, NSURLResponse* response, NSError* error) {
-                                                            [condition lock];
-                                                            downloadLocation = location;
-                                                            downloadResponse = response;
-                                                            downloadError = error;
-                                                            [condition signal];
-                                                            [condition unlock];
-                                                        }];
-    [downloadTask resume];
-
-    // Wait for download to complete.
-    [condition lock];
-    ASSERT_TRUE_MSG((downloadLocation || downloadResponse || downloadError) ||
-                        [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testDownloadTimeoutInSec]],
-                    "FAILED: Waiting for download timed out!");
-    [condition unlock];
-
-    // Make sure we get a download location.
-    ASSERT_TRUE_MSG((downloadLocation != nil), "FAILED: Downloaded location cannot be empty!");
-    LOG_INFO("File downloaded at location %@", downloadLocation);
-
-    // Make sure there was no error.
-    ASSERT_EQ_MSG(nil, downloadError, "FAILED: Download task returned error!");
-}
-
-inline int _GetLastDelegateCall(NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper) {
-    return [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:([downloadTaskTestHelper.delegateCallOrder count] - 1)]
-        integerValue];
-}
-
-/**
- * Test to verify a download task call can be successfully made and can be cancelled/resumed at runtime.
- */
-TEST(NSURLSession, DownloadTaskWithURL_WithCancelResume) {
-    NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
-    NSURLSession* session = [downloadTaskTestHelper createSession];
-    NSURL* url = [NSURL URLWithString:@"http://speedtest.ams01.softlayer.com/downloads/test500.zip"];
-    LOG_INFO("Establishing download task with url %@", url);
-    NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url];
-    [downloadTask resume];
-
-    // Wait for first delegate to be arrive.
-    [downloadTaskTestHelper.condition lock];
-    for (int i = 0; (i < 5) && ([downloadTaskTestHelper.delegateCallOrder count] != 1); i++) {
-        [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        ASSERT_NE(dataTask.taskIdentifier, downloadTask.taskIdentifier);
     }
-    [downloadTaskTestHelper.condition unlock];
-    ASSERT_EQ_MSG(1, [downloadTaskTestHelper.delegateCallOrder count], "FAILED: We should have received a delegate call by now!");
 
-    // Make sure the download started.
-    ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidWriteData,
-                  [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didWriteData should be the first delegate to be called!");
-    double fileSizeInMB = (double)downloadTaskTestHelper.totalBytesExpectedToWrite / 1024 / 1024;
-    LOG_INFO("Downloaded file size is %fMB", fileSizeInMB);
-    ASSERT_EQ_MSG(500, std::lround(fileSizeInMB), "FAILED: Expected download file size does not match!");
+    /**
+     * Test to verify a data task call can be successfully made and a valid data is received without a completion handler
+     */
+    TEST_METHOD(DataTaskWithURL) {
+        NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
+        NSURLSession* session = [dataTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"https://httpbin.org/cookies/set?Hello=World"];
+        LOG_INFO("Establishing data task with url %@", url);
+        NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url];
+        [dataTask resume];
 
-    // Make sure download is in progress.
-    double lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    LOG_INFO("Download in progress - %fMB", lastBytesDownloaded);
-    [NSThread sleepForTimeInterval:0.5];
-    double currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
-    ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
-    [NSThread sleepForTimeInterval:0.5];
-    lastBytesDownloaded = currentBytesDownloaded;
-    currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
-    ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
+        // Wait for data.
+        [dataTaskTestHelper.condition lock];
+        for (int i = 0; (i < 5) && ([dataTaskTestHelper.delegateCallOrder count] != 4); i++) {
+            [dataTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        [dataTaskTestHelper.condition unlock];
+        ASSERT_EQ_MSG(4, [dataTaskTestHelper.delegateCallOrder count], "FAILED: We should have received all four delegates call by now!");
 
-    // Now cancel the download
-    __block NSCondition* conditionCancelled = [[NSCondition alloc] init];
-    __block NSData* downloadResumeData = nil;
-    LOG_INFO("Cancelling download...");
-    [downloadTask cancelByProducingResumeData:^(NSData* resumeData) {
+        // Make sure willPerformHTTPRedirection delegate was first called.
+        ASSERT_EQ_MSG(NSURLSessionDelegateWillPerformHTTPRedirection,
+                      [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: willPerformHTTPRedirection should be the first delegate to be called!");
+
+        // Make sure we received a response.
+        ASSERT_EQ_MSG(NSURLSessionDataDelegateDidReceiveResponse,
+                      [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
+                      "FAILED: didReceiveResponse should be the second delegate to be called!");
+        ASSERT_TRUE_MSG((dataTaskTestHelper.response != nil), "FAILED: Response cannot be empty!");
+        NSURLResponse* response = dataTaskTestHelper.response;
+        if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+            ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+        }
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+        LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
+        ASSERT_EQ_MSG(200, [httpResponse statusCode], "FAILED: HTTP status 200 expected!");
+        LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
+
+        // Make sure we received data.
+        ASSERT_EQ_MSG(NSURLSessionDataDelegateDidReceiveData,
+                      [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:2] integerValue],
+                      "FAILED: didReceiveData should be the third delegate to be called!");
+        ASSERT_TRUE_MSG((dataTaskTestHelper.data != nil), "FAILED: We should have received some data!");
+        LOG_INFO("Received data: %@", [[NSString alloc] initWithData:dataTaskTestHelper.data encoding:NSUTF8StringEncoding]);
+
+        // Make sure didCompleteWithError delegate was called last.
+        ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
+                      [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:3] integerValue],
+                      "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
+        // Make sure there was no error.
+        ASSERT_TRUE_MSG((dataTaskTestHelper.completedWithError == nil),
+                        "FAILED: Data task returned error %@!",
+                        dataTaskTestHelper.completedWithError);
+    }
+
+    /**
+     * Test to verify a data task call can be successfully made without a completion handler but no data was received but a valid response
+     * error code was received.
+     */
+    TEST_METHOD(DataTaskWithURL_Failure) {
+        NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
+        NSURLSession* session = [dataTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"https://httpbin.org/status/500"];
+        LOG_INFO("Establishing data task with url %@", url);
+        NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url];
+        [dataTask resume];
+
+        // Wait for data.
+        [dataTaskTestHelper.condition lock];
+        for (int i = 0; (i < 5) && ([dataTaskTestHelper.delegateCallOrder count] != 2); i++) {
+            [dataTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        [dataTaskTestHelper.condition unlock];
+
+        ASSERT_EQ_MSG(2, [dataTaskTestHelper.delegateCallOrder count], "FAILED: We should have received all two delegates call by now!");
+
+        // Make sure we received a response.
+        ASSERT_EQ_MSG(NSURLSessionDataDelegateDidReceiveResponse,
+                      [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: didReceiveResponse should be the second delegate to be called!");
+        ASSERT_TRUE_MSG((dataTaskTestHelper.response != nil), "FAILED: Response cannot be empty!");
+        NSURLResponse* response = dataTaskTestHelper.response;
+        if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+            ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+        }
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+        LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
+        ASSERT_EQ_MSG(500, [httpResponse statusCode], "FAILED: HTTP status 500 expected!");
+
+        // Make sure we did not receive any data.
+        ASSERT_TRUE_MSG((dataTaskTestHelper.data == nil), "FAILED: We should have not received any data!");
+
+        // Make sure didCompleteWithError delegate was called last.
+        ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
+                      [(NSNumber*)[dataTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
+                      "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
+        // Make sure there was no error.
+        ASSERT_TRUE_MSG((dataTaskTestHelper.completedWithError == nil),
+                        "FAILED: Data task returned error %@!",
+                        dataTaskTestHelper.completedWithError);
+    }
+
+    /**
+     * Test to verify a data task call can be successfully made and a valid data is received with a completion handler
+     */
+    TEST_METHOD(DataTaskWithURL_WithCompletionHandler) {
+        __block NSCondition* condition = [[NSCondition alloc] init];
+        __block NSURLResponse* taskResponse;
+        __block NSData* taskData;
+        __block NSError* taskError;
+
+        NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
+        NSURLSession* session = [dataTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"https://httpbin.org/cookies/set?You=There"];
+        LOG_INFO("Establishing data task with url %@", url);
+        NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url
+                                                completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+                                                    [condition lock];
+                                                    taskResponse = response;
+                                                    taskData = data;
+                                                    taskError = error;
+                                                    [condition signal];
+                                                    [condition unlock];
+                                                }];
+        [dataTask resume];
+
+        // Wait for data.
+        [condition lock];
+        ASSERT_TRUE_MSG((taskResponse || taskData || taskError) ||
+                            [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for connection timed out!");
+        [condition unlock];
+
+        // Make sure we received a response.
+        ASSERT_TRUE_MSG((taskResponse != nil), "FAILED: Response cannot be empty!");
+        if (![taskResponse isKindOfClass:[NSHTTPURLResponse class]]) {
+            ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+        }
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)taskResponse;
+        LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
+        ASSERT_EQ_MSG(200, [httpResponse statusCode], "FAILED: HTTP status 200 expected!");
+        LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
+
+        // Make sure we received data.
+        ASSERT_TRUE_MSG((taskData != nil), "FAILED: We should have received some data!");
+        LOG_INFO("Received data: %@", [[NSString alloc] initWithData:taskData encoding:NSUTF8StringEncoding]);
+
+        // Make sure there was no error.
+        ASSERT_EQ_MSG(nil, taskError, "FAILED: Task returned error!");
+    }
+
+    /**
+     * Test to verify a data task call can be successfully made with a completion handler but no data was received but a valid response
+     * error code was received.
+     */
+    TEST_METHOD(DataTaskWithURL_WithCompletionHandler_Failure) {
+        __block NSCondition* condition = [[NSCondition alloc] init];
+        __block NSURLResponse* taskResponse;
+        __block NSData* taskData;
+        __block NSError* taskError;
+
+        NSURLSessionDataTaskTestHelper* dataTaskTestHelper = [[NSURLSessionDataTaskTestHelper alloc] init];
+        NSURLSession* session = [dataTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"https://httpbin.org/status/403"];
+        LOG_INFO("Establishing data task with url %@", url);
+        NSURLSessionDataTask* dataTask = [session dataTaskWithURL:url
+                                                completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+                                                    [condition lock];
+                                                    taskResponse = response;
+                                                    taskData = data;
+                                                    taskError = error;
+                                                    [condition signal];
+                                                    [condition unlock];
+                                                }];
+        [dataTask resume];
+
+        // Wait for data.
+        [condition lock];
+        ASSERT_TRUE_MSG((taskResponse || taskData || taskError) ||
+                            [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for connection timed out!");
+        [condition unlock];
+
+        // Make sure we received a response.
+        ASSERT_TRUE_MSG((taskResponse != nil), "FAILED: Response cannot be empty!");
+        if (![taskResponse isKindOfClass:[NSHTTPURLResponse class]]) {
+            ASSERT_FALSE_MSG(true, "FAILED: Response should be of kind NSHTTPURLResponse class!");
+        }
+        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)taskResponse;
+        LOG_INFO("Received HTTP response status: %ld", [httpResponse statusCode]);
+        ASSERT_EQ_MSG(403, [httpResponse statusCode], "FAILED: HTTP status 403 expected!");
+
+        // Make sure we did not receive any data.
+        ASSERT_TRUE_MSG((taskData == nil), "FAILED: We should not have received any data!");
+
+        // Make sure there was no error.
+        ASSERT_EQ_MSG(nil, taskError, "FAILED: Connection returned error!");
+    }
+
+    //
+    // NSURLSessionDownloadTask tests
+    //
+
+    /**
+     * Test to verify a download task call can be successfully made without a completion handler
+     */
+    TEST_METHOD(DownloadTaskWithURL) {
+// Disable Test on ARM as it tries to hit a real endpoint and download significant data
+// and arm machines may not have a stable ethernet connection like a build server does.
+#ifdef _M_ARM
+        BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"ignore", L"true")
+        END_TEST_METHOD_PROPERTIES()
+#endif
+
+        NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
+        NSURLSession* session = [downloadTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"http://speedtest.sea01.softlayer.com/downloads/test10.zip"];
+        LOG_INFO("Establishing download task with url %@", url);
+        NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url];
+        [downloadTask resume];
+
+        // Wait for download to complete.
+        [downloadTaskTestHelper.condition lock];
+        for (int i = 0; (i < 5) && ([downloadTaskTestHelper.delegateCallOrder count] != 3); i++) {
+            [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        [downloadTaskTestHelper.condition unlock];
+        ASSERT_EQ_MSG(3,
+                      [downloadTaskTestHelper.delegateCallOrder count],
+                      "FAILED: We should have received all three delegates call by now!");
+
+        // Make sure the download started.
+        ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidWriteData,
+                      [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: didWriteData should be the first delegate to be called!");
+        double fileSizeInMB = (double)downloadTaskTestHelper.totalBytesExpectedToWrite / 1024 / 1024;
+        LOG_INFO("Downloaded file size is %fMB", fileSizeInMB);
+        ASSERT_EQ_MSG(11, std::lround(fileSizeInMB), "FAILED: Expected download file size does not match!");
+
+        // Make sure the didFinishDownloadingToURL got called.
+        ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidFinishDownloadingToURL,
+                      [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
+                      "FAILED: didFinishDownloadingToURL should be the second delegate to be called!");
+
+        // Make sure didCompleteWithError delegate was called last.
+        ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
+                      [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:2] integerValue],
+                      "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
+        // Make sure there was no error.
+        ASSERT_TRUE_MSG((downloadTaskTestHelper.completedWithError == nil),
+                        "FAILED: Data task returned error %@!",
+                        downloadTaskTestHelper.completedWithError);
+    }
+
+    /**
+     * Test to verify a download task call can be made without a completion handler
+     */
+    TEST_METHOD(DownloadTaskWithURL_Failure) {
+        NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
+        NSURLSession* session = [downloadTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"https://httpbin.org/status/401"];
+        LOG_INFO("Establishing download task with url %@", url);
+        NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url];
+        [downloadTask resume];
+
+        // Wait for download to complete.
+        [downloadTaskTestHelper.condition lock];
+        for (int i = 0; (i < 5) && ([downloadTaskTestHelper.delegateCallOrder count] != 2); i++) {
+            [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        [downloadTaskTestHelper.condition unlock];
+        ASSERT_EQ_MSG(2,
+                      [downloadTaskTestHelper.delegateCallOrder count],
+                      "FAILED: We should have received all two delegates call by now!");
+
+        ASSERT_EQ_MSG(0, downloadTaskTestHelper.totalBytesExpectedToWrite, "FAILED: Expected download file size to be ZERO!");
+
+        // Make sure the didFinishDownloadingToURL got called first. We would never get didWriteData delegate called as the download URL we
+        // have passed in invalid.
+        ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidFinishDownloadingToURL,
+                      [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: didFinishDownloadingToURL should be the second delegate to be called!");
+
+        // Make sure didCompleteWithError delegate was called last.
+        ASSERT_EQ_MSG(NSURLSessionDelegateDidCompleteWithError,
+                      [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
+                      "FAILED: willPerformHTTPRedirection should be the last delegate to be called!");
+        // Make sure there was no error.
+        ASSERT_TRUE_MSG((downloadTaskTestHelper.completedWithError == nil),
+                        "FAILED: Download task returned error %@!",
+                        downloadTaskTestHelper.completedWithError);
+    }
+
+    /**
+     * Test to verify a download task call can be successfully made with a completion handler
+     */
+    TEST_METHOD(DownloadTaskWithURL_WithCompletionHandler) {
+// Disable Test on ARM as it tries to hit a real endpoint and download significant data
+// and arm machines may not have a stable ethernet connection like a build server does.
+#ifdef _M_ARM
+        BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"ignore", L"true")
+        END_TEST_METHOD_PROPERTIES()
+#endif
+        __block NSCondition* condition = [[NSCondition alloc] init];
+        __block NSURLResponse* downloadResponse;
+        __block NSURL* downloadLocation;
+        __block NSError* downloadError;
+
+        NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
+        NSURLSession* session = [downloadTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"http://speedtest.sea01.softlayer.com/downloads/test10.zip"];
+        LOG_INFO("Establishing download task with url %@", url);
+        NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url
+                                                            completionHandler:^(NSURL* location, NSURLResponse* response, NSError* error) {
+                                                                [condition lock];
+                                                                downloadLocation = location;
+                                                                downloadResponse = response;
+                                                                downloadError = error;
+                                                                [condition signal];
+                                                                [condition unlock];
+                                                            }];
+        [downloadTask resume];
+
+        // Wait for download to complete.
+        [condition lock];
+        ASSERT_TRUE_MSG((downloadLocation || downloadResponse || downloadError) ||
+                            [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testDownloadTimeoutInSec]],
+                        "FAILED: Waiting for download timed out!");
+        [condition unlock];
+
+        // Make sure we get a download location.
+        ASSERT_TRUE_MSG((downloadLocation != nil), "FAILED: Downloaded location cannot be empty!");
+        LOG_INFO("File downloaded at location %@", downloadLocation);
+
+        // Make sure there was no error.
+        ASSERT_EQ_MSG(nil, downloadError, "FAILED: Download task returned error!");
+    }
+
+    inline int _GetLastDelegateCall(NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper) {
+        return [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:([downloadTaskTestHelper.delegateCallOrder count] - 1)]
+            integerValue];
+    }
+
+    /**
+     * Test to verify a download task call can be successfully made and can be cancelled/resumed at runtime.
+     */
+    TEST_METHOD(DownloadTaskWithURL_WithCancelResume) {
+        NSURLSessionDownloadTaskTestHelper* downloadTaskTestHelper = [[NSURLSessionDownloadTaskTestHelper alloc] init];
+        NSURLSession* session = [downloadTaskTestHelper createSession];
+        NSURL* url = [NSURL URLWithString:@"http://speedtest.ams01.softlayer.com/downloads/test500.zip"];
+        LOG_INFO("Establishing download task with url %@", url);
+        NSURLSessionDownloadTask* downloadTask = [session downloadTaskWithURL:url];
+        [downloadTask resume];
+
+        // Wait for first delegate to be arrive.
+        [downloadTaskTestHelper.condition lock];
+        for (int i = 0; (i < 5) && ([downloadTaskTestHelper.delegateCallOrder count] != 1); i++) {
+            [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        [downloadTaskTestHelper.condition unlock];
+        ASSERT_EQ_MSG(1, [downloadTaskTestHelper.delegateCallOrder count], "FAILED: We should have received a delegate call by now!");
+
+        // Make sure the download started.
+        ASSERT_EQ_MSG(NSURLSessionDownloadDelegateDidWriteData,
+                      [(NSNumber*)[downloadTaskTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
+                      "FAILED: didWriteData should be the first delegate to be called!");
+        double fileSizeInMB = (double)downloadTaskTestHelper.totalBytesExpectedToWrite / 1024 / 1024;
+        LOG_INFO("Downloaded file size is %fMB", fileSizeInMB);
+        ASSERT_EQ_MSG(500, std::lround(fileSizeInMB), "FAILED: Expected download file size does not match!");
+
+        // Make sure download is in progress.
+        double lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        LOG_INFO("Download in progress - %fMB", lastBytesDownloaded);
+        [NSThread sleepForTimeInterval:0.5];
+        double currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
+        ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
+        [NSThread sleepForTimeInterval:0.5];
+        lastBytesDownloaded = currentBytesDownloaded;
+        currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
+        ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
+
+        // Now cancel the download
+        __block NSCondition* conditionCancelled = [[NSCondition alloc] init];
+        __block NSData* downloadResumeData = nil;
+        LOG_INFO("Cancelling download...");
+        [downloadTask cancelByProducingResumeData:^(NSData* resumeData) {
+            [conditionCancelled lock];
+            downloadResumeData = resumeData;
+            [conditionCancelled signal];
+            [conditionCancelled unlock];
+            LOG_INFO("Download cancelled");
+        }];
+
+        // Wait for the task to be cancelled.
         [conditionCancelled lock];
-        downloadResumeData = resumeData;
-        [conditionCancelled signal];
+        ASSERT_TRUE_MSG(downloadResumeData || [conditionCancelled waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for download timed out!");
         [conditionCancelled unlock];
-        LOG_INFO("Download cancelled");
-    }];
 
-    // Wait for the task to be cancelled.
-    [conditionCancelled lock];
-    ASSERT_TRUE_MSG(downloadResumeData || [conditionCancelled waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
-                    "FAILED: Waiting for download timed out!");
-    [conditionCancelled unlock];
+        // Make sure download has stopped.
+        lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        [NSThread sleepForTimeInterval:0.5];
+        currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        ASSERT_EQ_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should have stopped!");
+        [NSThread sleepForTimeInterval:1];
+        lastBytesDownloaded = currentBytesDownloaded;
+        currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        ASSERT_EQ_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should have stopped!");
+        LOG_INFO("Download stuck at - %fMB", currentBytesDownloaded);
 
-    // Make sure download has stopped.
-    lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    [NSThread sleepForTimeInterval:0.5];
-    currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    ASSERT_EQ_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should have stopped!");
-    [NSThread sleepForTimeInterval:1];
-    lastBytesDownloaded = currentBytesDownloaded;
-    currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    ASSERT_EQ_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should have stopped!");
-    LOG_INFO("Download stuck at - %fMB", currentBytesDownloaded);
+        LOG_INFO("Resuming download...");
+        // Now resume the download
+        downloadTask = [session downloadTaskWithResumeData:downloadResumeData];
+        [downloadTask resume];
 
-    LOG_INFO("Resuming download...");
-    // Now resume the download
-    downloadTask = [session downloadTaskWithResumeData:downloadResumeData];
-    [downloadTask resume];
+        // Wait for resume delegate.
+        [downloadTaskTestHelper.condition lock];
+        int i = 0;
+        for (i = 0; (i < 5) && (NSURLSessionDownloadDelegateDidResumeAtOffset != _GetLastDelegateCall(downloadTaskTestHelper)); i++) {
+            [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        }
+        ASSERT_NE(i, 5);
+        [downloadTaskTestHelper.condition unlock];
 
-    // Wait for resume delegate.
-    [downloadTaskTestHelper.condition lock];
-    int i = 0;
-    for (i = 0; (i < 5) && (NSURLSessionDownloadDelegateDidResumeAtOffset != _GetLastDelegateCall(downloadTaskTestHelper)); i++) {
-        [downloadTaskTestHelper.condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]];
+        LOG_INFO("Download resumed");
+
+        // Make sure download is in progress again.
+        lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        LOG_INFO("Download in progress - %fMB", lastBytesDownloaded);
+        [NSThread sleepForTimeInterval:0.5];
+        currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
+        ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
+        [NSThread sleepForTimeInterval:0.5];
+        lastBytesDownloaded = currentBytesDownloaded;
+        currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
+        LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
+        ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
     }
-    ASSERT_NE(i, 5);
-    [downloadTaskTestHelper.condition unlock];
-
-    LOG_INFO("Download resumed");
-
-    // Make sure download is in progress again.
-    lastBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    LOG_INFO("Download in progress - %fMB", lastBytesDownloaded);
-    [NSThread sleepForTimeInterval:0.5];
-    currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
-    ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
-    [NSThread sleepForTimeInterval:0.5];
-    lastBytesDownloaded = currentBytesDownloaded;
-    currentBytesDownloaded = (double)downloadTaskTestHelper.totalBytesWritten / 1024 / 1024;
-    LOG_INFO("Download in progress - %fMB", currentBytesDownloaded);
-    ASSERT_GT_MSG(currentBytesDownloaded, lastBytesDownloaded, "FAILED: File download should be in progress!");
-}
+};

--- a/tests/functionaltests/Tests/NSURLStorageFileTests.mm
+++ b/tests/functionaltests/Tests/NSURLStorageFileTests.mm
@@ -20,82 +20,102 @@
 #import <UWP/WindowsFoundation.h>
 #import <UWP/WindowsStorage.h>
 
-TEST(NSURL, StorageFileURL) {
-    
-    // First up is to make a storage file for something. Lets create a new file and use that.
-    __block WSStorageFile* storageFile = nil;
-    __block bool signaled = false;
-    __block NSCondition* condition = [NSCondition new];
+//
+// NSURLStorageFileTests
+//
+extern void NSURLStorageFileURL();
 
-    [[[WSApplicationData current] localFolder] createFileAsync:@"tempStorageFile.txt" options:WSCreationCollisionOptionOpenIfExists 
-        success:^void(WSStorageFile* file) {
-           storageFile = file;
-           [condition lock];
-           signaled = true;
-           [condition signal];
-           [condition unlock];
-         }
+class NSURLStorageFileTests {
+public:
+    BEGIN_TEST_CLASS(NSURLStorageFileTests)
+    END_TEST_CLASS()
 
-         failure:^void(NSError* error) {
-            LOG_ERROR([[error description] UTF8String]);
-           [condition lock];
-           signaled = true;
-           [condition signal];
-           [condition unlock];
-         }];
+    TEST_CLASS_SETUP(NSURLStorageFileTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    [condition lock];
-    ASSERT_TRUE(signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]]);
-    [condition unlock];
+    TEST_METHOD_CLEANUP(NSURLStorageFileTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    ASSERT_TRUE(nil != storageFile);
+    TEST_METHOD(StorageFileURL) {
+        // First up is to make a storage file for something. Lets create a new file and use that.
+        __block WSStorageFile* storageFile = nil;
+        __block bool signaled = false;
+        __block NSCondition* condition = [NSCondition new];
 
-    WSStorageFile* lambdaStorageFile = storageFile; 
+        [[[WSApplicationData current] localFolder] createFileAsync:@"tempStorageFile.txt"
+            options:WSCreationCollisionOptionOpenIfExists
+            success:^void(WSStorageFile* file) {
+                storageFile = file;
+                [condition lock];
+                signaled = true;
+                [condition signal];
+                [condition unlock];
+            }
 
-    // Now that a storage file is created. Lets make sure we delete it in case of test failure.
-    auto deleter = wil::ScopeExit([&lambdaStorageFile]() {
-        __block NSCondition* deleterCondition = [NSCondition new];
-        __block bool deleterSignaled = false;
-        [[lambdaStorageFile deleteAsyncOverloadDefaultOptions] setCompleted:^void(RTObject<WFIAsyncAction>* asyncInfo, WFAsyncStatus asyncStatus) {
-           [deleterCondition lock];
-           deleterSignaled = true;
-           [deleterCondition signal];
-           [deleterCondition unlock];
-         }];
+            failure:^void(NSError* error) {
+                LOG_ERROR([[error description] UTF8String]);
+                [condition lock];
+                signaled = true;
+                [condition signal];
+                [condition unlock];
+            }];
 
-        [deleterCondition lock];
-        ASSERT_TRUE(deleterSignaled || [deleterCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]]);
-        [deleterCondition unlock];
-    });
+        [condition lock];
+        ASSERT_TRUE(signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]]);
+        [condition unlock];
 
-    // Ok all the logistics are taken care of. Lets get to work on the meat of the test. mmmmm URLs.
-    NSURL* storageUrl = [NSURL URLWithStorageFile:storageFile];
+        ASSERT_TRUE(nil != storageFile);
 
-    // Lets write some data!!!!
-    unsigned char rawDataToWrite[] = { 'a', 'b', 'c' };
-    NSData* writeData = [NSData dataWithBytesNoCopy:rawDataToWrite length:_countof(rawDataToWrite) freeWhenDone:NO];
-    ASSERT_TRUE([writeData writeToURL:storageUrl options:0 error:nil]);
+        WSStorageFile* lambdaStorageFile = storageFile;
 
-    // Ok now lets read it out!!!
-    NSData* readData = [NSData dataWithContentsOfURL:storageUrl];
-    ASSERT_TRUE([readData isEqual:writeData]);
+        // Now that a storage file is created. Lets make sure we delete it in case of test failure.
+        auto deleter = wil::ScopeExit([&lambdaStorageFile]() {
+            __block NSCondition* deleterCondition = [NSCondition new];
+            __block bool deleterSignaled = false;
+            [[lambdaStorageFile deleteAsyncOverloadDefaultOptions]
+                setCompleted:^void(RTObject<WFIAsyncAction>* asyncInfo, WFAsyncStatus asyncStatus) {
+                    [deleterCondition lock];
+                    deleterSignaled = true;
+                    [deleterCondition signal];
+                    [deleterCondition unlock];
+                }];
 
-    // Try writing different data!!!
-    unsigned char rawDataToWrite2[] = { 'e', 'f', 'g' };
-    writeData = [NSData dataWithBytesNoCopy:rawDataToWrite2 length:_countof(rawDataToWrite2) freeWhenDone:NO];
-    ASSERT_TRUE([writeData writeToURL:storageUrl options:0 error:nil]);
+            [deleterCondition lock];
+            ASSERT_TRUE(deleterSignaled || [deleterCondition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:10]]);
+            [deleterCondition unlock];
+        });
 
-    readData = [NSData dataWithContentsOfURL:storageUrl];
-    ASSERT_TRUE([readData isEqual:writeData]);
+        // Ok all the logistics are taken care of. Lets get to work on the meat of the test. mmmmm URLs.
+        NSURL* storageUrl = [NSURL URLWithStorageFile:storageFile];
 
-    // Now with appending!
-    writeData = [NSData dataWithBytesNoCopy:rawDataToWrite length:_countof(rawDataToWrite) freeWhenDone:NO];
-    ASSERT_TRUE([writeData writeToURL:storageUrl options:NSDataWritingWithoutOverwriting error:nil]);
+        // Lets write some data!!!!
+        unsigned char rawDataToWrite[] = { 'a', 'b', 'c' };
+        NSData* writeData = [NSData dataWithBytesNoCopy:rawDataToWrite length:_countof(rawDataToWrite) freeWhenDone:NO];
+        ASSERT_TRUE([writeData writeToURL:storageUrl options:0 error:nil]);
 
+        // Ok now lets read it out!!!
+        NSData* readData = [NSData dataWithContentsOfURL:storageUrl];
+        ASSERT_TRUE([readData isEqual:writeData]);
 
-    unsigned char rawDataToValidate[] = { 'e', 'f', 'g', 'a', 'b', 'c'}; 
-    NSData* appendData = [NSData dataWithBytesNoCopy:rawDataToValidate length:_countof(rawDataToValidate) freeWhenDone:NO];
+        // Try writing different data!!!
+        unsigned char rawDataToWrite2[] = { 'e', 'f', 'g' };
+        writeData = [NSData dataWithBytesNoCopy:rawDataToWrite2 length:_countof(rawDataToWrite2) freeWhenDone:NO];
+        ASSERT_TRUE([writeData writeToURL:storageUrl options:0 error:nil]);
 
-    readData = [NSData dataWithContentsOfURL:storageUrl];
-    ASSERT_TRUE([readData isEqual:appendData]);
-}
+        readData = [NSData dataWithContentsOfURL:storageUrl];
+        ASSERT_TRUE([readData isEqual:writeData]);
+
+        // Now with appending!
+        writeData = [NSData dataWithBytesNoCopy:rawDataToWrite length:_countof(rawDataToWrite) freeWhenDone:NO];
+        ASSERT_TRUE([writeData writeToURL:storageUrl options:NSDataWritingWithoutOverwriting error:nil]);
+
+        unsigned char rawDataToValidate[] = { 'e', 'f', 'g', 'a', 'b', 'c' };
+        NSData* appendData = [NSData dataWithBytesNoCopy:rawDataToValidate length:_countof(rawDataToValidate) freeWhenDone:NO];
+
+        readData = [NSData dataWithContentsOfURL:storageUrl];
+        ASSERT_TRUE([readData isEqual:appendData]);
+    }
+};

--- a/tests/functionaltests/Tests/NSUserDefaultsTests.mm
+++ b/tests/functionaltests/Tests/NSUserDefaultsTests.mm
@@ -19,61 +19,79 @@
 #import <Corefoundation/CFBase.h>
 #import <Corefoundation/CFPreferences.h>
 
-TEST(NSUserDefaults, Basic) {
-    NSUserDefaults* userDefault = [NSUserDefaults standardUserDefaults];
-    ASSERT_TRUE(userDefault != nil);
+//
+// NSUserDefaults Tests
+//
+class NSUserDefaultsTests {
+public:
+    BEGIN_TEST_CLASS(NSUserDefaultsTests)
+    END_TEST_CLASS()
 
-    NSString* key = @"testKey";
-
-    // verify non file url is good
-    NSURL* url1 = [[NSURL alloc] initWithString:@"http://www.test.com/"];
-    [userDefault setURL:url1 forKey:key];
-
-    NSURL* url2 = [userDefault URLForKey:key];
-    ASSERT_OBJCEQ_MSG(url1, url2, "url should be equal");
-
-    // verify file path url is good
-    NSURL* url3 = [[NSURL alloc] initWithString:@"file://localhost/test1/test2/test3/"];
-    [userDefault setURL:url3 forKey:key];
-
-    NSURL* url4 = [userDefault URLForKey:key];
-    ASSERT_OBJCEQ_MSG(url3, url4, "url should be equal");
-
-    [url1 release];
-    [url3 release];
-}
-
-TEST(NSUserDefaults, KVCArray) {
-    [[NSUserDefaults standardUserDefaults] setObject:@[ @"User Preference 1" ] forKey:@"userPref1"];
-    NSMutableArray* mutableSetting = [[NSUserDefaults standardUserDefaults] mutableArrayValueForKeyPath:@"userPref1"];
-    EXPECT_OBJCNE(nil, mutableSetting);
-    EXPECT_NO_THROW([mutableSetting addObject:@"Another"]);
-    EXPECT_TRUE([[[NSUserDefaults standardUserDefaults] objectForKey:@"userPref1"] containsObject:@"Another"]);
-
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"nonexistentPreference"];
-    mutableSetting = [[NSUserDefaults standardUserDefaults] mutableArrayValueForKeyPath:@"nonexistentPreference"];
-    EXPECT_OBJCNE(nil, mutableSetting);
-    EXPECT_NO_THROW([mutableSetting addObject:@"Another"]);
-    EXPECT_TRUE([[[NSUserDefaults standardUserDefaults] objectForKey:@"nonexistentPreference"] containsObject:@"Another"]);
-
-    [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
-TEST(NSUserDefaults, Remove) {
-	[[NSUserDefaults standardUserDefaults] setObject:@"Cheddar" forKey:@"FavoriteCheese"];
-	NSString* actualCheese = [[NSUserDefaults standardUserDefaults] stringForKey:@"FavoriteCheese"];
-	EXPECT_OBJCEQ(@"Cheddar", actualCheese);
-	[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"FavoriteCheese"];
-	actualCheese = [[NSUserDefaults standardUserDefaults] stringForKey:@"FavoriteCheese"];
-	EXPECT_OBJCEQ(nil, actualCheese);
-}
-
-TEST(NSUserDefaults, Perf) {
-    NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
-    for (int i = 0; i < 500; i++) {
-        [[NSUserDefaults standardUserDefaults] setValue:@(i) forKey:[NSString stringWithFormat:@"Test%d", i]];
+    TEST_CLASS_SETUP(NSURLClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
-    NSTimeInterval end = [NSDate timeIntervalSinceReferenceDate];
-    LOG_INFO("NSUserDefaults took %lf s", end - start);
-}
+    TEST_METHOD_CLEANUP(NSUserDefaultsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(Basic) {
+        NSUserDefaults* userDefault = [NSUserDefaults standardUserDefaults];
+        ASSERT_TRUE(userDefault != nil);
+
+        NSString* key = @"testKey";
+
+        // verify non file url is good
+        NSURL* url1 = [[NSURL alloc] initWithString:@"http://www.test.com/"];
+        [userDefault setURL:url1 forKey:key];
+
+        NSURL* url2 = [userDefault URLForKey:key];
+        ASSERT_OBJCEQ_MSG(url1, url2, "url should be equal");
+
+        // verify file path url is good
+        NSURL* url3 = [[NSURL alloc] initWithString:@"file://localhost/test1/test2/test3/"];
+        [userDefault setURL:url3 forKey:key];
+
+        NSURL* url4 = [userDefault URLForKey:key];
+        ASSERT_OBJCEQ_MSG(url3, url4, "url should be equal");
+
+        [url1 release];
+        [url3 release];
+    }
+
+    TEST_METHOD(KVCArray) {
+        [[NSUserDefaults standardUserDefaults] setObject:@[ @"User Preference 1" ] forKey:@"userPref1"];
+        NSMutableArray* mutableSetting = [[NSUserDefaults standardUserDefaults] mutableArrayValueForKeyPath:@"userPref1"];
+        EXPECT_OBJCNE(nil, mutableSetting);
+        EXPECT_NO_THROW([mutableSetting addObject:@"Another"]);
+        EXPECT_TRUE([[[NSUserDefaults standardUserDefaults] objectForKey:@"userPref1"] containsObject:@"Another"]);
+
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"nonexistentPreference"];
+        mutableSetting = [[NSUserDefaults standardUserDefaults] mutableArrayValueForKeyPath:@"nonexistentPreference"];
+        EXPECT_OBJCNE(nil, mutableSetting);
+        EXPECT_NO_THROW([mutableSetting addObject:@"Another"]);
+        EXPECT_TRUE([[[NSUserDefaults standardUserDefaults] objectForKey:@"nonexistentPreference"] containsObject:@"Another"]);
+
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+
+    TEST_METHOD(Remove) {
+        [[NSUserDefaults standardUserDefaults] setObject:@"Cheddar" forKey:@"FavoriteCheese"];
+        NSString* actualCheese = [[NSUserDefaults standardUserDefaults] stringForKey:@"FavoriteCheese"];
+        EXPECT_OBJCEQ(@"Cheddar", actualCheese);
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"FavoriteCheese"];
+        actualCheese = [[NSUserDefaults standardUserDefaults] stringForKey:@"FavoriteCheese"];
+        EXPECT_OBJCEQ(nil, actualCheese);
+    }
+
+    TEST_METHOD(Perf) {
+        NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
+        for (int i = 0; i < 500; i++) {
+            [[NSUserDefaults standardUserDefaults] setValue:@(i) forKey:[NSString stringWithFormat:@"Test%d", i]];
+        }
+
+        NSTimeInterval end = [NSDate timeIntervalSinceReferenceDate];
+        LOG_INFO("NSUserDefaults took %lf s", end - start);
+    }
+};

--- a/tests/functionaltests/Tests/ProjectionTests/CoreDispatcherTests.mm
+++ b/tests/functionaltests/Tests/ProjectionTests/CoreDispatcherTests.mm
@@ -24,58 +24,72 @@
 
 static const NSTimeInterval c_testTimeoutInSec = 60;
 
-TEST(Projection, WUCCoreDispatcherSanity) {
-    LOG_INFO("Projection CoreDispatcher Sanity Test: ");
+class ProjectionSDispatcherTest {
+public:
+    BEGIN_TEST_CLASS(ProjectionSDispatcherTest)
+    END_TEST_CLASS()
 
-    ASSERT_FALSE_MSG([NSThread isMainThread], "Failed: Test cannot run on Main thread")
+    TEST_CLASS_SETUP(ProjectionTestClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    __block dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    WUCDispatchedHandler dispatchedHandler = ^() {
-        dispatch_semaphore_signal(semaphore);
-    };
+    TEST_METHOD(WUCCoreDispatcherSanity) {
+        LOG_INFO("Projection CoreDispatcher Sanity Test: ");
 
-    __block StrongId<WUCCoreDispatcher> coreDispatcher;
+        ASSERT_FALSE_MSG([NSThread isMainThread], "Failed: Test cannot run on Main thread")
 
-    // Get the dispatcher for the main thread.
-    // RunAsync needs to be called on the dispatcher for main thread.
-    dispatch_sync(dispatch_get_main_queue(),
-                  ^{
-                      coreDispatcher = [[WUCCoreWindow getForCurrentThread] dispatcher];
-                  });
+        __block dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-    [coreDispatcher runAsync:WUCCoreDispatcherPriorityNormal agileCallback:dispatchedHandler];
-    long result = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(c_testTimeoutInSec * NSEC_PER_SEC)));
-    dispatch_release(semaphore);
+        WUCDispatchedHandler dispatchedHandler = ^() {
+            dispatch_semaphore_signal(semaphore);
+        };
 
-    ASSERT_EQ_MSG(0, result, "FAILED: Test timed out, handler not called\n");
-}
+        __block StrongId<WUCCoreDispatcher> coreDispatcher;
 
-TEST(Projection, AsyncOnBackgroundThread) {
-    LOG_INFO("Validate callback on a background thread");
-    __block bool callbackCalled = false;
+        // Get the dispatcher for the main thread.
+        // RunAsync needs to be called on the dispatcher for main thread.
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            coreDispatcher = [[WUCCoreWindow getForCurrentThread] dispatcher];
+        });
 
-    WDGBasicGeoposition* geoposition = [[WDGBasicGeoposition alloc] init];
-    geoposition.latitude = 47.6381966;
-    geoposition.longitude = -122.1313785;
+        [coreDispatcher runAsync:WUCCoreDispatcherPriorityNormal agileCallback:dispatchedHandler];
+        long result = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(c_testTimeoutInSec * NSEC_PER_SEC)));
+        dispatch_release(semaphore);
 
-    WDGGeopoint* geopoint = [WDGGeopoint make:geoposition];
+        ASSERT_EQ_MSG(0, result, "FAILED: Test timed out, handler not called\n");
+    }
 
-    dispatch_group_t group = dispatch_group_create();
-    dispatch_group_enter(group);
+    TEST_METHOD(AsyncOnBackgroundThread) {
+        LOG_INFO("Validate callback on a background thread");
+        __block bool callbackCalled = false;
 
-    [WSMMapLocationFinder findLocationsAtAsync:geopoint
-        success:^void(WSMMapLocationFinderResult* results) {
-            callbackCalled = true;
-            dispatch_group_leave(group);
-        }
-        failure:^void(NSError* error) {
-            callbackCalled = true;
-            dispatch_group_leave(group);
-        }];
+        WDGBasicGeoposition* geoposition = [[WDGBasicGeoposition alloc] init];
+        geoposition.latitude = 47.6381966;
+        geoposition.longitude = -122.1313785;
 
-    dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(c_testTimeoutInSec * NSEC_PER_SEC)));
-    dispatch_release(group);
+        WDGGeopoint* geopoint = [WDGGeopoint make:geoposition];
 
-    ASSERT_TRUE_MSG(callbackCalled, "FAILED: Test timed out before callback was invoked.\n");
-}
+        dispatch_group_t group = dispatch_group_create();
+        dispatch_group_enter(group);
+
+        [WSMMapLocationFinder findLocationsAtAsync:geopoint
+            success:^void(WSMMapLocationFinderResult* results) {
+                callbackCalled = true;
+                dispatch_group_leave(group);
+            }
+            failure:^void(NSError* error) {
+                callbackCalled = true;
+                dispatch_group_leave(group);
+            }];
+
+        dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(c_testTimeoutInSec * NSEC_PER_SEC)));
+        dispatch_release(group);
+
+        ASSERT_TRUE_MSG(callbackCalled, "FAILED: Test timed out before callback was invoked.\n");
+    }
+};

--- a/tests/functionaltests/Tests/ProjectionTests/SanityTests.mm
+++ b/tests/functionaltests/Tests/ProjectionTests/SanityTests.mm
@@ -26,6 +26,10 @@
 #endif
 #pragma push_macro("Nil")
 #undef Nil
+#pragma push_macro("__alignof")
+#define __alignof alignof
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmicrosoft"
 #endif
 
 #include <Windows.UI.Xaml.Media.h>
@@ -34,51 +38,69 @@
 #ifdef __OBJC__
 #pragma pop_macro("Nil")
 #pragma pop_macro("interface")
+#pragma pop_macro("__alignof")
+#pragma clang diagnostic pop
 #endif
 
 #import <UWP/WindowsUIXamlMedia.h>
 
 static const NSTimeInterval c_testTimeoutInSec = 5;
 
-// This file has ARC disabled as for some reason ARC
-// cannot be used with ASSERT_OBJCEQ_MSG macro.
-TEST(Projection, HStringTest) {
-    LOG_INFO("Projection HString Sanity Test: ");
-    StrongId<WUXITypeName> typeName = [WUXITypeName new];
-    NSString* expectedString = @"Test";
-    [typeName setName:expectedString];
-    ASSERT_OBJCEQ_MSG(expectedString, [typeName name], "FAILED: HString mismatch\n");
-}
+class ProjectionsSanityTest {
+public:
+    BEGIN_TEST_CLASS(ProjectionsSanityTest)
+    END_TEST_CLASS()
 
-TEST(Projection, CreateWithTest) {
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-    ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamilyFactory> fontFamilyFactory;
-    ASSERT_HRESULT_SUCCEEDED_MSG(ABI::Windows::Foundation::GetActivationFactory(
-                                     Microsoft::WRL::Wrappers::HString::MakeReference(L"Windows.UI.Xaml.Media.FontFamily").Get(),
-                                     &fontFamilyFactory),
-                                 "Failed: Could not get activation factory");
+    TEST_CLASS_SETUP(ProjectionTestClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    // Get the dispatcher for the main thread.
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamily> fontFamilyInstance;
-        HString hstr;
-        ASSERT_HRESULT_SUCCEEDED_MSG(hstr.Set(L"Comic Sans MS"), "Failed: HString::Set failed");
-        HRESULT hr = fontFamilyFactory->CreateInstanceWithName(hstr.Get(), nullptr, nullptr, fontFamilyInstance.GetAddressOf());
-        ASSERT_HRESULT_SUCCEEDED_MSG(hr, "Failed: CreateInstanceWithName failed");
-        StrongId<WUXMFontFamily> fontFamily;
-        ASSERT_NO_THROW_MSG(fontFamily = [WUXMFontFamily createWith:fontFamilyInstance.Get()], "Failed: createWith failed");
-        ASSERT_NE_MSG(fontFamily, nil, "Failed: CreateWithTest failed");
-    });
+    TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    // createWith method returns autoreleased object.
-    // So draining the pool should not throw.
-    EXPECT_NO_THROW([pool release]);
-}
+    // This file has ARC disabled as for some reason ARC
+    // cannot be used with ASSERT_OBJCEQ_MSG macro.
+    TEST_METHOD(HStringTest) {
+        LOG_INFO("Projection HString Sanity Test: ");
+        StrongId<WUXITypeName> typeName = [WUXITypeName new];
+        NSString* expectedString = @"Test";
+        [typeName setName:expectedString];
+        ASSERT_OBJCEQ_MSG(expectedString, [typeName name], "FAILED: HString mismatch\n");
+    }
 
-TEST(Projection, ComposableAttrClass) {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        StrongId<WUXMFontFamily> fontFamily;
-        EXPECT_NO_THROW(fontFamily = [WUXMFontFamily makeInstanceWithName:@"Comic Sans MS"]);
-        ASSERT_NE_MSG(fontFamily, nil, "FAILED: ComposableAttrClass Test failed\n");
-    });
-}
+    TEST_METHOD(CreateWithTest) {
+        NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+        ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamilyFactory> fontFamilyFactory;
+        ASSERT_HRESULT_SUCCEEDED_MSG(ABI::Windows::Foundation::GetActivationFactory(
+                                         Microsoft::WRL::Wrappers::HString::MakeReference(L"Windows.UI.Xaml.Media.FontFamily").Get(),
+                                         &fontFamilyFactory),
+                                     "Failed: Could not get activation factory");
+
+        // Get the dispatcher for the main thread.
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamily> fontFamilyInstance;
+            HString hstr;
+            ASSERT_HRESULT_SUCCEEDED_MSG(hstr.Set(L"Comic Sans MS"), "Failed: HString::Set failed");
+            HRESULT hr = fontFamilyFactory->CreateInstanceWithName(hstr.Get(), nullptr, nullptr, fontFamilyInstance.GetAddressOf());
+            ASSERT_HRESULT_SUCCEEDED_MSG(hr, "Failed: CreateInstanceWithName failed");
+            StrongId<WUXMFontFamily> fontFamily;
+            ASSERT_NO_THROW_MSG(fontFamily = [WUXMFontFamily createWith:fontFamilyInstance.Get()], "Failed: createWith failed");
+            ASSERT_NE_MSG(fontFamily, nil, "Failed: CreateWithTest failed");
+        });
+
+        // createWith method returns autoreleased object.
+        // So draining the pool should not throw.
+        EXPECT_NO_THROW([pool release]);
+    }
+
+    TEST_METHOD(ComposableAttrClass) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            StrongId<WUXMFontFamily> fontFamily;
+            EXPECT_NO_THROW(fontFamily = [WUXMFontFamily makeInstanceWithName:@"Comic Sans MS"]);
+            ASSERT_NE_MSG(fontFamily, nil, "FAILED: ComposableAttrClass Test failed\n");
+        });
+    }
+
+}; /* class ProjectionTest */

--- a/tests/functionaltests/Tests/ProjectionTests/SanityTestsWithARCEnabled.mm
+++ b/tests/functionaltests/Tests/ProjectionTests/SanityTestsWithARCEnabled.mm
@@ -41,32 +41,47 @@
 
 static const NSTimeInterval c_testTimeoutInSec = 5;
 
-TEST(Projection, ContainerOfContainers) {
-    StrongId<WSPFileSavePicker> fileSavePicker = [WSPFileSavePicker make];
-    StrongId<NSMutableArray> arr = [[NSMutableArray alloc] init];
-    [arr addObject:@".txt"];
-    NSMutableDictionary* dict = [fileSavePicker fileTypeChoices];
-    EXPECT_NO_THROW([dict setObject:arr forKey:@"Plain Text"]);
-}
-TEST(Projection, CreateWithARCEnabled) {
-    EXPECT_NO_THROW(@autoreleasepool {
-        StrongId<NSAutoreleasePool> pool = [[NSAutoreleasePool alloc] init];
-        ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamilyFactory> fontFamilyFactory;
-        ASSERT_HRESULT_SUCCEEDED_MSG(ABI::Windows::Foundation::GetActivationFactory(
-                                         Microsoft::WRL::Wrappers::HString::MakeReference(L"Windows.UI.Xaml.Media.FontFamily").Get(),
-                                         &fontFamilyFactory),
-                                     "Failed: Could not get activation factory");
+class ProjectionsWithARCTest {
+public:
+    BEGIN_TEST_CLASS(ProjectionsWithARCTest)
+    END_TEST_CLASS()
 
-        // Get the dispatcher for the main thread.
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamily> fontFamilyInstance;
-            HString hstr;
-            ASSERT_HRESULT_SUCCEEDED_MSG(hstr.Set(L"Comic Sans MS"), "Failed: HString::Set failed");
-            HRESULT hr = fontFamilyFactory->CreateInstanceWithName(hstr.Get(), nullptr, nullptr, fontFamilyInstance.GetAddressOf());
-            ASSERT_HRESULT_SUCCEEDED_MSG(hr, "Failed: CreateInstanceWithName failed");
-            StrongId<WUXMFontFamily> fontFamily;
-            ASSERT_NO_THROW_MSG(fontFamily = [WUXMFontFamily createWith:fontFamilyInstance.Get()], "Failed: createWith failed");
-        });
-    } // autoreleasepool
-                    );
-}
+    TEST_CLASS_SETUP(ProjectionTestClassSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
+
+    TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(ContainerOfContainers) {
+        StrongId<WSPFileSavePicker> fileSavePicker = [WSPFileSavePicker make];
+        StrongId<NSMutableArray> arr = [[NSMutableArray alloc] init];
+        [arr addObject:@".txt"];
+        NSMutableDictionary* dict = [fileSavePicker fileTypeChoices];
+        EXPECT_NO_THROW([dict setObject:arr forKey:@"Plain Text"]);
+    }
+    TEST_METHOD(CreateWithARCEnabled) {
+        EXPECT_NO_THROW(@autoreleasepool {
+            StrongId<NSAutoreleasePool> pool = [[NSAutoreleasePool alloc] init];
+            ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamilyFactory> fontFamilyFactory;
+            ASSERT_HRESULT_SUCCEEDED_MSG(ABI::Windows::Foundation::GetActivationFactory(
+                                             Microsoft::WRL::Wrappers::HString::MakeReference(L"Windows.UI.Xaml.Media.FontFamily").Get(),
+                                             &fontFamilyFactory),
+                                         "Failed: Could not get activation factory");
+
+            // Get the dispatcher for the main thread.
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                ComPtr<ABI::Windows::UI::Xaml::Media::IFontFamily> fontFamilyInstance;
+                HString hstr;
+                ASSERT_HRESULT_SUCCEEDED_MSG(hstr.Set(L"Comic Sans MS"), "Failed: HString::Set failed");
+                HRESULT hr = fontFamilyFactory->CreateInstanceWithName(hstr.Get(), nullptr, nullptr, fontFamilyInstance.GetAddressOf());
+                ASSERT_HRESULT_SUCCEEDED_MSG(hr, "Failed: CreateInstanceWithName failed");
+                StrongId<WUXMFontFamily> fontFamily;
+                ASSERT_NO_THROW_MSG(fontFamily = [WUXMFontFamily createWith:fontFamilyInstance.Get()], "Failed: createWith failed");
+            });
+        } // autoreleasepool
+                        );
+    }
+};

--- a/tests/functionaltests/Tests/ToastNotificationTests.mm
+++ b/tests/functionaltests/Tests/ToastNotificationTests.mm
@@ -125,92 +125,119 @@ MOCK_CLASS(MockToastNotificationActivatedEventArgs,
 
 @end
 
-// Creates test method which we call in TEST_CLASS_SETUP to activate app
-TEST(ToastNotificationTest, ForegroundActivation) {
-    LOG_INFO("Toast Notification Foreground Activation Test: ");
+class ToastNotificationForegroundActivation {
+    BEGIN_TEST_CLASS(ToastNotificationForegroundActivation)
+    END_TEST_CLASS()
 
-    // Create mocked data to pass into application
-    RTObject* value = [WFPropertyValue createString:@"TOAST_NOTIFICATION_TEST_VALUE"];
-    WFCValueSet* wfcUserInput = [WFCValueSet make];
-    [wfcUserInput setObject:value forKey:@"TOAST_NOTIFICATION_TEST_KEY"];
+    TEST_CLASS_SETUP(ToastNotificationForegroundTestClassSetup) {
+        // The class setup allows us to activate the app in our test method, but can only be done once per class
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread([]() {
+            LOG_INFO("Toast Notification Foreground Activation Test: ");
 
-    auto fakeToastNotificationActivatedEventArgs = Make<MockToastNotificationActivatedEventArgs>();
-    fakeToastNotificationActivatedEventArgs->Setget_Argument([](HSTRING* argument) {
-        Wrappers::HString value;
-        value.Set(L"TOAST_NOTIFICATION_TEST");
-        *argument = value.Detach();
-        return S_OK;
-    });
+            // Create mocked data to pass into application
+            RTObject* value = [WFPropertyValue createString:@"TOAST_NOTIFICATION_TEST_VALUE"];
+            WFCValueSet* wfcUserInput = [WFCValueSet make];
+            [wfcUserInput setObject:value forKey:@"TOAST_NOTIFICATION_TEST_KEY"];
 
-    fakeToastNotificationActivatedEventArgs->Setget_UserInput([&wfcUserInput](IPropertySet** userInput) {
-        wfcUserInput.comObj.CopyTo(userInput);
-        return S_OK;
-    });
+            auto fakeToastNotificationActivatedEventArgs = Make<MockToastNotificationActivatedEventArgs>();
+            fakeToastNotificationActivatedEventArgs->Setget_Argument([](HSTRING* argument) {
+                Wrappers::HString value;
+                value.Set(L"TOAST_NOTIFICATION_TEST");
+                *argument = value.Detach();
+                return S_OK;
+            });
 
-    fakeToastNotificationActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
-        *kind = ActivationKind_ToastNotification;
-        return S_OK;
-    });
+            fakeToastNotificationActivatedEventArgs->Setget_UserInput([&wfcUserInput](IPropertySet** userInput) {
+                wfcUserInput.comObj.CopyTo(userInput);
+                return S_OK;
+            });
 
-    fakeToastNotificationActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
-        *state = ApplicationExecutionState_NotRunning;
-        return S_OK;
-    });
+            fakeToastNotificationActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
+                *kind = ActivationKind_ToastNotification;
+                return S_OK;
+            });
 
-    // Pass activation argument to method which activates the app
-    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeToastNotificationActivatedEventArgs.Get()),
-                                NSStringFromClass([ToastNotificationForegroundActivationTestDelegate class]));
-}
+            fakeToastNotificationActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
+                *state = ApplicationExecutionState_NotRunning;
+                return S_OK;
+            });
 
-TEST(ToastNotificationTest, ForegroundActivationDelegateMethodsCalled) {
-    ToastNotificationForegroundActivationTestDelegate* testDelegate = [[UIApplication sharedApplication] delegate];
-    NSDictionary* methodsCalled = [testDelegate methodsCalled];
-    EXPECT_TRUE(methodsCalled);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:willFinishLaunchingWithOptions:"]);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didFinishLaunchingWithOptions:"]);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveToastAction:"]);
-}
+            // Pass activation argument to method which activates the app
+            UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeToastNotificationActivatedEventArgs.Get()),
+                                        NSStringFromClass([ToastNotificationForegroundActivationTestDelegate class]));
+        }));
+    }
 
-TEST(ToastNotificationTest, ActivatedAppReceivesToastNotification) {
-    LOG_INFO("Activated App Receives Toast Notification Test: ");
+    TEST_METHOD_CLEANUP(ToastNotificationForegroundCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    ActivatedAppReceivesToastNotificationDelegate* testDelegate = [ActivatedAppReceivesToastNotificationDelegate new];
-    [[UIApplication sharedApplication] setDelegate:testDelegate];
+    TEST_METHOD(ForegroundActivationDelegateMethodsCalled) {
+        ToastNotificationForegroundActivationTestDelegate* testDelegate = [[UIApplication sharedApplication] delegate];
+        NSDictionary* methodsCalled = [testDelegate methodsCalled];
+        EXPECT_TRUE(methodsCalled);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:willFinishLaunchingWithOptions:"]);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didFinishLaunchingWithOptions:"]);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveToastAction:"]);
+    }
+};
 
-    // Create mocked data to pass into application
-    RTObject* value = [WFPropertyValue createString:@"TOAST_NOTIFICATION_TEST_VALUE"];
-    WFCValueSet* wfcUserInput = [WFCValueSet make];
-    [wfcUserInput setObject:value forKey:@"TOAST_NOTIFICATION_TEST_KEY"];
+class ActivatedAppReceivesToastNotification {
+    BEGIN_TEST_CLASS(ActivatedAppReceivesToastNotification)
+    END_TEST_CLASS()
 
-    auto fakeToastNotificationActivatedEventArgs = Make<MockToastNotificationActivatedEventArgs>();
-    fakeToastNotificationActivatedEventArgs->Setget_Argument([](HSTRING* argument) {
-        Wrappers::HString value;
-        value.Set(L"TOAST_NOTIFICATION_TEST");
-        *argument = value.Detach();
-        return S_OK;
-    });
+    TEST_CLASS_SETUP(ActivatedAppReceivesToastNotificationTestClassSetup) {
+        // The class setup allows us to activate the app in our test method, but can only be done once per class
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    fakeToastNotificationActivatedEventArgs->Setget_UserInput([&wfcUserInput](IPropertySet** userInput) {
-        wfcUserInput.comObj.CopyTo(userInput);
-        return S_OK;
-    });
+    TEST_METHOD_CLEANUP(ActivatedAppReceivesToastNotificationCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-    fakeToastNotificationActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
-        *kind = ActivationKind_ToastNotification;
-        return S_OK;
-    });
+    TEST_METHOD(EnsureDelegateMethodsCalled) {
+        LOG_INFO("Activated App Receives Toast Notification Test: ");
 
-    fakeToastNotificationActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
-        *state = ApplicationExecutionState_Running;
-        return S_OK;
-    });
+        ActivatedAppReceivesToastNotificationDelegate* testDelegate = [ActivatedAppReceivesToastNotificationDelegate new];
+        [[UIApplication sharedApplication] setDelegate:testDelegate];
 
-    // Calls OnActivated, which should not go through activation because we are activated
-    // But should still call our new delegate method
-    UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeToastNotificationActivatedEventArgs.Get()),
-                                NSStringFromClass([ToastNotificationForegroundActivationTestDelegate class]));
+        // Create mocked data to pass into application
+        RTObject* value = [WFPropertyValue createString:@"TOAST_NOTIFICATION_TEST_VALUE"];
+        WFCValueSet* wfcUserInput = [WFCValueSet make];
+        [wfcUserInput setObject:value forKey:@"TOAST_NOTIFICATION_TEST_KEY"];
 
-    NSDictionary* methodsCalled = [testDelegate methodsCalled];
-    EXPECT_TRUE(methodsCalled);
-    EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveToastAction:"]);
-}
+        auto fakeToastNotificationActivatedEventArgs = Make<MockToastNotificationActivatedEventArgs>();
+        fakeToastNotificationActivatedEventArgs->Setget_Argument([](HSTRING* argument) {
+            Wrappers::HString value;
+            value.Set(L"TOAST_NOTIFICATION_TEST");
+            *argument = value.Detach();
+            return S_OK;
+        });
+
+        fakeToastNotificationActivatedEventArgs->Setget_UserInput([&wfcUserInput](IPropertySet** userInput) {
+            wfcUserInput.comObj.CopyTo(userInput);
+            return S_OK;
+        });
+
+        fakeToastNotificationActivatedEventArgs->Setget_Kind([](ActivationKind* kind) {
+            *kind = ActivationKind_ToastNotification;
+            return S_OK;
+        });
+
+        fakeToastNotificationActivatedEventArgs->Setget_PreviousExecutionState([](ApplicationExecutionState* state) {
+            *state = ApplicationExecutionState_Running;
+            return S_OK;
+        });
+
+        // Calls OnActivated, which should not go through activation because we are activated
+        // But should still call our new delegate method
+        UIApplicationActivationTest(reinterpret_cast<IInspectable*>(fakeToastNotificationActivatedEventArgs.Get()),
+                                    NSStringFromClass([ToastNotificationForegroundActivationTestDelegate class]));
+
+        NSDictionary* methodsCalled = [testDelegate methodsCalled];
+        EXPECT_TRUE(methodsCalled);
+        EXPECT_TRUE([methodsCalled objectForKey:@"application:didReceiveToastAction:"]);
+    }
+};

--- a/tests/functionaltests/Tests/UIApplicationTests.mm
+++ b/tests/functionaltests/Tests/UIApplicationTests.mm
@@ -17,20 +17,29 @@
 #include <TestFramework.h>
 #import <UIKit/UIKit.h>
 
-TEST(UIApplicationTests, OpenURL) {
-    // This test is to verify openURL does not block when an invalid URL is used.
-    __block NSCondition* condition = [[NSCondition new] autorelease];
-    __block BOOL success = YES;
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),
-                   ^{
-                       NSString* urlString = @"itms-apps://itunes.com/apps/iplayfulinc";
-                       [condition lock];
-                       success = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString]];
-                       [condition signal];
-                       [condition unlock];
-                   });
+class UIApplicationTests {
+public:
+    BEGIN_TEST_CLASS(UIApplicationTests)
+    END_TEST_CLASS()
 
-    [condition lock];
-    ASSERT_TRUE (!success || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]]);
-    [condition unlock];
-}
+    TEST_CLASS_SETUP(UIApplicationTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
+
+    TEST_METHOD(OpenURL) {
+        // This test is to verify openURL does not block when an invalid URL is used.
+        __block NSCondition* condition = [[NSCondition new] autorelease];
+        __block BOOL success = YES;
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+            NSString* urlString = @"itms-apps://itunes.com/apps/iplayfulinc";
+            [condition lock];
+            success = [[UIApplication sharedApplication] openURL:[NSURL URLWithString:urlString]];
+            [condition signal];
+            [condition unlock];
+        });
+
+        [condition lock];
+        ASSERT_TRUE(!success || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:2]]);
+        [condition unlock];
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
@@ -30,37 +30,60 @@
 #include "ObjCXamlControls.h"
 #import "UWP/WindowsUIXamlControls.h"
 
-TEST(UIActionSheet, CreateXamlElement) {
-    // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateContentDialog());
-    ASSERT_TRUE(xamlElement);
-}
+class UIKitActionSheetTests {
+public:
+    BEGIN_TEST_CLASS(UIKitActionSheetTests)
+    END_TEST_CLASS()
 
-TEST(UIActionSheet, GetXamlElement) {
-    UIActionSheet* actionSheet = [[[UIActionSheet alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [actionSheet xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-}
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-TEST(UIActionSheet, NilParameters) {
-    UIActionSheet* actionSheet =
-        [[[UIActionSheet alloc] initWithTitle:nil delegate:nil cancelButtonTitle:nil destructiveButtonTitle:nil otherButtonTitles:nil]
-            autorelease];
-    WXFrameworkElement* backingElement = [actionSheet xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            // TODO: Switch to UIKit.Xaml projections when they're available.
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateContentDialog());
+            ASSERT_TRUE(xamlElement);
+        });
+    }
 
-    // Check that cancel button index, destructive button index, other button index are correct
-    NSInteger numButtons = [actionSheet numberOfButtons];
-    ASSERT_TRUE(numButtons == 0);
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIActionSheet* actionSheet = [[[UIActionSheet alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [actionSheet xamlElement];
+            ASSERT_TRUE(backingElement);
 
-    NSInteger cancelIndex = [actionSheet cancelButtonIndex];
-    ASSERT_TRUE(cancelIndex == -1);
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+        });
+    }
 
-    NSInteger destructiveIndex = [actionSheet destructiveButtonIndex];
-    ASSERT_TRUE(cancelIndex == -1);
+    TEST_METHOD(NilParameters) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIActionSheet* actionSheet = [[[UIActionSheet alloc] initWithTitle:nil
+                                                                      delegate:nil
+                                                             cancelButtonTitle:nil
+                                                        destructiveButtonTitle:nil
+                                                             otherButtonTitles:nil] autorelease];
+            WXFrameworkElement* backingElement = [actionSheet xamlElement];
+            ASSERT_TRUE(backingElement);
 
-    NSInteger otherIndex = [actionSheet firstOtherButtonIndex];
-    ASSERT_TRUE(otherIndex == -1);
-}
+            // Check that cancel button index, destructive button index, other button index are correct
+            NSInteger numButtons = [actionSheet numberOfButtons];
+            ASSERT_TRUE(numButtons == 0);
+
+            NSInteger cancelIndex = [actionSheet cancelButtonIndex];
+            ASSERT_TRUE(cancelIndex == -1);
+
+            NSInteger destructiveIndex = [actionSheet destructiveButtonIndex];
+            ASSERT_TRUE(cancelIndex == -1);
+
+            NSInteger otherIndex = [actionSheet firstOtherButtonIndex];
+            ASSERT_TRUE(otherIndex == -1);
+        });
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UIActivityIndicatorTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIActivityIndicatorTests.mm
@@ -30,17 +30,36 @@
 #include "ObjCXamlControls.h"
 #import "UWP/WindowsUIXamlControls.h"
 
-TEST(UIActivityIndicatorView, CreateXamlElement) {
-    // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateProgressRing());
-    ASSERT_TRUE(xamlElement);
-}
+class UIKitActivityIndicatorTests {
+public:
+    BEGIN_TEST_CLASS(UIKitActivityIndicatorTests)
+    END_TEST_CLASS()
 
-TEST(UIActivityIndicatorView, GetXamlElement) {
-    UIView* view = [[[UIActivityIndicatorView alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [view xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    // TODO: Fix up when UIActivityIndicator moves fully to XAML
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-}
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            // TODO: Switch to UIKit.Xaml projections when they're available.
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateProgressRing());
+            ASSERT_TRUE(xamlElement);
+        });
+    }
+
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UIActivityIndicatorView alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [view xamlElement];
+            ASSERT_TRUE(backingElement);
+
+            // TODO: Fix up when UIActivityIndicator moves fully to XAML
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+        });
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
@@ -36,90 +36,112 @@
 // TODO: Consolidate this into a common place so that all tests can use it
 static const NSTimeInterval c_testTimeoutInSec = 5;
 
-TEST(UIButton, CreateXamlElement) {
-    // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateButton());
-    ASSERT_TRUE(xamlElement);
-}
+class UIKitButtonTests {
+public:
+    BEGIN_TEST_CLASS(UIKitButtonTests)
+    END_TEST_CLASS()
 
-TEST(UIButton, GetXamlElement) {
-    UIView* view = [[[UIButton alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [view xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    // TODO: Fix up when UIButton moves fully to XAML
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-}
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
 
-TEST(UIButton, BackgroundColorChanged) {
-    __block UIButtonViewController* buttonVC;
-    __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
-    __block WXUIElement* backingElement = nil;
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            // TODO: Switch to UIKit.Xaml projections when they're available.
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateButton());
+            ASSERT_TRUE(xamlElement);
+        });
+    }
 
-    dispatch_sync(dispatch_get_main_queue(), ^{
-        buttonVC = [[UIButtonViewController alloc] init];
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UIButton alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [view xamlElement];
+            ASSERT_TRUE(backingElement);
 
-        // TODO: Remove this line once we hook up to the root view controller which will trigger the view method
-        [buttonVC view];
+            // TODO: Fix up when UIButton moves fully to XAML
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+        });
+    }
 
-        // Extract the UIButton example from an existing XAMLCatalog cell in a TableViewController
-        NSIndexPath* indexPath = [NSIndexPath indexPathForRow:1 inSection:0];
-        UITableViewCell* cell = [buttonVC tableView : buttonVC.tableView cellForRowAtIndexPath:indexPath];
-        ASSERT_TRUE(cell);
+    TEST_METHOD(BackgroundColorChanged) {
+        __block UIButtonViewController* buttonVC;
+        __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
+        __block WXUIElement* backingElement = nil;
 
-        // TODO: Formalize a way to extract existing buttons and their states from our test or sample apps
-        UILabel* cellLabel = [cell.subviews objectAtIndex:1];
-        UIButton* cellButton = [cell.subviews objectAtIndex:2];
-        LOG_INFO(@"Cell subview[1] text: %@", cellLabel.text);
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            buttonVC = [[UIButtonViewController alloc] init];
 
-        // We have to artificially ref the element since the block needs to keep it around
-        backingElement = [cellButton xamlElement];
-        [backingElement retain];
+            // TODO: Remove this line once we hook up to the root view controller which will trigger the view method
+            [buttonVC view];
 
-        // Register callback and wait for the property changed event to trigger
-        int64_t callbackToken = [backingElement
-            registerPropertyChangedCallback:[WXCControl backgroundProperty]
-                            callback:^(WXDependencyObject* sender, WXDependencyProperty* dp) {
-                WUXMSolidColorBrush* solidBrush = rt_dynamic_cast([WUXMSolidColorBrush class], [sender getValue:dp]);
-                ASSERT_TRUE(solidBrush);
+            // Extract the UIButton example from an existing XAMLCatalog cell in a TableViewController
+            NSIndexPath* indexPath = [NSIndexPath indexPathForRow:1 inSection:0];
+            UITableViewCell* cell = [buttonVC tableView:buttonVC.tableView cellForRowAtIndexPath:indexPath];
+            ASSERT_TRUE(cell);
 
-                LOG_INFO("Backing XAML element backgroundColor (rgba): %d,%d,%d,%d",
-                    [solidBrush.color r],
-                    [solidBrush.color g],
-                    [solidBrush.color b],
-                    [solidBrush.color a]);
+            // TODO: Formalize a way to extract existing buttons and their states from our test or sample apps
+            UILabel* cellLabel = [cell.subviews objectAtIndex:1];
+            UIButton* cellButton = [cell.subviews objectAtIndex:2];
+            LOG_INFO(@"Cell subview[1] text: %@", cellLabel.text);
 
-                CGFloat red, green, blue, alpha;
-                [cellButton.backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha];
-                LOG_INFO("UIButton.backgroundColor (rgba): %.2f,%.2f,%.2f,%.2f", red, green, blue, alpha);
+            // We have to artificially ref the element since the block needs to keep it around
+            backingElement = [cellButton xamlElement];
+            [backingElement retain];
 
-                // Validate that the change is reflected on the backing XAML control
-                EXPECT_EQ_MSG(solidBrush.color.r, (int)(red * 255), @"Failed to match red component");
-                EXPECT_EQ_MSG(solidBrush.color.g, (int)(green * 255), @"Failed to match green component");
-                EXPECT_EQ_MSG(solidBrush.color.b, (int)(blue * 255), @"Failed to match blue component");
-                EXPECT_EQ_MSG(solidBrush.color.a, (int)(alpha * 255), @"Failed to match alpha component");
+            // Register callback and wait for the property changed event to trigger
+            int64_t callbackToken = [backingElement
+                registerPropertyChangedCallback:[WXCControl backgroundProperty]
+                                       callback:^(WXDependencyObject* sender, WXDependencyProperty* dp) {
+                                           WUXMSolidColorBrush* solidBrush =
+                                               rt_dynamic_cast([WUXMSolidColorBrush class], [sender getValue:dp]);
+                                           ASSERT_TRUE(solidBrush);
 
-                // UIButton's background should be grayColor to match the value set for this button cell in XAMLCatalog
-                EXPECT_EQ_MSG(solidBrush.color.r, 127, @"Failed to match expected value for red component");
-                EXPECT_EQ_MSG(solidBrush.color.g, 127, @"Failed to match expected value for green component");
-                EXPECT_EQ_MSG(solidBrush.color.b, 127, @"Failed to match expected value for blue component");
-                EXPECT_EQ_MSG(solidBrush.color.a, 255, @"Failed to match expected value for alpha component");
+                                           LOG_INFO("Backing XAML element backgroundColor (rgba): %d,%d,%d,%d",
+                                                    [solidBrush.color r],
+                                                    [solidBrush.color g],
+                                                    [solidBrush.color b],
+                                                    [solidBrush.color a]);
 
-                // Unregister the callback
-                [backingElement unregisterPropertyChangedCallback:[WXCControl backgroundProperty] token:callbackToken];
+                                           CGFloat red, green, blue, alpha;
+                                           [cellButton.backgroundColor getRed:&red green:&green blue:&blue alpha:&alpha];
+                                           LOG_INFO("UIButton.backgroundColor (rgba): %.2f,%.2f,%.2f,%.2f", red, green, blue, alpha);
 
-                [condition lock];
-                [condition signal];
-                [condition unlock];
-        }];
-    });
+                                           // Validate that the change is reflected on the backing XAML control
+                                           EXPECT_EQ_MSG(solidBrush.color.r, (int)(red * 255), @"Failed to match red component");
+                                           EXPECT_EQ_MSG(solidBrush.color.g, (int)(green * 255), @"Failed to match green component");
+                                           EXPECT_EQ_MSG(solidBrush.color.b, (int)(blue * 255), @"Failed to match blue component");
+                                           EXPECT_EQ_MSG(solidBrush.color.a, (int)(alpha * 255), @"Failed to match alpha component");
 
-    [condition lock];
-    ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
-        "FAILED: Waiting for property changed event timed out!");
-    [condition unlock];
+                                           // UIButton's background should be grayColor to match the value set for this button cell in
+                                           // XAMLCatalog
+                                           EXPECT_EQ_MSG(solidBrush.color.r, 127, @"Failed to match expected value for red component");
+                                           EXPECT_EQ_MSG(solidBrush.color.g, 127, @"Failed to match expected value for green component");
+                                           EXPECT_EQ_MSG(solidBrush.color.b, 127, @"Failed to match expected value for blue component");
+                                           EXPECT_EQ_MSG(solidBrush.color.a, 255, @"Failed to match expected value for alpha component");
 
-    // Don't leak
-    [backingElement release];
-    [buttonVC release];
-}
+                                           // Unregister the callback
+                                           [backingElement unregisterPropertyChangedCallback:[WXCControl backgroundProperty]
+                                                                                       token:callbackToken];
+
+                                           [condition lock];
+                                           [condition signal];
+                                           [condition unlock];
+                                       }];
+        });
+
+        [condition lock];
+        ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for property changed event timed out!");
+        [condition unlock];
+
+        // Don't leak
+        [backingElement release];
+        [buttonVC release];
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UIScrollViewTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIScrollViewTests.mm
@@ -30,17 +30,36 @@
 #include "ObjCXamlControls.h"
 #import "UWP/WindowsUIXamlControls.h"
 
-TEST(UIScrollView, CreateXamlElement) {
-    // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateScrollViewer());
-    ASSERT_TRUE(xamlElement);
-}
+class UIKitScrollViewTests {
+public:
+    BEGIN_TEST_CLASS(UIKitScrollViewTests)
+    END_TEST_CLASS()
 
-TEST(UIScrollView, GetXamlElement) {
-    UIView* view = [[[UIScrollView alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [view xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    // TODO: Fix up when UIScrollView moves fully to XAML
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-}
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            // TODO: Switch to UIKit.Xaml projections when they're available.
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateScrollViewer());
+            ASSERT_TRUE(xamlElement);
+        });
+    }
+
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UIScrollView alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [view xamlElement];
+            ASSERT_TRUE(backingElement);
+
+            // TODO: Fix up when UIScrollView moves fully to XAML
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+        });
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UISliderTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UISliderTests.mm
@@ -30,17 +30,36 @@
 #include "ObjCXamlControls.h"
 #import "UWP/WindowsUIXamlControls.h"
 
-TEST(UISlider, CreateXamlElement) {
-    // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateSlider());
-    ASSERT_TRUE(xamlElement);
-}
+class UIKitSliderTests {
+public:
+    BEGIN_TEST_CLASS(UIKitSliderTests)
+    END_TEST_CLASS()
 
-TEST(UISlider, GetXamlElement) {
-    UIView* view = [[[UISlider alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [view xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    // TODO: Fix up when UISlider moves fully to XAML
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-}
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            // TODO: Switch to UIKit.Xaml projections when they're available.
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateSlider());
+            ASSERT_TRUE(xamlElement);
+        });
+    }
+
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UISlider alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [view xamlElement];
+            ASSERT_TRUE(backingElement);
+
+            // TODO: Fix up when UISlider moves fully to XAML
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+        });
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
@@ -30,17 +30,36 @@
 #include "ObjCXamlControls.h"
 #import "UWP/WindowsUIXamlControls.h"
 
-TEST(UITextField, CreateXamlElement) {
-    // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateTextBox());
-    ASSERT_TRUE(xamlElement);
-}
+class UIKitTextFieldTests {
+public:
+    BEGIN_TEST_CLASS(UIKitTextFieldTests)
+    END_TEST_CLASS()
 
-TEST(UITextField, GetXamlElement) {
-    UIView* view = [[[UITextField alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [view xamlElement];
-    ASSERT_TRUE(backingElement);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    }
 
-    // TODO: Fix up when UITextField moves fully to XAML
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-}
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
+    }
+
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            // TODO: Switch to UIKit.Xaml projections when they're available.
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateTextBox());
+            ASSERT_TRUE(xamlElement);
+        });
+    }
+
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UITextField alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [view xamlElement];
+            ASSERT_TRUE(backingElement);
+
+            // TODO: Fix up when UITextField moves fully to XAML
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+        });
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UIViewTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIViewTests.mm
@@ -20,154 +20,203 @@
 #import <UIKit/UIView.h>
 #import "UWP/WindowsUIXamlControls.h"
 
-TEST(UIView, Create) {
-    EXPECT_FALSE([NSThread isMainThread]);
-
-    // Try to create and destroy a UIView on a non-UI thread
-    [[[UIView alloc] initWithFrame:CGRectMake(0, 0, 10, 10)] release];
-}
-
-TEST(UIView, GetXamlElement) {
-    UIView* view = [[[UIView alloc] init] autorelease];
-    WXFrameworkElement* backingElement = [view xamlElement];
-    ASSERT_TRUE(backingElement);
-    ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
-    ASSERT_TRUE([backingElement.name isEqualToString:@"UIView"]);
-}
-
-class UIViewTestHelper {
+class UIKitViewTests {
 public:
-    UIViewTestHelper() {
-        _rootView = [[UIView alloc] init];
-        _view0 = [[UIView alloc] init];
-        _view1 = [[UIView alloc] init];
-        _view2 = [[UIView alloc] init];
-        _view3 = [[UIView alloc] init];
-        _viewNonSibling = [[UIView alloc] init];
+    BEGIN_TEST_CLASS(UIKitViewTests)
+    END_TEST_CLASS()
 
-        [_rootView addSubview:_view0];
-        [_rootView addSubview:_view1];
-        [_rootView addSubview:_view2];
-        [_rootView addSubview:_view3];
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
     }
 
-    int indexOf(UIView* view) {
-        NSUInteger index = [[_rootView subviews] indexOfObject:view];
-
-        return (int)index;
+    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
-    void testInsertSubviewAtIndex(int index) {
-        [_rootView insertSubview:_view1 atIndex:index];
-        ASSERT_EQ(index, indexOf(_view1));
+    TEST_METHOD(Create) {
+        EXPECT_FALSE([NSThread isMainThread]);
+
+        // Try to create and destroy a UIView on a non-UI thread
+        [[[UIView alloc] initWithFrame:CGRectMake(0, 0, 10, 10)] release];
     }
 
-    void testInsertSubviewBelowSubview(UIView* belowSubview, int expectedIndex) {
-        [_rootView insertSubview:_view1 belowSubview:belowSubview];
-        ASSERT_EQ(expectedIndex, indexOf(_view1));
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UIView alloc] init] autorelease];
+            WXFrameworkElement* backingElement = [view xamlElement];
+            ASSERT_TRUE(backingElement);
+            ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
+            ASSERT_TRUE([backingElement.name isEqualToString:@"UIView"]);
+        });
     }
 
-    void testInsertSubviewAboveSubview(UIView* aboveSubview, int expectedIndex) {
-        [_rootView insertSubview:_view1 aboveSubview:aboveSubview];
-        ASSERT_EQ(expectedIndex, indexOf(_view1));
+    class UIViewTestHelper {
+    public:
+        UIViewTestHelper() {
+            _rootView = [[UIView alloc] init];
+            _view0 = [[UIView alloc] init];
+            _view1 = [[UIView alloc] init];
+            _view2 = [[UIView alloc] init];
+            _view3 = [[UIView alloc] init];
+            _viewNonSibling = [[UIView alloc] init];
+
+            [_rootView addSubview:_view0];
+            [_rootView addSubview:_view1];
+            [_rootView addSubview:_view2];
+            [_rootView addSubview:_view3];
+        }
+
+        int indexOf(UIView* view) {
+            NSUInteger index = [[_rootView subviews] indexOfObject:view];
+
+            return (int)index;
+        }
+
+        void testInsertSubviewAtIndex(int index) {
+            [_rootView insertSubview:_view1 atIndex:index];
+            ASSERT_EQ(index, indexOf(_view1));
+        }
+
+        void testInsertSubviewBelowSubview(UIView* belowSubview, int expectedIndex) {
+            [_rootView insertSubview:_view1 belowSubview:belowSubview];
+            ASSERT_EQ(expectedIndex, indexOf(_view1));
+        }
+
+        void testInsertSubviewAboveSubview(UIView* aboveSubview, int expectedIndex) {
+            [_rootView insertSubview:_view1 aboveSubview:aboveSubview];
+            ASSERT_EQ(expectedIndex, indexOf(_view1));
+        }
+
+        StrongId<UIView> _rootView;
+        StrongId<UIView> _view0;
+        StrongId<UIView> _view1;
+        StrongId<UIView> _view2;
+        StrongId<UIView> _view3;
+        StrongId<UIView> _viewNonSibling;
+    };
+
+    TEST_METHOD(InsertSubviewAtIndex0) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAtIndex(0);
+        });
     }
 
-    StrongId<UIView> _rootView;
-    StrongId<UIView> _view0;
-    StrongId<UIView> _view1;
-    StrongId<UIView> _view2;
-    StrongId<UIView> _view3;
-    StrongId<UIView> _viewNonSibling;
+    TEST_METHOD(InsertSubviewAtIndex1) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAtIndex(1);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAtIndex2) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAtIndex(2);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAtIndex3) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAtIndex(3);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewBelowSubview0) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewBelowSubview(testHelper._view0, 0);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewBelowSubview1) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+
+            // Special case: pops on top
+            testHelper.testInsertSubviewBelowSubview(testHelper._view1, 3);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewBelowSubview2) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewBelowSubview(testHelper._view2, 1);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewBelowSubview3) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewBelowSubview(testHelper._view3, 2);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAboveSubview0) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAboveSubview(testHelper._view0, 1);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAboveSubview1) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+
+            // Special case: pops on top
+            testHelper.testInsertSubviewAboveSubview(testHelper._view1, 3);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAboveSubview2) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAboveSubview(testHelper._view2, 2);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAboveSubview3) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+            testHelper.testInsertSubviewAboveSubview(testHelper._view3, 3);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewBelowSubviewNonSibling) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+
+            // Non-sibling pops on top
+            testHelper.testInsertSubviewBelowSubview(testHelper._viewNonSibling, 3);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAboveSubviewNonSibling) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+
+            // Non-sibling pops on top
+            testHelper.testInsertSubviewAboveSubview(testHelper._viewNonSibling, 3);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewBelowSubviewNil) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+
+            // Nil unaffects index
+            testHelper.testInsertSubviewBelowSubview(nil, 1);
+        });
+    }
+
+    TEST_METHOD(InsertSubviewAboveSubviewNil) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIViewTestHelper testHelper;
+
+            // Nil unaffects index
+            testHelper.testInsertSubviewAboveSubview(nil, 1);
+        });
+    }
 };
-
-TEST(UIView, InsertSubviewAtIndex0) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAtIndex(0);
-}
-
-TEST(UIView, InsertSubviewAtIndex1) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAtIndex(1);
-}
-
-TEST(UIView, InsertSubviewAtIndex2) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAtIndex(2);
-}
-
-TEST(UIView, InsertSubviewAtIndex3) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAtIndex(3);
-}
-
-TEST(UIView, InsertSubviewBelowSubview0) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewBelowSubview(testHelper._view0, 0);
-}
-
-TEST(UIView, InsertSubviewBelowSubview1) {
-    UIViewTestHelper testHelper;
-
-    // Special case: pops on top
-    testHelper.testInsertSubviewBelowSubview(testHelper._view1, 3);
-}
-
-TEST(UIView, InsertSubviewBelowSubview2) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewBelowSubview(testHelper._view2, 1);
-}
-
-TEST(UIView, InsertSubviewBelowSubview3) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewBelowSubview(testHelper._view3, 2);
-}
-
-TEST(UIView, InsertSubviewAboveSubview0) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAboveSubview(testHelper._view0, 1);
-}
-
-TEST(UIView, InsertSubviewAboveSubview1) {
-    UIViewTestHelper testHelper;
-
-    // Special case: pops on top
-    testHelper.testInsertSubviewAboveSubview(testHelper._view1, 3);
-}
-
-TEST(UIView, InsertSubviewAboveSubview2) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAboveSubview(testHelper._view2, 2);
-}
-
-TEST(UIView, InsertSubviewAboveSubview3) {
-    UIViewTestHelper testHelper;
-    testHelper.testInsertSubviewAboveSubview(testHelper._view3, 3);
-}
-
-TEST(UIView, InsertSubviewBelowSubviewNonSibling) {
-    UIViewTestHelper testHelper;
-
-    // Non-sibling pops on top
-    testHelper.testInsertSubviewBelowSubview(testHelper._viewNonSibling, 3);
-}
-
-TEST(UIView, InsertSubviewAboveSubviewNonSibling) {
-    UIViewTestHelper testHelper;
-
-    // Non-sibling pops on top
-    testHelper.testInsertSubviewAboveSubview(testHelper._viewNonSibling, 3);
-}
-
-TEST(UIView, InsertSubviewBelowSubviewNil) {
-    UIViewTestHelper testHelper;
-
-    // Nil unaffects index
-    testHelper.testInsertSubviewBelowSubview(nil, 1);
-}
-
-TEST(UIView, InsertSubviewAboveSubviewNil) {
-    UIViewTestHelper testHelper;
-
-    // Nil unaffects index
-    testHelper.testInsertSubviewAboveSubview(nil, 1);
-}


### PR DESCRIPTION
… trampoline functions and paves the way for other ObjC tests to use the RunAs:UAP functionality that the test framework provies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1523)
<!-- Reviewable:end -->
