### PR TITLE
Reverting:  "Moving the bulk of app initialization off of the app activation path.  We should let the app activate before calling into app code to finish starting up."

### DIFF
--- a/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
+++ b/Frameworks/UIKit/StarboardXaml/ApplicationCompositor.cpp
@@ -59,24 +59,19 @@ extern "C" void RunApplicationMain(Platform::String^ principalClassName,
                                    float windowHeight,
                                    ActivationType activationType,
                                    Platform::Object^ activationArg) {
-    // Return from activation immediatly; push all subsequent app launch work to 
-    // be performed *after* initial app activation.
-    CoreWindow::GetForCurrentThread()->Dispatcher->RunAsync(
-        CoreDispatcherPriority::Normal, 
-        ref new DispatchedHandler([=]() {
-            // Perform initialization
-            InitializeApp();
 
-            // Kick off iOS application main startup
-            // Convert Object^ to IInspectable* so it can be passed into Objective C and there converted to its projection
-            ApplicationMainStart(
-                Strings::WideToNarrow(principalClassName->Data()).c_str(),
-                Strings::WideToNarrow(delegateClassName->Data()).c_str(),
-                windowWidth,
-                windowHeight,
-                activationType,
-                reinterpret_cast<IInspectable*>(activationArg));
-    }));
+    // Perform initialization
+    InitializeApp();
+
+    // Kick off iOS application main startup
+    // Convert Object^ to IInspectable* so it can be passed into Objective C and there converted to its projection
+    ApplicationMainStart(
+            Strings::WideToNarrow(principalClassName->Data()).c_str(),
+            Strings::WideToNarrow(delegateClassName->Data()).c_str(),
+            windowWidth,
+            windowHeight,
+            activationType,
+            reinterpret_cast<IInspectable*>(activationArg));
 }
 
 // clang-format off


### PR DESCRIPTION
Reverting: "Moving the bulk of app initialization off of the app activation path.  We should let the app activate before calling into app code to finish starting up."

It doesn't seem to be needed for perf improvements, and it broke some functional tests.  We'll resurrect the change if needed, along with fixed tests.

This reverts commit b3e269ee1ddf7bb48f9f4b0f61611d5d381fff10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1640)
<!-- Reviewable:end -->
