### PR TITLE
Add support+tests for clipping context rendering to an image mask.

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -478,6 +478,7 @@ HRESULT __CGContext::PushLayer(CGRect* rect) {
     newDrawingState.shadowColor = { 0.f, 0.f, 0.f, 0.f };
     // newDrawingState.blendMode = kCGBlendModeNormal; // TODO GH#1389
     newDrawingState.clippingGeometry = nullptr;
+    newDrawingState.opacityBrush = nullptr;
     if (rect) {
         CGRect transformedClippingRegion = CGContextConvertRectToDeviceSpace(this, *rect);
 

--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -1861,7 +1861,7 @@ void CGContextFillEllipseInRect(CGContextRef context, CGRect rect) {
  @Status Interoperable
  @Notes The current path is cleared as a side effect of this function.
 */
-void CGContextStrokeLineSegments(CGContextRef context, const CGPoint* points, unsigned count) {
+void CGContextStrokeLineSegments(CGContextRef context, const CGPoint* points, size_t count) {
     NOISY_RETURN_IF_NULL(context);
     RETURN_IF(!context->ShouldDraw());
 

--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -845,7 +845,6 @@ HRESULT _CGImageConvertToMaskCompatibleWICBitmap(CGImageRef image, IWICBitmap** 
     RETURN_HR_IF_NULL(E_INVALIDARG, image);
     RETURN_HR_IF_NULL(E_POINTER, pBitmap);
 
-    ComPtr<IWICBitmap> wicBitmap;
     if (CGImageIsMask(image)) {
         // Hard way: Convert the image's gray values to alpha values A where G = <pixel gray value>; A = (1 - G)
         // We can perhaps take the easy way out and create an A8 only image, since D2D supports them.

--- a/Frameworks/include/CGIWICBitmap.h
+++ b/Frameworks/include/CGIWICBitmap.h
@@ -152,7 +152,7 @@ public:
     }
 
     // IWICBitmap interface
-    // TODO #1379: Today we do not support locking of a region smaller than the entire bitmap.
+    // TODO #1124: Today we do not support locking a region of the WIC bitmap for rendering. We only support locking the complete bitmap.
     // This will suffice CoreText requirement but needs to be revisted for CoreGraphics usage in future.
 
     HRESULT STDMETHODCALLTYPE Lock(_In_ const WICRect* region, _In_ DWORD flags, _COM_Outptr_ IWICBitmapLock** outLock) {
@@ -187,36 +187,17 @@ public:
                                          _Out_writes_all_(cbBufferSize) BYTE* buffer) {
         RETURN_HR_IF_NULL(E_POINTER, buffer);
 
-        const WICRect fullRect = { 0, 0, m_width, m_height };
         Microsoft::WRL::ComPtr<IWICBitmapLock> lock;
-        // TODO #1379: Support sub-regional locking.
-        RETURN_IF_FAILED(Lock(&fullRect, 0, &lock));
+        RETURN_IF_FAILED(Lock(copyRect, 0, &lock));
 
-        if (!copyRect) {
-            copyRect = &fullRect;
-        }
-
-        UINT sourceDataStride;
         UINT sourceDataSize;
         BYTE* sourceData;
-        RETURN_IF_FAILED(lock->GetStride(&sourceDataStride));
         RETURN_IF_FAILED(lock->GetDataPointer(&sourceDataSize, &sourceData));
 
-        if (copyRect->X == 0 && copyRect->Y == 0 && copyRect->Width == m_width && copyRect->Height == m_height) {
-            RETURN_HR_IF(E_INVALIDARG, sourceDataSize > bufferSize);
-            RETURN_HR_IF(E_UNEXPECTED, memcpy_s(buffer, bufferSize, sourceData, sourceDataSize) != 0);
-        } else {
-            // Once we support sub-regional locking we can fix this stride copier.
-            size_t bytesPerPixel = sourceDataStride / fullRect.Width;
-            ptrdiff_t xOffBytes = copyRect->X * bytesPerPixel;
-            for (off_t i = 0, j = copyRect->Y; i < copyRect->Height; ++i, ++j) {
-                RETURN_HR_IF(E_UNEXPECTED,
-                             memcpy_s(buffer + (stride * i),
-                                      bufferSize - (stride * i),
-                                      sourceData + xOffBytes + (sourceDataStride * j),
-                                      stride));
-            }
-        }
+        RETURN_HR_IF(E_INVALIDARG, sourceDataSize > bufferSize);
+
+        // TODO #1379 - should support regional copying.
+        RETURN_HR_IF(E_UNEXPECTED, memcpy_s(buffer, bufferSize, sourceData, sourceDataSize) != 0);
         return S_OK;
     }
 

--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -135,3 +135,5 @@ COREGRAPHICS_EXPORT CGImageRef _CGImageCreateCopyWithPixelFormat(CGImageRef imag
 
 typedef void (*CGImageDestructionListener)(CGImageRef img);
 COREGRAPHICS_EXPORT void CGImageAddDestructionListener(CGImageDestructionListener listener);
+
+HRESULT _CGImageConvertToMaskCompatibleWICBitmap(CGImageRef image, IWICBitmap** pBitmap);

--- a/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
@@ -246,6 +246,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawingTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawing_FillTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawing_ShadowTests.cpp" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawing_ImageMaskTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGPathDrawingTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\DrawingTest.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\ImageComparison.cpp" />

--- a/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
@@ -98,7 +98,6 @@ DISABLED_DRAW_TEST_F(CGContext, DrawAContextIntoAnImage, UIKitMimicTest) {
     CGContextDrawImage(context, bounds, image.get());
 }
 
-
 DISABLED_DRAW_TEST_F(CGContext, FillThenStrokeIsSameAsDrawFillStroke, WhiteBackgroundTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();

--- a/tests/unittests/CoreGraphics.drawing/CGContextDrawing_ImageMaskTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextDrawing_ImageMaskTests.cpp
@@ -172,19 +172,12 @@ protected:
         return s_clippingImages.at(shape | type).get();
     }
 
-    void _FillContextWithColorAndLines() {
+    void _FillContext() {
         CGContextRef context = GetDrawingContext();
         CGRect bounds = GetDrawingBounds();
-        CGContextSetRGBStrokeColor(context, 1.0, 0.0, 0.0, 1.0);
-        CGContextSetRGBFillColor(context, 0.0, 0.0, 0.0, 1.0);
+        CGContextSetRGBFillColor(context, 0.0, 0.0, 1.0, 1.0);
 
         CGContextFillRect(context, bounds);
-
-        for (CGFloat i = 0.5f; i < bounds.size.width; i += 10.0f) {
-            CGContextMoveToPoint(context, i, 0);
-            CGContextAddLineToPoint(context, i, bounds.size.height);
-            CGContextStrokePath(context);
-        }
     }
 };
 
@@ -203,7 +196,7 @@ TEST_P(CGContextClipping, StraightMask) {
 
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
 
-    _FillContextWithColorAndLines();
+    _FillContext();
 }
 
 TEST_P(CGContextClipping, TransformedMask) {
@@ -217,7 +210,7 @@ TEST_P(CGContextClipping, TransformedMask) {
 
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
 
-    _FillContextWithColorAndLines();
+    _FillContext();
 }
 
 TEST_P(CGContextClipping, StackedMaskSameType) {
@@ -232,7 +225,7 @@ TEST_P(CGContextClipping, StackedMaskSameType) {
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(otherShape, type));
 
-    _FillContextWithColorAndLines();
+    _FillContext();
 }
 
 TEST_P(CGContextClipping, StackedMaskOtherType) {
@@ -248,7 +241,7 @@ TEST_P(CGContextClipping, StackedMaskOtherType) {
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(otherShape, otherType));
 
-    _FillContextWithColorAndLines();
+    _FillContext();
 }
 
 TEST_P(CGContextClipping, MaskedAndClipped) {
@@ -264,7 +257,7 @@ TEST_P(CGContextClipping, MaskedAndClipped) {
 
     CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
 
-    _FillContextWithColorAndLines();
+    _FillContext();
 }
 
 INSTANTIATE_TEST_CASE_P(Clipping,

--- a/tests/unittests/CoreGraphics.drawing/CGContextDrawing_ImageMaskTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextDrawing_ImageMaskTests.cpp
@@ -1,0 +1,314 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//****************************************************************************** 
+
+#include "DrawingTest.h"
+#include "DrawingTestConfig.h"
+#include "ImageHelpers.h"
+#include <windows.h>
+
+#include <unordered_map>
+#include <vector>
+#include <functional>
+
+enum ClippingShape {
+    ClippingShapeDiamond = 0x10,
+    ClippingShapeSquare = 0x20,
+    ClippingShapeRectangle = 0x30,
+};
+
+enum ClippingType {
+    ClippingTypeMask = 0x0,
+    ClippingTypeAlpha = 0x1,
+};
+
+template <typename TLambda>
+// TLambda is a function of type void(CGContextRef, CGSize, ClippingType).
+CGImageRef __CreateClipImage(CGSize size, ClippingType clipType, TLambda&& drawFunction) {
+    size_t bitsPerColor = 8;
+    size_t componentsPerPixel = clipType == ClippingTypeAlpha ? 4 : 1; // RGBA or G8
+    woc::unique_cf<CGColorSpaceRef> colorSpace{ clipType == ClippingTypeAlpha ? CGColorSpaceCreateDeviceRGB() :
+                                                                                CGColorSpaceCreateDeviceGray() };
+
+    woc::unique_cf<CGContextRef> bitmapContext{ CGBitmapContextCreate(nullptr,
+                                                                      size.width,
+                                                                      size.height,
+                                                                      8,
+                                                                      size.width * componentsPerPixel,
+                                                                      colorSpace.get(),
+                                                                      componentsPerPixel == 4 ? kCGImageAlphaPremultipliedFirst :
+                                                                                                kCGImageAlphaNone) };
+    CGContextRef context = bitmapContext.get();
+
+    drawFunction(context, size, clipType);
+
+    woc::unique_cf<CGImageRef> maskImage{ CGBitmapContextCreateImage(context) };
+
+    if (clipType == ClippingTypeMask) {
+        maskImage.reset(CGImageMaskCreate(CGImageGetWidth(maskImage.get()),
+                                          CGImageGetHeight(maskImage.get()),
+                                          CGImageGetBitsPerComponent(maskImage.get()),
+                                          CGImageGetBitsPerPixel(maskImage.get()),
+                                          CGImageGetBytesPerRow(maskImage.get()),
+                                          CGImageGetDataProvider(maskImage.get()),
+                                          nullptr,
+                                          true));
+    }
+
+    return maskImage.release();
+}
+
+auto __MakeSquareMaskGenerator(CGAffineTransform transform) {
+    // All this work to create a square/diamond with a diamond hole in the middle.
+    return [transform](CGContextRef context, CGSize size, ClippingType clipType) {
+        if (clipType == ClippingTypeMask) {
+            // Since it's a mask, flood it with white.
+            CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0);
+            CGContextFillRect(context, { CGPointZero, size });
+        }
+
+        CGContextTranslateCTM(context, size.width / 2.f, size.height / 2.f);
+        CGContextConcatCTM(context, transform);
+        CGContextTranslateCTM(context, -(size.width / 2.f), -(size.height / 2.f));
+
+        CGContextBeginPath(context);
+
+        // Add a set of nested diamonds and clip to them. They should be anchored at 1/4 and 2/3 of the way through the context,
+        // respectively.
+        CGContextAddRect(context, { size.width / 4.f, size.height / 4.f, size.width / 2.f, size.height / 2.f });
+        CGContextAddRect(context, { size.width * .75 / 2.f, size.height * .75 / 2.f, size.width / 4.f, size.height / 4.f });
+        CGContextEOClip(context);
+
+        CGContextSetRGBFillColor(context, 0.5, 0.5, 0.5, clipType == ClippingTypeAlpha ? 0.5 : 1.0);
+        CGContextFillRect(context, { CGPointZero, size });
+
+        // Add an additional full-brightness region (the bottom tip of the diamond.)
+        CGContextSaveGState(context);
+        CGContextAddRect(context, { CGPointZero, size.width / 2.f, size.height / 2.f });
+        CGContextClip(context);
+
+        CGContextSetRGBFillColor(context, 0.0, 0.0, 0.0, 1.0);
+        CGContextFillRect(context, { CGPointZero, size });
+    };
+}
+
+void __GradientMaskGenerator(CGContextRef context, CGSize size, ClippingType clipType) {
+    for (size_t i = 0; i < 256; ++i) {
+        float val = (float)i / 255.f;
+        CGContextSetRGBStrokeColor(context, val, val, val, clipType == ClippingTypeAlpha ? (1.0 - val) : 1.0);
+        CGPoint line[]{
+            { i + .5, 0 }, { i + .5, size.height },
+        };
+        CGContextStrokeLineSegments(context, line, 2);
+    }
+}
+
+class CGContextClipping : public ::testing::DrawTest,
+                          public ::testing::WithParamInterface<::testing::tuple<ClippingShape, ClippingType, CGSize>> {
+private:
+    static std::vector<std::tuple<ClippingShape, CGSize, std::function<void(CGContextRef, CGSize, ClippingType)>>> s_maskGenerators;
+
+protected:
+    CFStringRef CreateOutputFilename() {
+        const ::testing::TestInfo* const test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+        ClippingShape shape = ::testing::get<0>(GetParam());
+        ClippingType type = ::testing::get<1>(GetParam());
+        const char* shapeName = "unk";
+        const char* typeName;
+        switch (shape) {
+            case ClippingShapeDiamond:
+                shapeName = "di";
+                break;
+            case ClippingShapeSquare:
+                shapeName = "sq";
+                break;
+            case ClippingShapeRectangle:
+                shapeName = "rct";
+                break;
+        }
+        switch (type) {
+            case ClippingTypeMask:
+                typeName = "mask";
+                break;
+            case ClippingTypeAlpha:
+                typeName = "alpha";
+                break;
+        }
+        return CFStringCreateWithFormat(nullptr,
+                                        nullptr,
+                                        CFSTR("TestImage.CGContextClipping.%s.%s.%s.png"),
+                                        test_info->name(),
+                                        shapeName,
+                                        typeName);
+    }
+
+    CGImageRef GetClippingImage(ClippingShape shape, ClippingType type) {
+        static ClippingType s_clippingTypes[]{
+            ClippingTypeAlpha, ClippingTypeMask,
+        };
+        static std::unordered_map<unsigned int, woc::unique_cf<CGImageRef>> s_clippingImages = []() -> decltype(s_clippingImages) {
+            decltype(s_clippingImages) clippingImages;
+            for (auto& tpl : s_maskGenerators) {
+                for (auto& newType : s_clippingTypes) {
+                    ClippingShape newShape = std::get<0>(tpl);
+                    woc::unique_cf<CGImageRef> clipImage{ __CreateClipImage(std::get<1>(tpl), newType, std::get<2>(tpl)) };
+                    clippingImages.emplace(newShape | newType, std::move(clipImage));
+                }
+            }
+            return std::move(clippingImages);
+        }();
+        return s_clippingImages.at(shape | type).get();
+    }
+
+    void _FillContextWithColorAndLines() {
+        CGContextRef context = GetDrawingContext();
+        CGRect bounds = GetDrawingBounds();
+        CGContextSetRGBStrokeColor(context, 1.0, 0.0, 0.0, 1.0);
+        CGContextSetRGBFillColor(context, 0.0, 0.0, 0.0, 1.0);
+
+        CGContextFillRect(context, bounds);
+
+        for (CGFloat i = 0.5f; i < bounds.size.width; i += 10.0f) {
+            CGContextMoveToPoint(context, i, 0);
+            CGContextAddLineToPoint(context, i, bounds.size.height);
+            CGContextStrokePath(context);
+        }
+    }
+};
+
+std::vector<std::tuple<ClippingShape, CGSize, std::function<void(CGContextRef, CGSize, ClippingType)>>> CGContextClipping::s_maskGenerators{
+    { ClippingShapeSquare, CGSize{ 128, 128 }, __MakeSquareMaskGenerator(CGAffineTransformIdentity) },
+    { ClippingShapeDiamond, CGSize{ 128, 128 }, __MakeSquareMaskGenerator(CGAffineTransformMakeRotation(45.f * M_PI / 180.f)) },
+    { ClippingShapeRectangle, CGSize{ 256, 128 }, __GradientMaskGenerator },
+};
+
+TEST_P(CGContextClipping, StraightMask) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    ClippingShape shape = ::testing::get<0>(GetParam());
+    ClippingType type = ::testing::get<1>(GetParam());
+    CGSize clipSize = ::testing::get<2>(GetParam());
+
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
+
+    _FillContextWithColorAndLines();
+}
+
+TEST_P(CGContextClipping, TransformedMask) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    ClippingShape shape = ::testing::get<0>(GetParam());
+    ClippingType type = ::testing::get<1>(GetParam());
+    CGSize clipSize = ::testing::get<2>(GetParam());
+
+    CGContextConcatCTM(context, CGAffineTransformMake(1.0, 0.0, 0.75, 1.0, 0.0, 0.0));
+
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
+
+    _FillContextWithColorAndLines();
+}
+
+TEST_P(CGContextClipping, StackedMaskSameType) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    ClippingShape shape = ::testing::get<0>(GetParam());
+    ClippingType type = ::testing::get<1>(GetParam());
+    CGSize clipSize = ::testing::get<2>(GetParam());
+
+    ClippingShape otherShape = (shape == ClippingShapeSquare ? ClippingShapeDiamond : ClippingShapeSquare);
+
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(otherShape, type));
+
+    _FillContextWithColorAndLines();
+}
+
+TEST_P(CGContextClipping, StackedMaskOtherType) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    ClippingShape shape = ::testing::get<0>(GetParam());
+    ClippingType type = ::testing::get<1>(GetParam());
+    CGSize clipSize = ::testing::get<2>(GetParam());
+
+    ClippingShape otherShape = (shape == ClippingShapeSquare ? ClippingShapeDiamond : ClippingShapeSquare);
+    ClippingType otherType = (type == ClippingTypeAlpha ? ClippingTypeMask : ClippingTypeAlpha);
+
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(otherShape, otherType));
+
+    _FillContextWithColorAndLines();
+}
+
+TEST_P(CGContextClipping, MaskedAndClipped) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    ClippingShape shape = ::testing::get<0>(GetParam());
+    ClippingType type = ::testing::get<1>(GetParam());
+    CGSize clipSize = ::testing::get<2>(GetParam());
+
+    CGContextBeginPath(context);
+    CGContextAddEllipseInRect(context, _CGRectCenteredOnPoint({ clipSize.width / 2.f, clipSize.height / 2.f }, _CGRectGetCenter(bounds)));
+    CGContextEOClip(context);
+
+    CGContextClipToMask(context, _CGRectCenteredOnPoint(clipSize, _CGRectGetCenter(bounds)), GetClippingImage(shape, type));
+
+    _FillContextWithColorAndLines();
+}
+
+INSTANTIATE_TEST_CASE_P(Clipping,
+                        CGContextClipping,
+                        ::testing::Combine(::testing::Values(ClippingShapeSquare, ClippingShapeDiamond, ClippingShapeRectangle),
+                                           ::testing::Values(ClippingTypeMask, ClippingTypeAlpha),
+                                           ::testing::Values(CGSize{ 128, 128 }, CGSize{ 128, 256 }, CGSize{ 256, 256 })));
+
+// This image should be completely empty.
+DRAW_TEST(CGContextClipping, NonOverlappingImageMasks) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    woc::unique_cf<CGImageRef> clipImage{
+        __CreateClipImage({64, 64}, ClippingTypeAlpha, [](CGContextRef context, CGSize size, ClippingType clipType) {
+            CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0);
+            CGContextFillRect(context, { CGPointZero, size });
+        })
+    };
+
+    CGContextClipToMask(context, { CGPointZero, { 64, 64 } }, clipImage.get());
+    CGContextClipToMask(context, { { 0, bounds.size.height - 64 }, { 64, 64 } }, clipImage.get());
+
+    CGContextSetRGBFillColor(context, 0.0, 0.0, 1.0, 1.0);
+    CGContextFillRect(context, bounds);
+}
+
+// Clip by the same 64x64 image, but shifted 2x2 px.
+// The result should be a 62x62 image bounded by the original 64x64 clip with 2x2px to its bottom right.
+DRAW_TEST(CGContextClipping, CrossTransformedImageMasks) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    woc::unique_cf<CGImageRef> clipImage{
+        __CreateClipImage({64, 64}, ClippingTypeAlpha, [](CGContextRef context, CGSize size, ClippingType clipType) {
+            CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0);
+            CGContextFillRect(context, { CGPointZero, size });
+        })
+    };
+
+    CGContextClipToMask(context, { CGPointZero, { 64, 64 } }, clipImage.get());
+    CGContextTranslateCTM(context, 2.0, 2.0);
+    CGContextClipToMask(context, { CGPointZero, { 64, 64 } }, clipImage.get());
+
+    CGContextSetRGBFillColor(context, 0.0, 0.0, 1.0, 1.0);
+    CGContextFillRect(context, bounds);
+}

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.ClipATransparencyLayer.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.ClipATransparencyLayer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a31fe6ea6ec286453c370ece759480ff8cf2743ffeaaee79a64788bda3be061
+size 790

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.CrossTransformedImageMasks.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.CrossTransformedImageMasks.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:804e83d307a664248bc9b03fd29fa51952417c243bc6bb5cf526b8eda88ab7b1
+size 2553

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_0.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_0.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d18cc490ef6cdd069ced0c22ca4019521a1aa0d53af2f1bde9dd5471c2c51879
+size 1912

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_1.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_1.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da5e0df78569720214b7e8add546aa5eb854f897b6dc2d9ab03d4488564c4524
+size 2536

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_10.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_10.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:244cb2be43d51427ab1ef5caaddfbd4dcbf46f203eff4ca8de7c258d1eb8f3ff
+size 2839

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_11.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_11.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c721ae609d37f879d0ef702e1e96f0ab617072b74c1f5e504aac1f5e2bd1dce
+size 3580

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_12.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_12.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54ec0a257c0f13b3c14d6937cefd1549c4653a4768d0157109bfc4573856bc2
+size 1939

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_13.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_13.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4eab59774783bac7d9a317f7c72835afb1966b55bd8dd56311f4bce34e5d30
+size 2556

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_14.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_14.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7b4b236ef0490e3821019d33ddbaa24f48e78691d299d24b59c8ea54eb627f8
+size 3196

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_15.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_15.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f54ec0a257c0f13b3c14d6937cefd1549c4653a4768d0157109bfc4573856bc2
+size 1939

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_16.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_16.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4eab59774783bac7d9a317f7c72835afb1966b55bd8dd56311f4bce34e5d30
+size 2556

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_17.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_17.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7b4b236ef0490e3821019d33ddbaa24f48e78691d299d24b59c8ea54eb627f8
+size 3196

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_2.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_2.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77e3de4f8642f4bc6ca0fb617df3c1581541506ce4e73e07c854bab35ee955b4
+size 2950

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_3.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_3.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c83fcef12d3cbffbe30133dc8fee11d3bfacf7a1c532fdf7cd795261980202f
+size 1943

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_4.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_4.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76c65ad25ad767033fce5761ee5a314c65c759cd388d80b452cd5a48d6e51f1b
+size 2570

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_5.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_5.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caa980338a3f1397d32fb89ef65006dc4eb0af79f4494caad3068febfa33ca55
+size 2995

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_6.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_6.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cb31daaed715c98cb55441f50caa13d64775f0032fea6f7794cbc1973bd2eab
+size 2179

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_7.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_7.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:320d4d6f49dd0a8dc0245ecefb575b6e86cb53f2ac318ee63ea04ab8a57095e3
+size 2808

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_8.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_8.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3867e52461697df22f0f6bcb705c389966148909bac0d8ec361811602e371b1c
+size 3530

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_9.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.MaskedAndClipped_9.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50978fd4860b694d2bebff109c9e6d4dd610556beb7af9a01a4f765dd211a18f
+size 2216

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.NonOverlappingImageMasks.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.NonOverlappingImageMasks.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adf0319b9f824f3c4daca876dc4334bbd7ca919a44f85ad39aaa30069409bf66
+size 2381

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.PushClipPopClip.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.PushClipPopClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66864da8751ccdc8bf7ccfc158e973f19eec0496285a264c99796f1a0624336f
+size 1888

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_0.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_0.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:097388bef8b1675b62b70cf9a071e35fda45be7b35615b55aa5cb200994a3cb6
+size 1444

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_1.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_1.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3dec596513c1091d2a2503995e82487b43cf7504fe086d45786c6af520de9e6
+size 1641

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_10.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_10.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3dec596513c1091d2a2503995e82487b43cf7504fe086d45786c6af520de9e6
+size 1641

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_11.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_11.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ddf77d4b0c2534ac8c8a629ee092d107ad78e39f42c788c0b0b54ee4ca1e1f0
+size 1726

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_12.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_12.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ed7925962291a92602174774936f21761f8e5ffbb9139a1247982a713d88d0a
+size 956

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_13.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_13.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e88f34e58751ca355f5c7d2ad827e9f26bc49b427adc4208c3331c7ac71ee89d
+size 1088

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_14.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_14.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f3a48a531c45db45c3717c24c0720e95866b57030bef3b9f304be5cf37ea51f
+size 1111

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_15.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_15.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ed7925962291a92602174774936f21761f8e5ffbb9139a1247982a713d88d0a
+size 956

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_16.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_16.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e88f34e58751ca355f5c7d2ad827e9f26bc49b427adc4208c3331c7ac71ee89d
+size 1088

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_17.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_17.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f657484f2f2c0b6e681d20d61c5ecc86438b15c0b1eeb623473cc17f62ad42
+size 1111

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_2.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_2.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ddf77d4b0c2534ac8c8a629ee092d107ad78e39f42c788c0b0b54ee4ca1e1f0
+size 1726

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_3.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_3.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e6b9503c8028aa96d20957ee41a3abcb2890fe6b98ee318a16cca565501ad22
+size 1442

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_4.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_4.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e37cf7d313e7492c599acd145753e5a1e485e38e022717c1c6f65aacfef46ed9
+size 1643

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_5.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_5.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7638b58a4036c0e29eb63871c9b3a0daf8dea76526230029fd34b643e2823e72
+size 1728

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_6.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_6.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e6b9503c8028aa96d20957ee41a3abcb2890fe6b98ee318a16cca565501ad22
+size 1442

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_7.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_7.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e37cf7d313e7492c599acd145753e5a1e485e38e022717c1c6f65aacfef46ed9
+size 1643

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_8.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_8.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7638b58a4036c0e29eb63871c9b3a0daf8dea76526230029fd34b643e2823e72
+size 1728

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_9.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskOtherType_9.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:097388bef8b1675b62b70cf9a071e35fda45be7b35615b55aa5cb200994a3cb6
+size 1444

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_0.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_0.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6035baf4824f44cca1dd727b399d41b5ffa8711923d564b292fa4919f662bde2
+size 1433

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_1.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_1.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15d2c9273ce550590849991c0d1403cf56e6910970ba0fa6051c36006bd31944
+size 1631

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_10.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_10.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5598babcd7b118b827c94debb7f6b17a8a42a824b94f36fffec787b3327d52f
+size 1643

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_11.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_11.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66c23fa7efc0d895fc2d5ed9bc74ced6f20b31bb2d536aedf35e147f7259814c
+size 1729

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_12.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_12.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ed7925962291a92602174774936f21761f8e5ffbb9139a1247982a713d88d0a
+size 956

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_13.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_13.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e88f34e58751ca355f5c7d2ad827e9f26bc49b427adc4208c3331c7ac71ee89d
+size 1088

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_14.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_14.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65f657484f2f2c0b6e681d20d61c5ecc86438b15c0b1eeb623473cc17f62ad42
+size 1111

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_15.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_15.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ed7925962291a92602174774936f21761f8e5ffbb9139a1247982a713d88d0a
+size 956

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_16.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_16.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e88f34e58751ca355f5c7d2ad827e9f26bc49b427adc4208c3331c7ac71ee89d
+size 1088

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_17.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_17.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f3a48a531c45db45c3717c24c0720e95866b57030bef3b9f304be5cf37ea51f
+size 1111

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_2.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_2.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd43c39227f323bf3c934e08c30daf4133a86a9f0ee9a5eadeebcd1b31c787d
+size 1727

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_3.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_3.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:023e905bb5928b057bdfbfdf53608b8c4642bbe8aacc642918863529a68f204c
+size 1446

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_4.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_4.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5598babcd7b118b827c94debb7f6b17a8a42a824b94f36fffec787b3327d52f
+size 1643

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_5.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_5.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66c23fa7efc0d895fc2d5ed9bc74ced6f20b31bb2d536aedf35e147f7259814c
+size 1729

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_6.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_6.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6035baf4824f44cca1dd727b399d41b5ffa8711923d564b292fa4919f662bde2
+size 1433

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_7.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_7.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15d2c9273ce550590849991c0d1403cf56e6910970ba0fa6051c36006bd31944
+size 1631

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_8.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_8.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd43c39227f323bf3c934e08c30daf4133a86a9f0ee9a5eadeebcd1b31c787d
+size 1727

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_9.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StackedMaskSameType_9.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:023e905bb5928b057bdfbfdf53608b8c4642bbe8aacc642918863529a68f204c
+size 1446

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_0.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_0.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b50ca88e2505cdeef3573eee314cf213b2c24b95b82019d5fd75580cf3c66f0
+size 844

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_1.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_1.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d34351a9a365e98846337900f0ce8ff7fd77802b99ca382a09d81b2963b6a80
+size 979

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_10.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_10.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53454e26749773a447dacb5c8f8b40baadc1f3afd4774e36bfbb9937ab2ec92d
+size 1908

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_11.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_11.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92d32b0a8bafeab35ace3442250ca228e218bae347008bf59540ba6395e2ddd5
+size 1963

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_12.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_12.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11dccd66c1ccd2bf301fe16ae9f37ed00723bc85d25e2ff07debabed4297ebb7
+size 985

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_13.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_13.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07ccf0fb34f2dfc01e0df8738733098f98b513d8799ec44b90265a2edeb86dfd
+size 1254

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_14.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_14.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83b03d14f7f3f089975ba4c951f883c7e8a59e4e3f3bf038a117d607666eb0c3
+size 1273

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_15.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_15.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11dccd66c1ccd2bf301fe16ae9f37ed00723bc85d25e2ff07debabed4297ebb7
+size 985

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_16.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_16.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07ccf0fb34f2dfc01e0df8738733098f98b513d8799ec44b90265a2edeb86dfd
+size 1254

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_17.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_17.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83b03d14f7f3f089975ba4c951f883c7e8a59e4e3f3bf038a117d607666eb0c3
+size 1273

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_2.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_2.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:144753f2e9ad5a697993ff74eda3cc6392ac89f3bef4fab5ced57ac2fef38e26
+size 972

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_3.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_3.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2db6844cb6387ac6b9e98545cdc17ce0515f1c98a35cfdd490fafd65ff2a5a1e
+size 844

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_4.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_4.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44f9a3481f4a84979de04fe6e88f9e07dd678bc3dd479af2c8246bcb71ca55aa
+size 979

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_5.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_5.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c137f79f9d81a82138911c5f33bfc7716c6072dfdd84a2e67d4deb5c1f94103d
+size 972

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_6.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_6.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0da6bde7191f410b550c8a8be46464aaf8ab353645042bdb059d63046cf8236f
+size 1639

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_7.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_7.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e358ba92dfc30200ce262c546001cc387803d91658fcf102a3da335905666c11
+size 1906

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_8.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_8.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff05898002d46826ca035fd3cf362138016e88248bb21dc4be8bb16a0e867031
+size 1954

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_9.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.StraightMask_9.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf595e50ffe1037d5b9a2757c364c4632ad7be52017b446701b17f7db9e976ee
+size 1640

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_0.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_0.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0eec258c1889c7d116e70cf6bf57de745e831cd7ab6ca381a548782bbf7841cc
+size 1053

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_1.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_1.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3bcd4869c833784cdca3afdea719746419a97c489f9b4a705bed3a135d3eba0
+size 1417

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_10.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_10.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a02e3732e000ac07c6e7acee932e5d3b99f3e4718b9716db4cd5c12565efc97
+size 2334

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_11.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_11.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e9a61fed28bead111d0949e69d0cc96d1d375350a89c93cf706992e270430f9
+size 2333

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_12.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_12.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:422fd035e7cfb4f08fe995607f7dea15de9f848b70290cc7b00dce8a7c258036
+size 4903

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_13.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_13.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0204e32f66415efb0f6546a42b9f01b11e0ee025c868eb57ccd372b926bb173
+size 8710

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_14.rct.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_14.rct.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:653130e0d9e4262950af1a8df4d82fc7e1462926edaa801112dc2f0915cf4396
+size 10584

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_15.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_15.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:422fd035e7cfb4f08fe995607f7dea15de9f848b70290cc7b00dce8a7c258036
+size 4903

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_16.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_16.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0204e32f66415efb0f6546a42b9f01b11e0ee025c868eb57ccd372b926bb173
+size 8710

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_17.rct.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_17.rct.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:653130e0d9e4262950af1a8df4d82fc7e1462926edaa801112dc2f0915cf4396
+size 10584

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_2.sq.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_2.sq.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55377921d7828f75ae419f12c1f435048d076e0b7cf9abea9f55f25937d14af6
+size 1577

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_3.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_3.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d63a1226c8df29578543272cf6440038dc4b8107553da80ebf909b5e5422a03e
+size 1051

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_4.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_4.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b195e694b65b983edc30e136d7a18606913d89aaed5024ae125a2731fe5f61fe
+size 1416

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_5.sq.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_5.sq.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4bcaa2ec21c7453792d1448f2cb1ec112dcd75f1d7311f1719640975d8aa11e
+size 1571

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_6.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_6.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce9c4a0c5de73f776602b023e0f72b97d9688d61a55f28bb1ee53eca7bb4d42
+size 1612

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_7.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_7.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0fa41149bb49a55f12aa3fc228452ffb45d3cf7dfefee0a42f45353607317f3
+size 2264

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_8.di.mask.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_8.di.mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5fcaf2ce2b7fbc2d19a0e89f5bca16bb2e2dffe9dd58912d040126bcb0e149f
+size 2326

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_9.di.alpha.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContextClipping.TransformedMask_9.di.alpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d89937b39fa4e8379484a848358417db25f4bcfa354c63d65fe60a9d12c3856
+size 1562


### PR DESCRIPTION
This pull request adds support for clipping rendering into a context by an image or an image mask in terms of Direct2D opacity brushes.

An image mask is a grayscale image whose pixel values range from 0 to 100%, and those values are taken as inverse alpha. That is: a fully black image (px=0.0) will be rendered through at alpha 1.0; a fully white pixel will be at alpha 0.0 and values between the two will be interpolated appropriately.

Masks can be stacked. This is implemented in terms of a double composite operation; the two opacity brushes are combined and used to draw a black region into a new image. The new image will serve as the final bitmap backing the new opacity brush.

Since Direct2D does not support b/w masks natively, an effort was undertaken to translate them into alpha channel masks.

Black/white masks do, unfortunately, not work with CGBitmapContext as-is. We cannot render an image into a 1-component colorspace bitmap. This requires that this pull request be merged after #1529.

Fixes #1421. Provides a base implementation for #1425.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1528)
<!-- Reviewable:end -->
