### PR TITLE
Change implementation of [NSProgress fractionCompleted]

### DIFF
--- a/Frameworks/Foundation/NSProgress.mm
+++ b/Frameworks/Foundation/NSProgress.mm
@@ -211,7 +211,7 @@ static decltype(s_currentProgressStack) & _getProgressStackForCurrentThread() {
             // See NSProgress class reference:
             // If you don’t create any child progress objects between the calls to becomeCurrentWithPendingUnitCount: and resignCurrent,
             // the "parent" progress automatically updates its completedUnitCount by adding the pending units.
-            if (currentProgress.childCreated) {
+            if (!currentProgress.childCreated) {
                 @synchronized(self) {
                     [self setCompletedUnitCount:self.completedUnitCount + currentProgress.pendingUnitCountToAssign];
                 }

--- a/Frameworks/Foundation/NSProgress.mm
+++ b/Frameworks/Foundation/NSProgress.mm
@@ -288,7 +288,11 @@ static decltype(s_currentProgressStack) & _getProgressStackForCurrentThread() {
     @synchronized(self) { // Property is atomic
         [self willChangeValueForKey:@"fractionCompleted"];
         [self willChangeValueForKey:@"indeterminate"];
+                double ratio = (double)inUnitCount / _totalUnitCount;
         _totalUnitCount = inUnitCount;
+        [self _updateCompletedUnitsBy:0
+                  fractionCompletedBy:(_fractionCompleted / ratio) - _fractionCompleted
+                 unitCountForFraction:_totalUnitCount];
         [self didChangeValueForKey:@"indeterminate"];
         [self didChangeValueForKey:@"fractionCompleted"];
     }

--- a/Frameworks/Foundation/NSProgress.mm
+++ b/Frameworks/Foundation/NSProgress.mm
@@ -203,8 +203,7 @@ static decltype(s_currentProgressStack) & _getProgressStackForCurrentThread() {
     auto currentProgressStack = _getProgressStackForCurrentThread();
 
     // If self is the top element on the current progress stack, pop it
-    // Be sure to check if self == nil here, otherwise [nil resignCurrent] may cause a pop on an empty stack
-    if (self && !currentProgressStack->empty()) {
+    if (!currentProgressStack->empty()) {
         CurrentProgress currentProgress = currentProgressStack->top();
 
         if ([currentProgress.progress isEqual:self]) {
@@ -222,7 +221,7 @@ static decltype(s_currentProgressStack) & _getProgressStackForCurrentThread() {
         }
     }
 
-    // self was nil, or otherwise was not currentProgress
+    // self was not currentProgress
     [NSException raise:NSInvalidArgumentException
                 format:@"NSProgress was not the current progress on this thread %@", [NSThread currentThread]];
 }
@@ -245,6 +244,7 @@ static decltype(s_currentProgressStack) & _getProgressStackForCurrentThread() {
             fractionCompletedBy:(double)deltaFraction
            unitCountForFraction:(int64_t)unitCountForFraction {
     @synchronized(self) {
+        [self willChangeValueForKey:@"completedUnitCount"];
         [self willChangeValueForKey:@"fractionCompleted"];
         [self willChangeValueForKey:@"indeterminate"];
         double prevFraction = _fractionCompleted;
@@ -261,6 +261,7 @@ static decltype(s_currentProgressStack) & _getProgressStackForCurrentThread() {
         }
         [self didChangeValueForKey:@"indeterminate"];
         [self didChangeValueForKey:@"fractionCompleted"];
+        [self didChangeValueForKey:@"completedUnitCount"];
 
         if (_parent) {
             if (_fractionCompleted >= 1) {

--- a/tests/unittests/Foundation/NSProgressTests.mm
+++ b/tests/unittests/Foundation/NSProgressTests.mm
@@ -135,7 +135,9 @@ TEST(NSProgress, FractionCompleted) {
                      [userInfo setCompletedUnitCount:1];
                  }
         andExpectChangeCallbacks:nil];
-    EXPECT_EQ(2, kvoListener.hits);
+
+    // Depending on OSX version, the implementation differs slightly, and changes the number of hits
+    EXPECT_TRUE((kvoListener.hits == 1) || (kvoListener.hits == 2));
 
     ASSERT_EQ(0.5, [userInfo fractionCompleted]);
 }

--- a/tests/unittests/Foundation/NSProgressTests.mm
+++ b/tests/unittests/Foundation/NSProgressTests.mm
@@ -267,6 +267,17 @@ TEST(NSProgress, ChainImplicit_EdgeCases) {
     ASSERT_NEAR((80.0f / 120.0f) - (1.0f / 18.0f), [prog2 fractionCompleted], c_errorMargin); // Increases by 20/120
     ASSERT_NEAR((80.0f / 120.0f) - (1.0f / 18.0f), [prog1 fractionCompleted], c_errorMargin); // Increases by 20/120
 
+    // Change prog3's total unit count to 9
+    [prog3 setTotalUnitCount:9];
+
+    ASSERT_EQ(3, [prog3 completedUnitCount]);
+    ASSERT_EQ(100, [prog2 completedUnitCount]);
+    ASSERT_EQ(0, [prog1 completedUnitCount]);
+
+    ASSERT_NEAR(1.0f / 3.0f, [prog3 fractionCompleted], c_errorMargin);
+    ASSERT_NEAR(0.5f, [prog2 fractionCompleted], c_errorMargin); // lower by 20/120, increase by 1/3 * 20/120
+    ASSERT_NEAR(0.5f, [prog1 fractionCompleted], c_errorMargin); // lower by 20/120, increase by 1/3 * 20/120
+
     // Reset prog2 to 0 (probably shouldn't ever be done in production)
     [prog2 setCompletedUnitCount:0];
 
@@ -274,7 +285,7 @@ TEST(NSProgress, ChainImplicit_EdgeCases) {
     ASSERT_EQ(0, [prog2 completedUnitCount]); // Hard resets without taking anything from prog3 into account
     ASSERT_EQ(0, [prog1 completedUnitCount]);
 
-    ASSERT_EQ(1, [prog3 fractionCompleted]);
+    ASSERT_NEAR(1.0f / 3.0f, [prog3 fractionCompleted], c_errorMargin);
     ASSERT_NEAR(0, [prog2 fractionCompleted], c_errorMargin); // fractionCompleted floors at 0
     ASSERT_NEAR(0, [prog1 fractionCompleted], c_errorMargin);
 


### PR DESCRIPTION
Instead of being linked directly to a NSProgress's completedUnitCount,
it now adds fractionCompleted from children if applicable,
including becoming out of sync if a child reverses in progress or completes more than once.
(This matches the reference platform behavior)

Fixes #834

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1663)
<!-- Reviewable:end -->
