### PR TITLE
Fix [GitHub Issue #1561] Typing mid-string in a UIKit/XAML text field…

### DIFF
--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -129,13 +129,17 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 
         [_secureModeLock lock];
         if (_secureTextMode) {
-            _passwordBox.password = _text;
+            if (![_passwordBox.password isEqualToString:_text]) {
+                _passwordBox.password = _text;
+            }
         } else {
-            _textBox.text = _text;
-            // Ensure caret at end of field in case we programmatically
-            // gain focus (becomeFirstResponder) after the text is set:
-            _textBox.selectionStart = [_text length];
-            _textBox.selectionLength = 0;
+            if (![_textBox.text isEqualToString:_text]) {
+                _textBox.text = _text;
+                // Ensure caret at end of field in case we programmatically
+                // gain focus (becomeFirstResponder) after the text is set:
+                _textBox.selectionStart = [_text length];
+                _textBox.selectionLength = 0;
+            }
         }
         [_secureModeLock unlock];
 
@@ -240,8 +244,8 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     _passwordBox.fontFamily = _textBox.fontFamily = [WUXMFontFamily makeInstanceWithName:[font _compatibleFamilyName]];
 
     // The following enums map from DWrite directly to Xaml
-    _passwordBox.fontStretch = _textBox.fontStretch = (WUTFontStretch)[font _fontStretch]; 
-    _passwordBox.fontStyle = _textBox.fontStyle = (WUTFontStyle)[font _fontStyle]; 
+    _passwordBox.fontStretch = _textBox.fontStretch = (WUTFontStretch)[font _fontStretch];
+    _passwordBox.fontStyle = _textBox.fontStyle = (WUTFontStyle)[font _fontStyle];
     _passwordBox.fontSize = _textBox.fontSize = font.pointSize;
 
     WUTFontWeight* weight = nil;
@@ -250,7 +254,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
         case DWRITE_FONT_WEIGHT_THIN:
             weight = [WUTFontWeights thin];
             break;
-        //case DWRITE_FONT_WEIGHT_EXTRA_LIGHT:
+        // case DWRITE_FONT_WEIGHT_EXTRA_LIGHT:
         case DWRITE_FONT_WEIGHT_ULTRA_LIGHT:
             weight = [WUTFontWeights extraLight];
             break;
@@ -259,25 +263,25 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
             break;
         case DWRITE_FONT_WEIGHT_SEMI_LIGHT:
             weight = [WUTFontWeights semiLight];
-        //case DWRITE_FONT_WEIGHT_NORMAL:
+        // case DWRITE_FONT_WEIGHT_NORMAL:
         case DWRITE_FONT_WEIGHT_REGULAR:
             weight = [WUTFontWeights normal];
             break;
         case DWRITE_FONT_WEIGHT_MEDIUM:
             weight = [WUTFontWeights medium];
             break;
-        //case DWRITE_FONT_WEIGHT_DEMI_BOLD:
+        // case DWRITE_FONT_WEIGHT_DEMI_BOLD:
         case DWRITE_FONT_WEIGHT_SEMI_BOLD:
             weight = [WUTFontWeights semiBold];
             break;
         case DWRITE_FONT_WEIGHT_BOLD:
             weight = [WUTFontWeights bold];
             break;
-        //case DWRITE_FONT_WEIGHT_EXTRA_BOLD:
+        // case DWRITE_FONT_WEIGHT_EXTRA_BOLD:
         case DWRITE_FONT_WEIGHT_ULTRA_BOLD:
             weight = [WUTFontWeights extraBold];
             break;
-        //case DWRITE_FONT_WEIGHT_BLACK:
+        // case DWRITE_FONT_WEIGHT_BLACK:
         case DWRITE_FONT_WEIGHT_HEAVY:
             weight = [WUTFontWeights black];
             break;
@@ -291,7 +295,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
             break;
     }
 
-    _passwordBox.fontWeight = _textBox.fontWeight = weight; 
+    _passwordBox.fontWeight = _textBox.fontWeight = weight;
 }
 
 /**
@@ -418,7 +422,8 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 
     // If the min size is greater than our font size, the font wins out.
     // If the font's pointsize is smaller than the global min font size, the font wins out.
-    if (self.adjustsFontSizeToFitWidth && (self.minimumFontSize < _adjustedFont.pointSize) && (_adjustedFont.pointSize > g_minimumFontSize) && self.text && self.text.length) {
+    if (self.adjustsFontSizeToFitWidth && (self.minimumFontSize < _adjustedFont.pointSize) &&
+        (_adjustedFont.pointSize > g_minimumFontSize) && self.text && self.text.length) {
         NSString* passwordString = nil;
         CGFloat elementWidth = 0.0f;
 
@@ -430,7 +435,8 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
                 return;
             }
             passwordString = [@"" stringByPaddingToLength:self.text.length withString:_passwordBox.passwordChar startingAtIndex:0];
-            elementWidth = _passwordContentElement.actualWidth - _passwordContentElement.padding.left - _passwordContentElement.padding.right;
+            elementWidth =
+                _passwordContentElement.actualWidth - _passwordContentElement.padding.left - _passwordContentElement.padding.right;
         } else {
             if (_textContentElement == nil) {
                 // Not an error, we just might not be loaded yet.
@@ -1424,7 +1430,8 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
             strongSelf->_passwordBox.placeholderText = strongSelf.placeholder;
 
             // retrieve the ContentElement from the template
-            strongSelf->_passwordContentElement = rt_dynamic_cast<WXCControl>(FindTemplateChild(strongSelf->_passwordBox, @"ContentElement"));
+            strongSelf->_passwordContentElement =
+                rt_dynamic_cast<WXCControl>(FindTemplateChild(strongSelf->_passwordBox, @"ContentElement"));
 
             if (strongSelf->_passwordContentElement == nullptr) {
                 TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");

--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -308,20 +308,16 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 - (UIColor*)textColor {
     WUXMSolidColorBrush* colorBrush = nil;
     if (_secureTextMode) {
-        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_passwordBox.background);
-        if (colorBrush != nil) {
-            return ConvertWUColorToUIColor(colorBrush.color);
-        } else {
-            return nil;
-        }
+        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_passwordBox.foreground);
     } else {
-        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_textBox.background);
-        if (colorBrush != nil) {
-            return ConvertWUColorToUIColor(colorBrush.color);
-        } else {
-            return nil;
-        }
+        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_textBox.foreground);
     }
+
+    if (colorBrush != nil) {
+        return ConvertWUColorToUIColor(colorBrush.color);
+    }
+
+    return nil;
 }
 
 /**
@@ -351,19 +347,15 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     WUXMSolidColorBrush* colorBrush = nil;
     if (_secureTextMode) {
         colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_passwordBox.background);
-        if (colorBrush != nil) {
-            return ConvertWUColorToUIColor(colorBrush.color);
-        } else {
-            return nil;
-        }
     } else {
         colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_textBox.background);
-        if (colorBrush != nil) {
-            return ConvertWUColorToUIColor(colorBrush.color);
-        } else {
-            return nil;
-        }
     }
+
+    if (colorBrush != nil) {
+        return ConvertWUColorToUIColor(colorBrush.color);
+    } 
+    
+    return nil;
 }
 
 /**
@@ -374,6 +366,8 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     if (!_secureTextMode) {
         // passwordBox does not support text alignment
         _textBox.textAlignment = ConvertUITextAlignmentToWXTextAlignment(alignment);
+    } else {
+        UNIMPLEMENTED_WITH_MSG("SecureTextEntry mode does not support UITextAlignment");
     }
     [_secureModeLock unlock];
 }

--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -60,7 +60,6 @@ NSString* const UITextFieldTextDidEndEditingNotification = @"UITextFieldTextDidE
 @end
 
 void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlignment alignment) {
-    [control applyTemplate];
     WXFrameworkElement* elem = FindTemplateChild(control, @"ContentElement");
 
     // set verticalAligment of both content and placeholder of TextBox (or PasswordBox) to be the same value
@@ -75,15 +74,9 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 }
 
 @implementation UITextField {
-    StrongId<NSString> _text;
-    StrongId<NSString> _placeHolder;
     StrongId<UIFont> _font;
     StrongId<UIFont> _adjustedFont;
-    StrongId<UIColor> _textColor;
-    StrongId<UIColor> _backgroundColor;
     StrongId<UIImage> _backgroundImage;
-
-    UITextAlignment _alignment;
     UITextBorderStyle _borderStyle;
 
     BOOL _secureTextMode;
@@ -120,38 +113,30 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (void)setText:(NSString*)text {
-    if (![_text isEqualToString:text]) {
-        if (text != nil) {
-            _text = [text copy];
-        } else {
-            _text = nil;
-        }
-
-        [_secureModeLock lock];
-        if (_secureTextMode) {
-            if (![_passwordBox.password isEqualToString:_text]) {
-                _passwordBox.password = _text;
-            }
-        } else {
-            if (![_textBox.text isEqualToString:_text]) {
-                _textBox.text = _text;
-                // Ensure caret at end of field in case we programmatically
-                // gain focus (becomeFirstResponder) after the text is set:
-                _textBox.selectionStart = [_text length];
-                _textBox.selectionLength = 0;
-            }
-        }
-        [_secureModeLock unlock];
-
-        [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
+    [_secureModeLock lock];
+    if (_secureTextMode) {
+        _passwordBox.password = [text copy];
+    } else {
+        _textBox.text = [text copy];
+        // Ensure caret at end of field in case we programmatically
+        // gain focus (becomeFirstResponder) after the text is set:
+        _textBox.selectionStart = [text length];
+        _textBox.selectionLength = 0;
     }
+    [_secureModeLock unlock];
+
+    [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
 }
 
 /**
  @Status Interoperable
 */
 - (NSString*)text {
-    return _text;
+    if (_secureTextMode) {
+        return _passwordBox.password;
+    } else {
+        return _textBox.text;
+    }
 }
 
 /**
@@ -173,28 +158,24 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (void)setPlaceholder:(NSString*)placeholder {
-    if (![_placeHolder isEqualToString:placeholder]) {
-        if (placeholder != nil) {
-            _placeHolder = [placeholder copy];
-        } else {
-            _placeHolder = nil;
-        }
-
-        [_secureModeLock lock];
-        if (_secureTextMode) {
-            _passwordBox.placeholderText = _placeHolder;
-        } else {
-            _textBox.placeholderText = _placeHolder;
-        }
-        [_secureModeLock unlock];
+    [_secureModeLock lock];
+    if (_secureTextMode) {
+        _passwordBox.placeholderText = [placeholder copy];
+    } else {
+        _textBox.placeholderText = [placeholder copy];
     }
+    [_secureModeLock unlock];
 }
 
 /**
  @Status Interoperable
 */
 - (NSString*)placeholder {
-    return _placeHolder;
+    if (_secureTextMode) {
+        return _passwordBox.placeholderText;
+    } else {
+        return _textBox.placeholderText;
+    }
 }
 
 /**
@@ -309,9 +290,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (void)setTextColor:(UIColor*)color {
-    _textColor = color;
-
-    WUColor* convertedColor = ConvertUIColorToWUColor(_textColor);
+    WUColor* convertedColor = ConvertUIColorToWUColor(color);
     WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
 
     [_secureModeLock lock];
@@ -327,20 +306,33 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (UIColor*)textColor {
-    return _textColor;
+    WUXMSolidColorBrush* colorBrush = nil;
+    if (_secureTextMode) {
+        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_passwordBox.background);
+        if (colorBrush != nil) {
+            return ConvertWUColorToUIColor(colorBrush.color);
+        } else {
+            return nil;
+        }
+    } else {
+        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_textBox.background);
+        if (colorBrush != nil) {
+            return ConvertWUColorToUIColor(colorBrush.color);
+        } else {
+            return nil;
+        }
+    }
 }
 
 /**
  @Status Interoperable
 */
 - (void)setBackgroundColor:(UIColor*)color {
-    _backgroundColor = color;
-
     // In class WXCTextBox and WXCPasswordBox, there is just one ivar 'background' for both background color and background image.
     // When setting background color, clear out _backgroundImage assigning it to nil.
     _backgroundImage = nil;
 
-    WUColor* convertedColor = ConvertUIColorToWUColor(_backgroundColor);
+    WUColor* convertedColor = ConvertUIColorToWUColor(color);
     WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
 
     [_secureModeLock lock];
@@ -356,19 +348,32 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (UIColor*)backgroundColor {
-    return _backgroundColor;
+    WUXMSolidColorBrush* colorBrush = nil;
+    if (_secureTextMode) {
+        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_passwordBox.background);
+        if (colorBrush != nil) {
+            return ConvertWUColorToUIColor(colorBrush.color);
+        } else {
+            return nil;
+        }
+    } else {
+        colorBrush = rt_dynamic_cast<WUXMSolidColorBrush>(_textBox.background);
+        if (colorBrush != nil) {
+            return ConvertWUColorToUIColor(colorBrush.color);
+        } else {
+            return nil;
+        }
+    }
 }
 
 /**
  @Status Interoperable
 */
 - (void)setTextAlignment:(UITextAlignment)alignment {
-    _alignment = alignment;
-
     [_secureModeLock lock];
     if (!_secureTextMode) {
         // passwordBox does not support text alignment
-        _textBox.textAlignment = ConvertUITextAlignmentToWXTextAlignment(_alignment);
+        _textBox.textAlignment = ConvertUITextAlignmentToWXTextAlignment(alignment);
     }
     [_secureModeLock unlock];
 }
@@ -377,7 +382,11 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
  @Status Interoperable
 */
 - (UITextAlignment)textAlignment {
-    return _alignment;
+    if (_secureTextMode) {
+        return UITextAlignmentLeft;
+    } else {
+        return ConvertWXTextAlignmentToUITextAlignment(_textBox.textAlignment);
+    }
 }
 
 /**
@@ -571,7 +580,7 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
             SetControlBorderStyle(_textBox, _borderStyle);
         }
 
-        WUColor* convertedColor = ConvertUIColorToWUColor(_backgroundColor);
+        WUColor* convertedColor = ConvertUIColorToWUColor(self.backgroundColor);
         WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
 
         // If _borderStyle is set to the UITextBorderStyleRoundedRect,
@@ -959,12 +968,12 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 - (void)setSecureTextEntry:(BOOL)secure {
     [_secureModeLock lock];
     if (_secureTextMode != secure) {
-        _secureTextMode = secure;
-        if (_secureTextMode) {
+        if (secure) {
             [self _initPasswordBox:nil];
         } else {
             [self _initTextBox:nil];
         }
+        _secureTextMode = secure;
     }
     [_secureModeLock unlock];
 }
@@ -982,28 +991,30 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 */
 - (instancetype)initWithCoder:(NSCoder*)coder {
     if (self = [super initWithCoder:coder]) {
+        // move to top so that setting properties below can happen on xamlElement
+        [self _initUITextField:nil];
+
         _font = [coder decodeObjectForKey:@"UIFont"];
-        _alignment = (UITextAlignment)[coder decodeInt32ForKey:@"UITextAlignment"];
-        _borderStyle = (UITextBorderStyle)[coder decodeInt32ForKey:@"UIBorderStyle"];
+        self.textAlignment = (UITextAlignment)[coder decodeInt32ForKey:@"UITextAlignment"];
+        self.borderStyle = (UITextBorderStyle)[coder decodeInt32ForKey:@"UIBorderStyle"];
         _keyboardType = (UIKeyboardType)[coder decodeInt32ForKey:@"UIKeyboardType"];
         _secureTextMode = [coder decodeInt32ForKey:@"UISecureTextEntry"];
-        _text = [coder decodeObjectForKey:@"UIText"];
-        _placeHolder = [coder decodeObjectForKey:@"UIPlaceholder"];
-        _textColor = [coder decodeObjectForKey:@"UITextColor"];
+        self.text = [coder decodeObjectForKey:@"UIText"];
+        self.placeholder = [coder decodeObjectForKey:@"UIPlaceholder"];
+        UIColor* textColor = [coder decodeObjectForKey:@"UITextColor"];
+        if (textColor == nil) {
+            textColor = [UIColor blackColor];
+        }
+        self.textColor = textColor;
 
         if (_font == nil) {
             _font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
         }
 
-        if (_textColor == nil) {
-            _textColor = [UIColor blackColor];
-        }
-
-        _backgroundColor = [UIColor lightGrayColor];
+        self.backgroundColor = [UIColor lightGrayColor];
         _backgroundImage = nil;
         _isFirstResponder = NO;
 
-        [self _initUITextField:nil];
         [self _adjustFontSizeToFitWidthOrApplyCurrentFont];
     }
 
@@ -1015,19 +1026,19 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 */
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
+        // move to top so that setting properties below can happen on xamlElement
+        [self _initUITextField:nil];
+
         // TODO: Remove duplicate code from here and the initWithFrame:xamlElement: implementation.
         _font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
-        _alignment = UITextAlignmentLeft;
-        _borderStyle = UITextBorderStyleNone;
+        self.textAlignment = UITextAlignmentLeft;
+        self.borderStyle = UITextBorderStyleNone;
         _secureTextMode = NO;
-        _text = nil;
-        _textColor = [UIColor blackColor];
-        _backgroundColor = [UIColor lightGrayColor];
+        self.textColor = [UIColor blackColor];
+        self.backgroundColor = [UIColor lightGrayColor];
         _backgroundImage = nil;
         _spellCheckingType = UITextSpellCheckingTypeDefault;
         _isFirstResponder = NO;
-
-        [self _initUITextField:nil];
     }
 
     return self;
@@ -1037,18 +1048,18 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     // TODO: We're passing nil to initWithFrame:xamlElement: because we have to *contain* either a TextBox or a PasswordBox.
     // Note: Pass 'xamlElement' instead, once we move to a *single* backing Xaml element for UITextField.
     if (self = [super initWithFrame:frame xamlElement:nil]) {
+        // move to top so that setting properties below can happen on xamlElement
+        [self _initUITextField:xamlElement];
+
         _font = [UIFont fontWithName:@"Segoe UI" size:[UIFont labelFontSize]];
-        _alignment = UITextAlignmentLeft;
-        _borderStyle = UITextBorderStyleNone;
+        self.textAlignment = UITextAlignmentLeft;
+        self.borderStyle = UITextBorderStyleNone;
         _secureTextMode = NO;
-        _text = nil;
-        _textColor = [UIColor blackColor];
-        _backgroundColor = [UIColor lightGrayColor];
+        self.textColor = [UIColor blackColor];
+        self.backgroundColor = [UIColor lightGrayColor];
         _backgroundImage = nil;
         _spellCheckingType = UITextSpellCheckingTypeDefault;
         _isFirstResponder = NO;
-
-        [self _initUITextField:xamlElement];
     }
 
     return self;
@@ -1327,56 +1338,65 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
 // Helper to initialize textbox
 - (void)_initTextBox:(WXFrameworkElement*)xamlElement {
     if (xamlElement != nil && [xamlElement isKindOfClass:[WXCTextBox class]]) {
-        self->_textBox = static_cast<WXCTextBox*>(xamlElement);
+        _textBox = static_cast<WXCTextBox*>(xamlElement);
     } else {
-        self->_textBox = [WXCTextBox make];
+        _textBox = [WXCTextBox make];
     }
 
-    self->_passwordBox = nil;
-    __weak UITextField* weakSelf = self;
+    // Remove the old subview (if it exists)
+    [_subView removeFromSuperview];
 
-    // setting up textbox properties, e.g., foreground, textalignment, border, and input scope, text content etc...
+    // Create a new view for the xaml element and add it as a subview of ourselves
+    _subView = [[UIView alloc] initWithFrame:self.bounds xamlElement:_textBox];
+    [_subView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
+    [self addSubview:_subView];
+
+    // if passwordbox exits, need to transfer the properties that we set on passwordbox to textbox
+    if (_passwordBox != nil) {
+        if (_backgroundImage == nil || self.borderStyle == UITextBorderStyleRoundedRect) {
+            WUColor* convertedColor = ConvertUIColorToWUColor(self.backgroundColor);
+            WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
+            _textBox.background = brush;
+        }
+
+        WUColor* convertedTextColor = ConvertUIColorToWUColor(self.textColor);
+        WUXMSolidColorBrush* textBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedTextColor];
+        _textBox.foreground = textBrush;
+
+        _textBox.textAlignment = ConvertUITextAlignmentToWXTextAlignment(self.textAlignment);
+        _textBox.inputScope = ConvertKeyboardTypeToInputScope(_keyboardType, NO);
+        _textBox.text = self.text;
+        _textBox.placeholderText = self.placeholder;
+        _textBox.isSpellCheckEnabled = (self.spellCheckingType == UITextSpellCheckingTypeYes);
+
+        // clean up passwordbox after transfering the properties
+        self->_passwordBox = nil;
+    }
+
+    // setting up addtional textbox properties in loaded listener that requires looking into control template
+    __weak UITextField* weakSelf = self;
     [self->_textBox addLoadedEvent:^void(RTObject* sender, WXRoutedEventArgs* e) {
         __strong UITextField* strongSelf = weakSelf;
-        if (strongSelf) {
-            if (strongSelf->_backgroundImage == nil || _borderStyle == UITextBorderStyleRoundedRect) {
-                WUColor* convertedColor = ConvertUIColorToWUColor(strongSelf.backgroundColor);
-                WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
-                strongSelf->_textBox.background = brush;
-            }
+        SetControlBorderStyle(strongSelf->_textBox, strongSelf.borderStyle);
+        WXVerticalAlignment verticalAlignment =
+            ConvertUIControlContentVerticalAlignmentToWXVerticalAlignment(strongSelf.contentVerticalAlignment);
+        SetTextControlContentVerticalAlignment(strongSelf->_textBox, verticalAlignment);
 
-            WUColor* convertedTextColor = ConvertUIColorToWUColor(strongSelf.textColor);
-            WUXMSolidColorBrush* textBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedTextColor];
-            strongSelf->_textBox.foreground = textBrush;
+        // retrieve the ContentElement from the template
+        WXFrameworkElement* frameworkElement = FindTemplateChild(strongSelf->_textBox, @"ContentElement");
+        strongSelf->_textContentElement = (frameworkElement != nullptr) ? rt_dynamic_cast<WXCControl>(frameworkElement) : nullptr;
 
-            strongSelf->_textBox.textAlignment = ConvertUITextAlignmentToWXTextAlignment(strongSelf.textAlignment);
-
-            SetControlBorderStyle(strongSelf->_textBox, strongSelf.borderStyle);
-
-            WXVerticalAlignment verticalAlignment =
-                ConvertUIControlContentVerticalAlignmentToWXVerticalAlignment(strongSelf.contentVerticalAlignment);
-            SetTextControlContentVerticalAlignment(strongSelf->_textBox, verticalAlignment);
-            strongSelf->_textBox.inputScope = ConvertKeyboardTypeToInputScope(strongSelf->_keyboardType, NO);
-            strongSelf->_textBox.text = strongSelf.text;
-            strongSelf->_textBox.placeholderText = strongSelf.placeholder;
-            strongSelf->_textBox.isSpellCheckEnabled = (strongSelf.spellCheckingType == UITextSpellCheckingTypeYes);
-
-            // retrieve the ContentElement from the template
-            strongSelf->_textContentElement = rt_dynamic_cast<WXCControl>(FindTemplateChild(strongSelf->_textBox, @"ContentElement"));
-
-            if (strongSelf->_textContentElement == nullptr) {
-                TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");
-            }
-
-            [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
+        if (strongSelf->_textContentElement == nullptr) {
+            TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");
         }
+
+        [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
     }];
 
     // set up text change event handler
     [self->_textBox addTextChangedEvent:^void(RTObject* sender, WXRoutedEventArgs* e) {
         __strong UITextField* strongSelf = weakSelf;
         if (strongSelf) {
-            strongSelf.text = strongSelf->_textBox.text;
             dispatch_async(dispatch_get_main_queue(), ^{
                 [strongSelf sendActionsForControlEvents:UIControlEventEditingChanged];
                 [[NSNotificationCenter defaultCenter] postNotificationName:UITextFieldTextDidChangeNotification object:strongSelf];
@@ -1388,69 +1408,11 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     [self _setupControlGotFocusHandler:_textBox];
     [self _setupControlLostFocusHandler:_textBox];
     [self _setupControlKeyDownHandler:_textBox];
-
-    // Remove the old subview (if it exists)
-    [_subView removeFromSuperview];
-
-    // Create a new view for the xaml element and add it as a subview of ourselves
-    _subView = [[UIView alloc] initWithFrame:self.bounds xamlElement:_textBox];
-    [_subView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
-    [self addSubview:_subView];
 }
 
 // Helper to Initialize passwordBox
 - (void)_initPasswordBox:(WXFrameworkElement*)xamlElement {
-    self->_passwordBox = [WXCPasswordBox make];
-
-    self->_textBox = nil;
-    __weak UITextField* weakSelf = self;
-
-    // setting up loadedEvent to update properties
-    [self->_passwordBox addLoadedEvent:^void(RTObject* sender, WXRoutedEventArgs* e) {
-        __strong UITextField* strongSelf = weakSelf;
-        if (strongSelf) {
-            if (strongSelf->_backgroundImage == nil || _borderStyle == UITextBorderStyleRoundedRect) {
-                WUColor* convertedColor = ConvertUIColorToWUColor(strongSelf.backgroundColor);
-                WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
-                strongSelf->_passwordBox.background = brush;
-            }
-
-            WUColor* convertedTextColor = ConvertUIColorToWUColor(strongSelf.textColor);
-            WUXMSolidColorBrush* textBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedTextColor];
-            strongSelf->_passwordBox.foreground = textBrush;
-            // passwordBox does not support textAlignment
-
-            // border manipulate the control tempate and must be done after loaded
-            SetControlBorderStyle(strongSelf->_passwordBox, strongSelf.borderStyle);
-            WXVerticalAlignment verticalAlignment =
-                ConvertUIControlContentVerticalAlignmentToWXVerticalAlignment(strongSelf.contentVerticalAlignment);
-            SetTextControlContentVerticalAlignment(strongSelf->_passwordBox, verticalAlignment);
-            strongSelf->_passwordBox.inputScope = ConvertKeyboardTypeToInputScope(strongSelf->_keyboardType, YES);
-            strongSelf->_passwordBox.password = strongSelf.text;
-            strongSelf->_passwordBox.placeholderText = strongSelf.placeholder;
-
-            // retrieve the ContentElement from the template
-            strongSelf->_passwordContentElement =
-                rt_dynamic_cast<WXCControl>(FindTemplateChild(strongSelf->_passwordBox, @"ContentElement"));
-
-            if (strongSelf->_passwordContentElement == nullptr) {
-                TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");
-            }
-
-            [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
-        }
-    }];
-
-    // set up password change handler
-    [self->_passwordBox addPasswordChangedEvent:^void(RTObject* sender, WXRoutedEventArgs* e) {
-        __strong UITextField* strongSelf = weakSelf;
-        if (strongSelf) {
-            strongSelf.text = strongSelf->_passwordBox.password;
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [strongSelf sendActionsForControlEvents:UIControlEventEditingChanged];
-            });
-        }
-    }];
+    _passwordBox = [WXCPasswordBox make];
 
     // set up focus and keydown handlers
     [self _setupControlGotFocusHandler:_passwordBox];
@@ -1464,6 +1426,63 @@ void SetTextControlContentVerticalAlignment(WXCControl* control, WXVerticalAlign
     _subView = [[UIView alloc] initWithFrame:self.bounds xamlElement:_passwordBox];
     [_subView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     [self addSubview:_subView];
+
+    // if textbox exists, need to transfer the properties from textbox to passwordbox
+    if (_textBox != nil) {
+        if (_backgroundImage == nil || self.borderStyle == UITextBorderStyleRoundedRect) {
+            WUColor* convertedColor = ConvertUIColorToWUColor(self.backgroundColor);
+            WUXMSolidColorBrush* brush = [WUXMSolidColorBrush makeInstanceWithColor:convertedColor];
+            _passwordBox.background = brush;
+        }
+
+        WUColor* convertedTextColor = ConvertUIColorToWUColor(self.textColor);
+        WUXMSolidColorBrush* textBrush = [WUXMSolidColorBrush makeInstanceWithColor:convertedTextColor];
+        _passwordBox.foreground = textBrush;
+        // passwordBox does not support textAlignment
+
+        // border manipulate the control tempate and must be done after loaded
+        SetControlBorderStyle(_passwordBox, self.borderStyle);
+        WXVerticalAlignment verticalAlignment =
+            ConvertUIControlContentVerticalAlignmentToWXVerticalAlignment(self.contentVerticalAlignment);
+        SetTextControlContentVerticalAlignment(_passwordBox, verticalAlignment);
+        _passwordBox.inputScope = ConvertKeyboardTypeToInputScope(_keyboardType, YES);
+
+        _passwordBox.password = self.text;
+        _passwordBox.placeholderText = self.placeholder;
+
+        // clean up textbox after transfering the properties
+        _textBox = nil;
+    }
+
+    // set up password change handler
+    __weak UITextField* weakSelf = self;
+
+    [self->_passwordBox addLoadedEvent:^void(RTObject* sender, WXRoutedEventArgs* e) {
+        __strong UITextField* strongSelf = weakSelf;
+        SetControlBorderStyle(strongSelf->_passwordBox, strongSelf.borderStyle);
+        WXVerticalAlignment verticalAlignment =
+            ConvertUIControlContentVerticalAlignmentToWXVerticalAlignment(strongSelf.contentVerticalAlignment);
+        SetTextControlContentVerticalAlignment(strongSelf->_passwordBox, verticalAlignment);
+
+        // retrieve the ContentElement from the template
+        WXFrameworkElement* frameworkElement = FindTemplateChild(strongSelf->_passwordBox, @"ContentElement");
+        strongSelf->_textContentElement = (frameworkElement != nullptr) ? rt_dynamic_cast<WXCControl>(frameworkElement) : nullptr;
+
+        if (strongSelf->_textContentElement == nullptr) {
+            TraceWarning(TAG, L"Could not find ContentElement in control template: adjustsFontSizeToFitWidth will not function");
+        }
+
+        [strongSelf _adjustFontSizeToFitWidthOrApplyCurrentFont];
+    }];
+
+    [self->_passwordBox addPasswordChangedEvent:^void(RTObject* sender, WXRoutedEventArgs* e) {
+        __strong UITextField* strongSelf = weakSelf;
+        if (strongSelf) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [strongSelf sendActionsForControlEvents:UIControlEventEditingChanged];
+            });
+        }
+    }];
 }
 
 // Main entrance to initialize TextField

--- a/Frameworks/UIKit/XamlUtilities.h
+++ b/Frameworks/UIKit/XamlUtilities.h
@@ -37,6 +37,9 @@ WUXMFontFamily* WUXFontFamilyFromUIFontName(NSString* uiFontName);
 // Convert UIColor to Color on windows
 WUColor* ConvertUIColorToWUColor(UIColor* uiColor);
 
+// Convert windows color to UIColor
+UIColor* ConvertWUColorToUIColor(WUColor* wuColor);
+
 // Convert UIImage to WUXMImageBrush on windows
 WUXMImageBrush* ConvertUIImageToWUXMImageBrush(UIImage* image);
 

--- a/Frameworks/UIKit/XamlUtilities.mm
+++ b/Frameworks/UIKit/XamlUtilities.mm
@@ -33,6 +33,10 @@ WUColor* ConvertUIColorToWUColor(UIColor* uiColor) {
         [WUColorHelper fromArgb:(unsigned char)(a * 255) r:(unsigned char)(r * 255) g:(unsigned char)(g * 255) b:(unsigned char)(b * 255)];
 }
 
+UIColor* ConvertWUColorToUIColor(WUColor* wuColor) {
+    return [UIColor colorWithRed:wuColor.r / 255 green:wuColor.g / 255 blue:wuColor.b / 255 alpha:wuColor.a / 255];
+}
+
 WUXMImageBrush* ConvertUIImageToWUXMImageBrush(UIImage* image) {
     if (!image) {
         return nil;
@@ -235,7 +239,6 @@ void SetControlBorderStyle(WXCControl* control, UITextBorderStyle style) {
             break;
 
         case UITextBorderStyleRoundedRect:
-            [control applyTemplate];
             WXFrameworkElement* elem = FindTemplateChild(control, @"BorderElement");
 
             // if the control template has not been loaded yet, it can return nullptr for borderElement

--- a/samples/XAMLCatalog/XAMLCatalog/UITextFieldViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UITextFieldViewController.m
@@ -23,24 +23,23 @@ static const CGFloat c_height = 40;
 static const CGFloat c_labelFontSize = 17.0f;
 
 @implementation UITextFieldViewController {
-    @private
-        NSMutableArray* _textFields;
+@private
+    NSMutableArray* _textFields;
 }
 
--(UITextField*)_createTextFieldWithColor:(UIColor*)color
-background : (UIColor*)background
-    secureTextEntry : (BOOL)secureTextEntry
-    placeHolder : (NSString*)placeHolder
-    keyboardType : (UIKeyboardType)keyboardType
-    borderStyle : (UITextBorderStyle)borderStyle
-    textAlignment : (UITextAlignment)textAlignment
-    spellCheckingType : (UITextSpellCheckingType)spellCheckingType {
+- (UITextField*)_createTextFieldWithColor:(UIColor*)color
+                               background:(UIColor*)background
+                          secureTextEntry:(BOOL)secureTextEntry
+                              placeHolder:(NSString*)placeHolder
+                             keyboardType:(UIKeyboardType)keyboardType
+                              borderStyle:(UITextBorderStyle)borderStyle
+                            textAlignment:(UITextAlignment)textAlignment
+                        spellCheckingType:(UITextSpellCheckingType)spellCheckingType {
     CGRect frame = CGRectMake(c_originX, c_originY, c_width, c_height);
     UITextField* textField = [[UITextField alloc] initWithFrame:frame];
     textField.textColor = color;
     textField.backgroundColor = background;
-    textField.secureTextEntry = secureTextEntry;
-    textField.font = [UIFont systemFontOfSize : 17.0];
+    textField.font = [UIFont systemFontOfSize:17.0];
     textField.placeholder = placeHolder;
     textField.keyboardType = keyboardType;
     textField.borderStyle = borderStyle;
@@ -49,20 +48,23 @@ background : (UIColor*)background
     textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
     textField.delegate = self;
 
+    // intentially move down to make sure properties is transferred correctly
+    textField.secureTextEntry = secureTextEntry;
+
     // Set the accessibility identifier so we can access these controls via automation
-    textField.accessibilityIdentifier = [NSString stringWithFormat : @"textField_%ld", [_textFields count]];
+    textField.accessibilityIdentifier = [NSString stringWithFormat:@"textField_%ld", [_textFields count]];
 
     return textField;
 }
 
--(UITextField*)_createTextFieldWithColor:(UIColor*)color
-placeHolder : (NSString*)placeHolder
-    borderStyle : (UITextBorderStyle)borderStyle
-    backgroundImage : (UIImage*)backgroundImage {
+- (UITextField*)_createTextFieldWithColor:(UIColor*)color
+                              placeHolder:(NSString*)placeHolder
+                              borderStyle:(UITextBorderStyle)borderStyle
+                          backgroundImage:(UIImage*)backgroundImage {
     CGRect frame = CGRectMake(c_originX, c_originY, c_width, c_height);
     UITextField* textField = [[UITextField alloc] initWithFrame:frame];
     textField.textColor = color;
-    textField.font = [UIFont systemFontOfSize : c_labelFontSize];
+    textField.font = [UIFont systemFontOfSize:c_labelFontSize];
     textField.placeholder = placeHolder;
     textField.borderStyle = borderStyle;
     textField.background = backgroundImage;
@@ -70,20 +72,20 @@ placeHolder : (NSString*)placeHolder
     textField.delegate = self;
 
     // Set the accessibility identifier so we can access these controls via automation
-    textField.accessibilityIdentifier = [NSString stringWithFormat : @"textField_%ld", [_textFields count]];
+    textField.accessibilityIdentifier = [NSString stringWithFormat:@"textField_%ld", [_textFields count]];
 
     return textField;
 }
 
--(UITextField*)_createTextFieldWithColor:(UIColor*)color
-placeHolder : (NSString*)placeHolder
-    borderStyle : (UITextBorderStyle)borderStyle
-    fontSize : (CGFloat)fontSize
-    minimumFontSize : (CGFloat)minFontSize {
+- (UITextField*)_createTextFieldWithColor:(UIColor*)color
+                              placeHolder:(NSString*)placeHolder
+                              borderStyle:(UITextBorderStyle)borderStyle
+                                 fontSize:(CGFloat)fontSize
+                          minimumFontSize:(CGFloat)minFontSize {
     CGRect frame = CGRectMake(c_originX, c_originY, c_width, c_height);
     UITextField* textField = [[UITextField alloc] initWithFrame:frame];
     textField.textColor = color;
-    textField.font = [UIFont systemFontOfSize: fontSize];
+    textField.font = [UIFont systemFontOfSize:fontSize];
     textField.placeholder = placeHolder;
     textField.borderStyle = borderStyle;
     textField.contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
@@ -92,168 +94,180 @@ placeHolder : (NSString*)placeHolder
     textField.minimumFontSize = minFontSize;
 
     // Set the accessibility identifier so we can access these controls via automation
-    textField.accessibilityIdentifier = [NSString stringWithFormat : @"textField_%ld", [_textFields count]];
+    textField.accessibilityIdentifier = [NSString stringWithFormat:@"textField_%ld", [_textFields count]];
 
     return textField;
 }
 
--(void)viewDidLoad {
+- (void)viewDidLoad {
     [super viewDidLoad];
 
     // creating the text Fields
     _textFields = [[NSMutableArray alloc] init];
 
     // Row 0. password with number keyboard with Round border
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : YES
-        placeHolder : @"password"
-        keyboardType : UIKeyboardTypeNumberPad
-        borderStyle : UITextBorderStyleRoundedRect
-        textAlignment : UITextAlignmentLeft
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:YES
+                                               placeHolder:@"password"
+                                              keyboardType:UIKeyboardTypeNumberPad
+                                               borderStyle:UITextBorderStyleRoundedRect
+                                             textAlignment:UITextAlignmentLeft
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 1. Normal text with right aligned and blue ground
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor blueColor]
-        secureTextEntry : NO
-        placeHolder : @"blue background, right aligned"
-        keyboardType : UIKeyboardTypeASCIICapable
-        borderStyle : UITextBorderStyleRoundedRect
-        textAlignment : UITextAlignmentRight
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor blueColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"blue background, right aligned"
+                                              keyboardType:UIKeyboardTypeASCIICapable
+                                               borderStyle:UITextBorderStyleRoundedRect
+                                             textAlignment:UITextAlignmentRight
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 2. center aligned, red text, line border and spell check enabled
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor redColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"red text, alignment center"
-        keyboardType : UIKeyboardTypeDefault
-        borderStyle : UITextBorderStyleLine
-        textAlignment : UITextAlignmentCenter
-        spellCheckingType : UITextSpellCheckingTypeYes]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor redColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"red text, alignment center"
+                                              keyboardType:UIKeyboardTypeDefault
+                                               borderStyle:UITextBorderStyleLine
+                                             textAlignment:UITextAlignmentCenter
+                                         spellCheckingType:UITextSpellCheckingTypeYes]];
 
     // Row 3. UITextField rejects focus
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"This control rejects focus"
-        keyboardType : UIKeyboardTypeDefault
-        borderStyle : UITextBorderStyleLine
-        textAlignment : UITextAlignmentCenter
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"This control rejects focus"
+                                              keyboardType:UIKeyboardTypeDefault
+                                               borderStyle:UITextBorderStyleLine
+                                             textAlignment:UITextAlignmentCenter
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 4. URL keyboard and no border
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"type in URL"
-        keyboardType : UIKeyboardTypeURL
-        borderStyle : UITextBorderStyleNone
-        textAlignment : UITextAlignmentLeft
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"type in URL"
+                                              keyboardType:UIKeyboardTypeURL
+                                               borderStyle:UITextBorderStyleNone
+                                             textAlignment:UITextAlignmentLeft
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 5. Name and Phone and using "UITextBorderStyleBezel" style border which is
     // treated as line
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"type in your Name and Phone"
-        keyboardType : UIKeyboardTypeNamePhonePad
-        borderStyle : UITextBorderStyleNone
-        textAlignment : UITextBorderStyleBezel
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"type in your Name and Phone"
+                                              keyboardType:UIKeyboardTypeNamePhonePad
+                                               borderStyle:UITextBorderStyleNone
+                                             textAlignment:UITextBorderStyleBezel
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 6. Email address
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"type in your email address"
-        keyboardType : UIKeyboardTypeEmailAddress
-        borderStyle : UITextBorderStyleNone
-        textAlignment : UITextBorderStyleLine
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"type in your email address"
+                                              keyboardType:UIKeyboardTypeEmailAddress
+                                               borderStyle:UITextBorderStyleNone
+                                             textAlignment:UITextBorderStyleLine
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 7. Decimal
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"Decimal"
-        keyboardType : UIKeyboardTypeDecimalPad
-        borderStyle : UITextBorderStyleNone
-        textAlignment : UITextBorderStyleLine
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"Decimal"
+                                              keyboardType:UIKeyboardTypeDecimalPad
+                                               borderStyle:UITextBorderStyleNone
+                                             textAlignment:UITextBorderStyleLine
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 8. Name or Phone number
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"type in name or Phone Number"
-        keyboardType : UIKeyboardTypeNamePhonePad
-        borderStyle : UITextBorderStyleNone
-        textAlignment : UITextBorderStyleLine
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"type in name or Phone Number"
+                                              keyboardType:UIKeyboardTypeNamePhonePad
+                                               borderStyle:UITextBorderStyleNone
+                                             textAlignment:UITextBorderStyleLine
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 9. Decimal
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"Phone Number"
-        keyboardType : UIKeyboardTypePhonePad
-        borderStyle : UITextBorderStyleNone
-        textAlignment : UITextBorderStyleLine
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"Phone Number"
+                                              keyboardType:UIKeyboardTypePhonePad
+                                               borderStyle:UITextBorderStyleNone
+                                             textAlignment:UITextBorderStyleLine
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 10. Enter to dismiss keyboard
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        background : [UIColor lightGrayColor]
-        secureTextEntry : NO
-        placeHolder : @"Press enter to dismiss keyboard"
-        keyboardType : UIKeyboardTypeNamePhonePad
-        borderStyle : UIKeyboardTypePhonePad
-        textAlignment : UITextBorderStyleLine
-        spellCheckingType : UITextSpellCheckingTypeNo]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                                background:[UIColor lightGrayColor]
+                                           secureTextEntry:NO
+                                               placeHolder:@"Press enter to dismiss keyboard"
+                                              keyboardType:UIKeyboardTypeNamePhonePad
+                                               borderStyle:UIKeyboardTypePhonePad
+                                             textAlignment:UITextBorderStyleLine
+                                         spellCheckingType:UITextSpellCheckingTypeNo]];
 
     // Row 11. Background image
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor redColor]
-        placeHolder : @"background image"
-        borderStyle : UITextBorderStyleLine
-        backgroundImage : [UIImage imageNamed : @"photo1.jpg"]]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor redColor]
+                                               placeHolder:@"background image"
+                                               borderStyle:UITextBorderStyleLine
+                                           backgroundImage:[UIImage imageNamed:@"photo1.jpg"]]];
 
     // Row 12. Adjusts font size to fit width (should clamp to 14.0f)
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        placeHolder : @"Adjusts font size 17pt"
-        borderStyle : UITextBorderStyleLine
-        fontSize : 17.0f 
-        minimumFontSize : 1.0f ]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                               placeHolder:@"Adjusts font size 17pt"
+                                               borderStyle:UITextBorderStyleLine
+                                                  fontSize:17.0f
+                                           minimumFontSize:1.0f]];
 
     // Row 13. Should not adjust font size to width (10.0f < system min size)
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        placeHolder : @"Adjusts font size 10pt"
-        borderStyle : UITextBorderStyleLine
-        fontSize : 10.0f 
-        minimumFontSize : 1.0f ]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                               placeHolder:@"Adjusts font size 10pt"
+                                               borderStyle:UITextBorderStyleLine
+                                                  fontSize:10.0f
+                                           minimumFontSize:1.0f]];
 
     // Row 14. Adjusts font size to fit width down to 17.0f
-    [_textFields addObject : [self _createTextFieldWithColor:[UIColor blackColor]
-        placeHolder : @"Adjusts font size 22pt"
-        borderStyle : UITextBorderStyleLine
-        fontSize : 22.0f 
-        minimumFontSize : 17.0f ]];
+    [_textFields addObject:[self _createTextFieldWithColor:[UIColor blackColor]
+                                               placeHolder:@"Adjusts font size 22pt"
+                                               borderStyle:UITextBorderStyleLine
+                                                  fontSize:22.0f
+                                           minimumFontSize:17.0f]];
+
+    // creating a Secured text entry and change it to non-secure
+    UITextField* temp = [self _createTextFieldWithColor:[UIColor blackColor]
+                                             background:[UIColor lightGrayColor]
+                                        secureTextEntry:YES
+                                            placeHolder:@"From Securty to Non-Secure"
+                                           keyboardType:UIKeyboardTypeDefault
+                                            borderStyle:UITextBorderStyleRoundedRect
+                                          textAlignment:UITextAlignmentLeft
+                                      spellCheckingType:UITextSpellCheckingTypeNo];
+    temp.secureTextEntry = NO;
+    [_textFields addObject:temp];
 
     [self tableView].allowsSelection = NO;
 }
 
--(NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection : (NSInteger)section {
-    return[_textFields count];
+- (NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection:(NSInteger)section {
+    return [_textFields count];
 }
 
--(CGFloat)tableView : (UITableView*)tableView heightForRowAtIndexPath : (NSIndexPath*)indexPath {
+- (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
     return 60;
 }
 
 // Asks the delegate if editing should begin in the specified text field.
--(BOOL)textFieldShouldBeginEditing : (UITextField*)textField {
+- (BOOL)textFieldShouldBeginEditing:(UITextField*)textField {
     if (textField == _textFields[3]) {
         return NO;
     }
@@ -261,21 +275,21 @@ placeHolder : (NSString*)placeHolder
     return YES;
 }
 
--(BOOL)textFieldShouldEndEditing:(UITextField*)textField {
+- (BOOL)textFieldShouldEndEditing:(UITextField*)textField {
     return YES;
 }
 
--(BOOL)textFieldShouldReturn : (UITextField*)textField {
+- (BOOL)textFieldShouldReturn:(UITextField*)textField {
     return YES;
 }
 
--(UITableViewCell*)tableView : (UITableView*)tableView cellForRowAtIndexPath : (NSIndexPath*)indexPath {
-    UITableViewCell* cell = [tableView dequeueReusableCellWithIdentifier : @"MenuCell"];
+- (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
+    UITableViewCell* cell = [tableView dequeueReusableCellWithIdentifier:@"MenuCell"];
     if (nil == cell) {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier : @"MenuCell"];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"MenuCell"];
     }
 
-    [cell addSubview : [_textFields objectAtIndex : indexPath.row]];
+    [cell addSubview:[_textFields objectAtIndex:indexPath.row]];
     return cell;
 }
 


### PR DESCRIPTION
When we got notification from textbox/password that string value changed, we should use the new value to set it on textbox/password themselves again because the values are the same.  This also fix the issue that we always setting the cursor position to end of the string when user typing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1604)
<!-- Reviewable:end -->
