### PR TITLE
Fix '#1544: Use-after-free AV possible in CAAnimation' - grab a strong…

### DIFF
--- a/Frameworks/QuartzCore/CAAnimation.mm
+++ b/Frameworks/QuartzCore/CAAnimation.mm
@@ -295,11 +295,14 @@ static const wchar_t* TAG = L"CAAnimation";
         [layer _displayChanged];
     }
 
-    [_attachedLayer _removeAnimation:self];
-    _attachedLayer = nil;
+    // Grab a strong reference to ourselves before removal from the layer, 
+    // in case the layer was holding the *only* remaining strong reference.
+    StrongId<CAAnimation> strongSelf(self); 
+    [_attachedLayer _removeAnimation: strongSelf];
+    strongSelf->_attachedLayer = nil;
 
     //  Make sure we don't create an animation in case we're transacted
-    _wasRemoved = TRUE;
+    strongSelf->_wasRemoved = TRUE;
 }
 
 /**

--- a/Frameworks/QuartzCore/CAAnimation.mm
+++ b/Frameworks/QuartzCore/CAAnimation.mm
@@ -298,7 +298,7 @@ static const wchar_t* TAG = L"CAAnimation";
     // Grab a strong reference to ourselves before removal from the layer, 
     // in case the layer was holding the *only* remaining strong reference.
     StrongId<CAAnimation> strongSelf(self); 
-    [_attachedLayer _removeAnimation: strongSelf];
+    [_attachedLayer _removeAnimation:strongSelf];
     strongSelf->_attachedLayer = nil;
 
     //  Make sure we don't create an animation in case we're transacted


### PR DESCRIPTION
… reference to self before clearing from _attachedLayer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1547)
<!-- Reviewable:end -->
