### PR TITLE
Fix Affine Transform in CGPath

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -827,14 +827,15 @@ void CGContextAddPath(CGContextRef context, CGPathRef path) {
         return;
     }
 
+    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
+
     if (!context->HasPath()) {
         // If we don't curerntly have a path, take this one in as our own.
-        woc::unique_cf<CGMutablePathRef> copiedPath{ CGPathCreateMutableCopy(path) };
+        woc::unique_cf<CGMutablePathRef> copiedPath{ CGPathCreateMutableCopyByTransformingPath(path, &userToDeviceTransform) };
         context->SetPath(copiedPath.get());
         return;
     }
 
-    CGAffineTransform userToDeviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(context);
     CGPathAddPath(context->Path(), &userToDeviceTransform, path);
 }
 

--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -754,21 +754,34 @@ CGPathRef CGPathCreateCopyByStrokingPath(
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes Creates a mutable copy
 */
 CGPathRef CGPathCreateCopyByTransformingPath(CGPathRef path, const CGAffineTransform* transform) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return CGPathCreateMutableCopyByTransformingPath(path, transform);
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Interoperable
 */
 CGMutablePathRef CGPathCreateMutableCopyByTransformingPath(CGPathRef path, const CGAffineTransform* transform) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    RETURN_NULL_IF(!path);
+
+    if (transform) {
+        if (CGAffineTransformEqualToTransform(*transform, CGAffineTransformIdentity)) {
+            return CGPathCreateMutableCopy(path);
+        }
+
+        CGMutablePathRef transformedPath = CGPathCreateMutable();
+        path->ClosePath();
+
+        FAIL_FAST_IF_FAILED(transformedPath->AddGeometryToPathWithTransformation(path->GetPathGeometry().Get(), transform));
+        transformedPath->SetCurrentPoint(CGPointApplyAffineTransform(path->GetCurrentPoint(), *transform));
+        transformedPath->SetStartingPoint(CGPointApplyAffineTransform(path->GetStartingPoint(), *transform));
+        transformedPath->SetLastTransform(transform);
+        return transformedPath;
+    }
+    return CGPathCreateMutableCopy(path);
 }
 
 /**
@@ -782,7 +795,7 @@ CGPathRef CGPathCreateWithRoundedRect(CGRect rect, CGFloat cornerWidth, CGFloat 
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2) {
     return __CGPathEqual(path1, path2);

--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -228,7 +228,7 @@ CGMutablePathRef CGPathCreateMutable() {
 }
 
 /**
- @Status Caveat
+ @Status Interoperable
  @Notes Creates a mutable copy
 */
 CGPathRef CGPathCreateCopy(CGPathRef path) {
@@ -751,7 +751,7 @@ CGPathRef CGPathCreateCopyByStrokingPath(
 }
 
 /**
- @Status Caveat
+ @Status Interoperable
  @Notes Creates a mutable copy
 */
 CGPathRef CGPathCreateCopyByTransformingPath(CGPathRef path, const CGAffineTransform* transform) {

--- a/include/CoreGraphics/CGPath.h
+++ b/include/CoreGraphics/CGPath.h
@@ -57,11 +57,11 @@ COREGRAPHICS_EXPORT CGPathRef CGPathCreateWithRect(CGRect rect, const CGAffineTr
 COREGRAPHICS_EXPORT CGPathRef CGPathCreateWithRoundedRect(CGRect rect,
                                                           CGFloat cornerWidth,
                                                           CGFloat cornerHeight,
-                                                          const CGAffineTransform* transform) STUB_METHOD;
+                                                          const CGAffineTransform* transform);
 
 COREGRAPHICS_EXPORT CGPathRef CGPathCreateCopy(CGPathRef path);
 
-COREGRAPHICS_EXPORT CGPathRef CGPathCreateCopyByTransformingPath(CGPathRef path, const CGAffineTransform* transform) STUB_METHOD;
+COREGRAPHICS_EXPORT CGPathRef CGPathCreateCopyByTransformingPath(CGPathRef path, const CGAffineTransform* transform);
 
 COREGRAPHICS_EXPORT CGPathRef CGPathCreateCopyByDashingPath(
     CGPathRef path, const CGAffineTransform* transform, CGFloat phase, const CGFloat* lengths, size_t count) STUB_METHOD;
@@ -74,8 +74,7 @@ COREGRAPHICS_EXPORT CGPathRef CGPathCreateCopyByStrokingPath(CGPathRef path,
 
 COREGRAPHICS_EXPORT CGMutablePathRef CGPathCreateMutableCopy(CGPathRef path);
 
-COREGRAPHICS_EXPORT CGMutablePathRef CGPathCreateMutableCopyByTransformingPath(CGPathRef path,
-                                                                               const CGAffineTransform* transform) STUB_METHOD;
+COREGRAPHICS_EXPORT CGMutablePathRef CGPathCreateMutableCopyByTransformingPath(CGPathRef path, const CGAffineTransform* transform);
 
 COREGRAPHICS_EXPORT void CGPathRelease(CGPathRef path);
 COREGRAPHICS_EXPORT CGPathRef CGPathRetain(CGPathRef path);
@@ -110,7 +109,7 @@ COREGRAPHICS_EXPORT void CGPathAddRect(CGMutablePathRef path, const CGAffineTran
 
 COREGRAPHICS_EXPORT void CGPathAddRects(CGMutablePathRef path, const CGAffineTransform* m, const CGRect* rects, size_t count) STUB_METHOD;
 COREGRAPHICS_EXPORT void CGPathAddRoundedRect(
-    CGMutablePathRef path, const CGAffineTransform* transform, CGRect rect, CGFloat cornerWidth, CGFloat cornerHeight) STUB_METHOD;
+    CGMutablePathRef path, const CGAffineTransform* transform, CGRect rect, CGFloat cornerWidth, CGFloat cornerHeight);
 COREGRAPHICS_EXPORT void CGPathApply(CGPathRef path, void* info, CGPathApplierFunction function);
 
 COREGRAPHICS_EXPORT void CGPathMoveToPoint(CGMutablePathRef path, const CGAffineTransform* m, CGFloat x, CGFloat y);

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -36,7 +36,7 @@ DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DISABLED_DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -36,7 +36,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -58,7 +58,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -84,7 +84,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -116,7 +116,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest) {
     CGPathRelease(theSecondPath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -141,7 +141,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -159,7 +159,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -196,7 +196,7 @@ DISABLED_DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -223,7 +223,7 @@ DISABLED_DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, GetBoundingBox, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, GetBoundingBox, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -261,7 +261,7 @@ static void CGPathApplyCallback(void* context, const CGPathElement* element) {
     CGContextStrokePath((CGContextRef)context);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, PathApplyDraw, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, PathApplyDraw, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     applyBounds = GetDrawingBounds();
     CGFloat width = applyBounds.size.width;
@@ -319,7 +319,7 @@ static void CGPathControlPointCallback(void* context, const CGPathElement* eleme
     }
 }
 
-DISABLED_DRAW_TEST_F(CGPath, PathApplyControlPointsQuadCurve, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, PathApplyControlPointsQuadCurve, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGFloat width = bounds.size.width;
@@ -345,7 +345,7 @@ DISABLED_DRAW_TEST_F(CGPath, PathApplyControlPointsQuadCurve, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, PathApplyControlPointsArcs, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, PathApplyControlPointsArcs, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGFloat width = bounds.size.width;
@@ -381,7 +381,7 @@ DISABLED_DRAW_TEST_F(CGPath, PathApplyControlPointsArcs, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, PathApplyControlPointsArcsSimple, UIKitMimicTest) {
+DRAW_TEST_F(CGPath, PathApplyControlPointsArcsSimple, UIKitMimicTest) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGFloat width = bounds.size.width;

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddCurveToPoint.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddCurveToPoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20ff54c516f0b8a9194379a40903b1c4be1dbf8bac881ec6f342e6ea2a3eb2cb
+size 6253

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddEllipse.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddEllipse.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da43777b882d56ec5de1e29204f0b0718bb170709c3d60f5259797b44ce6b3a1
+size 16213

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddEllipse.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddEllipse.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da43777b882d56ec5de1e29204f0b0718bb170709c3d60f5259797b44ce6b3a1
-size 16213

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddLineToPoint.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddLineToPoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8660958470acc68d170b518ec2fe74b53e95e56c74dcac5da172f3ca7dca0d0
+size 12667

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddPath.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddPath.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33097a3b36e9d278049eb3b1d878409a6ce32e9bdb2170e51647308d444d7da2
+size 13440

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddQuadCurveToPoint.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddQuadCurveToPoint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b9579e1030999f46c6a0e0f490c811f2a69faa0e4b5ea5d065c369a6f12fff8
+size 8929

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddRect.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddRect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fdc855cf44d05bddf7e2360310ad878af4eb9aeadc37fa092567a19b76aaac6
+size 3785

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.Apply.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.Apply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47363c21e1d5b4508a05faa29b9908d73c64323447deef8cc3680bbd44e0bc51
+size 18712

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.CloseSubpath.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.CloseSubpath.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17ff7ca318abd62253bdf4b02eff90fee708e11cd90bd30fc6b7c826de9fe51a
+size 4945

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.GetBoundingBox.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.GetBoundingBox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03ebda2a23b06094a529a740d0c2f47de0f38391ba13cbecd2f160dc0145c0fb
+size 13254

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyControlPointsArcs.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyControlPointsArcs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cc1aa4bafb2163472e384e6cc744ed9034897621759226a4a77de2075fcf86c
+size 29831

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyControlPointsArcsSimple.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyControlPointsArcsSimple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abb6cbd3c4c4d934d4c9c339cae25b011849b5aa46cbcf59c301a00fd7aa0c69
+size 17467

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyControlPointsQuadCurve.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyControlPointsQuadCurve.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c49fe787ce0393bdcb58b87e0ebfcce76069dc3b565ecde47e13dfa979028c45
+size 10898

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyDraw.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.PathApplyDraw.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f465c04fb4e6f0f6ae0e128bab91d26c79687683fd61082724b490f432abd65a
+size 12284


### PR DESCRIPTION
Implement the CGPathCreateMutableCopyByTransformingPath API which allows CGContext to properly transform any paths in conjunction with the User-To-Device transform. Unit tests show identical output.

Fixes #1179

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1550)
<!-- Reviewable:end -->
