### PR TITLE
Fix ImageIO for WIC & do a lot fewer image conversions in CGImage/CGContext.

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -2145,12 +2145,19 @@ void CGContextDrawGlyphRun(CGContextRef context, const DWRITE_GLYPH_RUN* glyphRu
 struct __CGBitmapContext : CoreFoundation::CppBase<__CGBitmapContext, __CGContext> {
     woc::unique_cf<CGImageRef> _image;
 
-    __CGBitmapContext(ID2D1RenderTarget* renderTarget) : Parent(renderTarget) {
+    __CGBitmapContext(ID2D1RenderTarget* renderTarget, REFWICPixelFormatGUID outputPixelFormat) : Parent(renderTarget), _outputPixelFormat(outputPixelFormat) {
     }
 
     inline void SetImage(CGImageRef image) {
         _image.reset(CGImageRetain(image));
     }
+
+    inline REFWICPixelFormatGUID GetOutputPixelFormat() const {
+        return _outputPixelFormat;
+    }
+
+private:
+    WICPixelFormatGUID _outputPixelFormat;
 };
 
 /**
@@ -2187,11 +2194,15 @@ CGContextRef CGBitmapContextCreateWithData(void* data,
 
     // bitsperpixel = ((bytesPerRow/width) * 8bits/byte)
     size_t bitsPerPixel = ((bytesPerRow / width) << 3);
-    REFGUID pixelFormat = _CGImageGetWICPixelFormatFromImageProperties(bitsPerComponent, bitsPerPixel, space, bitmapInfo);
+    REFWICPixelFormatGUID outputPixelFormat = _CGImageGetWICPixelFormatFromImageProperties(bitsPerComponent, bitsPerPixel, space, bitmapInfo);
+    WICPixelFormatGUID pixelFormat = outputPixelFormat;
 
     if (!_CGIsValidRenderTargetPixelFormat(pixelFormat)) {
-        UNIMPLEMENTED_WITH_MSG("CGBitmapContext does not currently support conversion and can only render into 32bpp PRGBA buffers.");
-        return nullptr;
+        if (data) {
+            UNIMPLEMENTED_WITH_MSG("CGBitmapContext does not currently support input conversion and can only render into 32bpp PRGBA buffers.");
+            return nullptr;
+        }
+        pixelFormat = GUID_WICPixelFormat32bppPRGBA;
     }
 
     // if data is null, enough memory is allocated via CGIWICBitmap
@@ -2206,7 +2217,8 @@ CGContextRef CGBitmapContextCreateWithData(void* data,
 
     ComPtr<ID2D1RenderTarget> renderTarget;
     RETURN_NULL_IF_FAILED(factory->CreateWicBitmapRenderTarget(customBitmap.Get(), D2D1::RenderTargetProperties(), &renderTarget));
-    return _CGBitmapContextCreateWithRenderTarget(renderTarget.Get(), image.get());
+    CGContextRef context = _CGBitmapContextCreateWithRenderTarget(renderTarget.Get(), image.get(), outputPixelFormat);
+    return context;
 }
 
 /**
@@ -2288,7 +2300,14 @@ void* CGBitmapContextGetData(CGContextRef context) {
 */
 CGImageRef CGBitmapContextCreateImage(CGContextRef context) {
     NOISY_RETURN_IF_NULL(context, nullptr);
-    return CGImageCreateCopy(CGBitmapContextGetImage(context));
+    if (CFGetTypeID(context) != __CGBitmapContext::GetTypeID()) {
+        TraceError(TAG, L"Image requested from non-bitmap CGContext.");
+        return nullptr;
+    }
+
+    // This copy is a no-op if the output format requested matches the backing image format.
+    __CGBitmapContext* bitmapContext = (__CGBitmapContext*)context;
+    return _CGImageCreateCopyWithPixelFormat(bitmapContext->_image.get(), bitmapContext->GetOutputPixelFormat());
 }
 
 CGImageRef CGBitmapContextGetImage(CGContextRef context) {
@@ -2300,9 +2319,9 @@ CGImageRef CGBitmapContextGetImage(CGContextRef context) {
     return ((__CGBitmapContext*)context)->_image.get();
 }
 
-CGContextRef _CGBitmapContextCreateWithRenderTarget(ID2D1RenderTarget* renderTarget, CGImageRef img) {
+CGContextRef _CGBitmapContextCreateWithRenderTarget(ID2D1RenderTarget* renderTarget, CGImageRef img, WICPixelFormatGUID outputPixelFormat) {
     RETURN_NULL_IF(!renderTarget);
-    __CGBitmapContext* context = __CGBitmapContext::CreateInstance(kCFAllocatorDefault, renderTarget);
+    __CGBitmapContext* context = __CGBitmapContext::CreateInstance(kCFAllocatorDefault, renderTarget, outputPixelFormat);
     __CGContextPrepareDefaults(context);
     context->SetImage(img);
     return context;

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -317,7 +317,7 @@ CGContextRef CreateLayerContentsBitmapContext32(int width, int height, float sca
         RETURN_NULL_IF_FAILED(factory->CreateWicBitmapRenderTarget(customWICBtmap.Get(), D2D1::RenderTargetProperties(), &renderTarget));
         renderTarget->SetDpi(c_windowsDPI * scale, c_windowsDPI * scale);
 
-        return _CGBitmapContextCreateWithRenderTarget(renderTarget.Get(), image.get());
+        return _CGBitmapContextCreateWithRenderTarget(renderTarget.Get(), image.get(), GUID_WICPixelFormat32bppPBGRA);
     }
 
     return nullptr;

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -22,6 +22,7 @@
 #include <COMIncludes.h>
 #import <DWrite.h>
 #import <D2d1.h>
+#import <wincodec.h>
 #include <COMIncludes_End.h>
 
 #import "CoreGraphicsInternal.h"
@@ -40,6 +41,6 @@ COREGRAPHICS_EXPORT bool CGContextIsPointInPath(CGContextRef c, bool eoFill, flo
 COREGRAPHICS_EXPORT void CGContextDrawGlyphRun(CGContextRef ctx, const DWRITE_GLYPH_RUN* glyphRun);
 
 // Bitmap Context Internal
-COREGRAPHICS_EXPORT CGContextRef _CGBitmapContextCreateWithRenderTarget(ID2D1RenderTarget* renderTarget, CGImageRef img = nullptr);
+COREGRAPHICS_EXPORT CGContextRef _CGBitmapContextCreateWithRenderTarget(ID2D1RenderTarget* renderTarget, CGImageRef img, WICPixelFormatGUID outputPixelFormat);
 COREGRAPHICS_EXPORT CGContextRef _CGBitmapContextCreateWithFormat(int width, int height, __CGSurfaceFormat fmt);
 COREGRAPHICS_EXPORT CGImageRef CGBitmapContextGetImage(CGContextRef ctx);

--- a/Frameworks/include/CGIWICBitmap.h
+++ b/Frameworks/include/CGIWICBitmap.h
@@ -196,6 +196,8 @@ public:
             copyRect = &fullRect;
         }
 
+        RETURN_HR_IF(E_INVALIDARG, copyRect->Width == 0 || copyRect->Height == 0 || copyRect->X < 0 || copyRect->Y < 0);
+
         UINT sourceDataStride;
         UINT sourceDataSize;
         BYTE* sourceData;
@@ -207,9 +209,10 @@ public:
             RETURN_HR_IF(E_UNEXPECTED, memcpy_s(buffer, bufferSize, sourceData, sourceDataSize) != 0);
         } else {
             // Once we support sub-regional locking we can fix this stride copier.
+            RETURN_HR_IF(E_NOTIMPL, sourceDataStride < fullRect.Width);
             size_t bytesPerPixel = sourceDataStride / fullRect.Width;
             ptrdiff_t xOffBytes = copyRect->X * bytesPerPixel;
-            for (off_t i = 0, j = copyRect->Y; i < copyRect->Height; ++i, ++j) {
+            for (size_t i = 0, j = copyRect->Y; i < copyRect->Height; ++i, ++j) {
                 RETURN_HR_IF(E_UNEXPECTED,
                              memcpy_s(buffer + (stride * i),
                                       bufferSize - (stride * i),

--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -117,7 +117,7 @@ COREGRAPHICS_EXPORT NSData* _CGImageRepresentation(CGImageRef image, REFGUID gui
 
 COREGRAPHICS_EXPORT CGImageRef _CGImageCreateWithWICBitmap(IWICBitmap* bitmap);
 
-HRESULT _CGImageGetWICImageSource(CGImageRef image, IWICBitmap** source);
+COREGRAPHICS_EXPORT HRESULT _CGImageGetWICImageSource(CGImageRef image, IWICBitmap** source);
 
 // Obtain a direct pointer to the data.
 COREGRAPHICS_EXPORT void* _CGImageGetRawBytes(CGImageRef image);

--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -55,21 +55,25 @@ static const std::map<GUID, int, GuidPixelLess> s_ValidRenderTargetPixelFormat =
                                                                                    { GUID_WICPixelFormat32bppPBGRA, 1 } };
 
 static const std::map<GUID, __CGImagePixelProperties, GuidPixelLess> s_PixelFormats = {
-    /*Alpha First,Last*/
-    { GUID_WICPixelFormat32bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 8, 32 } },
-    { GUID_WICPixelFormat32bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 8, 32 } },
+    // Last = RGBA, 32Little = forward: RGBA
+    // First = ARGB, 32Big = backward: BGRA
+    { GUID_WICPixelFormat32bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrder32Little), 8, 32 } },
+    { GUID_WICPixelFormat32bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaFirst | kCGBitmapByteOrder32Big), 8, 32 } },
+    { GUID_WICPixelFormat32bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Little), 8, 32 } },
+    { GUID_WICPixelFormat32bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Big), 8, 32 } },
+
+    // 64bpp formats (CoreGraphics has limited support for these.)
     { GUID_WICPixelFormat64bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
     { GUID_WICPixelFormat64bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
-    /*Alpha Premultiplied Last/First */
-    { GUID_WICPixelFormat32bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 8, 32 } },
-    { GUID_WICPixelFormat32bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 8, 32 } },
     { GUID_WICPixelFormat64bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 16, 64 } },
     { GUID_WICPixelFormat64bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 16, 64 } },
-    /*Alpha None, AlphaNoneSkipFirst, AlphaNoneSkipLast*/
+
+    // Non-alpha formats.
     { GUID_WICPixelFormat24bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 24 } },
     { GUID_WICPixelFormat24bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 24 } },
-    { GUID_WICPixelFormat32bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 32 } },
-    { GUID_WICPixelFormat32bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 32 } },
+    // Alpha-Skip formats (32bpp, but has alpha)
+    { GUID_WICPixelFormat32bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNoneSkipLast | kCGBitmapByteOrder32Little), 8, 32 } },
+    { GUID_WICPixelFormat32bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big), 8, 32 } },
     { GUID_WICPixelFormat48bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 48 } },
     { GUID_WICPixelFormat48bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 48 } },
     { GUID_WICPixelFormat64bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 64 } },
@@ -87,9 +91,9 @@ static const std::map<GUID, __CGImagePixelProperties, GuidPixelLess> s_PixelForm
     { GUID_WICPixelFormat32bppGrayFloat, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapFloatComponents), 32, 32 } },
     /*Indexed*/
     { GUID_WICPixelFormat1bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 1, 1 } },
-    { GUID_WICPixelFormat2bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 1, 2 } },
-    { GUID_WICPixelFormat4bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 1, 4 } },
-    { GUID_WICPixelFormat8bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 1, 8 } }
+    { GUID_WICPixelFormat2bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 2, 2 } },
+    { GUID_WICPixelFormat4bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 4, 4 } },
+    { GUID_WICPixelFormat8bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 8 } }
 };
 
 bool _CGIsValidRenderTargetPixelFormat(WICPixelFormatGUID pixelFormat);

--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -49,10 +49,11 @@ struct GuidPixelLess : public std::binary_function<GUID, GUID, bool> {
     }
 };
 
-static const std::map<GUID, int, GuidPixelLess> s_ValidRenderTargetPixelFormat = { { GUID_WICPixelFormat8bppAlpha, 1 },
-                                                                                   { GUID_WICPixelFormat32bppPRGBA, 1 },
-                                                                                   { GUID_WICPixelFormat32bppBGR, 1 },
-                                                                                   { GUID_WICPixelFormat32bppPBGRA, 1 } };
+static const std::map<GUID, int, GuidPixelLess> s_ValidRenderTargetPixelFormat = { { GUID_WICPixelFormat8bppAlpha, 1 },    // A8 Straight
+                                                                                   { GUID_WICPixelFormat32bppRGB, 1 },     // RGBX
+                                                                                   { GUID_WICPixelFormat32bppPRGBA, 1 },   // RGBA Premultiplied
+                                                                                   { GUID_WICPixelFormat32bppBGR, 1 },     // BGRX
+                                                                                   { GUID_WICPixelFormat32bppPBGRA, 1 } }; // BGRX Premultiplied
 
 static const std::map<GUID, __CGImagePixelProperties, GuidPixelLess> s_PixelFormats = {
     // Last = RGBA, 32Little = forward: RGBA

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -361,6 +361,7 @@ LIBRARY CoreGraphics
         _CGImageJPEGRepresentation
         _CGImageRepresentation
         _CGImageCreateWithWICBitmap
+        _CGImageGetWICImageSource
         _CGImageCreateCopyWithPixelFormat
         _CGImageGetRawBytes
         _CGImageGetDisplayTexture

--- a/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
@@ -222,3 +222,11 @@ DISABLED_DRAW_TEST_F(CGContext, ChangeCTMAfterCreatingPath, WhiteBackgroundTest)
     CGContextStrokePath(context);
     CGContextRestoreGState(context);
 }
+
+DRAW_TEST(CGContext, PremultipliedAlphaImage) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    CGContextSetRGBFillColor(context, 1.0, 0.0, 0.0, 0.5);
+    CGContextFillRect(context, { 0, 0, 100, 100 });
+}

--- a/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
+++ b/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
@@ -18,91 +18,203 @@
 #include "ImageHelpers.h"
 
 #include <CoreGraphics/CGGeometry.h>
+#include <algorithm>
+#include <vector>
 
-struct bgraPixel {
-    uint8_t b, g, r, a;
-};
-
-struct rgbaPixel {
+struct Pixel {
     uint8_t r, g, b, a;
+    bool operator==(const Pixel& o) const {
+        return r == o.r && g == o.g && g == o.g && a == o.a;
+    }
 };
 
-template <typename T, typename U>
-bool operator==(const T& t, const U& u) {
-    return t.r == u.r && t.g == u.g && t.b == u.b && t.a == u.a;
-}
+struct ImagePixelAccess {
+private:
+    woc::unique_cf<CGImageRef> _image;
+    woc::unique_cf<CFDataRef> _cfData;
+    const uint8_t* _data; // view into cfData
+    CGBitmapInfo _byteOrder;
+    CGImageAlphaInfo _alphaInfo;
+    bool _premultiplied;
+    bool _alphaFirst;
+    bool _alphaSkip;
+
+    static uint8_t unpremultiply(uint8_t val, uint8_t alpha) {
+        if (alpha == 0) {
+            return 0;
+        }
+        float fval = (float)val / (float(alpha) / 255.f);
+        return std::min((unsigned int)roundf(fval), 255U);
+    }
+
+public:
+    size_t width;
+    size_t height;
+
+    ImagePixelAccess(CGImageRef image)
+        : _image(CGImageRetain(image)),
+          _cfData(_CFDataCreateFromCGImage(image)),
+          _data(reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(_cfData.get()))),
+          _alphaInfo(CGImageGetAlphaInfo(image)),
+          width(CGImageGetWidth(image)),
+          height(CGImageGetHeight(image)) {
+        _premultiplied = _alphaInfo == kCGImageAlphaPremultipliedFirst || _alphaInfo == kCGImageAlphaPremultipliedLast;
+        _alphaFirst =
+            _alphaInfo == kCGImageAlphaPremultipliedFirst || _alphaInfo == kCGImageAlphaFirst || _alphaInfo == kCGImageAlphaNoneSkipFirst;
+        _alphaSkip = _alphaInfo == kCGImageAlphaNoneSkipFirst || _alphaInfo == kCGImageAlphaNoneSkipLast;
+
+        CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(image);
+        _byteOrder = bitmapInfo & kCGBitmapByteOrderMask;
+        if (_byteOrder == kCGBitmapByteOrderDefault) {
+            _byteOrder = kCGBitmapByteOrder32Host;
+        }
+    }
+
+    Pixel at(size_t x, size_t y) {
+        if (_alphaInfo == kCGImageAlphaNone) {
+            uint8_t(&rawData)[3] = *(((decltype(&rawData))_data) + (y * width) + x);
+            switch (_byteOrder) {
+                case kCGBitmapByteOrder32Big:
+                    // raw data is B G R
+                    return { rawData[2], rawData[1], rawData[0], 255 };
+                case kCGBitmapByteOrder32Little:
+                    // raw data is R G B
+                    return { rawData[0], rawData[1], rawData[2], 255 };
+                default:
+                    return { 0, 0, 0, 255 };
+            }
+        } else if (_alphaInfo != kCGImageAlphaOnly) {
+            uint8_t(&rawData)[4] = *(((decltype(&rawData))_data) + (y * width) + x);
+            Pixel p;
+            if (_alphaFirst) {
+                switch (_byteOrder) {
+                    case kCGBitmapByteOrder32Big:
+                        // raw data is B G R A
+                        p = { rawData[2], rawData[1], rawData[0], rawData[3] };
+                        break;
+                    case kCGBitmapByteOrder32Little:
+                        // raw data is A R G B
+                        p = { rawData[1], rawData[2], rawData[3], rawData[0] };
+                        break;
+                }
+            } else {
+                switch (_byteOrder) {
+                    case kCGBitmapByteOrder32Big:
+                        // raw data is A B G R
+                        p = { rawData[3], rawData[2], rawData[1], rawData[0] };
+                        break;
+                    case kCGBitmapByteOrder32Little:
+                        // raw data is R G B A
+                        p = { rawData[0], rawData[1], rawData[2], rawData[3] };
+                        break;
+                }
+            }
+
+            if (_alphaSkip) {
+                p.a = 255;
+            }
+
+            if (_premultiplied) {
+                p.r = unpremultiply(p.r, p.a);
+                p.g = unpremultiply(p.g, p.a);
+                p.b = unpremultiply(p.b, p.a);
+            }
+
+            return p;
+        } else {
+            // Alpha-only images are not supported.
+            return { 0, 0, 0, 255 };
+        }
+    }
+};
+
+struct RGBAImageBuffer {
+private:
+    std::vector<Pixel> _pixels;
+    RGBAImageBuffer(const RGBAImageBuffer& other) = delete;
+
+public:
+    size_t width;
+    size_t height;
+
+    RGBAImageBuffer(size_t width, size_t height) : _pixels(width * height, { 0, 0, 0, 0 }), width(width), height(height) {
+    }
+
+    Pixel& at(size_t x, size_t y) {
+        return _pixels[(y * width) + x];
+    }
+
+    const void* data() const {
+        return _pixels.data();
+    }
+
+    const size_t len() const {
+        return stride() * height;
+    };
+
+    const size_t stride() const {
+        return width * sizeof(decltype(_pixels[0]));
+    }
+};
 
 ImageDelta PixelByPixelImageComparator::CompareImages(CGImageRef left, CGImageRef right) {
     if (!left || !right) {
         return { ImageComparisonResult::Incomparable };
     }
 
-    CGSize leftSize{
-        (CGFloat)CGImageGetWidth(left), (CGFloat)CGImageGetHeight(left),
-    };
+    ImagePixelAccess leftAccess{ left };
+    ImagePixelAccess rightAccess{ right };
 
-    CGSize rightSize{
-        (CGFloat)CGImageGetWidth(right), (CGFloat)CGImageGetHeight(right),
-    };
-
-    size_t leftPixelCount = leftSize.width * leftSize.height;
-    size_t rightPixelCount = rightSize.width * rightSize.height;
+    size_t leftPixelCount = leftAccess.width * leftAccess.height;
+    size_t rightPixelCount = rightAccess.width * rightAccess.height;
 
     if (leftPixelCount != rightPixelCount) {
         return { ImageComparisonResult::Incomparable };
     }
 
-    woc::unique_cf<CFDataRef> leftData{ _CFDataCreateFromCGImage(left) };
-    woc::unique_cf<CFDataRef> rightData{ _CFDataCreateFromCGImage(right) };
-
-    CFIndex leftLength = CFDataGetLength(leftData.get());
-    if (leftLength != CFDataGetLength(rightData.get())) {
-        return { ImageComparisonResult::Incomparable };
-    }
-
-    woc::unique_iw<uint8_t> deltaBuffer{ static_cast<uint8_t*>(IwCalloc(leftLength, 1)) };
-
-    const bgraPixel* leftPixels{ reinterpret_cast<const bgraPixel*>(CFDataGetBytePtr(leftData.get())) };
-    const rgbaPixel* rightPixels{ reinterpret_cast<const rgbaPixel*>(CFDataGetBytePtr(rightData.get())) };
-    rgbaPixel* deltaPixels{ reinterpret_cast<rgbaPixel*>(deltaBuffer.get()) };
+    RGBAImageBuffer deltaBuffer{ leftAccess.width, leftAccess.height };
 
     // ASSUMPTION: The context draw did not cover the top left pixel;
     // We can use it as the background to detect accidental background deletion and miscomposition.
-    auto background = leftPixels[0];
+    Pixel background = leftAccess.at(0, 0);
 
     size_t npxchg = 0;
-    for (off_t i = 0; i < leftLength / sizeof(rgbaPixel); ++i) {
-        auto& bp = leftPixels[i];
-        auto& cp = rightPixels[i];
-        auto& gp = deltaPixels[i];
-        if (!(bp == cp)) {
-            ++npxchg;
-            if (cp == background) {
-                // Pixel is in EXPECTED but not ACTUAL
-                gp.r = gp.a = 255;
-            } else if (bp == background) {
-                // Pixel is in ACTUAL but not EXPECTED
-                gp.g = gp.a = 255;
+    for (off_t y = 0; y < leftAccess.height; ++y) {
+        for (off_t x = 0; x < leftAccess.width; ++x) {
+            auto bp = leftAccess.at(x, y);
+            auto cp = rightAccess.at(x, y);
+            auto& gp = deltaBuffer.at(x, y);
+            if (!(bp == cp)) {
+                ++npxchg;
+                if (cp == background) {
+                    // Pixel is in EXPECTED but not ACTUAL
+                    gp.r = gp.a = 255;
+                } else if (bp == background) {
+                    // Pixel is in ACTUAL but not EXPECTED
+                    gp.g = gp.a = 255;
+                } else {
+                    // Pixel is in BOTH but DIFFERENT
+                    gp.r = gp.g = gp.a = 255;
+                }
             } else {
-                // Pixel is in BOTH but DIFFERENT
-                gp.r = gp.g = gp.a = 255;
+                gp.r = gp.g = gp.b = 0;
+                gp.a = 255;
             }
-        } else {
-            gp.r = gp.g = gp.b = 0;
-            gp.a = 255;
         }
     }
 
-    woc::unique_cf<CFDataRef> deltaData{ CFDataCreateWithBytesNoCopy(nullptr, deltaBuffer.release(), leftLength, kCFAllocatorDefault) };
+    woc::unique_cf<CFDataRef> deltaData{
+        CFDataCreateWithBytesNoCopy(nullptr, reinterpret_cast<const UInt8*>(deltaBuffer.data()), deltaBuffer.len(), kCFAllocatorNull)
+    };
     woc::unique_cf<CGDataProviderRef> deltaProvider{ CGDataProviderCreateWithCFData(deltaData.get()) };
 
-    woc::unique_cf<CGImageRef> deltaImage{ CGImageCreate(leftSize.width,
-                                                         leftSize.height,
+    woc::unique_cf<CGImageRef> deltaImage{ CGImageCreate(deltaBuffer.width,
+                                                         deltaBuffer.height,
                                                          8,
                                                          32,
-                                                         leftSize.width * 4,
+                                                         deltaBuffer.stride(),
                                                          CGImageGetColorSpace(left),
-                                                         CGImageGetBitmapInfo(left),
+                                                         kCGBitmapByteOrder32Little | kCGImageAlphaLast,
                                                          deltaProvider.get(),
                                                          nullptr,
                                                          FALSE,

--- a/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
+++ b/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
@@ -26,6 +26,9 @@ struct Pixel {
     bool operator==(const Pixel& o) const {
         return r == o.r && g == o.g && g == o.g && a == o.a;
     }
+    bool operator!=(const Pixel& o) const {
+        return !(*this == o);
+    }
 };
 
 struct ImagePixelAccess {
@@ -55,8 +58,8 @@ private:
     }
 
 public:
-    size_t width;
-    size_t height;
+    const size_t width;
+    const size_t height;
 
     ImagePixelAccess(CGImageRef image)
         : _image(CGImageRetain(image)),
@@ -141,8 +144,8 @@ private:
     RGBAImageBuffer(const RGBAImageBuffer& other) = delete;
 
 public:
-    size_t width;
-    size_t height;
+    const size_t width;
+    const size_t height;
 
     RGBAImageBuffer(size_t width, size_t height) : _pixels(width * height, { 0, 0, 0, 0 }), width(width), height(height) {
     }
@@ -191,7 +194,7 @@ ImageDelta PixelByPixelImageComparator::CompareImages(CGImageRef left, CGImageRe
             auto bp = leftAccess.at(x, y);
             auto cp = rightAccess.at(x, y);
             auto& gp = deltaBuffer.at(x, y);
-            if (!(bp == cp)) {
+            if (bp != cp) {
                 ++npxchg;
                 if (cp == background) {
                     // Pixel is in EXPECTED but not ACTUAL

--- a/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
+++ b/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
@@ -43,8 +43,15 @@ private:
         if (alpha == 0) {
             return 0;
         }
-        float fval = (float)val / (float(alpha) / 255.f);
-        return std::min((unsigned int)roundf(fval), 255U);
+
+        if (alpha == 255) {
+            return val;
+        }
+
+        uint32_t multiplier16bpp = (uint32_t)floor((255. / double(alpha)) * 65536.);
+        // Use the above multiplier to calculate the pixel's 16bpp unpremultiplied value.
+        uint32_t pixelValue = val * multiplier16bpp;
+        return std::min(255U, (pixelValue >> 16));
     }
 
 public:

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.PremultipliedAlphaImage.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.PremultipliedAlphaImage.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b347035f3e9f7927668c822c4911adebb41172b5ee0f4c24e9baa98bd175c4cc
+size 2736

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -230,7 +230,7 @@ TEST_P(BitmapFormats, BufferCompare) {
     const BitmapFormatTestCase& testInfo = GetParam();
     const size_t width = 4;
     const size_t height = 1;
-    size_t bytesPerPixel = std::pow(2, testInfo.bitsPerPixel >> 3);
+    size_t bytesPerPixel = 2 << (testInfo.bitsPerPixel >> 3);
     size_t stride = width * bytesPerPixel;
     std::vector<uint8_t> data(stride * height, 0xAB);
     woc::unique_cf<CGColorSpaceRef> rgbColorSpace{ CGColorSpaceCreateDeviceRGB() };
@@ -249,8 +249,6 @@ TEST_P(BitmapFormats, BufferCompare) {
     // Premultiplied: 0x10 0x20 0x00 0x80
     CGContextSetRGBFillColor(context.get(), 32. / 255., 64. / 255., 0.0, 128. / 255.);
     CGContextFillRect(context.get(), { CGPointZero, { width, height } });
-
-    std::vector<uint8_t> transformedData(stride * height, 0xAB);
 
     size_t maskLength = testInfo.mask.size();
     size_t compareBufferLength = testInfo.expectedPixelValues.size();

--- a/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGBitmapContextTests.mm
@@ -159,7 +159,7 @@ TEST(CGBitmapContext, BitmapInfoAPIs_Gray) {
     EXPECT_EQ(context, nullptr);
 
     context = CGBitmapContextCreate(nullptr, 120, 20, 8, 480, grayColorSpace, 0);
-    EXPECT_EQ(context, nullptr);
+    EXPECT_NE(context, nullptr);
 }
 
 TEST(CGBitmapContext, BitmapInfoAPIs_RGB) {

--- a/tests/unittests/CoreGraphics/CGImageTests.mm
+++ b/tests/unittests/CoreGraphics/CGImageTests.mm
@@ -41,7 +41,7 @@ static const _ImageInfo imagesJPEG[] = {
 static const _ImageInfo imagesPNG[] = {
     /*{"filename",height,width,isMask,bit per pixel, bits per component} */
     { @"data/png1.png", 700, 1044, false, 32, 8 },
-    { @"data/png2.png", 136, 370, false, 8, 1 },
+    { @"data/png2.png", 136, 370, false, 8, 8 },
     { @"data/png3.png", 795, 1197, false, 32, 8 },
 };
 

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -81,15 +81,15 @@ TEST(ImageIO, ImageAtIndexWithData) {
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
 
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRef));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRef));
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 }
 
@@ -107,15 +107,15 @@ TEST(ImageIO, ImageAtIndexWithDataProvider) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRef));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRef));
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 }
 
@@ -132,15 +132,15 @@ TEST(ImageIO, ImageAtIndexWithUrl) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithURL returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRef));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRef));
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 }
 
@@ -173,13 +173,13 @@ TEST(ImageIO, ThumbnailAtIndexFromSrcWithoutThumbnail) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRef));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRef));
     CFRelease(imageSource);
 }
 
@@ -200,13 +200,13 @@ TEST(ImageIO, ThumbnailAtIndexFromAsymmetricSrcWithThumbnail) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(149, CGImageGetHeight(imageRef));
+    EXPECT_EQ(227, CGImageGetWidth(imageRef));
     CFRelease(imageSource);
 }
 
@@ -227,13 +227,13 @@ TEST(ImageIO, ThumbnailSizesRelativeToImage) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 10, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 10, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(10, CGImageGetHeight(imageRef));
+    EXPECT_EQ(10, CGImageGetWidth(imageRef));
     CFRelease(imageSource);
 
     options = @{
@@ -249,13 +249,13 @@ TEST(ImageIO, ThumbnailSizesRelativeToImage) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(149, CGImageGetHeight(imageRef));
+    EXPECT_EQ(227, CGImageGetWidth(imageRef));
     CFRelease(imageSource);
 }
 
@@ -276,14 +276,14 @@ TEST(ImageIO, GIF_TIFF_MultiFrameSourceTest) {
     ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"com.compuserve.gif", "FAILED: ImageIOTest::Incorrect Image Type");
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 4, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(4, frameCount);
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRef));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(1024, CGImageGetHeight(imageRef));
+    EXPECT_EQ(683, CGImageGetWidth(imageRef));
 
     imageFile = L"photo8_4layers_1024x683.tif";
     imageData = getDataFromImageFile(imageFile);
@@ -302,13 +302,13 @@ TEST(ImageIO, GIF_TIFF_MultiFrameSourceTest) {
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"public.tiff", "FAILED: ImageIOTest::Incorrect Image Type");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 4, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(1024, CGImageGetHeight(imageRef));
+    EXPECT_EQ(683, CGImageGetWidth(imageRef));
     CFRelease(imageSource);
 }
 
@@ -329,14 +329,14 @@ TEST(ImageIO, BMP_ICO_PNG_SingleFrameSourceTest) {
     ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"com.microsoft.bmp", "FAILED: ImageIOTest::Incorrect Image Type");
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(1, frameCount);
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRef));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(149, CGImageGetHeight(imageRef));
+    EXPECT_EQ(227, CGImageGetWidth(imageRef));
 
     // RGBA 8-bit ICO frame
     imageFile = L"photo2_683x1024.ico";
@@ -355,14 +355,14 @@ TEST(ImageIO, BMP_ICO_PNG_SingleFrameSourceTest) {
     ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"com.microsoft.ico", "FAILED: ImageIOTest::Incorrect Image Type");
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(1, frameCount);
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRef));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(1024, CGImageGetHeight(imageRef));
+    EXPECT_EQ(683, CGImageGetWidth(imageRef));
 
     // Paletted/Indexed PNG
     imageFile = L"seafloor_256x256.png";
@@ -381,14 +381,14 @@ TEST(ImageIO, BMP_ICO_PNG_SingleFrameSourceTest) {
     ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"public.png", "FAILED: ImageIOTest::Incorrect Image Type");
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(1, frameCount);
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRef));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 256, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 256, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(256, CGImageGetHeight(imageRef));
+    EXPECT_EQ(256, CGImageGetWidth(imageRef));
     CFRelease(imageSource);
 }
 
@@ -402,23 +402,23 @@ TEST(ImageIO, NegativeScenarioTest) {
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData(nullptr, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData should return nullptr");
+    ASSERT_EQ_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData should return nullptr");
 
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nullptr);
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
 
     imageSource = CGImageSourceCreateWithData(nullptr, nullptr);
-    ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData should return nullptr");
+    ASSERT_EQ_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData should return nullptr");
 
     CGDataProviderRef imgDataProvider = CGDataProviderCreateWithCFData((CFDataRef)imageData);
     imageSource = CGImageSourceCreateWithDataProvider(nullptr, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider should return nullptr");
+    ASSERT_EQ_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider should return nullptr");
 
     imageSource = CGImageSourceCreateWithDataProvider(imgDataProvider, nullptr);
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider returned nullptr");
 
     imageSource = CGImageSourceCreateWithDataProvider(nullptr, nullptr);
-    ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider should return nullptr");
+    ASSERT_EQ_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider should return nullptr");
 
     // get test startup full path
     wchar_t fullPath[_MAX_PATH];
@@ -438,25 +438,25 @@ TEST(ImageIO, NegativeScenarioTest) {
 
     CFURLRef imgUrl = (CFURLRef)[NSURL fileURLWithPath:directoryWithFile];
     imageSource = CGImageSourceCreateWithURL(nullptr, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithURL should return nullptr");
+    ASSERT_EQ_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithURL should return nullptr");
 
     imageSource = CGImageSourceCreateWithURL(nullptr, nullptr);
-    ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithURL should return nullptr");
+    ASSERT_EQ_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithURL should return nullptr");
 
     imageSource = CGImageSourceCreateWithURL(imgUrl, nullptr);
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithURL returned nullptr");
 
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 5, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
 
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, -1, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
 
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, nullptr);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
 
     imageRef = CGImageSourceCreateImageAtIndex(nullptr, 0, nullptr);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
 
     size_t frameCount = CGImageSourceGetCount(nullptr);
     ASSERT_EQ_MSG(frameCount, 0, "FAILED: ImageIOTest::FrameCount");
@@ -471,13 +471,13 @@ TEST(ImageIO, NegativeScenarioTest) {
     };
 
     imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 5, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex should return nullptr");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex should return nullptr");
 
     imageRef = CGImageSourceCreateThumbnailAtIndex(nullptr, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex should return nullptr");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex should return nullptr");
 
     imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, nullptr);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex should return nullptr");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex should return nullptr");
     CFRelease(imageSource);
 }
 
@@ -504,7 +504,7 @@ TEST(ImageIO, CopyJPEGPropertiesTest) {
     ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
-        ASSERT_EQ_MSG(fileSize, 218940, "FAILED: ImageIOTest::FileSize");
+        EXPECT_EQ(218940, fileSize);
     }
 
     CFRelease(imageSource);
@@ -520,7 +520,7 @@ TEST(ImageIO, CopyGIFPropertiesTest) {
     ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
-        ASSERT_EQ_MSG(fileSize, 669893, "FAILED: ImageIOTest::FileSize");
+        EXPECT_EQ(669893, fileSize);
     }
 
     CFRelease(imageSource);
@@ -536,7 +536,7 @@ TEST(ImageIO, CopyTIFFPropertiesTest) {
     ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
-        ASSERT_EQ_MSG(fileSize, 4187742, "FAILED: ImageIOTest::FileSize");
+        EXPECT_EQ(4187742, fileSize);
     }
 
     CFRelease(imageSource);
@@ -552,7 +552,7 @@ TEST(ImageIO, CopyPNGPropertiesTest) {
     ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
-        ASSERT_EQ_MSG(fileSize, 59506, "FAILED: ImageIOTest::FileSize");
+        EXPECT_EQ(59506, fileSize);
     }
 
     CFRelease(imageSource);
@@ -568,7 +568,7 @@ TEST(ImageIO, CopyBMPPropertiesTest) {
     ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
-        ASSERT_EQ_MSG(fileSize, 35050, "FAILED: ImageIOTest::FileSize");
+        EXPECT_EQ(35050, fileSize);
     }
 
     CFRelease(imageSource);
@@ -584,7 +584,7 @@ TEST(ImageIO, CopyICOPropertiesTest) {
     ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
-        ASSERT_EQ_MSG(fileSize, 1041876, "FAILED: ImageIOTest::FileSize");
+        EXPECT_EQ(1041876, fileSize);
     }
 
     CFRelease(imageSource);
@@ -632,14 +632,14 @@ TEST(ImageIO, CopyGIFPropertiesAtIndexTest) {
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPixelHeight),
                     "FAILED: ImageIOTest::GIF PixelHeight Property not found");
     int actualHeight = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight) intValue];
-    ASSERT_EQ_MSG(actualHeight, 1024, "FAILED: ImageIOTest::ActualHeight");
+    EXPECT_EQ(1024, actualHeight);
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyGIFDictionary),
                     "FAILED: ImageIOTest::GIF Dictionary not found");
     CFDictionaryRef gifDictionary = (CFDictionaryRef)CFDictionaryGetValue(imageProperties, kCGImagePropertyGIFDictionary);
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(gifDictionary, kCGImagePropertyGIFDelayTime),
                     "FAILED: ImageIOTest::GIF dictionary does not contain Delay Time");
     double actualDelayTime = [(id)CFDictionaryGetValue(gifDictionary, kCGImagePropertyGIFDelayTime) doubleValue];
-    ASSERT_NEAR_MSG(actualDelayTime, 0.1, 0.01, "FAILED: ImageIOTest::Delay Time mismatch");
+    EXPECT_NEAR_MSG(actualDelayTime, 0.1, 0.01, "FAILED: ImageIOTest::Delay Time mismatch");
 
     CFRelease(imageSource);
 }
@@ -664,7 +664,7 @@ TEST(ImageIO, CopyTIFFPropertiesAtIndexTest) {
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(tiffDictionary, kCGImagePropertyTIFFResolutionUnit),
                     "FAILED: ImageIOTest::TIFF dictionary does not contain Resolution Unit");
     int actualResolutionUnit = [(id)CFDictionaryGetValue(tiffDictionary, kCGImagePropertyTIFFResolutionUnit) intValue];
-    ASSERT_EQ_MSG(actualResolutionUnit, 2, "FAILED: ImageIOTest::ResolutionUnit");
+    EXPECT_EQ(2, actualResolutionUnit);
 
     CFRelease(imageSource);
 }
@@ -689,7 +689,7 @@ TEST(ImageIO, CopyPNGPropertiesAtIndexTest) {
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(pngDictionary, kCGImagePropertyPNGGamma),
                     "FAILED: ImageIOTest::PNG dictionary does not contain Gamma");
     int actualGamma = [(id)CFDictionaryGetValue(pngDictionary, kCGImagePropertyPNGGamma) intValue];
-    ASSERT_EQ_MSG(actualGamma, 45455, "FAILED: ImageIOTest::PngGamma");
+    EXPECT_EQ(45455, actualGamma);
 
     CFRelease(imageSource);
 }
@@ -717,15 +717,15 @@ TEST(ImageIO, DestinationTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 
     // Written as RGB
@@ -744,15 +744,15 @@ TEST(ImageIO, DestinationTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 
     // Written as RGB
@@ -771,15 +771,15 @@ TEST(ImageIO, DestinationTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 
     // Written as BGRX
@@ -798,15 +798,15 @@ TEST(ImageIO, DestinationTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNoneSkipFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNoneSkipFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 
     // Written as Paletted/Indexed
@@ -825,15 +825,15 @@ TEST(ImageIO, DestinationTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(670, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
     CFRelease(myImageDest);
 }
@@ -860,15 +860,15 @@ TEST(ImageIO, DestinationFromSourceTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(149, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(227, CGImageGetWidth(imageRefOut));
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
 
     // Written as RGB
     const wchar_t* outFile2 = L"outphoto2.jpg";
@@ -887,15 +887,15 @@ TEST(ImageIO, DestinationFromSourceTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(149, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(227, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
 
     // Written as RGB
     const wchar_t* outFile3 = L"outphoto2.png";
@@ -914,15 +914,15 @@ TEST(ImageIO, DestinationFromSourceTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(149, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(227, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
 
     // Written as BGRX
     const wchar_t* outFile4 = L"outphoto2.bmp";
@@ -941,15 +941,15 @@ TEST(ImageIO, DestinationFromSourceTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNoneSkipFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 149, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 227, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNoneSkipFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(149, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(227, CGImageGetWidth(imageRefOut));
     frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 }
 
@@ -987,33 +987,33 @@ TEST(ImageIO, DestinationMultiFrameTest) {
 
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(1024, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(683, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     CFRelease(imageSource);
 }
@@ -1052,33 +1052,33 @@ TEST(ImageIO, DestinationMultiFrameGifTest) {
 
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(1024, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(683, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     CFRelease(imageSource);
 }
@@ -1104,13 +1104,13 @@ TEST(ImageIO, DestinationDataTest) {
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
+    EXPECT_EQ(1024, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(683, CGImageGetWidth(imageRefOut));
     CFRelease(imageSource);
 }
 
@@ -1144,33 +1144,33 @@ TEST(ImageIO, DestinationMultiFrameDataTest) {
 
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(1024, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(683, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     CFRelease(imageSource);
 }
@@ -1203,15 +1203,15 @@ TEST(ImageIO, DestinationOptionsTest) {
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(24, CGImageGetBitsPerPixel(imageRefOut));
+    EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
+    EXPECT_EQ(670, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
     size_t frameCount = CGImageSourceGetCount(imageSource);
-    ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
+    EXPECT_EQ(1, frameCount);
     CFRelease(imageSource);
 
     imageFile = L"photo2_683x1024.ico";
@@ -1265,37 +1265,37 @@ TEST(ImageIO, DestinationOptionsTest) {
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(gifDictionary, kCGImagePropertyGIFLoopCount),
                     "FAILED: ImageIOTest::GIF dictionary does not contain Loop Count");
     int actualLoopCount = [(id)CFDictionaryGetValue(gifDictionary, kCGImagePropertyGIFLoopCount) intValue];
-    ASSERT_EQ_MSG(actualLoopCount, loopCount, "FAILED: ImageIOTest::LoopCount");
+    EXPECT_EQ(loopCount, actualLoopCount);
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(1024, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(683, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
-    ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetAlphaInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNone, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
+    EXPECT_EQ(8, CGImageGetBitsPerPixel(imageRefOut));
     // TODO: Check Paletted/Indexed color space.
-    ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
-    ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
+    EXPECT_EQ(683, CGImageGetHeight(imageRefOut));
+    EXPECT_EQ(1024, CGImageGetWidth(imageRefOut));
 
     CFRelease(imageSource);
 }
@@ -1378,11 +1378,11 @@ TEST(ImageIO, DestinationImageOptionsTIFFTest) {
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPixelHeight), "FAILED: ImageIOTest::Pixel Height not found");
     int actualPixelHeight = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight) intValue];
-    ASSERT_EQ_MSG(actualPixelHeight, 1024, "FAILED: ImageIOTest::Height");
+    EXPECT_EQ(1024, actualPixelHeight);
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyOrientation), "FAILED: ImageIOTest::Orientation not found");
     int actualOrientation = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyOrientation) intValue];
-    ASSERT_EQ_MSG(actualOrientation, 3, "FAILED: ImageIOTest::Orientation");
+    EXPECT_EQ(3, actualOrientation);
 
     CFRelease(imageSource);
 }
@@ -1463,11 +1463,11 @@ TEST(ImageIO, DestinationImageOptionsJPEGTest) {
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPixelHeight), "FAILED: ImageIOTest::Pixel Height not found");
     int actualPixelHeight = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight) intValue];
-    ASSERT_EQ_MSG(actualPixelHeight, 1024, "FAILED: ImageIOTest::Height");
+    EXPECT_EQ(1024, actualPixelHeight);
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyOrientation), "FAILED: ImageIOTest::Orientation not found");
     int actualOrientation = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyOrientation) intValue];
-    ASSERT_EQ_MSG(actualOrientation, 2, "FAILED: ImageIOTest::Orientation");
+    EXPECT_EQ(2, actualOrientation);
 
     CFRelease(imageSource);
 }
@@ -1523,7 +1523,7 @@ TEST(ImageIO, DestinationImageOptionsGIFTest) {
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPixelHeight), "FAILED: ImageIOTest::Pixel Height not found");
     int actualPixelHeight = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight) intValue];
-    ASSERT_EQ_MSG(actualPixelHeight, 1024, "FAILED: ImageIOTest::Height");
+    EXPECT_EQ(1024, actualPixelHeight);
 
     CFRelease(imageSource);
 }
@@ -1571,7 +1571,7 @@ TEST(ImageIO, DestinationImageOptionsPNGTest) {
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(pngDictionary, kCGImagePropertyPNGGamma),
                     "FAILED: ImageIOTest::PNG dictionary does not contain Gamma");
     int actualGamma = [(id)CFDictionaryGetValue(pngDictionary, kCGImagePropertyPNGGamma) intValue];
-    ASSERT_EQ_MSG(actualGamma, 45045, "FAILED: ImageIOTest::PngGamma");
+    EXPECT_EQ(45045, actualGamma);
 
     CFRelease(imageSource);
 }
@@ -2169,16 +2169,16 @@ TEST(ImageIO, NonIncrementalJPEGSource) {
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nullptr);
     ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
 
-    ASSERT_EQ_MSG(CGImageSourceGetStatus(imageSource), kCGImageStatusComplete, "FAILED: ImageIOTest::ContainerStatus");
-    ASSERT_EQ_MSG(CGImageSourceGetStatusAtIndex(imageSource, 0), kCGImageStatusUnknownType, "FAILED: ImageIOTest::ImageStatusAtIndex");
+    EXPECT_EQ(kCGImageStatusComplete, CGImageSourceGetStatus(imageSource));
+    ASSERT_EQ(kCGImageStatusUnknownType, CGImageSourceGetStatusAtIndex(imageSource, 0));
 
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, nullptr);
     ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageSourceGetStatusAtIndex(imageSource, 0), kCGImageStatusComplete, "FAILED: ImageIOTest::ImageStatusAtIndex");
+    EXPECT_EQ(kCGImageStatusComplete, CGImageSourceGetStatusAtIndex(imageSource, 0));
 
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 1, nullptr);
-    ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
-    ASSERT_EQ_MSG(CGImageSourceGetStatusAtIndex(imageSource, 1), kCGImageStatusUnknownType, "FAILED: ImageIOTest::ImageStatusAtIndex");
+    ASSERT_EQ_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
+    EXPECT_EQ(kCGImageStatusUnknownType, CGImageSourceGetStatusAtIndex(imageSource, 1));
 
     CFRelease(imageSource);
 }

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -70,21 +70,21 @@ static CFURLRef getURLRefForOutFile(const wchar_t* filename) {
 TEST(ImageIO, ImageAtIndexWithData) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
 
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
@@ -96,7 +96,7 @@ TEST(ImageIO, ImageAtIndexWithData) {
 TEST(ImageIO, ImageAtIndexWithDataProvider) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
@@ -104,13 +104,13 @@ TEST(ImageIO, ImageAtIndexWithDataProvider) {
     };
     CGDataProviderRef imgDataProvider = CGDataProviderCreateWithCFData((CFDataRef)imageData);
     CGImageSourceRef imageSource = CGImageSourceCreateWithDataProvider(imgDataProvider, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
@@ -129,13 +129,13 @@ TEST(ImageIO, ImageAtIndexWithUrl) {
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithURL(imgUrl, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithURL returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithURL returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
@@ -147,11 +147,11 @@ TEST(ImageIO, ImageAtIndexWithUrl) {
 TEST(ImageIO, ImageTypeTest) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nullptr);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFStringRef imageType = CGImageSourceGetType(imageSource);
-    ASSERT_TRUE_MSG(imageType != nil, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
+    ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"public.jpeg", "FAILED: ImageIOTest::Incorrect Image Type");
     CFRelease(imageSource);
 }
@@ -159,7 +159,7 @@ TEST(ImageIO, ImageTypeTest) {
 TEST(ImageIO, ThumbnailAtIndexFromSrcWithoutThumbnail) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
@@ -170,13 +170,13 @@ TEST(ImageIO, ThumbnailAtIndexFromSrcWithoutThumbnail) {
         @"kCGImageSourceCreateThumbnailWithTransform" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 1024, "FAILED: ImageIOTest::Width");
@@ -186,7 +186,7 @@ TEST(ImageIO, ThumbnailAtIndexFromSrcWithoutThumbnail) {
 TEST(ImageIO, ThumbnailAtIndexFromAsymmetricSrcWithThumbnail) {
     const wchar_t* imageFile = L"photo6_1024x670_thumbnail_227x149.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
@@ -197,13 +197,13 @@ TEST(ImageIO, ThumbnailAtIndexFromAsymmetricSrcWithThumbnail) {
         @"kCGImageSourceCreateThumbnailWithTransform" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 149, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 227, "FAILED: ImageIOTest::Width");
@@ -213,7 +213,7 @@ TEST(ImageIO, ThumbnailAtIndexFromAsymmetricSrcWithThumbnail) {
 TEST(ImageIO, ThumbnailSizesRelativeToImage) {
     const wchar_t* imageFile = L"photo6_1024x670_thumbnail_227x149.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
@@ -224,13 +224,13 @@ TEST(ImageIO, ThumbnailSizesRelativeToImage) {
         @"kCGImageSourceCreateThumbnailWithTransform" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 10, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 10, "FAILED: ImageIOTest::Width");
@@ -246,13 +246,13 @@ TEST(ImageIO, ThumbnailSizesRelativeToImage) {
         @"kCGImageSourceCreateThumbnailWithTransform" : @"kCFBooleanTrue"
     };
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateThumbnailAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 149, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 227, "FAILED: ImageIOTest::Width");
@@ -262,50 +262,50 @@ TEST(ImageIO, ThumbnailSizesRelativeToImage) {
 TEST(ImageIO, GIF_TIFF_MultiFrameSourceTest) {
     const wchar_t* imageFile = L"photo7_4layers_683x1024.gif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeGIF",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 2, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     CFStringRef imageType = CGImageSourceGetType(imageSource);
-    ASSERT_TRUE_MSG(imageType != nil, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
+    ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"com.compuserve.gif", "FAILED: ImageIOTest::Incorrect Image Type");
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 4, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 1024, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 683, "FAILED: ImageIOTest::Width");
 
     imageFile = L"photo8_4layers_1024x683.tif";
     imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeTIFF",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 3, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     imageType = CGImageSourceGetType(imageSource);
-    ASSERT_TRUE_MSG(imageType != nil, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
+    ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"public.tiff", "FAILED: ImageIOTest::Incorrect Image Type");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 4, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 1024, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 683, "FAILED: ImageIOTest::Width");
@@ -315,76 +315,78 @@ TEST(ImageIO, GIF_TIFF_MultiFrameSourceTest) {
 TEST(ImageIO, BMP_ICO_PNG_SingleFrameSourceTest) {
     const wchar_t* imageFile = L"testimg_227x149.bmp";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeBMP",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     CFStringRef imageType = CGImageSourceGetType(imageSource);
-    ASSERT_TRUE_MSG(imageType != nil, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
+    ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"com.microsoft.bmp", "FAILED: ImageIOTest::Incorrect Image Type");
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 149, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 227, "FAILED: ImageIOTest::Width");
 
+    // RGBA 8-bit ICO frame
     imageFile = L"photo2_683x1024.ico";
     imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeICO",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     imageType = CGImageSourceGetType(imageSource);
-    ASSERT_TRUE_MSG(imageType != nil, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
+    ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"com.microsoft.ico", "FAILED: ImageIOTest::Incorrect Image Type");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 1024, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 683, "FAILED: ImageIOTest::Width");
 
+    // Paletted/Indexed PNG
     imageFile = L"seafloor_256x256.png";
     imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypePNG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     imageType = CGImageSourceGetType(imageSource);
-    ASSERT_TRUE_MSG(imageType != nil, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
+    ASSERT_NE_MSG(nil, imageType, "FAILED: ImageIOTest::CGImageSourceGetType returned nullptr");
     ASSERT_OBJCEQ_MSG(static_cast<NSString*>(imageType), @"public.png", "FAILED: ImageIOTest::Incorrect Image Type");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRef), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRef), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRef), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRef), 256, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRef), 256, "FAILED: ImageIOTest::Width");
     CFRelease(imageSource);
@@ -393,7 +395,7 @@ TEST(ImageIO, BMP_ICO_PNG_SingleFrameSourceTest) {
 TEST(ImageIO, NegativeScenarioTest) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
@@ -403,7 +405,7 @@ TEST(ImageIO, NegativeScenarioTest) {
     ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData should return nullptr");
 
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nullptr);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
 
     imageSource = CGImageSourceCreateWithData(nullptr, nullptr);
     ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData should return nullptr");
@@ -413,7 +415,7 @@ TEST(ImageIO, NegativeScenarioTest) {
     ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider should return nullptr");
 
     imageSource = CGImageSourceCreateWithDataProvider(imgDataProvider, nullptr);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider returned nullptr");
 
     imageSource = CGImageSourceCreateWithDataProvider(nullptr, nullptr);
     ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithDataProvider should return nullptr");
@@ -442,7 +444,7 @@ TEST(ImageIO, NegativeScenarioTest) {
     ASSERT_TRUE_MSG(imageSource == nil, "FAILED: ImageIOTest::CGImageSourceCreateWithURL should return nullptr");
 
     imageSource = CGImageSourceCreateWithURL(imgUrl, nullptr);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithURL returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithURL returned nullptr");
 
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 5, (CFDictionaryRef)options);
     ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
@@ -451,7 +453,7 @@ TEST(ImageIO, NegativeScenarioTest) {
     ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
 
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, nullptr);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
 
     imageRef = CGImageSourceCreateImageAtIndex(nullptr, 0, nullptr);
     ASSERT_TRUE_MSG(imageRef == nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex should return nullptr");
@@ -495,11 +497,11 @@ TEST(ImageIO, TypeIdentifierTest) {
 TEST(ImageIO, CopyJPEGPropertiesTest) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nil);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, nil);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
         ASSERT_EQ_MSG(fileSize, 218940, "FAILED: ImageIOTest::FileSize");
@@ -511,11 +513,11 @@ TEST(ImageIO, CopyJPEGPropertiesTest) {
 TEST(ImageIO, CopyGIFPropertiesTest) {
     const wchar_t* imageFile = L"photo7_4layers_683x1024.gif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nil);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, nil);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
         ASSERT_EQ_MSG(fileSize, 669893, "FAILED: ImageIOTest::FileSize");
@@ -527,11 +529,11 @@ TEST(ImageIO, CopyGIFPropertiesTest) {
 TEST(ImageIO, CopyTIFFPropertiesTest) {
     const wchar_t* imageFile = L"photo8_4layers_1024x683.tif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nil);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, nil);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
         ASSERT_EQ_MSG(fileSize, 4187742, "FAILED: ImageIOTest::FileSize");
@@ -543,11 +545,11 @@ TEST(ImageIO, CopyTIFFPropertiesTest) {
 TEST(ImageIO, CopyPNGPropertiesTest) {
     const wchar_t* imageFile = L"seafloor_256x256.png";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nil);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, nil);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
         ASSERT_EQ_MSG(fileSize, 59506, "FAILED: ImageIOTest::FileSize");
@@ -559,11 +561,11 @@ TEST(ImageIO, CopyPNGPropertiesTest) {
 TEST(ImageIO, CopyBMPPropertiesTest) {
     const wchar_t* imageFile = L"testimg_227x149.bmp";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nil);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, nil);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
         ASSERT_EQ_MSG(fileSize, 35050, "FAILED: ImageIOTest::FileSize");
@@ -575,11 +577,11 @@ TEST(ImageIO, CopyBMPPropertiesTest) {
 TEST(ImageIO, CopyICOPropertiesTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nil);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, nil);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
     if (imageProperties && CFDictionaryContainsKey(imageProperties, kCGImagePropertyFileSize)) {
         int fileSize = [(id)CFDictionaryGetValue(imageProperties, kCGImagePropertyFileSize) intValue];
         ASSERT_EQ_MSG(fileSize, 1041876, "FAILED: ImageIOTest::FileSize");
@@ -591,16 +593,16 @@ TEST(ImageIO, CopyICOPropertiesTest) {
 TEST(ImageIO, CopyJPEGPropertiesAtIndexTest) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeJPEG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyJFIFDictionary),
                     "FAILED: ImageIOTest::JFIF dictionary not found");
@@ -616,16 +618,16 @@ TEST(ImageIO, CopyJPEGPropertiesAtIndexTest) {
 TEST(ImageIO, CopyGIFPropertiesAtIndexTest) {
     const wchar_t* imageFile = L"photo7_4layers_683x1024.gif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeGIF",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPixelHeight),
                     "FAILED: ImageIOTest::GIF PixelHeight Property not found");
@@ -645,16 +647,16 @@ TEST(ImageIO, CopyGIFPropertiesAtIndexTest) {
 TEST(ImageIO, CopyTIFFPropertiesAtIndexTest) {
     const wchar_t* imageFile = L"photo8_4layers_1024x683.tif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypeTIFF",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyTIFFDictionary),
                     "FAILED: ImageIOTest::TIFF dictionary not found");
@@ -670,16 +672,16 @@ TEST(ImageIO, CopyTIFFPropertiesAtIndexTest) {
 TEST(ImageIO, CopyPNGPropertiesAtIndexTest) {
     const wchar_t* imageFile = L"seafloor_256x256.png";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSDictionary* options = @{
         @"kCGImageSourceTypeIdentifierHint" : @"kUTTypePNG",
         @"kCGImageSourceShouldAllowFloat" : @"kCFBooleanTrue",
         @"kCGImageSourceShouldCache" : @"kCFBooleanTrue"
     };
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, (CFDictionaryRef)options);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPNGDictionary),
                     "FAILED: ImageIOTest::PNG dictionary not found");
@@ -692,13 +694,14 @@ TEST(ImageIO, CopyPNGPropertiesAtIndexTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationTest) {
+TEST(ImageIO, DestinationTest) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     CFRelease(imageSource);
 
+    // Written as BGRA
     const wchar_t* outFile = L"outphoto.tif";
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
@@ -709,13 +712,13 @@ DISABLED_TEST(ImageIO, DestinationTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -725,6 +728,7 @@ DISABLED_TEST(ImageIO, DestinationTest) {
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
     CFRelease(imageSource);
 
+    // Written as RGB
     const wchar_t* outFile2 = L"outphoto.jpg";
     imgUrl = getURLRefForOutFile(outFile2);
 
@@ -735,15 +739,15 @@ DISABLED_TEST(ImageIO, DestinationTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile2);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile2);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile2);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
@@ -751,6 +755,7 @@ DISABLED_TEST(ImageIO, DestinationTest) {
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
     CFRelease(imageSource);
 
+    // Written as RGB
     const wchar_t* outFile3 = L"outphoto.png";
     imgUrl = getURLRefForOutFile(outFile3);
 
@@ -761,15 +766,15 @@ DISABLED_TEST(ImageIO, DestinationTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile3);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile3);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile3);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
@@ -777,6 +782,7 @@ DISABLED_TEST(ImageIO, DestinationTest) {
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
     CFRelease(imageSource);
 
+    // Written as BGRX
     const wchar_t* outFile4 = L"outphoto.bmp";
     imgUrl = getURLRefForOutFile(outFile4);
 
@@ -787,13 +793,13 @@ DISABLED_TEST(ImageIO, DestinationTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile4);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile4);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile4);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNoneSkipFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -803,6 +809,7 @@ DISABLED_TEST(ImageIO, DestinationTest) {
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
     CFRelease(imageSource);
 
+    // Written as Paletted/Indexed
     const wchar_t* outFile5 = L"outphoto.gif";
     imgUrl = getURLRefForOutFile(outFile5);
 
@@ -813,16 +820,16 @@ DISABLED_TEST(ImageIO, DestinationTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile5);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile5);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile5);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
     frameCount = CGImageSourceGetCount(imageSource);
@@ -831,11 +838,12 @@ DISABLED_TEST(ImageIO, DestinationTest) {
     CFRelease(myImageDest);
 }
 
-DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
+TEST(ImageIO, DestinationFromSourceTest) {
     const wchar_t* imageFile = L"testimg_227x149.bmp";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
 
+    // Written as BGRA
     const wchar_t* outFile = L"outphoto2.tif";
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
@@ -847,13 +855,13 @@ DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
     // Read back in the newly written image to check properties
     CFRelease(imageSource);
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -862,6 +870,7 @@ DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
 
+    // Written as RGB
     const wchar_t* outFile2 = L"outphoto2.jpg";
     imgUrl = getURLRefForOutFile(outFile2);
 
@@ -873,21 +882,22 @@ DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile2);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile2);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile2);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 149, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 227, "FAILED: ImageIOTest::Width");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
 
+    // Written as RGB
     const wchar_t* outFile3 = L"outphoto2.png";
     imgUrl = getURLRefForOutFile(outFile3);
 
@@ -899,21 +909,22 @@ DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile3);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile3);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile3);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 149, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 227, "FAILED: ImageIOTest::Width");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
 
+    // Written as BGRX
     const wchar_t* outFile4 = L"outphoto2.bmp";
     imgUrl = getURLRefForOutFile(outFile4);
 
@@ -925,13 +936,13 @@ DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile4);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile4);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile4);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNoneSkipFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -942,7 +953,7 @@ DISABLED_TEST(ImageIO, DestinationFromSourceTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationMultiFrameTest) {
+TEST(ImageIO, DestinationMultiFrameTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -953,6 +964,7 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameTest) {
     CGImageSourceRef imageSource2 = CGImageSourceCreateWithData((CFDataRef)imageData2, NULL);
     CGImageRef imageRef2 = CGImageSourceCreateImageAtIndex(imageSource2, 0, NULL);
 
+    // Written as BGRA
     const wchar_t* outFile = L"outphoto_multiframe.tif";
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
@@ -967,16 +979,16 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 3, "FAILED: ImageIOTest::FrameCount");
 
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -984,9 +996,9 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameTest) {
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -994,9 +1006,9 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameTest) {
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -1006,7 +1018,7 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationMultiFrameGifTest) {
+TEST(ImageIO, DestinationMultiFrameGifTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1017,6 +1029,7 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameGifTest) {
     CGImageSourceRef imageSource2 = CGImageSourceCreateWithData((CFDataRef)imageData2, NULL);
     CGImageRef imageRef2 = CGImageSourceCreateImageAtIndex(imageSource2, 0, NULL);
 
+    // Written as Paletted/Indexed
     const wchar_t* outFile = L"outphoto_multiframe.gif";
     CFURLRef imgUrl = getURLRefForOutFile(outFile);
 
@@ -1031,46 +1044,46 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameGifTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 3, "FAILED: ImageIOTest::FrameCount");
 
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
 
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationDataTest) {
+TEST(ImageIO, DestinationDataTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1086,13 +1099,13 @@ DISABLED_TEST(ImageIO, DestinationDataTest) {
     CFRelease(myImageDest);
 
     imageSource = CGImageSourceCreateWithData((CFDataRef)dataBuffer, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 1, "FAILED: ImageIOTest::FrameCount");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -1101,7 +1114,7 @@ DISABLED_TEST(ImageIO, DestinationDataTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationMultiFrameDataTest) {
+TEST(ImageIO, DestinationMultiFrameDataTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1125,14 +1138,14 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameDataTest) {
 
     // Read back in the newly written image to check properties
     imageSource = CGImageSourceCreateWithData((CFDataRef)dataBuffer, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     size_t frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 3, "FAILED: ImageIOTest::FrameCount");
 
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -1140,9 +1153,9 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameDataTest) {
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -1150,9 +1163,9 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameDataTest) {
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaFirst, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaFirst | kCGBitmapByteOrder32Big, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
     ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
@@ -1162,7 +1175,7 @@ DISABLED_TEST(ImageIO, DestinationMultiFrameDataTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationOptionsTest) {
+TEST(ImageIO, DestinationOptionsTest) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1185,15 +1198,15 @@ DISABLED_TEST(ImageIO, DestinationOptionsTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 24, "FAILED: ImageIOTest::BitsPerPixel");
     ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 670, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
@@ -1237,14 +1250,14 @@ DISABLED_TEST(ImageIO, DestinationOptionsTest) {
 
     // Read back in the newly written image to check properties
     imageData = getDataFromImageFile(outFile2);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile2);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile2);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     frameCount = CGImageSourceGetCount(imageSource);
     ASSERT_EQ_MSG(frameCount, 3, "FAILED: ImageIOTest::FrameCount");
 
     CFDictionaryRef imageProperties = CGImageSourceCopyProperties(imageSource, NULL);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyProperties returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyGIFDictionary),
                     "FAILED: ImageIOTest::GIF dictionary not found");
@@ -1255,39 +1268,39 @@ DISABLED_TEST(ImageIO, DestinationOptionsTest) {
     ASSERT_EQ_MSG(actualLoopCount, loopCount, "FAILED: ImageIOTest::LoopCount");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 1024, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 683, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
 
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
-    ASSERT_TRUE_MSG(imageRefOut != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
-    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::AlphaInfo");
-    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaLast, "FAILED: ImageIOTest::BitmapInfo");
+    ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_EQ_MSG(CGImageGetAlphaInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::AlphaInfo");
+    ASSERT_EQ_MSG(CGImageGetBitmapInfo(imageRefOut), kCGImageAlphaNone, "FAILED: ImageIOTest::BitmapInfo");
     ASSERT_EQ_MSG(CGImageGetBitsPerComponent(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerComponent");
-    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 32, "FAILED: ImageIOTest::BitsPerPixel");
-    ASSERT_EQ_MSG(CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)), 3, "FAILED: ImageIOTest::ColorSpaceComponentCount");
+    ASSERT_EQ_MSG(CGImageGetBitsPerPixel(imageRefOut), 8, "FAILED: ImageIOTest::BitsPerPixel");
+    // TODO: Check Paletted/Indexed color space.
     ASSERT_EQ_MSG(CGImageGetHeight(imageRefOut), 683, "FAILED: ImageIOTest::Height");
     ASSERT_EQ_MSG(CGImageGetWidth(imageRefOut), 1024, "FAILED: ImageIOTest::Width");
 
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationImageOptionsTIFFTest) {
+TEST(ImageIO, DestinationImageOptionsTIFFTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1339,11 +1352,11 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsTIFFTest) {
     CFRelease(myImageDest);
 
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     // Note that this XResolution was actually passed in as 100. This field aliases with DPIWidth.
     // As observed on iOS, for TIFF, DPIWidth takes precedence, while for JPEG, XResolution takes precedence.
@@ -1374,7 +1387,7 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsTIFFTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationImageOptionsJPEGTest) {
+TEST(ImageIO, DestinationImageOptionsJPEGTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1426,11 +1439,11 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsJPEGTest) {
     CFRelease(myImageDest);
 
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyJFIFDictionary),
                     "FAILED: ImageIOTest::JFIF dictionary not found");
@@ -1438,7 +1451,7 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsJPEGTest) {
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(jfifDictionary, kCGImagePropertyJFIFXDensity),
                     "FAILED: ImageIOTest::JFIF dictionary does not contain XDensity");
     double actualXDensity = [(id)CFDictionaryGetValue(jfifDictionary, kCGImagePropertyJFIFXDensity) doubleValue];
-    ASSERT_NEAR_MSG(actualXDensity, 0.0, 0.01, "FAILED: ImageIOTest::XDensity mismatch"); // Not set, should be 0
+    ASSERT_NEAR_MSG(actualXDensity, 96.0, 0.01, "FAILED: ImageIOTest::XDensity mismatch"); // By default, set to 96.0 (Windows Direct2D/WIC DPI)
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyGPSDictionary),
                     "FAILED: ImageIOTest::GPS dictionary not found");
@@ -1459,7 +1472,7 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsJPEGTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationImageOptionsGIFTest) {
+TEST(ImageIO, DestinationImageOptionsGIFTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1490,11 +1503,11 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsGIFTest) {
     CFRelease(myImageDest);
 
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyGIFDictionary),
                     "FAILED: ImageIOTest::GIF dictionary not found");
@@ -1515,7 +1528,7 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsGIFTest) {
     CFRelease(imageSource);
 }
 
-DISABLED_TEST(ImageIO, DestinationImageOptionsPNGTest) {
+TEST(ImageIO, DestinationImageOptionsPNGTest) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
@@ -1546,11 +1559,11 @@ DISABLED_TEST(ImageIO, DestinationImageOptionsPNGTest) {
     CFRelease(myImageDest);
 
     imageData = getDataFromImageFile(outFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", outFile);
     imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
     CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-    ASSERT_TRUE_MSG(imageProperties != nil, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageProperties, "FAILED: ImageIOTest::CGImageSourceCopyPropertiesAtIndex returned nullptr");
 
     ASSERT_TRUE_MSG(CFDictionaryContainsKey(imageProperties, kCGImagePropertyPNGDictionary),
                     "FAILED: ImageIOTest::PNG dictionary not found");
@@ -1571,7 +1584,7 @@ TEST(ImageIO, TypeIDTest) {
 TEST(ImageIO, IncrementalJPEGImageWithFrameCheck) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references
@@ -1592,7 +1605,7 @@ TEST(ImageIO, IncrementalJPEGImageWithFrameCheck) {
     static const std::vector<int> c_streamLengthForFrame = { 1, 95, 96, 3850, 3851, 218939, 218940 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Check container status change sequence at corresponding stream lengths
     for (int index = 0; index < c_streamLengthForContainer.size(); index++) {
@@ -1628,7 +1641,7 @@ TEST(ImageIO, IncrementalJPEGImageWithFrameCheck) {
 TEST(ImageIO, IncrementalBMPImageWithFrameCheck) {
     const wchar_t* imageFile = L"testimg_227x149.bmp";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references
@@ -1651,7 +1664,7 @@ TEST(ImageIO, IncrementalBMPImageWithFrameCheck) {
     static const std::vector<int> c_streamLengthForFrame = { 1, 95, 96, 35049, 35050 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Check container status change sequence at corresponding stream lengths
     for (int index = 0; index < c_streamLengthForContainer.size(); index++) {
@@ -1687,7 +1700,7 @@ TEST(ImageIO, IncrementalBMPImageWithFrameCheck) {
 TEST(ImageIO, IncrementalPNGImageWithFrameCheck) {
     const wchar_t* imageFile = L"seafloor_256x256.png";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references - 907 for Apple's implementation
@@ -1709,7 +1722,7 @@ TEST(ImageIO, IncrementalPNGImageWithFrameCheck) {
     static const std::vector<int> c_streamLengthForFrame = { 1, 95, 96, 906, 907, 59505, 59506 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Check container status change sequence at corresponding stream lengths
     for (int index = 0; index < c_streamLengthForContainer.size(); index++) {
@@ -1745,7 +1758,7 @@ TEST(ImageIO, IncrementalPNGImageWithFrameCheck) {
 TEST(ImageIO, IncrementalTIFFImageWithFrameCheck) {
     const wchar_t* imageFile = L"photo8_4layers_1024x683.tif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references
@@ -1787,7 +1800,7 @@ TEST(ImageIO, IncrementalTIFFImageWithFrameCheck) {
     static const std::vector<int> c_streamLengthForFrame4 = { 1, 95, 96, 4184267, 4184268, 4187741, 4187742 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Check container status change sequence at corresponding stream lengths
     for (int index = 0; index < c_streamLengthForContainer.size(); index++) {
@@ -1876,7 +1889,7 @@ TEST(ImageIO, IncrementalTIFFImageWithFrameCheck) {
 TEST(ImageIO, IncrementalGIFImageWithFrameCheck) {
     const wchar_t* imageFile = L"photo7_4layers_683x1024.gif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references
@@ -1922,7 +1935,7 @@ TEST(ImageIO, IncrementalGIFImageWithFrameCheck) {
     static const std::vector<int> c_streamLengthForFrame4 = { 1, 95, 96, 613937, 613938, 613946, 613947, 614712, 614713, 669892, 669893 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Check container status change sequence at corresponding stream lengths
     for (int index = 0; index < c_streamLengthForContainer.size(); index++) {
@@ -2011,7 +2024,7 @@ TEST(ImageIO, IncrementalGIFImageWithFrameCheck) {
 TEST(ImageIO, IncrementalICOImageWithFrameCheck) {
     const wchar_t* imageFile = L"photo2_683x1024.ico";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references
@@ -2034,7 +2047,7 @@ TEST(ImageIO, IncrementalICOImageWithFrameCheck) {
     static const std::vector<int> c_streamLengthForFrame = { 1, 95, 96, 1041875, 1041876 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Check container status change sequence at corresponding stream lengths
     for (int index = 0; index < c_streamLengthForContainer.size(); index++) {
@@ -2070,7 +2083,7 @@ TEST(ImageIO, IncrementalICOImageWithFrameCheck) {
 TEST(ImageIO, IncrementalTIFFNegativeScenario) {
     const wchar_t* imageFile = L"photo8_4layers_1024x683.tif";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
     NSUInteger imageLength = [imageData length];
 
     // Minimum Stream Length at which CGImageSourceCreateImageAtIndex returns valid image references
@@ -2096,7 +2109,7 @@ TEST(ImageIO, IncrementalTIFFNegativeScenario) {
     static const std::vector<int> c_streamLengthForFrame3 = { 1, 95, 96, 3129165, 3129166, 4184257, 4184258 };
 
     CGImageSourceRef imageRef = CGImageSourceCreateIncremental(nil);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: CGImageSourceCreateIncremental returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: CGImageSourceCreateIncremental returned nullptr");
 
     // Different indices fed to CGImageSourceCreateImageAtIndex and CGImageSourceGetStatusAtIndex
     bool imageStart = false;
@@ -2151,16 +2164,16 @@ TEST(ImageIO, IncrementalTIFFNegativeScenario) {
 TEST(ImageIO, NonIncrementalJPEGSource) {
     const wchar_t* imageFile = L"photo6_1024x670.jpg";
     NSData* imageData = getDataFromImageFile(imageFile);
-    ASSERT_TRUE_MSG(imageData != nil, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
+    ASSERT_NE_MSG(nil, imageData, "FAILED: ImageIOTest::Could not find file: [%s]", imageFile);
 
     CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, nullptr);
-    ASSERT_TRUE_MSG(imageSource != nil, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
+    ASSERT_NE_MSG(nil, imageSource, "FAILED: ImageIOTest::CGImageSourceCreateWithData returned nullptr");
 
     ASSERT_EQ_MSG(CGImageSourceGetStatus(imageSource), kCGImageStatusComplete, "FAILED: ImageIOTest::ContainerStatus");
     ASSERT_EQ_MSG(CGImageSourceGetStatusAtIndex(imageSource, 0), kCGImageStatusUnknownType, "FAILED: ImageIOTest::ImageStatusAtIndex");
 
     CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, nullptr);
-    ASSERT_TRUE_MSG(imageRef != nil, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
+    ASSERT_NE_MSG(nil, imageRef, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     ASSERT_EQ_MSG(CGImageSourceGetStatusAtIndex(imageSource, 0), kCGImageStatusComplete, "FAILED: ImageIOTest::ImageStatusAtIndex");
 
     imageRef = CGImageSourceCreateImageAtIndex(imageSource, 1, nullptr);


### PR DESCRIPTION
* CGBitmapContext should be free to upconvert and downconvert image formats *if the user has not provided a buffer.*
* CGImageDestination can use CGImage's internal IWICBitmap instead of doing a raw data copy through its provider.
  * This was wrong because sometimes images are _not_ PRGBA.
* CGImageSource can provide CGImage with the WIC bitmap it loaded directly!
  * The tests were **all** written expecting RGBA buffers and raw data copying. They've been fixed to more accurately represent what we are generating.
* The image test harness's image pixel reader has been brought into the 21st century with support for additional pixel formats.
  * A test for premultiplied alpha inputs has been added (and passes!)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1529)
<!-- Reviewable:end -->
