### PR TITLE
Added missing value to EAGLRenderingAPI enum and a property to get current version of rendering API

### DIFF
--- a/include/OpenGLES/EAGL.h
+++ b/include/OpenGLES/EAGL.h
@@ -20,10 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <OpenGLES/EAGLExport.h>
 
-enum {
-   kEAGLRenderingAPIOpenGLES1 = 1,
-   kEAGLRenderingAPIOpenGLES2 = 2
-};
+enum { kEAGLRenderingAPIOpenGLES1 = 1, kEAGLRenderingAPIOpenGLES2 = 2, kEAGLRenderingAPIOpenGLES3 = 3 };
 typedef uint32_t EAGLRenderingAPI;
 
 @interface EAGLSharegroup : NSObject
@@ -31,16 +28,17 @@ typedef uint32_t EAGLRenderingAPI;
 
 EAGL_EXPORT_CLASS
 @interface EAGLContext : NSObject
-@property (readonly) EAGLSharegroup *sharegroup;
+@property (readonly) EAGLSharegroup* sharegroup;
+@property (readonly) NSUInteger API;
 @property (getter=isMultiThreaded, nonatomic) BOOL multiThreaded;
 
 - (id)initWithAPI:(EAGLRenderingAPI)api;
-- (id)initWithAPI:(EAGLRenderingAPI)api sharegroup:(EAGLSharegroup *)sharegroup;
-- (BOOL) presentRenderbuffer: (int) obj;
-- (BOOL) renderbufferStorage: (int) dest fromDrawable: (id) layer;
+- (id)initWithAPI:(EAGLRenderingAPI)api sharegroup:(EAGLSharegroup*)sharegroup;
+- (BOOL)presentRenderbuffer:(int)obj;
+- (BOOL)renderbufferStorage:(int)dest fromDrawable:(id)layer;
 
-+ (BOOL) setCurrentContext: (id) newContext;
-+ (EAGLContext *) currentContext;
++ (BOOL)setCurrentContext:(id)newContext;
++ (EAGLContext*)currentContext;
 
 @end
 


### PR DESCRIPTION
added missing value to EAGLRenderingAPI enum
added readonly property in order to be able to get current version of OpenGL  API
code styling changes according to ClangFormat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1666)
<!-- Reviewable:end -->
