### PR TITLE
Fix -classForCoder on bridged classes to respect mutability.

### DIFF
--- a/Frameworks/CoreFoundation/String.subproj/CFString.c
+++ b/Frameworks/CoreFoundation/String.subproj/CFString.c
@@ -252,6 +252,11 @@ CF_INLINE Boolean __CFStrIsConstant(CFStringRef str) {
 #endif
 }
 
+// WINOBJC: _CFStringIsMutable is for Foundation's benefit. It should not be consumed by anyone else.
+CF_PRIVATE CF_EXPORT Boolean _CFStringIsMutable(CFStringRef str) {
+    return __CFStrIsMutable(str);
+}
+
 CF_INLINE SInt32 __CFStrSkipAnyLengthByte(CFStringRef str)          {return ((str->base._cfinfo[CF_INFO_BITS] & __kCFHasLengthByteMask) == __kCFHasLengthByte) ? 1 : 0;}    // Number of bytes to skip over the length byte in the contents
 
 /* Returns ptr to the buffer (which might include the length byte).

--- a/Frameworks/Foundation/NSCFArray.mm
+++ b/Frameworks/Foundation/NSCFArray.mm
@@ -75,6 +75,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFArray)
 @implementation NSCFArray
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFArrayRef, CFArrayGetTypeID, NSArray, NSCFArray)
+BRIDGED_MUTABLE_CLASS_FOR_CODER(CFArrayRef, _CFArrayIsMutable, NSArray, NSMutableArray)
 
 - (NSUInteger)count {
     return CFArrayGetCount((CFArrayRef)self);

--- a/Frameworks/Foundation/NSCFAttributedString.mm
+++ b/Frameworks/Foundation/NSCFAttributedString.mm
@@ -81,6 +81,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFAttributedString)
 @implementation NSCFAttributedString
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFAttributedStringRef, CFAttributedStringGetTypeID, NSAttributedString, NSCFAttributedString)
+BRIDGED_MUTABLE_CLASS_FOR_CODER(CFAttributedStringRef, _CFAttributedStringIsMutable, NSAttributedString, NSMutableAttributedString)
 
 - (NSString*)string {
     return (__bridge NSString*)CFAttributedStringGetString(reinterpret_cast<CFAttributedStringRef>(self));

--- a/Frameworks/Foundation/NSCFCalendar.mm
+++ b/Frameworks/Foundation/NSCFCalendar.mm
@@ -171,6 +171,7 @@ static NSDateComponents* _descriptionToComponents(NSCalendar* self, NSCalendarUn
 @implementation NSCFCalendar
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFCalendarRef, CFCalendarGetTypeID, NSCalendar, NSCFCalendar)
+BRIDGED_CLASS_FOR_CODER(NSCalendar)
 
 + (void)initialize {
     _initAllFlagsComponents();

--- a/Frameworks/Foundation/NSCFCharacterSet.mm
+++ b/Frameworks/Foundation/NSCFCharacterSet.mm
@@ -56,6 +56,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFCharacterSet)
 @implementation NSCFCharacterSet
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFCharacterSetRef, CFCharacterSetGetTypeID, NSCharacterSet, NSCFCharacterSet)
+BRIDGED_MUTABLE_CLASS_FOR_CODER(CFCharacterSetRef, __CFCharacterSetIsMutable, NSCharacterSet, NSMutableCharacterSet)
 
 - (BOOL)characterIsMember:(unichar)aCharacter {
     return CFCharacterSetIsCharacterMember(static_cast<CFCharacterSetRef>(self), aCharacter);

--- a/Frameworks/Foundation/NSCFData.mm
+++ b/Frameworks/Foundation/NSCFData.mm
@@ -101,6 +101,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFData)
 @implementation NSCFData
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFDataRef, CFDataGetTypeID, NSData, NSCFData)
+BRIDGED_MUTABLE_CLASS_FOR_CODER(CFDataRef, _CFDataIsMutable, NSData, NSMutableData)
 
 - (const void*)bytes {
     return CFDataGetBytePtr(static_cast<CFDataRef>(self));

--- a/Frameworks/Foundation/NSCFDate.mm
+++ b/Frameworks/Foundation/NSCFDate.mm
@@ -53,6 +53,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFDate)
 @implementation NSCFDate
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFDateRef, CFDateGetTypeID, NSDate, NSCFDate)
+BRIDGED_CLASS_FOR_CODER(NSDate)
 
 - (double)timeIntervalSinceReferenceDate {
     return CFDateGetAbsoluteTime(static_cast<CFDateRef>(self));

--- a/Frameworks/Foundation/NSCFDictionary.mm
+++ b/Frameworks/Foundation/NSCFDictionary.mm
@@ -89,6 +89,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFDictionary)
 @implementation NSCFDictionary
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFDictionaryRef, CFDictionaryGetTypeID, NSDictionary, NSCFDictionary)
+BRIDGED_MUTABLE_CLASS_FOR_CODER(CFDictionaryRef, _CFDictionaryIsMutable, NSDictionary, NSMutableDictionary)
 
 - (id)objectForKey:(id)key {
     if (key == nil) {

--- a/Frameworks/Foundation/NSCFError.mm
+++ b/Frameworks/Foundation/NSCFError.mm
@@ -24,6 +24,7 @@
 @implementation NSCFError
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFErrorRef, CFErrorGetTypeID, NSError, NSCFError)
+BRIDGED_CLASS_FOR_CODER(NSError)
 
 - (NSString*)domain {
     return static_cast<NSString*>(CFErrorGetDomain(static_cast<CFErrorRef>(self)));

--- a/Frameworks/Foundation/NSCFInputStream.mm
+++ b/Frameworks/Foundation/NSCFInputStream.mm
@@ -51,6 +51,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFInputStream)
 @implementation NSCFInputStream
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFReadStreamRef, CFReadStreamGetTypeID, NSURL, NSCFInputStream)
+BRIDGED_CLASS_FOR_CODER(NSInputStream)
 
 /**
  @Status Interoperable

--- a/Frameworks/Foundation/NSCFLocale.mm
+++ b/Frameworks/Foundation/NSCFLocale.mm
@@ -51,6 +51,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFLocale)
 @implementation NSCFLocale
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFLocaleRef, CFLocaleGetTypeID, NSLocale, NSCFLocale)
+BRIDGED_CLASS_FOR_CODER(NSLocale)
 
 - (NSString*)displayNameForKey:(id)key value:(id)value {
     return [(static_cast<NSString*>(CFLocaleCopyDisplayNameForPropertyValue(static_cast<CFLocaleRef>(self),

--- a/Frameworks/Foundation/NSCFOutputStream.mm
+++ b/Frameworks/Foundation/NSCFOutputStream.mm
@@ -62,7 +62,8 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFOutputStream)
 #pragma region NSCFOutputStream
 @implementation NSCFOutputStream
 
-BRIDGED_CLASS_REQUIRED_IMPLS(CFWriteStreamRef, CFWriteStreamGetTypeID, NSURL, NSCFOutputStream)
+BRIDGED_CLASS_REQUIRED_IMPLS(CFWriteStreamRef, CFWriteStreamGetTypeID, NSOutputStream, NSCFOutputStream)
+BRIDGED_CLASS_FOR_CODER(NSOutputStream)
 
 /**
  @Status Interoperable

--- a/Frameworks/Foundation/NSCFSet.mm
+++ b/Frameworks/Foundation/NSCFSet.mm
@@ -82,6 +82,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFSet)
 @implementation NSCFSet
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFSetRef, CFSetGetTypeID, NSSet, NSCFSet)
+BRIDGED_MUTABLE_CLASS_FOR_CODER(CFSetRef, _CFSetIsMutable, NSSet, NSMutableSet)
 
 - (unsigned)count {
     return CFSetGetCount(static_cast<CFSetRef>(self));

--- a/Frameworks/Foundation/NSCFTimeZone.mm
+++ b/Frameworks/Foundation/NSCFTimeZone.mm
@@ -53,6 +53,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSTimeZonePrototype)
 @implementation NSCFTimeZone
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFTimeZoneRef, CFTimeZoneGetTypeID, NSTimeZone, NSCFTimeZone)
+BRIDGED_CLASS_FOR_CODER(NSTimeZone)
 
 - (NSString*)abbreviationForDate:(NSDate*)aDate {
     return [static_cast<NSString*>(CFTimeZoneCopyAbbreviation(static_cast<CFTimeZoneRef>(self), [aDate timeIntervalSinceReferenceDate]))

--- a/Frameworks/Foundation/NSCFURL.mm
+++ b/Frameworks/Foundation/NSCFURL.mm
@@ -77,6 +77,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(NSCFURL)
 @implementation NSCFURL
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CFURLRef, CFURLGetTypeID, NSURL, NSCFURL)
+BRIDGED_CLASS_FOR_CODER(NSURL)
 
 - (BOOL)getFileSystemRepresentation:(char*)buffer maxLength:(NSUInteger)maxBufferLength {
     return CFURLGetFileSystemRepresentation(static_cast<CFURLRef>(self), true, reinterpret_cast<uint8_t*>(buffer), maxBufferLength);

--- a/Frameworks/Foundation/NSCharacterSet.mm
+++ b/Frameworks/Foundation/NSCharacterSet.mm
@@ -242,7 +242,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSCharacterSet, NSMutableCharacterSetPrototype, CFChar
 */
 - (instancetype)initWithCoder:(NSCoder*)coder {
     if (self = [super init]) {
-        self = [[NSCharacterSet
+        self = [[[self class]
             characterSetWithBitmapRepresentation:[coder decodeObjectOfClass:[NSData class] forKey:@"bitmapRepresentation"]] retain];
     }
     return self;

--- a/Frameworks/Foundation/NSKeyedArchiver.mm
+++ b/Frameworks/Foundation/NSKeyedArchiver.mm
@@ -99,6 +99,11 @@ static id makeReference(unsigned objectId) {
     [_enc setObject:o forKey:aKey];
 }
 
+- (void)_encodeRawObject:(NSObject*)object forKey:(NSString*)key {
+    _checkKey(key, _enc);
+    [_enc setObject:object forKey:key];
+}
+
 /**
  @Status Interoperable
 */

--- a/Frameworks/Foundation/NSKeyedArchiverInternal.h
+++ b/Frameworks/Foundation/NSKeyedArchiverInternal.h
@@ -21,4 +21,5 @@
 
 @interface NSKeyedArchiver ()
 - (void)_encodeArrayOfObjects:(NSArray*)anArray forKey:(NSString*)aKey;
+- (void)_encodeRawObject:(NSObject*)object forKey:(NSString*)key;
 @end

--- a/Frameworks/Foundation/NSString.mm
+++ b/Frameworks/Foundation/NSString.mm
@@ -2021,7 +2021,13 @@ static std::vector<NSStringEncoding> _getNSStringEncodings() {
  @Status Interoperable
 */
 - (void)encodeWithCoder:(NSCoder*)coder {
-    [coder encodeObject:self forKey:@"NS.string"];
+    if ([coder isKindOfClass:[NSKeyedArchiver class]]) {
+        [coder _encodeRawObject:self forKey:@"NS.string"];
+    } else {
+        // This can cause custom string subclasses to act up.
+        // Ideally, a developer would override encodeWithCoder:.
+        [coder encodeObject:[NSString stringWithString:self] forKey:@"NS.string"];
+    }
 }
 
 /**

--- a/Frameworks/UIKit/UICTFont.mm
+++ b/Frameworks/UIKit/UICTFont.mm
@@ -47,6 +47,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(UICTFont)
 @implementation UICTFont
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CTFontRef, CTFontGetTypeID, UIFont, UICTFont)
+BRIDGED_CLASS_FOR_CODER(UIFont)
 
 + (UIFont*)fontWithName:(NSString*)name size:(float)size {
     return [(__bridge UIFont*)CTFontCreateWithName((__bridge CFStringRef)name, size, nullptr) autorelease];

--- a/Frameworks/UIKit/UICTFontDescriptor.mm
+++ b/Frameworks/UIKit/UICTFontDescriptor.mm
@@ -44,6 +44,7 @@ PROTOTYPE_CLASS_REQUIRED_IMPLS(UICTFontDescriptor)
 @implementation UICTFontDescriptor
 
 BRIDGED_CLASS_REQUIRED_IMPLS(CTFontDescriptorRef, CTFontDescriptorGetTypeID, UIFontDescriptor, UICTFontDescriptor)
+BRIDGED_CLASS_FOR_CODER(UIFontDescriptor)
 
 - (NSDictionary<NSString*, id>*)fontAttributes {
     return [(__bridge NSDictionary<NSString*, id>*)CTFontDescriptorCopyAttributes(static_cast<CTFontDescriptorRef>(self)) autorelease];

--- a/Frameworks/include/BridgeHelpers.h
+++ b/Frameworks/include/BridgeHelpers.h
@@ -62,10 +62,19 @@ __pragma(clang diagnostic pop) \
 + (NSBridgedConcreteType*)allocWithZone:(NSZone*)zone { \
     FAIL_FAST(); \
     return nullptr; \
-} \
- \
+}
+
+#define BRIDGED_CLASS_FOR_CODER(NSBridgedType) \
 - (Class)classForCoder { \
-  return [NSBridgedType class];\
+    return [NSBridgedType class];\
+}
+
+#define BRIDGED_MUTABLE_CLASS_FOR_CODER(CFBridgedTypeRef, ISMutableFN, NSBridgedType, NSMutableBridgedType) \
+- (Class)classForCoder { \
+    if (ISMutableFN((CFBridgedTypeRef)self)) { \
+      return [NSMutableBridgedType class]; \
+    } \
+    return [NSBridgedType class]; \
 }
 // clang-format on
 

--- a/Frameworks/include/CFFoundationInternal.h
+++ b/Frameworks/include/CFFoundationInternal.h
@@ -50,6 +50,7 @@ CF_EXPORT Boolean _CFDataIsMutable(CFDataRef data);
 CF_EXPORT Boolean _CFDataOwnsBuffer(CFDataRef data);
 CF_EXPORT Boolean _CFAttributedStringIsMutable(CFAttributedStringRef attrStr);
 CF_EXPORT Boolean _CFSetIsMutable(CFSetRef hc);
+CF_EXPORT Boolean _CFStringIsMutable(CFStringRef string);
 CF_EXTERN_C_END
 
 // Copied from CFFileUtilities.c

--- a/tests/unittests/Foundation/NSArrayTests.mm
+++ b/tests/unittests/Foundation/NSArrayTests.mm
@@ -411,3 +411,17 @@ TEST(NSArray, SortedArrayWithOptions) {
 
     ASSERT_OBJCEQ(expectedStableSort, actualStableSort);
 }
+
+TEST(NSArray, MutableInstanceArchivesAsMutable) {
+    NSMutableArray* input = [NSMutableArray arrayWithObject:@"hello"];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableArray* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output addObject:@"world"]);
+
+    EXPECT_OBJCNE(input, output);
+}

--- a/tests/unittests/Foundation/NSAttributedStringTests.mm
+++ b/tests/unittests/Foundation/NSAttributedStringTests.mm
@@ -773,3 +773,18 @@ TEST(NSAttributedString, Subclass) {
     ASSERT_EQ(2, CFAttributedStringGetLength((__bridge CFAttributedStringRef)didOverride));
     ASSERT_EQ(YES, [didOverride methodCalled]);
 }
+
+DISABLED_TEST(NSAttributedString, MutableInstanceArchivesAsMutable) {
+    NSMutableAttributedString* input = [[[NSMutableAttributedString alloc] initWithString:@"hello"] autorelease];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableAttributedString* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output appendAttributedString:[[[NSMutableAttributedString alloc] initWithString:@" world"] autorelease]]);
+    EXPECT_OBJCEQ(@"hello world", [output string]);
+
+    EXPECT_OBJCNE(input, output);
+}

--- a/tests/unittests/Foundation/NSCharacterSetTests.m
+++ b/tests/unittests/Foundation/NSCharacterSetTests.m
@@ -223,3 +223,20 @@ TEST(NSCharacterSet, Polymorphic_Creators) {
     set = [NSMutableCharacterSet characterSetWithBitmapRepresentation:nil];
     EXPECT_TRUE([set isKindOfClass:[NSMutableCharacterSet class]]);
 }
+
+TEST(NSCharacterSet, MutableInstanceArchivesAsMutable) {
+    NSMutableCharacterSet* input = [NSMutableCharacterSet characterSetWithCharactersInString:@"a"];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableCharacterSet* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output addCharactersInString:@"b"]);
+
+    // We cannot compare these for equality. Despite having different ranges (!) they are considered equal
+    // on the reference platform.
+    EXPECT_FALSE([input characterIsMember:'b']);
+    EXPECT_TRUE([output characterIsMember:'b']);
+}

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -368,3 +368,18 @@ TEST(NSData, Copying_CustomBufferWithoutOwnership) {
     *(backingBuffer.get() + 5) = '!';
     ASSERT_OBJCNE(copiedData, originalNonOwningData);
 }
+
+TEST(NSData, MutableInstanceArchivesAsMutable) {
+    NSMutableData* input = [NSMutableData dataWithBytes:"hello" length:5];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableData* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output appendBytes:" world\0" length:7]);
+    EXPECT_STREQ("hello world", (const char*)output.bytes);
+
+    EXPECT_OBJCNE(input, output);
+}

--- a/tests/unittests/Foundation/NSDictionaryTests.mm
+++ b/tests/unittests/Foundation/NSDictionaryTests.mm
@@ -116,3 +116,17 @@ TEST(NSDictionary, KeysSortedByValueWithOptions_Stable) {
 
     ASSERT_OBJCEQ(expected, actual);
 }
+
+TEST(NSDictionary, MutableInstanceArchivesAsMutable) {
+    NSMutableDictionary* input = [NSMutableDictionary dictionaryWithObject:@"world" forKey:@"hello"];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableDictionary* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output setObject:@"morld" forKey:@"yello"]);
+
+    EXPECT_OBJCNE(input, output);
+}

--- a/tests/unittests/Foundation/NSIndexSetTests.mm
+++ b/tests/unittests/Foundation/NSIndexSetTests.mm
@@ -329,3 +329,17 @@ TEST(NSIndexSet, NSCodingNonemptySet) {
     NSMutableIndexSet* decodedSet = [[NSMutableIndexSet alloc] initWithCoder:decoder];
     EXPECT_OBJCEQ(set, decodedSet);
 }
+
+TEST(NSIndexSet, MutableInstanceArchivesAsMutable) {
+    NSMutableIndexSet* input = [NSMutableIndexSet indexSetWithIndexesInRange:{1, 5}];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableIndexSet* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output addIndex:10]);
+
+    EXPECT_OBJCNE(input, output);
+}

--- a/tests/unittests/Foundation/NSSetTests.mm
+++ b/tests/unittests/Foundation/NSSetTests.mm
@@ -129,3 +129,17 @@ TEST(NSSet, setByAddingObjectsFromArrayDuplicate) {
     NSSet* setFromDupArray = [set setByAddingObjectsFromArray:dupArray];
     ASSERT_EQ([setFromDupArray count], 6);
 }
+
+TEST(NSSet, MutableInstanceArchivesAsMutable) {
+    NSMutableSet* input = [NSMutableSet setWithObject:@"hello"];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableSet* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output addObject:@"world"]);
+
+    EXPECT_OBJCNE(input, output);
+}

--- a/tests/unittests/Foundation/NSStringTests.m
+++ b/tests/unittests/Foundation/NSStringTests.m
@@ -710,3 +710,18 @@ TEST(NSString, LastPathComponent) {
     string = @"/tmp/foo///";
     EXPECT_OBJCEQ(@"foo", string.lastPathComponent);
 }
+
+TEST(NSString, MutableInstanceArchivesAsMutable) {
+    NSMutableString* input = [NSMutableString stringWithString:@"hello"];
+
+    NSData* data = [NSKeyedArchiver archivedDataWithRootObject:input];
+    ASSERT_OBJCNE(nil, data);
+
+    NSMutableString* output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ASSERT_OBJCNE(nil, output);
+
+    EXPECT_NO_THROW([output appendString:@" world"]);
+    EXPECT_OBJCEQ(@"hello world", output);
+
+    EXPECT_OBJCNE(input, output);
+}


### PR DESCRIPTION
* Add tests for all of the cases we support.
* We do not support archival of NSAttributedString (!)

Fixes #902.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1679)
<!-- Reviewable:end -->
