### PR TITLE
Fixing a UIButton backgroundimage-stretching regression found in IslandwoodHouse

### DIFF
--- a/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
+++ b/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
@@ -824,11 +824,12 @@ void LayerCoordinator::_RegisterDependencyProperties() {
             ref new PropertyMetadata(0.0,
             ref new PropertyChangedCallback(&LayerCoordinator::_VisualHeightChangedCallback)));
 
+        // Store as an int (rather than as a ContentGravity enum value) so we can read the values in the VS debugger at runtime
         s_contentGravityProperty = DependencyProperty::RegisterAttached(
             "ContentGravity",
-            ContentGravity::typeid,
+            int::typeid,
             FrameworkElement::typeid,
-            ref new PropertyMetadata(ContentGravity::Resize, nullptr));
+            ref new PropertyMetadata(static_cast<Object^>(static_cast<int>(ContentGravity::Resize)), nullptr));
 
         s_contentCenterProperty = DependencyProperty::RegisterAttached(
             "ContentCenter",
@@ -1060,11 +1061,13 @@ void LayerCoordinator::_VisualHeightChangedCallback(DependencyObject^ sender, De
 
 // ContentGravity
 ContentGravity LayerCoordinator::GetContentGravity(FrameworkElement^ element) {
-    return static_cast<ContentGravity>(element->GetValue(s_contentGravityProperty));
+    // We store as an int (rather than as a ContentGravity enum value) so we can read the values in the VS debugger at runtime
+    return static_cast<ContentGravity>(static_cast<int>(element->GetValue(s_contentGravityProperty)));
 }
 
 void LayerCoordinator::SetContentGravity(FrameworkElement^ element, ContentGravity value) {
-    element->SetValue(s_contentGravityProperty, value);
+    // We store as an int (rather than as a ContentGravity enum value) so we can read the values in the VS debugger at runtime
+    element->SetValue(s_contentGravityProperty, ref new Platform::Box<int>(static_cast<int>(value)));
     _ApplyContentGravity(element, value);
 }
 

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -306,6 +306,10 @@ Microsoft Extension
     // Use the layer contents to draw the background image, similar to UIImageView.
     UIImageSetLayerContents([self layer], self.currentBackgroundImage);
 
+    // UIButton should always stretch its background.  Since we're leveraging our backing CALayer's background for 
+    // the UIButton background, we stretch it via the CALayer's contentsGravity.
+    self.layer.contentsGravity = kCAGravityResize;
+
     // Probably important to keep around for after the refactor.
     [super layoutSubviews];
 }


### PR DESCRIPTION
Our UIButton implementation renders its background via the backing CALayer's content image (similar to how this was done in our legacy UIButton implementation).

IslandwoodHouse loads its UIButtons from nibs; some of which were setting their contentMode values to UIViewContentModeScaleAspectFit.  We internally translate UIViewContentModeScaleAspectFit on a UIView to kCAGravityResizeAspect on its backing CALayer.  With kCAGravityResizeAspect set on the CALayer, we no longer stretch the button's background image (by design for kCAGravityResizeAspect).

The fix is to *always* use kCAGravityResize for UIButton's CALayer's contentsGravity, so we're sure to always stretch the background image (again, this is how it was done in the legacy UIButton implementation).

Also modifying LayerCoordinator to make it possible to view each layer's ContentsGravity value in the VS debugger.

Filing a separate issue to add samples that exercise this scenario.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1539)
<!-- Reviewable:end -->
