### PR TITLE
Implementation of planned AudioConverter Services APIs from AudioToolbox

### DIFF
--- a/Frameworks/AudioToolbox/AudioConverter.mm
+++ b/Frameworks/AudioToolbox/AudioConverter.mm
@@ -1,5 +1,6 @@
 //******************************************************************************
 //
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
 // Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
@@ -16,28 +17,160 @@
 
 #import <AudioToolbox/AudioConverter.h>
 #import <StubReturn.h>
+#import <NSBundleInternal.h>
+#import <NSLogging.h>
+#import "AssertARCEnabled.h"
+
+#include <COMIncludes.h>
+#import <wrl\client.h>
+#import <wrl\wrappers\corewrappers.h>
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mferror.h>
+#include <wmcodecdsp.h>
+#include <COMIncludes_End.h>
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+@interface AudioConverter : NSObject
+@property (atomic) ComPtr<IMFTransform> transform;
+@property (atomic) float sizeChangeMultiplier;
+- (instancetype)initWithSourceFormat:(const AudioStreamBasicDescription*)srcFormat
+                   destinationFormat:(const AudioStreamBasicDescription*)destFormat;
+- (ComPtr<IMFTransform>)getTransform;
+- (float)getSizeChangeMultiplier;
+@end
+
+static const wchar_t* TAG = L"AudioConverter";
+
+#define RETURN_AUDIOERR_IF_FAILED_WITH_MSG(hr, msg) \
+    if (FAILED(hr)) {                               \
+        NSTraceInfo(TAG, @"%@", msg);               \
+        return kAudioConverterErr_UnspecifiedError; \
+    }
+
+@implementation AudioConverter
+- (instancetype)initWithSourceFormat:(const AudioStreamBasicDescription*)srcFormat
+                   destinationFormat:(const AudioStreamBasicDescription*)destFormat {
+    if (self = [super init]) {
+        ComPtr<IUnknown> spTransformUnk;
+
+        RETURN_NULL_IF_FAILED(
+            CoCreateInstance(CLSID_AudioResamplerMediaObject, nullptr, CLSCTX_INPROC_SERVER, IID_IUnknown, (void**)&spTransformUnk));
+
+        RETURN_NULL_IF_FAILED(spTransformUnk.As(&_transform));
+
+        _sizeChangeMultiplier =
+            (destFormat->mSampleRate * destFormat->mBytesPerFrame) / (srcFormat->mSampleRate * srcFormat->mBytesPerFrame);
+    }
+
+    return self;
+}
+
+- (ComPtr<IMFTransform>)getTransform {
+    return _transform;
+}
+
+- (float)getSizeChangeMultiplier {
+    return _sizeChangeMultiplier;
+}
+@end
 
 /**
- @Status Stub
+ @Status Caveat: AudioConverter supported only for conversions through AudioConverterConvertBuffer.
+                 Returns kAudioConverterErr_UnspecifiedError on failure and noErr (0) on success. Other return types not supported.
  @Notes
 */
 OSStatus AudioConverterDispose(AudioConverterRef inAudioConverter) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFShutdown(), @"MFShutdown Failed");
+    CFBridgingRelease(inAudioConverter);
+    return noErr;
+}
+
+OSStatus _setMFProperties(const AudioStreamBasicDescription* format, IMFMediaType** mediaType) {
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateMediaType(mediaType), @"MFCreateMediaType failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio), @"Setting the major type failed");
+
+    if (format->mFormatFlags & kAudioFormatFlagIsFloat) {
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_Float), @"Setting the subtype failed");
+    } else {
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM), @"Setting the subtype failed");
+    }
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, format->mChannelsPerFrame),
+                                       @"Setting the number of audio channels failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, format->mSampleRate),
+                                       @"Setting the number of audio samples per second failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_BLOCK_ALIGNMENT, format->mBytesPerFrame),
+                                       @"Setting the block alignment failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)
+                                           ->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, format->mSampleRate * format->mBytesPerFrame),
+                                       @"Setting the average number of bytes per second failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, format->mBitsPerChannel),
+                                       @"Setting the number of bits per audio sample failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, TRUE),
+                                       @"Setting the audio sample independent flag failed");
+
+    return noErr;
 }
 
 /**
- @Status Stub
+@Status Caveat: AudioConverter supported only for conversions through AudioConverterConvertBuffer.
+                Only Linear PCM formats are supported with 1 Frame per Packet and equal source & destination Channels per Frame.
+                Returns kAudioConverterErr_UnspecifiedError on failure and noErr (0) on success. Other return types not supported.
 */
 OSStatus AudioConverterNew(const AudioStreamBasicDescription* inSourceFormat,
                            const AudioStreamBasicDescription* inDestinationFormat,
-                           DWORD* outAudioConverter) {
-    // TODO: outAudioConverter ought to be made AudioConverterRef _Nullable * when this is unstubbed
-    UNIMPLEMENTED();
-    if (outAudioConverter) {
-        *outAudioConverter = 1234;
+                           AudioConverterRef _Nullable* outAudioConverter) {
+    if (inSourceFormat->mFormatID != kAudioFormatLinearPCM || inDestinationFormat->mFormatID != kAudioFormatLinearPCM) {
+        UNIMPLEMENTED();
+        return StubReturn();
     }
-    return StubReturn();
+
+    if (inSourceFormat->mChannelsPerFrame != inDestinationFormat->mChannelsPerFrame) {
+        UNIMPLEMENTED();
+        return StubReturn();
+    }
+
+    if (inSourceFormat->mFramesPerPacket != 1 || inSourceFormat->mFramesPerPacket != inDestinationFormat->mFramesPerPacket) {
+        UNIMPLEMENTED();
+        return StubReturn();
+    }
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFStartup(MF_VERSION, MFSTARTUP_NOSOCKET), @"MFStartup Failed");
+
+    AudioConverter* outConverter = [[AudioConverter alloc] initWithSourceFormat:inSourceFormat destinationFormat:inDestinationFormat];
+
+    ComPtr<IMFTransform> mediaTransform = [outConverter getTransform];
+
+    ComPtr<IMFMediaType> sourceMediaType = nullptr;
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(_setMFProperties(inSourceFormat, &sourceMediaType), @"Creating source mediatype Failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->SetInputType(0, sourceMediaType.Get(), 0), @"MFTransform InputStream Failed");
+
+    ComPtr<IMFMediaType> destinationMediaType = nullptr;
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(_setMFProperties(inDestinationFormat, &destinationMediaType),
+                                       @"Creating destination mediatype Failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->SetOutputType(0, destinationMediaType.Get(), 0), @"MFTransform OutputStream Failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, NULL), @"MFTransform Flush Failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, NULL),
+                                       @"MFTransform Begin Streaming Failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, NULL),
+                                       @"MFTransform Start Streaming Failed");
+
+    *outAudioConverter = (AudioConverterRef)CFBridgingRetain(outConverter);
+    return noErr;
 }
 
 /**
@@ -99,13 +232,104 @@ OSStatus AudioConverterSetProperty(AudioConverterRef inAudioConverter,
 }
 
 /**
- @Status Stub
+ @Status Caveat: Returns kAudioConverterErr_UnspecifiedError, kAudioConverterErr_InvalidInputSize or
+                 kAudioConverterErr_InvalidOutputSize on failure and noErr (0) on success. Other return types not supported.
  @Notes
 */
 OSStatus AudioConverterConvertBuffer(
     AudioConverterRef inAudioConverter, UInt32 inInputDataSize, const void* inInputData, UInt32* ioOutputDataSize, void* outOutputData) {
-    UNIMPLEMENTED();
-    return StubReturn();
+    if (inAudioConverter == nullptr) {
+        return kAudioConverterErr_UnspecifiedError;
+    }
+
+    if (inInputData == nullptr || inInputDataSize == 0) {
+        return kAudioConverterErr_InvalidInputSize;
+    }
+
+    float multiplier = [(__bridge AudioConverter*)inAudioConverter getSizeChangeMultiplier];
+    if (outOutputData == nullptr || ioOutputDataSize == 0 || *ioOutputDataSize < ceil(float(inInputDataSize) * multiplier)) {
+        return kAudioConverterErr_InvalidOutputSize;
+    }
+
+    ComPtr<IMFMediaBuffer> mediaBufferIn = nullptr;
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateMemoryBuffer(inInputDataSize, &mediaBufferIn), @"Temp buffer creation failed");
+
+    BYTE* byteBufferIn = nullptr;
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaBufferIn->Lock(&byteBufferIn, nullptr, nullptr), @"Buffer Lock failed");
+
+    memcpy(byteBufferIn, inInputData, inInputDataSize);
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaBufferIn->Unlock(), @"Buffer Unlock failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaBufferIn->SetCurrentLength(inInputDataSize), @"Set Length failed");
+
+    ComPtr<IMFSample> sampleIn = nullptr;
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateSample(&sampleIn), @"MFSample creation failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(sampleIn->AddBuffer(mediaBufferIn.Get()), @"Buffer Addition failed");
+
+    ComPtr<IMFTransform> mediaTransform = [(__bridge AudioConverter*)inAudioConverter getTransform];
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessInput(0, sampleIn.Get(), 0), @"Input processing failed");
+
+    ComPtr<IMFSample> sampleOut = NULL;
+    // Create the output sample
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateSample(&sampleOut), @"Output sample creation failed");
+
+    ComPtr<IMFMediaBuffer> bufferOut = NULL;
+    // create a buffer for the output sample
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateMemoryBuffer(*ioOutputDataSize, &bufferOut), @"Output buffer creation failed");
+
+    // Add the output buffer
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(sampleOut->AddBuffer(bufferOut.Get()), @"Adding output buffer failed");
+
+    // Starting the counter for number of bytes written to "outOutputData"
+    *ioOutputDataSize = 0;
+    bool drainFlag = false;
+    MFT_OUTPUT_DATA_BUFFER dataBuffer;
+    dataBuffer.pSample = sampleOut.Get();
+    dataBuffer.dwStreamID = 0;
+    dataBuffer.dwStatus = 0;
+    dataBuffer.pEvents = NULL;
+    DWORD outputStatus;
+
+    for (;;) {
+        HRESULT status = mediaTransform->ProcessOutput(0, 1, &dataBuffer, &outputStatus);
+
+        // State 0: All of the Input data has been processed. There may still be some Output data yet to be processed.
+        if (status == MF_E_TRANSFORM_NEED_MORE_INPUT && drainFlag == false) {
+            RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, NULL),
+                                               @"End Stream notification failed");
+
+            RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, NULL),
+                                               @"Drain notification failed");
+
+            drainFlag = true;
+            continue;
+        }
+
+        // State 1: The remaining Output data has been processed.
+        if (status == MF_E_TRANSFORM_NEED_MORE_INPUT && drainFlag == true) {
+            RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaTransform->ProcessMessage(MFT_MESSAGE_NOTIFY_END_STREAMING, NULL),
+                                               @"Nearing-End Stream notification failed");
+            break;
+        }
+
+        ComPtr<IMFMediaBuffer> mediaBufferOut;
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG(sampleOut->ConvertToContiguousBuffer(&mediaBufferOut), @"Buffer conversion failed");
+
+        DWORD outputBytes = 0;
+        mediaBufferOut->GetCurrentLength(&outputBytes);
+
+        BYTE* outputByteBuffer = nullptr;
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaBufferOut->Lock(&outputByteBuffer, nullptr, nullptr), @"Output Buffer Lock failed");
+
+        memcpy(static_cast<BYTE*>(outOutputData) + *ioOutputDataSize, outputByteBuffer, outputBytes);
+        *ioOutputDataSize += outputBytes;
+
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG(mediaBufferOut->Unlock(), @"Output Buffer Unlock failed");
+    }
+
+    return noErr;
 }
 
 /**

--- a/build/AudioToolbox/dll/AudioToolbox.def
+++ b/build/AudioToolbox/dll/AudioToolbox.def
@@ -1,5 +1,8 @@
 LIBRARY AudioToolbox
     EXPORTS
+          AudioConverterDispose
+          AudioConverterNew
+          AudioConverterConvertBuffer
           AudioServicesCreateSystemSoundID
           AudioServicesDisposeSystemSoundID
           AudioServicesPlayAlertSound

--- a/build/AudioToolbox/dll/AudioToolbox.vcxproj
+++ b/build/AudioToolbox/dll/AudioToolbox.vcxproj
@@ -45,7 +45,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Link>
       <ModuleDefinitionFile>AudioToolbox.def</ModuleDefinitionFile>
-      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;mfuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
       <IncludePaths>$(StarboardBasePath)\deps\prebuilt\include;$(StarboardBasePath)\Frameworks\include;$(StarboardBasePath)\include\xplat</IncludePaths>
@@ -55,7 +55,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>
       <ModuleDefinitionFile>AudioToolbox.def</ModuleDefinitionFile>
-      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;mfuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
       <IncludePaths>$(StarboardBasePath)\deps\prebuilt\include;$(StarboardBasePath)\Frameworks\include;$(StarboardBasePath)\include\xplat</IncludePaths>
@@ -65,7 +65,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
     <Link>
       <ModuleDefinitionFile>AudioToolbox.def</ModuleDefinitionFile>
-      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;mfuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
       <IncludePaths>$(StarboardBasePath)\deps\prebuilt\include;$(StarboardBasePath)\Frameworks\include;$(StarboardBasePath)\include\xplat</IncludePaths>
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
     <Link>
       <ModuleDefinitionFile>AudioToolbox.def</ModuleDefinitionFile>
-      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>;WindowsApp.lib;libdispatch.lib;mfuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ClangCompile>
       <IncludePaths>$(StarboardBasePath)\deps\prebuilt\include;$(StarboardBasePath)\Frameworks\include;$(StarboardBasePath)\include\xplat</IncludePaths>

--- a/build/Tests/UnitTests/AudioToolbox/AudioToolbox.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/AudioToolbox/AudioToolbox.UnitTests.vcxproj
@@ -135,7 +135,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -144,6 +144,7 @@
       <OtherCPlusPlusFlags>-Wdeprecated-declarations</OtherCPlusPlusFlags>
       <PreprocessorDefinitions>NO_STUBS;_CRT_SECURE_NO_WARNINGS;DEBUG=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <AdditionalOptions>"-DAUDIOTOOLBOX_IMPEXP= " %(AdditionalOptions)</AdditionalOptions>
     </ClangCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -157,7 +158,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -166,6 +167,7 @@
       <OtherCPlusPlusFlags>-Wdeprecated-declarations</OtherCPlusPlusFlags>
       <PreprocessorDefinitions>NO_STUBS;_CRT_SECURE_NO_WARNINGS;DEBUG=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <AdditionalOptions>"-DAUDIOTOOLBOX_IMPEXP= " %(AdditionalOptions)</AdditionalOptions>
     </ClangCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -183,7 +185,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -192,6 +194,7 @@
       <PreprocessorDefinitions>NO_STUBS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <OptimizationLevel>Full</OptimizationLevel>
+      <AdditionalOptions>"-DAUDIOTOOLBOX_IMPEXP= " %(AdditionalOptions)</AdditionalOptions>
     </ClangCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -209,7 +212,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -218,6 +221,7 @@
       <PreprocessorDefinitions>NO_STUBS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <OptimizationLevel>Full</OptimizationLevel>
+      <AdditionalOptions>"-DAUDIOTOOLBOX_IMPEXP= " %(AdditionalOptions)</AdditionalOptions>
     </ClangCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/build/Tests/UnitTests/AudioToolbox/AudioToolbox.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/AudioToolbox/AudioToolbox.UnitTests.vcxproj
@@ -135,7 +135,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -157,7 +157,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -183,7 +183,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -209,7 +209,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>AudioToolbox.lib;mfuuid.lib;mfplat.lib;libdispatch.lib;mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AppContainer>false</AppContainer>
     </Link>
     <ClangCompile>
@@ -226,6 +226,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\AudioToolbox\ExampleTest.m" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\AudioToolbox\AudioConverterTest.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/include/AudioToolbox/AudioConverter.h
+++ b/include/AudioToolbox/AudioConverter.h
@@ -1,5 +1,6 @@
 //******************************************************************************
 //
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
 // Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
@@ -100,10 +101,10 @@ typedef OSStatus (*AudioConverterComplexInputDataProc)(AudioConverterRef inAudio
 typedef OSStatus (*AudioConverterInputDataProc)(AudioConverterRef inAudioConverter, UInt32* ioDataSize, void** outData, void* inUserData);
 typedef struct AudioConverterPrimeInfo AudioConverterPrimeInfo;
 
-AUDIOTOOLBOX_EXPORT OSStatus AudioConverterDispose(AudioConverterRef inAudioConverter) STUB_METHOD;
+AUDIOTOOLBOX_EXPORT OSStatus AudioConverterDispose(AudioConverterRef inAudioConverter);
 AUDIOTOOLBOX_EXPORT OSStatus AudioConverterNew(const AudioStreamBasicDescription* inSourceFormat,
                                                const AudioStreamBasicDescription* inDestinationFormat,
-                                               AudioConverterRef _Nullable* outAudioConverter) STUB_METHOD;
+                                               AudioConverterRef _Nullable* outAudioConverter);
 AUDIOTOOLBOX_EXPORT OSStatus AudioConverterNewSpecific(const AudioStreamBasicDescription* inSourceFormat,
                                                        const AudioStreamBasicDescription* inDestinationFormat,
                                                        UInt32 inNumberClassDescriptions,
@@ -126,7 +127,7 @@ AUDIOTOOLBOX_EXPORT OSStatus AudioConverterConvertBuffer(AudioConverterRef inAud
                                                          UInt32 inInputDataSize,
                                                          const void* inInputData,
                                                          UInt32* ioOutputDataSize,
-                                                         void* outOutputData) STUB_METHOD;
+                                                         void* outOutputData);
 AUDIOTOOLBOX_EXPORT OSStatus AudioConverterFillComplexBuffer(AudioConverterRef inAudioConverter,
                                                              AudioConverterComplexInputDataProc inInputDataProc,
                                                              void* inInputDataProcUserData,

--- a/include/AudioToolbox/AudioConverterInternal.h
+++ b/include/AudioToolbox/AudioConverterInternal.h
@@ -54,3 +54,5 @@ using namespace Microsoft::WRL::Wrappers;
 - (ComPtr<IMFTransform>)getTransform;
 - (float)getSizeChangeMultiplier;
 @end
+
+OSStatus _setMFProperties(const AudioStreamBasicDescription* format, IMFMediaType** mediaType);

--- a/include/AudioToolbox/AudioConverterInternal.h
+++ b/include/AudioToolbox/AudioConverterInternal.h
@@ -1,0 +1,56 @@
+//******************************************************************************
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#pragma once
+
+// This is needed for getting mfapi.h to build in unit tests. 
+#ifndef OUT
+#define OUT
+#endif
+
+#include <COMIncludes.h>
+#import <wrl\client.h>
+#import <wrl\wrappers\corewrappers.h>
+#include <mfapi.h>
+#include <mfidl.h>
+#include <mferror.h>
+#include <wmcodecdsp.h>
+#include <COMIncludes_End.h>
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+#define RETURN_AUDIOERR_IF_FAILED_WITH_MSG(hr, msg) \
+    if (FAILED(hr)) {                               \
+        NSTraceInfo(TAG, @"%@  %@", msg, hr);       \
+        return kAudioConverterErr_UnspecifiedError; \
+    }
+
+#define RETURN_NIL_IF_FAILED(hr)       \
+    if (FAILED(hr)) {                  \
+        self = nil;                    \
+        return nil;                    \
+    }
+
+
+@interface AudioConverter : NSObject
+@property (atomic) ComPtr<IMFTransform> transform;
+@property (atomic) float sizeChangeMultiplier;
+- (instancetype)initWithSourceFormat:(const AudioStreamBasicDescription*)srcFormat
+                   destinationFormat:(const AudioStreamBasicDescription*)destFormat;
+- (ComPtr<IMFTransform>)getTransform;
+- (float)getSizeChangeMultiplier;
+@end

--- a/samples/WOCCatalog/WOCCatalog/AudioToolboxViewController.mm
+++ b/samples/WOCCatalog/WOCCatalog/AudioToolboxViewController.mm
@@ -24,7 +24,7 @@ void soundCompletion(SystemSoundID ssID, void* self);
 - (void)viewDidLoad {
     [super viewDidLoad];
     CGRect bounds = [[UIScreen mainScreen] bounds];
-    
+
     scrollView = [[UIScrollView alloc] initWithFrame:CGRectMake(0, 0, bounds.size.width, bounds.size.height)];
     scrollView.backgroundColor = [UIColor whiteColor];
     scrollView.contentSize = CGSizeMake(bounds.size.width, 900);
@@ -64,31 +64,27 @@ void soundCompletion(SystemSoundID ssID, void* self);
     [callbackFunction setBackgroundColor:[UIColor whiteColor]];
     [callbackFunction addTarget:self action:@selector(callbackFunctionChanged:) forControlEvents:UIControlEventValueChanged];
     [scrollView addSubview:callbackFunction];
-    
+
     [self.view setBackgroundColor:[UIColor whiteColor]];
     [self.view addSubview:scrollView];
 }
 
-
 - (void)callbackFunctionChanged:(UISwitch*)callbackSwitch {
-    
     if ([callbackSwitch isOn]) {
-        AudioServicesAddSystemSoundCompletion(sid, nil, nil, soundCompletion, (__bridge void*)self); 
+        AudioServicesAddSystemSoundCompletion(sid, nil, nil, soundCompletion, (__bridge void*)self);
     } else {
         AudioServicesRemoveSystemSoundCompletion(sid);
     }
 }
 
-
 - (void)playAlertSoundPressed:(UIButton*)button {
     [self completionLabel:false];
-    AudioServicesPlayAlertSound(sid);  
+    AudioServicesPlayAlertSound(sid);
 }
-
 
 - (void)playSystemSoundPressed:(UIButton*)button {
     [self completionLabel:false];
-    AudioServicesPlaySystemSound(sid);  
+    AudioServicesPlaySystemSound(sid);
 }
 
 - (void)completionLabel:(BOOL)show {
@@ -102,6 +98,5 @@ void soundCompletion(SystemSoundID ssID, void* self);
 @end
 
 void soundCompletion(SystemSoundID ssID, void* self) {
-
     [(__bridge AudioToolboxViewController*)self completionLabel:true];
 }

--- a/tests/UnitTests/AudioToolbox/AudioConverterTest.mm
+++ b/tests/UnitTests/AudioToolbox/AudioConverterTest.mm
@@ -1,0 +1,148 @@
+//******************************************************************************
+//
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <TestFramework.h>
+#import <Foundation/Foundation.h>
+#import <AudioToolbox/AudioToolbox.h>
+#import <StubReturn.h>
+#import <NSBundleInternal.h>
+#import <NSLogging.h>
+
+// This is needed for getting mfapi.h to build
+#ifndef OUT
+#define OUT
+#endif
+
+#include <COMIncludes.h>
+#import <wrl\client.h>
+#import <wrl\wrappers\corewrappers.h>
+#import <mfapi.h>
+#include <mfidl.h>
+#include <mferror.h>
+#include <wmcodecdsp.h>
+#include <COMIncludes_End.h>
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+@interface AudioConverter : NSObject
+@property (atomic) ComPtr<IMFTransform> transform;
+@property (atomic) float sizeChangeMultiplier;
+- (float)getSizeChangeMultiplier;
+@end
+
+@implementation AudioConverter
+- (ComPtr<IMFTransform>)getTransform {
+    return _transform;
+}
+
+- (float)getSizeChangeMultiplier {
+    return _sizeChangeMultiplier;
+}
+@end
+
+static const wchar_t* TAG = L"AudioConverterTest";
+
+#define RETURN_AUDIOERR_IF_FAILED_WITH_MSG(hr, msg) \
+    if (FAILED(hr)) {                               \
+        NSTraceInfo(TAG, @"%@", msg);               \
+        return kAudioConverterErr_UnspecifiedError; \
+    }
+
+OSStatus _setMFProperties(const AudioStreamBasicDescription* format, IMFMediaType** mediaType) {
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateMediaType(mediaType), @"MFCreateMediaType failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio), @"Setting the major type failed");
+
+    if (format->mFormatFlags & kAudioFormatFlagIsFloat) {
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_Float), @"Setting the subtype failed");
+    } else {
+        RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM), @"Setting the subtype failed");
+    }
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, format->mChannelsPerFrame),
+                                       @"Setting the number of audio channels failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, format->mSampleRate),
+                                       @"Setting the number of audio samples per second failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_BLOCK_ALIGNMENT, format->mBytesPerFrame),
+                                       @"Setting the block alignment failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)
+                                           ->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, format->mSampleRate * format->mBytesPerFrame),
+                                       @"Setting the average number of bytes per second failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, format->mBitsPerChannel),
+                                       @"Setting the number of bits per audio sample failed");
+
+    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, TRUE),
+                                       @"Setting the audio sample independent flag failed");
+
+    return noErr;
+}
+
+TEST(AudioToolbox, AudioConverterTest) {
+    AudioStreamBasicDescription inFormat;
+    inFormat.mSampleRate = 44100;
+    inFormat.mFormatID = kAudioFormatLinearPCM;
+    inFormat.mFormatFlags = (kAudioFormatFlagIsPacked | kAudioFormatFlagIsSignedInteger);
+    inFormat.mBytesPerPacket = 4;
+    inFormat.mFramesPerPacket = 1;
+    inFormat.mBytesPerFrame = 4;
+    inFormat.mChannelsPerFrame = 2;
+    inFormat.mBitsPerChannel = 16;
+    inFormat.mReserved = 0;
+
+    AudioStreamBasicDescription outFormat;
+    outFormat.mSampleRate = 44100;
+    outFormat.mFormatID = kAudioFormatLinearPCM;
+    outFormat.mFormatFlags = (kAudioFormatFlagIsPacked | kAudioFormatFlagIsFloat);
+    outFormat.mBytesPerPacket = 8;
+    outFormat.mFramesPerPacket = 1;
+    outFormat.mBytesPerFrame = 8;
+    outFormat.mChannelsPerFrame = 2;
+    outFormat.mBitsPerChannel = 32;
+    outFormat.mReserved = 0;
+
+    AudioConverterRef converter;
+    OSStatus err = noErr;
+    err = AudioConverterNew(&inFormat, &outFormat, &converter);
+    ASSERT_EQ(err, 0);
+
+    DWORD flag = MF_MEDIATYPE_EQUAL_FORMAT_USER_DATA;
+    DWORD streamID = 0;
+    ComPtr<IMFTransform> mediaTransform = [(__bridge AudioConverter*)converter getTransform];
+
+    ComPtr<IMFMediaType> expectedInMediaType = nullptr;
+    _setMFProperties(&inFormat, &expectedInMediaType);
+    ComPtr<IMFMediaType> resInMediaType = nullptr;
+    mediaTransform->GetInputCurrentType(streamID, &resInMediaType);
+    HRESULT hr = resInMediaType->IsEqual(expectedInMediaType.Get(), &flag);
+    HRESULT hrExpected = S_OK;
+    ASSERT_EQ(hr, hrExpected);
+
+    ComPtr<IMFMediaType> expectedOutMediaType = nullptr;
+    _setMFProperties(&outFormat, &expectedOutMediaType);
+    ComPtr<IMFMediaType> resOutMediaType = nullptr;
+    mediaTransform->GetOutputCurrentType(streamID, &resOutMediaType);
+    hr = resOutMediaType->IsEqual(expectedOutMediaType.Get(), &flag);
+    ASSERT_EQ(hr, hrExpected);
+
+    err = AudioConverterDispose(converter);
+    ASSERT_EQ(err, 0);
+}

--- a/tests/UnitTests/AudioToolbox/AudioConverterTest.mm
+++ b/tests/UnitTests/AudioToolbox/AudioConverterTest.mm
@@ -27,50 +27,6 @@ static const wchar_t* TAG = L"AudioConverterTest";
 #import <AudioToolbox/AudioConverterInternal.h>
 
 
-@implementation AudioConverter
-- (ComPtr<IMFTransform>)getTransform {
-    return _transform;
-}
-
-- (float)getSizeChangeMultiplier {
-    return _sizeChangeMultiplier;
-}
-@end
-
-
-OSStatus _setMFProperties(const AudioStreamBasicDescription* format, IMFMediaType** mediaType) {
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateMediaType(mediaType), @"MFCreateMediaType failed");
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio), @"Setting the major type failed");
-
-    if (format->mFormatFlags & kAudioFormatFlagIsFloat) {
-        RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_Float), @"Setting the subtype failed");
-    } else {
-        RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM), @"Setting the subtype failed");
-    }
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, format->mChannelsPerFrame),
-                                       @"Setting the number of audio channels failed");
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, format->mSampleRate),
-                                       @"Setting the number of audio samples per second failed");
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_BLOCK_ALIGNMENT, format->mBytesPerFrame),
-                                       @"Setting the block alignment failed");
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)
-                                           ->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, format->mSampleRate * format->mBytesPerFrame),
-                                       @"Setting the average number of bytes per second failed");
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, format->mBitsPerChannel),
-                                       @"Setting the number of bits per audio sample failed");
-
-    RETURN_AUDIOERR_IF_FAILED_WITH_MSG((*mediaType)->SetUINT32(MF_MT_ALL_SAMPLES_INDEPENDENT, TRUE),
-                                       @"Setting the audio sample independent flag failed");
-
-    return noErr;
-}
-
 TEST(AudioToolbox, AudioConverterTest) {
     AudioStreamBasicDescription inFormat;
     inFormat.mSampleRate = 44100;

--- a/tests/UnitTests/AudioToolbox/AudioConverterTest.mm
+++ b/tests/UnitTests/AudioToolbox/AudioConverterTest.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
 // Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
@@ -22,28 +22,10 @@
 #import <NSBundleInternal.h>
 #import <NSLogging.h>
 
-// This is needed for getting mfapi.h to build
-#ifndef OUT
-#define OUT
-#endif
+static const wchar_t* TAG = L"AudioConverterTest";
 
-#include <COMIncludes.h>
-#import <wrl\client.h>
-#import <wrl\wrappers\corewrappers.h>
-#import <mfapi.h>
-#include <mfidl.h>
-#include <mferror.h>
-#include <wmcodecdsp.h>
-#include <COMIncludes_End.h>
+#import <AudioToolbox/AudioConverterInternal.h>
 
-using namespace Microsoft::WRL;
-using namespace Microsoft::WRL::Wrappers;
-
-@interface AudioConverter : NSObject
-@property (atomic) ComPtr<IMFTransform> transform;
-@property (atomic) float sizeChangeMultiplier;
-- (float)getSizeChangeMultiplier;
-@end
 
 @implementation AudioConverter
 - (ComPtr<IMFTransform>)getTransform {
@@ -55,13 +37,6 @@ using namespace Microsoft::WRL::Wrappers;
 }
 @end
 
-static const wchar_t* TAG = L"AudioConverterTest";
-
-#define RETURN_AUDIOERR_IF_FAILED_WITH_MSG(hr, msg) \
-    if (FAILED(hr)) {                               \
-        NSTraceInfo(TAG, @"%@", msg);               \
-        return kAudioConverterErr_UnspecifiedError; \
-    }
 
 OSStatus _setMFProperties(const AudioStreamBasicDescription* format, IMFMediaType** mediaType) {
     RETURN_AUDIOERR_IF_FAILED_WITH_MSG(MFCreateMediaType(mediaType), @"MFCreateMediaType failed");


### PR DESCRIPTION
Implementation of the following three AudioConverter Services APIs from AudioToolbox Framework and the corresponding WOCCatalog sample.

AudioConverterDispose
AudioConverterNew
AudioConverterConvertBuffer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1582)
<!-- Reviewable:end -->
