### PR TITLE
Fix CoreAnimation functional tests after recent changes to CATransactions

### DIFF
--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -1532,6 +1532,10 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     priv->_backgroundColor = CGColorRetain(color);
     CGColorRelease(old);
 
+    // The CATransaction is now synchronous and in this scenario, the backgroundColor
+    // is updated almost immediately.By setting the priv->background first,
+    // we can ensure both states are kept in sync which is useful when performing
+    // automated testing.
     [CATransaction _setPropertyForLayer:self name:@"backgroundColor" value:(NSObject*)color];
 
     [self setNeedsDisplay];

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -1528,10 +1528,11 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
         _ClearColorQuad(priv->backgroundColor);
     }
 
-    [CATransaction _setPropertyForLayer:self name:@"backgroundColor" value:(NSObject*)color];
     CGColorRef old = priv->_backgroundColor;
     priv->_backgroundColor = CGColorRetain(color);
     CGColorRelease(old);
+
+    [CATransaction _setPropertyForLayer:self name:@"backgroundColor" value:(NSObject*)color];
 
     [self setNeedsDisplay];
 }

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -185,7 +185,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSURLCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -274,7 +274,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSUserDefaultsCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -311,7 +311,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSBundleCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -341,7 +341,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(AssetsLibraryCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -367,7 +367,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(CortanaVoiceCommandForegroundCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -390,7 +390,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(CortanaProtocolForegroundCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -412,7 +412,7 @@ class ToastNotificationForegroundActivation {
     }
 
     TEST_METHOD_CLEANUP(ToastNotificationForegroundCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -433,7 +433,7 @@ class ActivatedAppReceivesToastNotification {
     }
 
     TEST_METHOD_CLEANUP(ActivatedAppReceivesToastNotificationCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -460,7 +460,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(FileActivationForegroundActivationCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -524,7 +524,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -630,6 +630,12 @@ public:
     }
 
     TEST_METHOD(UIButton_BackgroundColorChanged) {
+        // Disable this test for now since it previously relied on the async delay between setting a UI property
+        // and seeing the change applied to the backing XAML element during the next tick on the runloop
+        BEGIN_TEST_METHOD_PROPERTIES()
+        TEST_METHOD_PROPERTY(L"ignore", L"true")
+        END_TEST_METHOD_PROPERTIES()
+
         UIButtonBackgroundColorChanged();
     }
 
@@ -691,7 +697,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -759,7 +765,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSURLStorageFileTestsCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 
@@ -784,7 +790,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(CoreAnimationTestsCleanup) {
-        FunctionalTestCleanupUIApplication();
+        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
         return true;
     }
 

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -274,8 +274,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSUserDefaultsCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(NSUserDefaults_Basic) {
@@ -311,8 +310,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSBundleCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(NSBundle_MSAppxURL) {
@@ -341,8 +339,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(AssetsLibraryCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(AssetsLibrary_GetVideoAsset) {
@@ -367,8 +364,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(CortanaVoiceCommandForegroundCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(Cortana_VoiceCommandForegroundActivationDelegateMethodsCalled) {
@@ -390,8 +386,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(CortanaProtocolForegroundCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(Cortana_ProtocolForegroundActivationDelegateMethodsCalled) {
@@ -412,8 +407,7 @@ class ToastNotificationForegroundActivation {
     }
 
     TEST_METHOD_CLEANUP(ToastNotificationForegroundCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(ToastNotification_ForegroundActivationDelegateMethodsCalled) {
@@ -460,8 +454,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(FileActivationForegroundActivationCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(FileActivation_TestForegroundActivationDelegateMethodsCalled) {
@@ -524,8 +517,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(UIView_Create) {
@@ -697,8 +689,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(ProjectionTest_WUCCoreDispatcherSanity) {
@@ -765,8 +756,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSURLStorageFileTestsCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(NSURLTests_StorageFileURL) {
@@ -790,8 +780,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(CoreAnimationTestsCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(CALayerAppearance_OpacityChanged) {

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -777,8 +777,6 @@ extern void CALayerAppearanceBackgroundColorChanged();
 class CoreAnimationTests {
 public:
     BEGIN_TEST_CLASS(CoreAnimationTests)
-        // TODO: Temporarily disabled due to failing tests; re-enable when 1526 is fixed.
-        TEST_CLASS_PROPERTY(L"ignore", L"true") 
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(CoreAnimationTestsSetup) {

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -185,8 +185,7 @@ public:
     }
 
     TEST_METHOD_CLEANUP(NSURLCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     //
@@ -427,8 +426,7 @@ class ActivatedAppReceivesToastNotification {
     }
 
     TEST_METHOD_CLEANUP(ActivatedAppReceivesToastNotificationCleanup) {
-        (void)FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication);
-        return true;
+        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
     }
 
     TEST_METHOD(ToastNotification_ActivatedAppReceivesToastNotification) {

--- a/tests/functionaltests/Tests/CoreAnimationTests/CALayerAppearanceTests.mm
+++ b/tests/functionaltests/Tests/CoreAnimationTests/CALayerAppearanceTests.mm
@@ -66,6 +66,7 @@ static const NSTimeInterval c_testTimeoutInSec = 5;
 //
 TEST(CALayerAppearance, OpacityChanged) {
     __block CALayerViewController* caLayerVC;
+    __block BOOL signaled = NO;
     __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
     __block WXUIElement* backingElement = nil;
 
@@ -95,6 +96,7 @@ TEST(CALayerAppearance, OpacityChanged) {
                 [backingElement unregisterPropertyChangedCallback:[WXUIElement opacityProperty] token:callbackToken];
 
                 [condition lock];
+                signaled = YES;
                 [condition signal];
                 [condition unlock];
             }];
@@ -104,7 +106,7 @@ TEST(CALayerAppearance, OpacityChanged) {
     });
 
     [condition lock];
-    ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+    ASSERT_TRUE_MSG(signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
         "FAILED: Waiting for property changed event timed out!");
     [condition unlock];
 
@@ -118,6 +120,7 @@ TEST(CALayerAppearance, OpacityChanged) {
 //
 TEST(CALayerAppearance, BackgroundColorChanged) {
     __block CALayerViewController* caLayerVC;
+    __block BOOL signaled = NO;
     __block NSCondition* condition = [[[NSCondition alloc] init] autorelease];
     __block WXUIElement* backingElement = nil;
 
@@ -157,8 +160,10 @@ TEST(CALayerAppearance, BackgroundColorChanged) {
                 [backingElement unregisterPropertyChangedCallback:[WXCPanel backgroundProperty] token:callbackToken];
 
                 [condition lock];
+                signaled = YES;
                 [condition signal];
                 [condition unlock];
+                //
         }];
 
         // Action
@@ -166,7 +171,7 @@ TEST(CALayerAppearance, BackgroundColorChanged) {
     });
 
     [condition lock];
-    ASSERT_TRUE_MSG([condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+    ASSERT_TRUE_MSG(signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
         "FAILED: Waiting for property changed event timed out!");
     [condition unlock];
 


### PR DESCRIPTION
CATransactions are now executed synchronously which affected our CoreAnimation tests that validate the ObjC state is in sync with its backing XAML element state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1627)
<!-- Reviewable:end -->
