### PR TITLE
Waking the NSRunLoop upon app resume.  

### DIFF
--- a/Frameworks/UIKit/UIApplication.mm
+++ b/Frameworks/UIKit/UIApplication.mm
@@ -1137,6 +1137,9 @@ static void _sendMemoryWarningToViewControllers(UIView* subview) {
     if (isActive) {
         [self _sendEnteringForegroundEvents];
 
+        // Wake/unblock the main run loop so it starts processing messages again.
+        [[NSRunLoop mainRunLoop] _wakeUp];
+
         if ([self.delegate respondsToSelector:@selector(applicationDidBecomeActive:)]) {
             [self.delegate applicationDidBecomeActive:self];
         }


### PR DESCRIPTION
Without this change, we stay blocked in MainDispatcher::MainRunLoopTimedMultipleWait, and we never make it back into _DispatchMainRunLoopOnUIThread to continue processing messages until the app's window is resized.

This fixes the VSO bug around Climbers not resuming from PLM suspension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1660)
<!-- Reviewable:end -->
