### PR TITLE
Improve perf for CTFramesetterSuggestFrameSizeWithConstraints

### DIFF
--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -123,23 +123,18 @@ CTTypesetterRef CTFramesetterGetTypesetter(CTFramesetterRef framesetter) {
 }
 
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes frameAttributes parameter ignored
  @Notes
 */
 CGSize CTFramesetterSuggestFrameSizeWithConstraints(
     CTFramesetterRef framesetter, CFRange stringRange, CFDictionaryRef frameAttributes, CGSize constraints, CFRange* fitRange) {
-    CGRect frameSize = CGRectZero;
-    frameSize.size = constraints;
-
-    _CTFrame* frame = __CreateFrame(static_cast<_CTFramesetter*>(framesetter), frameSize, stringRange);
-    CGSize ret = frame ? frame->_frameRect.size : CGSizeZero;
-
-    if (fitRange) {
-        *fitRange = CTFrameGetVisibleStringRange(static_cast<CTFrameRef>(frame));
-    }
-
-    [frame release];
-    return ret;
+    return framesetter ?
+               _DWriteGetSize((CFAttributedStringRef) static_cast<_CTFramesetter*>(framesetter)->_typesetter->_attributedString.get(),
+                              stringRange,
+                              constraints,
+                              fitRange) :
+               CGSizeZero;
 }
 
 /**

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -129,12 +129,14 @@ CTTypesetterRef CTFramesetterGetTypesetter(CTFramesetterRef framesetter) {
 */
 CGSize CTFramesetterSuggestFrameSizeWithConstraints(
     CTFramesetterRef framesetter, CFRange stringRange, CFDictionaryRef frameAttributes, CGSize constraints, CFRange* fitRange) {
-    return framesetter ?
-               _DWriteGetSize((CFAttributedStringRef) static_cast<_CTFramesetter*>(framesetter)->_typesetter->_attributedString.get(),
-                              stringRange,
-                              constraints,
-                              fitRange) :
-               CGSizeZero;
+    if (framesetter == nil) {
+        return CGSizeZero;
+    }
+
+    CFAttributedStringRef string =
+        static_cast<CFAttributedStringRef>(static_cast<_CTFramesetter*>(framesetter)->_typesetter->_attributedString.get());
+
+    _DWriteGetSize(string, stringRange, constraints, fitRange);
 }
 
 /**

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -136,7 +136,7 @@ CGSize CTFramesetterSuggestFrameSizeWithConstraints(
     CFAttributedStringRef string =
         static_cast<CFAttributedStringRef>(static_cast<_CTFramesetter*>(framesetter)->_typesetter->_attributedString.get());
 
-    _DWriteGetSize(string, stringRange, constraints, fitRange);
+    return _DWriteGetSize(string, stringRange, constraints, fitRange);
 }
 
 /**

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -128,7 +128,7 @@ CGSize CTFramesetterSuggestFrameSizeWithConstraints(
     CFAttributedStringRef string =
         static_cast<CFAttributedStringRef>(static_cast<_CTFramesetter*>(framesetter)->_typesetter->_attributedString.get());
 
-    return _DWriteGetSize(string, stringRange, constraints, fitRange);
+    return _DWriteGetFrameSize(string, stringRange, constraints, fitRange);
 }
 
 /**

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -21,13 +21,27 @@
 #import "CGPathInternal.h"
 #import "DWriteWrapper_CoreText.h"
 
-using namespace std;
-
 @implementation _CTFramesetter : NSObject
 @end
 
-static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CFRange range) {
-    RETURN_NULL_IF(framesetter == nil);
+/**
+ @Status Interoperable
+*/
+CTFramesetterRef CTFramesetterCreateWithAttributedString(CFAttributedStringRef string) {
+    _CTFramesetter* ret = [_CTFramesetter alloc];
+    ret->_typesetter = static_cast<_CTTypesetter*>(CTTypesetterCreateWithAttributedString(string));
+    return static_cast<CTFramesetterRef>(ret);
+}
+
+/**
+ @Status Caveat
+ @Notes frameAttributes parameter ignored
+*/
+CTFrameRef CTFramesetterCreateFrame(CTFramesetterRef framesetterRef, CFRange range, CGPathRef path, CFDictionaryRef frameAttributes) {
+    RETURN_NULL_IF(framesetterRef == nil || path == nullptr);
+    CGRect frameRect;
+    _CGPathGetBoundingBoxInternal(path, &frameRect);
+    _CTFramesetter* framesetter = static_cast<_CTFramesetter*>(framesetterRef);
 
     // Call _DWriteWrapper to get _CTLine object list that makes up this frame
     _CTTypesetter* typesetter = static_cast<_CTTypesetter*>(framesetter->_typesetter);
@@ -36,10 +50,12 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CF
     }
 
     StrongId<_CTFrame> ret = _DWriteGetFrame(static_cast<CFAttributedStringRef>(typesetter->_attributedString.get()), range, frameRect);
+    ret->_path.reset(CGPathRetain(path));
+    ret->_frameRect.origin = frameRect.origin;
 
     // Trying to access attributes without any text will throw an error
     if (range.length <= 0L) {
-        return ret.detach();
+        return static_cast<CTFrameRef>(ret.detach());
     }
 
     CTParagraphStyleRef settings =
@@ -48,7 +64,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CF
                                                                    effectiveRange:nullptr]);
 
     if (settings == nullptr) {
-        return ret.detach();
+        return static_cast<CTFrameRef>(ret.detach());
     }
 
     // DWrite only gives manual control of lineheight when it is constant through a frame
@@ -87,31 +103,7 @@ static _CTFrame* __CreateFrame(_CTFramesetter* framesetter, CGRect frameRect, CF
         }
     }
 
-    return ret.detach();
-}
-
-/**
- @Status Interoperable
-*/
-CTFramesetterRef CTFramesetterCreateWithAttributedString(CFAttributedStringRef string) {
-    _CTFramesetter* ret = [_CTFramesetter alloc];
-    ret->_typesetter = static_cast<_CTTypesetter*>(CTTypesetterCreateWithAttributedString(string));
-    return static_cast<CTFramesetterRef>(ret);
-}
-
-/**
- @Status Caveat
- @Notes frameAttributes parameter ignored
-*/
-CTFrameRef CTFramesetterCreateFrame(CTFramesetterRef framesetter, CFRange stringRange, CGPathRef path, CFDictionaryRef frameAttributes) {
-    CGRect frameSize;
-    _CGPathGetBoundingBoxInternal(path, &frameSize);
-
-    _CTFrame* ret = __CreateFrame(static_cast<_CTFramesetter*>(framesetter), frameSize, stringRange);
-    ret->_path.reset(CGPathRetain(path));
-    ret->_frameRect.origin = frameSize.origin;
-
-    return static_cast<CTFrameRef>(ret);
+    return static_cast<CTFrameRef>(ret.detach());
 }
 
 /**

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -51,7 +51,7 @@ struct _DWriteGlyphRunDetails {
 
 bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Outptr_ DWRITE_GLYPH_RUN* dest);
 
-CGSize _DWriteGetSize(CFAttributedStringRef string, CFRange range, CGSize maxSize, CFRange* fitRange);
+CGSize _DWriteGetFrameSize(CFAttributedStringRef string, CFRange range, CGSize maxSize, CFRange* fitRange);
 _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CGRect frameSize);
 _CTLine* _DWriteGetLine(CFAttributedStringRef string);
 

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -51,6 +51,7 @@ struct _DWriteGlyphRunDetails {
 
 bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Outptr_ DWRITE_GLYPH_RUN* dest);
 
+CGSize _DWriteGetSize(CFAttributedStringRef string, CFRange range, CGSize maxSize, CFRange* fitRange);
 _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CGRect frameSize);
 _CTLine* _DWriteGetLine(CFAttributedStringRef string);
 

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -525,12 +525,15 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
     return frame;
 }
 
-static CGSize _DWriteGetSize(CFAttributedStringRef string, CFRange range, CGSize maxSize, CFRange* fitRange) {
+static CGSize _DWriteGetFrameSize(CFAttributedStringRef string, CFRange range, CGSize maxSize, CFRange* fitRange) {
     CGSize ret = CGSizeZero;
+
+    // Treat range.length of 0 as unlimited length
     if (range.length == 0L) {
-        range.length = CFAttributedStringGetLength(string);
+        range.length = CFAttributedStringGetLength(string) - range.location;
     }
 
+    // No text to draw, just return CGSizeZero
     if (!string || range.length <= 0L) {
         return ret;
     }
@@ -565,12 +568,12 @@ static CGSize _DWriteGetSize(CFAttributedStringRef string, CFRange range, CGSize
 
         float totalHeight = 0;
         CFIndex endPos = range.location;
-        for (size_t i = 0; i < lineCount; ++i) {
-            totalHeight += metrics[i].baseline;
+        for (auto metric : metrics) {
+            totalHeight += metric.baseline;
             if (totalHeight > ret.height) {
                 break;
             }
-            endPos += metrics[i].length;
+            endPos += metric.length;
         }
 
         fitRange->length = endPos;

--- a/Frameworks/UIKit/NSParagraphStyle.mm
+++ b/Frameworks/UIKit/NSParagraphStyle.mm
@@ -18,6 +18,7 @@
 #import <StubReturn.h>
 
 #import <UIKit/NSParagraphStyle.h>
+#import <UIKit/UIGraphics.h>
 #import "NSParagraphStyleInternal.h"
 
 @implementation NSParagraphStyle

--- a/Frameworks/UIKit/NSParagraphStyle.mm
+++ b/Frameworks/UIKit/NSParagraphStyle.mm
@@ -126,7 +126,7 @@
 - (CTParagraphStyleRef)_createCTParagraphStyle {
     CTLineBreakMode lineBreakMode = self.lineBreakMode;
     CTWritingDirection writingDirection = self.baseWritingDirection;
-    CTTextAlignment alignment = _NSTextAlignmentToCTTextAlignment(self.alignment);
+    CTTextAlignment alignment = NSTextAlignmentToCTTextAlignment(self.alignment);
     CTParagraphStyleSetting settings[14] =
         { { kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &alignment },
           { kCTParagraphStyleSpecifierFirstLineHeadIndent, sizeof(CGFloat), &_firstLineHeadIndent },

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -42,68 +42,6 @@ NSString* const UITextAttributeTextShadowOffset = @"UITextAttributeTextShadowOff
 
 @implementation NSString (UIKitAdditions)
 
-static void drawString(UIFont* font,
-                       CGContextRef context,
-                       NSString* string,
-                       CGRect rect,
-                       UILineBreakMode lineBreakMode,
-                       UITextAlignment alignment,
-                       CGSize* sizeOut) {
-    if (font == nil) {
-        TraceVerbose(TAG, L"drawString: font = nil!");
-        return;
-    }
-
-    if (rect.size.width == 0) {
-        rect.size.width = FLT_MAX;
-    }
-
-    if (rect.size.height == 0) {
-        rect.size.height = FLT_MAX;
-    }
-
-    CTParagraphStyleSetting styles[2];
-    CTTextAlignment align = _NSTextAlignmentToCTTextAlignment(alignment);
-    styles[0] = { kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &align };
-
-    CTLineBreakMode breakMode = static_cast<CTLineBreakMode>(lineBreakMode);
-    styles[1] = { kCTParagraphStyleSpecifierLineBreakMode, sizeof(CTLineBreakMode), &breakMode };
-
-    NSAttributedString* attr =
-        [[[NSAttributedString alloc] initWithString:string
-                                         attributes:@{
-                                             (NSString*)kCTForegroundColorFromContextAttributeName : (id)kCFBooleanTrue,
-                                             (NSString*)kCTParagraphStyleAttributeName : (id)CTParagraphStyleCreate(styles, 2),
-                                             (NSString*)kCTFontAttributeName : font
-                                         }] autorelease];
-
-    CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString(static_cast<CFAttributedStringRef>(attr));
-
-    CGPathRef path = CGPathCreateWithRect(rect, nullptr);
-    CTFrameRef frame = CTFramesetterCreateFrame(framesetter, {}, path, nullptr);
-
-    // Invert text matrix so glyphs are drawn with correct orientation
-    CGContextSetTextMatrix(context, CGAffineTransformMakeScale(1.0f, -1.0f));
-
-    // Can't draw the entire frame because it assumes our space has been flipped and translated
-    NSArray* lines = static_cast<NSArray*>(CTFrameGetLines(frame));
-    std::vector<CGPoint> origins([lines count]);
-    CTFrameGetLineOrigins(frame, {}, origins.data());
-    for (size_t i = 0; i < origins.size(); ++i) {
-        // Need to set text position so each line will be drawn in the correct position relative to each other
-        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, rect.origin.y + origins[i].y);
-        CTLineDraw(static_cast<CTLineRef>(lines[i]), context);
-    }
-
-    if (sizeOut) {
-        *sizeOut = _CTFrameGetSize(frame);
-    }
-
-    CGPathRelease(path);
-    CFRelease(framesetter);
-    CFRelease(frame);
-}
-
 static NSDictionary* _getDefaultUITextAttributes() {
     static NSDictionary* _defaultUITextAttributes;
     if (_defaultUITextAttributes == nil) {
@@ -114,17 +52,6 @@ static NSDictionary* _getDefaultUITextAttributes() {
     }
 
     return _defaultUITextAttributes;
-}
-
-/**
- @Status Interoperable
-*/
-- (CGSize)drawInRect:(CGRect)rct withFont:(UIFont*)font {
-    CGSize fontExtent;
-
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, UILineBreakModeWordWrap, UITextAlignmentLeft, &fontExtent);
-
-    return fontExtent;
 }
 
 /**
@@ -161,48 +88,78 @@ static NSDictionary* _getDefaultUITextAttributes() {
 /**
  @Status Interoperable
 */
-- (CGSize)drawInRect:(CGRect)rct withFont:(UIFont*)font lineBreakMode:(UILineBreakMode)lineBreakMode alignment:(UITextAlignment)alignment {
-    CGSize fontExtent;
-
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, lineBreakMode, alignment, &fontExtent);
-
-    return fontExtent;
+- (CGSize)drawInRect:(CGRect)rect withFont:(UIFont*)font {
+    return [self drawInRect:rect withFont:font lineBreakMode:UILineBreakModeWordWrap];
 }
 
 /**
  @Status Interoperable
 */
-- (CGSize)drawInRect:(CGRect)rct withFont:(UIFont*)font lineBreakMode:(UILineBreakMode)lineBreakMode {
-    CGSize fontExtent;
-
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, lineBreakMode, UITextAlignmentLeft, &fontExtent);
-
-    return fontExtent;
+- (CGSize)drawInRect:(CGRect)rect withFont:(UIFont*)font lineBreakMode:(UILineBreakMode)lineBreakMode {
+    return [self drawInRect:rect withFont:font lineBreakMode:lineBreakMode alignment:UITextAlignmentLeft];
 }
 
 /**
  @Status Interoperable
 */
-- (CGSize)drawAtPoint:(CGPoint)pt withFont:(UIFont*)font {
-    CGSize fontExtent;
+- (CGSize)drawInRect:(CGRect)rect withFont:(UIFont*)font lineBreakMode:(UILineBreakMode)lineBreakMode alignment:(UITextAlignment)alignment {
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (rect.size.width == 0) {
+        rect.size.width = std::numeric_limits<CGFloat>::max();
+    }
 
-    CGRect rct;
+    if (rect.size.height == 0) {
+        rect.size.height = std::numeric_limits<CGFloat>::max();
+    }
 
-    rct.origin.x = pt.x;
-    rct.origin.y = pt.y;
-    rct.size.width = 0;
-    rct.size.height = 0;
+    CTParagraphStyleSetting styles[2];
+    CTTextAlignment align = _NSTextAlignmentToCTTextAlignment(alignment);
+    styles[0] = { kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &align };
 
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, UILineBreakModeClip, UITextAlignmentLeft, &fontExtent);
+    CTLineBreakMode breakMode = static_cast<CTLineBreakMode>(lineBreakMode);
+    styles[1] = { kCTParagraphStyleSpecifierLineBreakMode, sizeof(CTLineBreakMode), &breakMode };
 
-    return fontExtent;
+    NSAttributedString* attr =
+        [[[NSAttributedString alloc] initWithString:self
+                                         attributes:@{
+                                             (NSString*)kCTForegroundColorFromContextAttributeName : (id)kCFBooleanTrue,
+                                             (NSString*)kCTParagraphStyleAttributeName : (id)CTParagraphStyleCreate(styles, 2),
+                                             (NSString*)kCTFontAttributeName : font
+                                         }] autorelease];
+
+    woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString(static_cast<CFAttributedStringRef>(attr)) };
+
+    woc::unique_cf<CGPathRef> path{ CGPathCreateWithRect(rect, nullptr) };
+    woc::unique_cf<CTFrameRef> frame{ CTFramesetterCreateFrame(framesetter.get(), {}, path.get(), nullptr) };
+
+    // Invert text matrix so glyphs are drawn with correct orientation
+    CGContextSetTextMatrix(context, CGAffineTransformMakeScale(1.0f, -1.0f));
+
+    // Can't draw the entire frame because it assumes our space has been flipped and translated
+    NSArray* lines = static_cast<NSArray*>(CTFrameGetLines(frame.get()));
+    std::vector<CGPoint> origins([lines count]);
+    CTFrameGetLineOrigins(frame.get(), {}, origins.data());
+    for (size_t i = 0; i < origins.size(); ++i) {
+        // Need to set text position so each line will be drawn in the correct position relative to each other
+        CGContextSetTextPosition(context, rect.origin.x + origins[i].x, rect.origin.y + origins[i].y);
+        CTLineDraw(static_cast<CTLineRef>(lines[i]), context);
+    }
+
+    return _CTFrameGetSize(frame.get());
+}
+
+/**
+ @Status Interoperable
+*/
+- (CGSize)drawAtPoint:(CGPoint)point withFont:(UIFont*)font {
+    return [self drawAtPoint:point forWidth:0 withFont:font];
 }
 
 /**
  @Status Caveat
  @Notes Currently UITextAttributeTextShadowColor and UITextAttributeTextShadowOffset will be ignored.
 */
-- (void)drawAtPoint:(CGPoint)pt withAttributes:(NSDictionary*)attrs {
+- (void)drawAtPoint:(CGPoint)point withAttributes:(NSDictionary*)attrs {
     if (attrs == nil) {
         attrs = _getDefaultUITextAttributes();
     }
@@ -225,73 +182,43 @@ static NSDictionary* _getDefaultUITextAttributes() {
 
     UIFont* uiFont = [attrs valueForKey:UITextAttributeFont];
     if (uiFont != nil) {
-        [self drawAtPoint:pt withFont:uiFont];
+        [self drawAtPoint:point withFont:uiFont];
     }
 }
 
-- (CGSize)drawAtPoint:(CGPoint)pt forWidth:(float)forWidth withFont:(UIFont*)font {
-    CGSize fontExtent;
-
-    CGRect rct;
-
-    rct.origin.x = pt.x;
-    rct.origin.y = pt.y;
-    rct.size.width = forWidth;
-    rct.size.height = 0;
-
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, UILineBreakModeClip, UITextAlignmentLeft, &fontExtent);
-
-    return fontExtent;
+- (CGSize)drawAtPoint:(CGPoint)point forWidth:(float)width withFont:(UIFont*)font {
+    return [self drawInRect:{ point, CGSizeMake(width, 0) } withFont:font lineBreakMode:UILineBreakModeClip];
 }
 
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes parameter baselineAdjustment and minFontSize are ignored as text is drawn at given text size
 */
-- (CGSize)drawAtPoint:(CGPoint)pt
-              forWidth:(float)forWidth
+- (CGSize)drawAtPoint:(CGPoint)point
+              forWidth:(float)width
               withFont:(UIFont*)font
            minFontSize:(float)minFontSize
         actualFontSize:(float*)actualFontSize
          lineBreakMode:(UILineBreakMode)lineBreak
     baselineAdjustment:(UIBaselineAdjustment)baseline {
-    CGSize fontExtent;
-    CGRect rct;
-
-    rct.origin.x = pt.x;
-    rct.origin.y = pt.y;
-    rct.size.width = forWidth;
-    rct.size.height = 0;
-
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, UILineBreakModeClip, UITextAlignmentLeft, &fontExtent);
     if (actualFontSize) {
         *actualFontSize = 10.0f;
     }
-
-    return fontExtent;
+    return [self drawInRect:{ point, CGSizeMake(width, 0) } withFont:font lineBreakMode:lineBreak];
 }
 
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes parameter baselineAdjustment is ignored
 */
-- (CGSize)drawAtPoint:(CGPoint)pt
-              forWidth:(float)forWidth
+- (CGSize)drawAtPoint:(CGPoint)point
+              forWidth:(float)width
               withFont:(UIFont*)font
               fontSize:(float)fontSize
          lineBreakMode:(UILineBreakMode)lineBreak
     baselineAdjustment:(UIBaselineAdjustment)baseline {
-    CGSize fontExtent;
-    CGRect rct;
-
-    rct.origin.x = pt.x;
-    rct.origin.y = pt.y;
-    rct.size.width = forWidth;
-    rct.size.height = 0;
-
     font = [font fontWithSize:fontSize];
-
-    drawString(font, UIGraphicsGetCurrentContext(), self, rct, UILineBreakModeClip, UITextAlignmentLeft, &fontExtent);
-
-    return fontExtent;
+    return [self drawInRect:{ point, CGSizeMake(width, 0) } withFont:font lineBreakMode:lineBreak];
 }
 
 // Private helper for sizeWith... functions

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -93,7 +93,8 @@ static NSDictionary* _getDefaultUITextAttributes() {
 }
 
 /**
- @Status Interoperable
+ @Status Caveat
+ @Notes Clipping line break modes unsupported
 */
 - (CGSize)drawInRect:(CGRect)rect withFont:(UIFont*)font lineBreakMode:(UILineBreakMode)lineBreakMode {
     return [self drawInRect:rect withFont:font lineBreakMode:lineBreakMode alignment:UITextAlignmentLeft];

--- a/Frameworks/UIKit/UIGraphics.mm
+++ b/Frameworks/UIKit/UIGraphics.mm
@@ -90,12 +90,18 @@ BOOL UIFloatRangeIsEqualToRange(UIFloatRange range, UIFloatRange otherRange) {
 }
 
 /**
- @Status Stub
+ @Status Interoperable
  @Notes
 */
-CTTextAlignment NSTextAlignmentToCTTextAlignment(NSTextAlignment nsTextAlignment) {
-    UNIMPLEMENTED();
-    return StubReturn();
+CTTextAlignment NSTextAlignmentToCTTextAlignment(NSTextAlignment alignment) {
+    switch (alignment) {
+        case NSTextAlignmentRight:
+            return kCTRightTextAlignment;
+        case NSTextAlignmentCenter:
+            return kCTCenterTextAlignment;
+        default:
+            return alignment;
+    }
 }
 
 /**

--- a/Frameworks/include/NSParagraphStyleInternal.h
+++ b/Frameworks/include/NSParagraphStyleInternal.h
@@ -42,15 +42,3 @@
 @property (nonatomic, readwrite) float hyphenationFactor;
 
 @end
-
-// The values of right and center CTTextAlignment and NSTextAlignment do not correspond so they can't be simply cast
-inline CTTextAlignment _NSTextAlignmentToCTTextAlignment(NSTextAlignment alignment) {
-    switch (alignment) {
-        case NSTextAlignmentRight:
-            return kCTRightTextAlignment;
-        case NSTextAlignmentCenter:
-            return kCTCenterTextAlignment;
-        default:
-            return alignment;
-    }
-}

--- a/include/UIKit/UIGraphics.h
+++ b/include/UIKit/UIGraphics.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011, The Iconfactory. All rights reserved.
- * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+ * Copyright (c) Microsoft. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -35,10 +35,6 @@
 
 @class UIImage;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 UIKIT_EXPORT void UIGraphicsPushContext(CGContextRef ctx);
 UIKIT_EXPORT void UIGraphicsPopContext(void);
 UIKIT_EXPORT CGContextRef UIGraphicsGetCurrentContext(void);
@@ -58,7 +54,4 @@ UIKIT_EXPORT void UIRectFillUsingBlendMode(CGRect rect, CGBlendMode blendMode);
 UIKIT_EXPORT void UIRectFrame(CGRect rect);
 UIKIT_EXPORT void UIRectFrameUsingBlendMode(CGRect rect, CGBlendMode blendMode);
 
-#ifdef __cplusplus
-}
-#endif
 UIKIT_EXPORT CTTextAlignment NSTextAlignmentToCTTextAlignment(NSTextAlignment nsTextAlignment);

--- a/include/UIKit/UIGraphics.h
+++ b/include/UIKit/UIGraphics.h
@@ -61,3 +61,4 @@ UIKIT_EXPORT void UIRectFrameUsingBlendMode(CGRect rect, CGBlendMode blendMode);
 #ifdef __cplusplus
 }
 #endif
+UIKIT_EXPORT CTTextAlignment NSTextAlignmentToCTTextAlignment(NSTextAlignment nsTextAlignment);

--- a/include/UIKit/UIGraphics.h
+++ b/include/UIKit/UIGraphics.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #import "UIKitExport.h"
+#import "UIKitTypes.h"
 #import <ApplicationServices/ApplicationServices.h>
 
 @class UIImage;


### PR DESCRIPTION
CTFramesetterSuggestFrameSizeWithConstraints was going through the entire process of creating a frame to get the size, which was very wasteful.  Now only does the minimum amount of layout to determine the suggested size.  Cleans up NSString+UIKitAdditions for better perf analysis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1603)
<!-- Reviewable:end -->
