### PR TITLE
Impromptu perf fix: NSString _fastestEncoding

### DIFF
--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -493,12 +493,12 @@ BASE_CLASS_REQUIRED_IMPLS(NSString, NSStringPrototype, CFStringGetTypeID);
  @Notes
 */
 - (BOOL)getBytes:(void*)buffer
-       maxLength:(NSUInteger)maxBuf
-      usedLength:(NSUInteger*)usedLength
-        encoding:(NSStringEncoding)encoding
-         options:(NSStringEncodingConversionOptions)options
-           range:(NSRange)range
-  remainingRange:(NSRangePointer)left {
+         maxLength:(NSUInteger)maxBuf
+        usedLength:(NSUInteger*)usedLength
+          encoding:(NSStringEncoding)encoding
+           options:(NSStringEncodingConversionOptions)options
+             range:(NSRange)range
+    remainingRange:(NSRangePointer)left {
     CFIndex totalBytesWritten = 0;
     unsigned int numCharsProcessed = 0;
     CFStringEncoding cfStringEncoding = CFStringConvertNSStringEncodingToEncoding(encoding);
@@ -1328,10 +1328,10 @@ BOOL _isALineSeparatorTypeCharacter(unichar ch) {
 }
 
 - (void)_getBlockStart:(NSUInteger*)startPtr
-                   end:(NSUInteger*)endPtr
-           contentsEnd:(NSUInteger*)contentsEndPtr
-              forRange:(NSRange)range
-  stopAtLineSeparators:(BOOL)line {
+                     end:(NSUInteger*)endPtr
+             contentsEnd:(NSUInteger*)contentsEndPtr
+                forRange:(NSRange)range
+    stopAtLineSeparators:(BOOL)line {
     NSUInteger len = [self length];
     unichar ch;
 
@@ -2138,8 +2138,19 @@ static std::vector<NSStringEncoding> _getNSStringEncodings() {
 
 - (CFStringEncoding)_fastestEncodingInCFStringEncoding {
     // Return Unicode encoding as soon as a single non-ASCII character is found. Otherwise, return ASCII encoding.
-    for (int32_t i = 0; i < [self length]; i++) {
-        if ([self characterAtIndex:i] > 0x7F) {
+    // Check characters in chunks for perf reasons
+    const size_t bufferSize = 512;
+    UniChar buf[bufferSize];
+
+    const NSUInteger length = self.length;
+    NSRange range;
+
+    for (range.location = 0; range.location < length; range.location += range.length) {
+        range.length = std::min(length - range.location, bufferSize);
+
+        [self getCharacters:buf range:range];
+
+        if (std::any_of(buf, buf + range.length, [](UniChar c) { return c > 0x7F; })) {
             return kCFStringEncodingUnicode;
         }
     }


### PR DESCRIPTION
Found while checking CTCatalog affine transform test.
In cases of longer strings, _DWriteGetFrame() spends an inordinate amount of time in:
_DWriteGetFrame (~30%) -> [NSString substring...] (~27%) -> [NSString _fastestEncodingWith...] (~25%)  (sample trace)

Changed this function to not call [self length] every iteration, fetch characters in chunks.
After this change, the same test looks like:
_DWriteGetFrame (~5%) -> [NSString substring...] (~1.2%) -> [NSString _fastestEncodingWith...] (~0.5%)  (sample trace)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1623)
<!-- Reviewable:end -->
