### PR TITLE
Fix issue [ARM] [uxe] WOCCatalog: Search bar - cancel button doesn’t do anything

### DIFF
--- a/Frameworks/UIKit/UISearchBar.mm
+++ b/Frameworks/UIKit/UISearchBar.mm
@@ -191,9 +191,9 @@ static void initInternal(UISearchBar* self) {
     } else {
         if (_cancelButton == nil) {
             self->_cancelButton.attach([[UIButton alloc] init]);
-            [self->_cancelButton setBackgroundColor:nil];
             [self->_cancelButton setTitle:cancelButtonText forState:UIControlStateNormal];
             [self->_cancelButton setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+            [self->_cancelButton addTarget:self action:@selector(_cancelButtonTouchUpInside:) forControlEvents:UIControlEventTouchUpInside];
             [self addSubview:self->_cancelButton];
         }
     }
@@ -367,6 +367,12 @@ static void initInternal(UISearchBar* self) {
         if ([_delegate respondsToSelector:@selector(searchBarTextDidEndEditing:)]) {
             [_delegate searchBarTextDidEndEditing:self];
         }
+    }
+}
+
+- (void)_cancelButtonTouchUpInside:(UIButton*)button {
+    if ([_delegate respondsToSelector:@selector(searchBarCancelButtonClicked:)]) {
+        [_delegate searchBarCancelButtonClicked:self];
     }
 }
 

--- a/samples/WOCCatalog/WOCCatalog/SearchBarViewController.h
+++ b/samples/WOCCatalog/WOCCatalog/SearchBarViewController.h
@@ -16,6 +16,6 @@
 
 #import <UIKit/UIKit.h>
 
-@interface SearchBarViewController : UITableViewController
+@interface SearchBarViewController : UITableViewController <UISearchBarDelegate>
 
 @end

--- a/samples/WOCCatalog/WOCCatalog/SearchBarViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/SearchBarViewController.m
@@ -64,9 +64,14 @@
         searchBar.showsCancelButton = true;
         [searchBar setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
         [cell addSubview:searchBar];
+        searchBar.delegate = self;
     }
 
     return cell;
+}
+
+- (void)searchBarCancelButtonClicked:(UISearchBar*)searchBar {
+    searchBar.text = @"";
 }
 
 @end


### PR DESCRIPTION
setting nil to background will disable hit-testing for cancel button which is the root cause of this issue. In the mean time, we hook up the searchBarCancelButtonClicked delegate and add test to it - by clearing the text in search bar to make it more obvious whether cancelbutton has worked or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1608)
<!-- Reviewable:end -->
