### PR TITLE
Fix last one for too small textfield in displayMode table in Woccatalog

### DIFF
--- a/samples/WOCCatalog/WOCCatalog/DisplayModeViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/DisplayModeViewController.m
@@ -299,7 +299,7 @@
     cell.textLabel.text = @"Tablet Mode";
     [self.rows addObject:cell];
 
-    fixedWidth = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 100, 25)];
+    fixedWidth = [[UITextField alloc] initWithFrame:CGRectMake(0, 0, 100, 30)];
     fixedWidth.text = [NSString stringWithFormat:@"%.1f", UIApplication.displayMode.fixedWidth];
     fixedWidth.borderStyle = UITextBorderStyleBezel;
     [fixedWidth addTarget:self action:@selector(setWidth:) forControlEvents:UIControlEventEditingDidEnd];


### PR DESCRIPTION
The height for most of other textField has already been fixed by change 88975cab8f6346ca3b318e2847b2ba6dae4aa767. 

This is only one left behind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1581)
<!-- Reviewable:end -->
