### PR TITLE
Fix for #1672.  Don't uninitialize in UIView's dealloc if we never initialized

### DIFF
--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -3395,6 +3395,11 @@ static float doRound(float f) {
 #pragma clang diagnostic pop
 
 - (void)_dealloc {
+    if (!self->priv) {
+        // If we were never initialized, there's nothing to do here.
+        return;
+    }
+
     if (_deallocating) {
         return;
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1674)
<!-- Reviewable:end -->
