### PR TITLE
use ws2tcpip.h for definitions of inet_* functions that are exported

### DIFF
--- a/build/Tests/UnitTests/WOCStdLib/WOCStdLib.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/WOCStdLib/WOCStdLib.UnitTests.vcxproj
@@ -224,6 +224,7 @@
   <ItemGroup>
     <ClangCompile Include="..\..\..\..\tests\unittests\WOCStdLib\mach\mach_task_info_test.mm" />
     <ClangCompile Include="..\..\..\..\tests\unittests\WOCStdLib\mach\mach_test.mm" />
+    <ClangCompile Include="..\..\..\..\tests\unittests\WOCStdLib\inettests.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/include/WOCStdLib/arpa/inet.h
+++ b/include/WOCStdLib/arpa/inet.h
@@ -149,9 +149,11 @@ uint16_t     ntohs(uint16_t);
 
 in_addr_t    inet_addr(const char *);
 /*const*/ char  *inet_ntoa(struct in_addr);
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 const char  *inet_ntop(int, const void * __restrict, char * __restrict,
             socklen_t);
 int      inet_pton(int, const char * __restrict, void * __restrict);
+#endif
 
 #if __BSD_VISIBLE
 int      inet_aton(const char *, struct in_addr *);

--- a/include/WOCStdLib/netinet/in.h
+++ b/include/WOCStdLib/netinet/in.h
@@ -531,10 +531,12 @@ __END_DECLS
 /*
  * Argument structure for IP_ADD_MEMBERSHIP and IP_DROP_MEMBERSHIP.
  */
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 struct ip_mreq {
     struct  in_addr imr_multiaddr;  /* IP multicast address of group */
     struct  in_addr imr_interface;  /* local IP address of interface */
 };
+#endif
 
 /*
  * Modified argument structure for IP_MULTICAST_IF, obtained from Linux.
@@ -550,12 +552,12 @@ struct ip_mreqn {
 /*
  * Argument structure for IPv4 Multicast Source Filter APIs. [RFC3678]
  */
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 struct ip_mreq_source {
     struct  in_addr imr_multiaddr;  /* IP multicast address of group */
     struct  in_addr imr_sourceaddr; /* IP address of source */
     struct  in_addr imr_interface;  /* local IP address of interface */
 };
-
 /*
  * Argument structures for Protocol-Independent Multicast Source
  * Filter APIs. [RFC3678]
@@ -570,6 +572,7 @@ struct group_source_req {
     struct sockaddr_storage gsr_group;  /* group address */
     struct sockaddr_storage gsr_source; /* source address */
 };
+#endif
 
 #ifndef __MSFILTERREQ_DEFINED
 #define __MSFILTERREQ_DEFINED
@@ -597,6 +600,7 @@ struct sockaddr;
  * The RFC specifies uint_t for the 6th argument to [sg]etsourcefilter().
  * We use uint32_t here to be consistent.
  */
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 int setipv4sourcefilter(int, struct in_addr, struct in_addr, uint32_t,
         uint32_t, struct in_addr *);
 int getipv4sourcefilter(int, struct in_addr, struct in_addr, uint32_t *,
@@ -605,6 +609,7 @@ int setsourcefilter(int, uint32_t, struct sockaddr *, socklen_t,
         uint32_t, uint32_t, struct sockaddr_storage *);
 int getsourcefilter(int, uint32_t, struct sockaddr *, socklen_t,
         uint32_t *, uint32_t *, struct sockaddr_storage *);
+#endif
 
 /*
  * Filter modes; also used to represent per-socket filter mode internally.

--- a/include/WOCStdLib/netinet6/in6.h
+++ b/include/WOCStdLib/netinet6/in6.h
@@ -136,6 +136,7 @@ typedef __uint8_t   sa_family_t;
 /*
  * IPv6 address
  */
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 struct in6_addr {
   union {
     __uint8_t   __u6_addr8[16];
@@ -143,6 +144,7 @@ struct in6_addr {
     __uint32_t  __u6_addr32[4];
   } __u6_addr;      /* 128-bit IP6 address */
 };
+#endif
 
 #define s6_addr   __u6_addr.__u6_addr8
 
@@ -154,6 +156,7 @@ struct in6_addr {
 #if !defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE)
 #define SIN6_LEN
 #endif /* !_POSIX_C_SOURCE || _DARWIN_C_SOURCE */
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 struct sockaddr_in6 {
   __uint8_t sin6_len; /* length of this struct(sa_family_t)*/
   sa_family_t sin6_family;  /* AF_INET6 (sa_family_t) */
@@ -162,6 +165,7 @@ struct sockaddr_in6 {
   struct in6_addr sin6_addr;  /* IP6 address */
   __uint32_t  sin6_scope_id;  /* scope zone index */
 };
+#endif
 
 /*
  * Definition of some useful macros to handle IP6 addresses
@@ -364,6 +368,7 @@ struct route_in6 {
 /*
  * Argument structure for IPV6_JOIN_GROUP and IPV6_LEAVE_GROUP.
  */
+#ifndef WINOBJC     // Defined by ws2tcpip.h
 struct ipv6_mreq {
   struct in6_addr ipv6mr_multiaddr;
   unsigned int  ipv6mr_interface;
@@ -376,6 +381,7 @@ struct in6_pktinfo {
   struct in6_addr ipi6_addr;  /* src/dst IPv6 address */
   unsigned int  ipi6_ifindex; /* send/recv interface index */
 };
+#endif
 
 /*
  * Argument for IPV6_PORTRANGE:

--- a/tests/unittests/WOCStdLib/inettests.mm
+++ b/tests/unittests/WOCStdLib/inettests.mm
@@ -14,9 +14,13 @@
 //
 //******************************************************************************
 
-#pragma once
+#include "gtest-api.h"
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 
-#include <Winsock2.h>
-#include <ws2tcpip.h>
-
-#define _SOCKLEN_T_DECLARED
+TEST(WOCStdLib, WinSockBuildTests) {
+    char addrBuf[INET_ADDRSTRLEN];
+    char testData[100];
+    inet_ntop(AF_INET, NULL, addrBuf, (socklen_t)sizeof(addrBuf));
+}


### PR DESCRIPTION
from ws2_32.lib. Fixes #533.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1664)
<!-- Reviewable:end -->
