### PR TITLE
NSRegularExpression firstMatchInString should return nil if there is no match

### DIFF
--- a/Frameworks/Foundation/NSRegularExpression.mm
+++ b/Frameworks/Foundation/NSRegularExpression.mm
@@ -129,7 +129,6 @@ static void _matchCallBack(void* context, CFRange* ranges, CFIndex count, _CFReg
  @Status Interoperable
 */
 - (NSTextCheckingResult*)firstMatchInString:(NSString*)string options:(NSMatchingOptions)options range:(NSRange)range {
-    NSRange tempRange = NSMakeRange(NSNotFound, 0);
     __block NSTextCheckingResult* result = nil;
 
     [self enumerateMatchesInString:string

--- a/Frameworks/Foundation/NSRegularExpression.mm
+++ b/Frameworks/Foundation/NSRegularExpression.mm
@@ -130,8 +130,7 @@ static void _matchCallBack(void* context, CFRange* ranges, CFIndex count, _CFReg
 */
 - (NSTextCheckingResult*)firstMatchInString:(NSString*)string options:(NSMatchingOptions)options range:(NSRange)range {
     NSRange tempRange = NSMakeRange(NSNotFound, 0);
-    __block NSTextCheckingResult* result =
-        [[NSTextCheckingResult regularExpressionCheckingResultWithRanges:&tempRange count:1 regularExpression:self] retain];
+    __block NSTextCheckingResult* result = nil;
 
     [self enumerateMatchesInString:string
                            options:options

--- a/tests/unittests/Foundation/NSRegularExpressionTests.m
+++ b/tests/unittests/Foundation/NSRegularExpressionTests.m
@@ -174,6 +174,11 @@ TEST(NSRegularExpression, RangeResultTests) {
 
     ASSERT_EQ(theRange.location, NSNotFound);
     ASSERT_EQ(theRange.length, 0);
+
+    StrongId<NSTextCheckingResult> result =
+        [regex firstMatchInString:testString options:NSRegularExpressionCaseInsensitive range:NSMakeRange(0, [testString length])];
+
+    ASSERT_EQ(nil, result);
 }
 
 TEST(NSRegularExpression, EscapeFormattingTests) {


### PR DESCRIPTION
NSRegularExpression firstMatchInString should return nil if there is no match.  Currently we are returning a non-nil value with range (NSNotFound, 0), which is not correct.  The documentation is vague on
this, but the examples on the documentation page show that the match
could be nil.  This fixes an internal test app that was used to parse
xml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1657)
<!-- Reviewable:end -->
