### PR TITLE
Fix '1544: Use-after-free AV possible in CAAnimation'

### DIFF
--- a/Frameworks/QuartzCore/CAAnimation.mm
+++ b/Frameworks/QuartzCore/CAAnimation.mm
@@ -295,11 +295,14 @@ static const wchar_t* TAG = L"CAAnimation";
         [layer _displayChanged];
     }
 
-    [_attachedLayer _removeAnimation:self];
-    _attachedLayer = nil;
+    // Grab a strong reference to ourselves before removal from the layer, 
+    // in case the layer was holding the *only* remaining strong reference.
+    StrongId<CAAnimation> strongSelf(self); 
+    [_attachedLayer _removeAnimation: strongSelf];
+    strongSelf->_attachedLayer = nil;
 
     //  Make sure we don't create an animation in case we're transacted
-    _wasRemoved = TRUE;
+    strongSelf->_wasRemoved = TRUE;
 }
 
 /**

--- a/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
+++ b/Frameworks/UIKit/StarboardXaml/LayerCoordinator.cpp
@@ -824,11 +824,12 @@ void LayerCoordinator::_RegisterDependencyProperties() {
             ref new PropertyMetadata(0.0,
             ref new PropertyChangedCallback(&LayerCoordinator::_VisualHeightChangedCallback)));
 
+        // Store as an int (rather than as a ContentGravity enum value) so we can read the values in the VS debugger at runtime
         s_contentGravityProperty = DependencyProperty::RegisterAttached(
             "ContentGravity",
-            ContentGravity::typeid,
+            int::typeid,
             FrameworkElement::typeid,
-            ref new PropertyMetadata(ContentGravity::Resize, nullptr));
+            ref new PropertyMetadata(static_cast<Object^>(static_cast<int>(ContentGravity::Resize)), nullptr));
 
         s_contentCenterProperty = DependencyProperty::RegisterAttached(
             "ContentCenter",
@@ -1060,11 +1061,13 @@ void LayerCoordinator::_VisualHeightChangedCallback(DependencyObject^ sender, De
 
 // ContentGravity
 ContentGravity LayerCoordinator::GetContentGravity(FrameworkElement^ element) {
-    return static_cast<ContentGravity>(element->GetValue(s_contentGravityProperty));
+    // We store as an int (rather than as a ContentGravity enum value) so we can read the values in the VS debugger at runtime
+    return static_cast<ContentGravity>(static_cast<int>(element->GetValue(s_contentGravityProperty)));
 }
 
 void LayerCoordinator::SetContentGravity(FrameworkElement^ element, ContentGravity value) {
-    element->SetValue(s_contentGravityProperty, value);
+    // We store as an int (rather than as a ContentGravity enum value) so we can read the values in the VS debugger at runtime
+    element->SetValue(s_contentGravityProperty, ref new Platform::Box<int>(static_cast<int>(value)));
     _ApplyContentGravity(element, value);
 }
 

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -306,6 +306,10 @@ Microsoft Extension
     // Use the layer contents to draw the background image, similar to UIImageView.
     UIImageSetLayerContents([self layer], self.currentBackgroundImage);
 
+    // UIButton should always stretch its background.  Since we're leveraging our backing CALayer's background for 
+    // the UIButton background, we stretch it via the CALayer's contentsGravity.
+    self.layer.contentsGravity = kCAGravityResize;
+
     // Probably important to keep around for after the refactor.
     [super layoutSubviews];
 }


### PR DESCRIPTION
Fix #1544 : Use-after-free AV possible in CAAnimation - grab a strong reference to self before clearing from _attachedLayer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1545)
<!-- Reviewable:end -->
