### PR TITLE
Fix exact match behavior after updating a unit.

### DIFF
--- a/Frameworks/Foundation/NSCFCalendar.mm
+++ b/Frameworks/Foundation/NSCFCalendar.mm
@@ -558,6 +558,22 @@ static NSDate* _validDateNormalUnit(NSCalendar* cal,
         workingDate = [cal dateByAddingComponents:updateUnit toDate:workingDate options:opts];
     }
 
+    NSDateComponents* directMatchingComps = [cal components:s_NSDateComponentsAllFlagOptions fromDate:workingDate];
+    for (int i = 0; i < _countof(s_NSDateComponentsIndividualFlags); i++) {
+        NSInteger expectedValue = [matchComps valueForComponent:s_NSDateComponentsIndividualFlags[i]];
+        NSInteger workingValue = [workingComps valueForComponent:s_NSDateComponentsIndividualFlags[i]];
+        if (expectedValue != NSUndefinedDateComponent) {
+            [directMatchingComps setValue:expectedValue forComponent:s_NSDateComponentsIndividualFlags[i]];
+        }
+    }
+
+    // Attempt to directly create the matching date using the expected matching components now that the largest
+    // possible unit has been updated.
+    if (_isValidDate(cal, directMatchingComps)) {
+        NSDate* exactDate = [cal dateFromComponents:directMatchingComps];
+        return exactDate;
+    }
+
     return workingDate;
 }
 

--- a/Frameworks/Foundation/NSCFCalendar.mm
+++ b/Frameworks/Foundation/NSCFCalendar.mm
@@ -559,9 +559,8 @@ static NSDate* _validDateNormalUnit(NSCalendar* cal,
     }
 
     NSDateComponents* directMatchingComps = [cal components:s_NSDateComponentsAllFlagOptions fromDate:workingDate];
-    for (int i = 0; i < _countof(s_NSDateComponentsIndividualFlags); i++) {
+    for (int i = 0; i < std::extent<decltype(s_NSDateComponentsIndividualFlags)>::value; i++) {
         NSInteger expectedValue = [matchComps valueForComponent:s_NSDateComponentsIndividualFlags[i]];
-        NSInteger workingValue = [workingComps valueForComponent:s_NSDateComponentsIndividualFlags[i]];
         if (expectedValue != NSUndefinedDateComponent) {
             [directMatchingComps setValue:expectedValue forComponent:s_NSDateComponentsIndividualFlags[i]];
         }

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -535,3 +535,28 @@ WIN32_DISABLED_TEST(NSCalendar, RangeOfWeekOfMonthTest) {
     EXPECT_EQ(range.location, 27);
     EXPECT_EQ(range.length, 6);
 }
+
+TEST(NSCalendar, ExactMatch) {
+    NSCalendar* calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    NSDate* start = [calendar dateWithEra:1 year:2010 month:3 day:1 hour:1 minute:2 second:3 nanosecond:0];
+
+    NSDateComponents* components = [[NSDateComponents new] autorelease];
+    components.day = 30;
+
+    __block int iterationsToTest = 0;
+
+    [calendar enumerateDatesStartingAfterDate:start
+                           matchingComponents:components
+                                      options:NSCalendarMatchPreviousTimePreservingSmallerUnits | NSCalendarSearchBackwards
+                                   usingBlock:^(NSDate* date, BOOL exactMatch, BOOL* stop) {
+                                       NSInteger month = [calendar component:NSCalendarUnitMonth fromDate:date];
+
+                                       if (month != 2) {
+                                           ASSERT_TRUE(exactMatch);
+                                           iterationsToTest++;
+                                       }
+                                       if (iterationsToTest > 20) {
+                                           *stop = YES;
+                                       }
+                                   }];
+}

--- a/tests/unittests/Foundation/NSCalendarTests.mm
+++ b/tests/unittests/Foundation/NSCalendarTests.mm
@@ -551,11 +551,13 @@ TEST(NSCalendar, ExactMatch) {
                                    usingBlock:^(NSDate* date, BOOL exactMatch, BOOL* stop) {
                                        NSInteger month = [calendar component:NSCalendarUnitMonth fromDate:date];
 
+                                       iterationsToTest++;
                                        if (month != 2) {
                                            ASSERT_TRUE(exactMatch);
-                                           iterationsToTest++;
+                                       } else {
+                                           ASSERT_TRUE(!exactMatch);
                                        }
-                                       if (iterationsToTest > 20) {
+                                       if (iterationsToTest > 24) {
                                            *stop = YES;
                                        }
                                    }];


### PR DESCRIPTION
After updating the largest allowed component of the date components for enumerating matches, attempt again to match the exact date using the newly updated date components.

Prior to this, the matching algorithm was incorrect such that iterating backwards to find the 30th day of a month for example would instead first find the 28th day of January due to February restricting the day component to 28.

Fixes #1629

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1677)
<!-- Reviewable:end -->
