### PR TITLE
Update objc2winmd binary: 

### DIFF
--- a/bin/objc2winmd.exe
+++ b/bin/objc2winmd.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f373225ed425dd20145b83a9b3f69f4ff85c7c62eb2e3cfb6664a3bd542f6a8
-size 590336
+oid sha256:a8c6074a22859bd4d24585d1db4284d236477f038c10ff276da208dc279d29ad
+size 593408


### PR DESCRIPTION
Added comment to generated code for Clang bug workaround (non-objc types are not captured by objc blocks).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1524)
<!-- Reviewable:end -->
