### PR TITLE
Reintegrate CoreGraphics and Accelerate.framework.

### DIFF
--- a/Frameworks/Accelerate/vImage.mm
+++ b/Frameworks/Accelerate/vImage.mm
@@ -59,8 +59,6 @@ vImage_Error vImageBuffer_InitWithCGImage(
         const CGColorSpaceModel srcCsModel = CGColorSpaceGetModel(srcColorSpace);
         const CGBitmapInfo srcBitmapInfo = CGImageGetBitmapInfo(image);
 
-        CGColorSpaceRelease(srcColorSpace);
-
         if (srcCsModel != dstCsModel) {
             TraceWarning(TAG, L"Colorspace conversions are not yet supported.");
         }

--- a/build/Tests/UnitTests/Accelerate/Accelerate.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Accelerate/Accelerate.UnitTests.vcxproj
@@ -22,6 +22,9 @@
     <ProjectReference Include="..\..\..\Foundation\dll\Foundation.vcxproj">
       <Project>{86127226-9A6E-439B-A070-420A572AF0C7}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\CoreFoundation\dll\CoreFoundation.vcxproj">
+      <Project>{81F30AF6-EAC3-4DFA-929A-C25D69E8080B}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Logging\dll\Logging.vcxproj">
       <Project>{862d36c2-cc83-4d04-b9b8-bef07f479905}</Project>
     </ProjectReference>

--- a/tests/unittests/Accelerate/vImageTest.mm
+++ b/tests/unittests/Accelerate/vImageTest.mm
@@ -488,7 +488,7 @@ static void vImageTestGetFormatFromCgImage(CGImageRef imageRef, vImage_CGImageFo
     ASSERT_TRUE(imageRef != nullptr);
 
     format->bitmapInfo = CGImageGetBitmapInfo(imageRef);
-    format->colorSpace = CGImageGetColorSpace(imageRef);
+    format->colorSpace = CGColorSpaceRetain(CGImageGetColorSpace(imageRef));
     format->bitsPerComponent = (uint32_t)CGImageGetBitsPerComponent(imageRef);
 
     const uint32_t alphaInfo = format->bitmapInfo & kCGBitmapAlphaInfoMask;
@@ -821,7 +821,7 @@ TEST(Accelerate, Convert) {
     vImageTestBufferFree(&rgbDest);
 }
 
-DISABLED_TEST(Accelerate, AlphaUnpremultiply) {
+TEST(Accelerate, AlphaUnpremultiply) {
     SetCACompositor(new NullCompositor);
 
     char fullPath[_MAX_PATH];
@@ -831,14 +831,23 @@ DISABLED_TEST(Accelerate, AlphaUnpremultiply) {
     strncpy(executablePath, relativePathToPhoto, strlen(relativePathToPhoto) + 1);
     UIImage* photo = [UIImage imageNamed:[NSString stringWithCString:fullPath]];
 
+    woc::unique_cf<CGColorSpaceRef> rgbColorSpace(CGColorSpaceCreateDeviceRGB());
+    woc::unique_cf<CGContextRef> rgbaConversionContext{
+        CGBitmapContextCreate(nullptr, photo.size.width, photo.size.height, 8, photo.size.width * 4, rgbColorSpace.get(), kCGBitmapByteOrder32Big | kCGImageAlphaLast)
+    };
+    CGContextDrawImage(rgbaConversionContext.get(), {CGPointZero, photo.size}, photo.CGImage);
+    woc::unique_cf<CGImageRef> rgbaImage{
+        CGBitmapContextCreateImage(rgbaConversionContext.get())
+    };
+
     vImage_Buffer unpremultipliedBufferSimd, unpremultipliedBufferNormal;
     const uint8_t alphaVal = 0x80;
 
     _vImageSetSimdOptmizationsState(false);
-    vImageTestSetAlphaAndUnpremultiply(photo.CGImage, &unpremultipliedBufferNormal, alphaVal);
+    vImageTestSetAlphaAndUnpremultiply(rgbaImage.get(), &unpremultipliedBufferNormal, alphaVal);
 
     _vImageSetSimdOptmizationsState(true);
-    vImageTestSetAlphaAndUnpremultiply(photo.CGImage, &unpremultipliedBufferSimd, alphaVal);
+    vImageTestSetAlphaAndUnpremultiply(rgbaImage.get(), &unpremultipliedBufferSimd, alphaVal);
 
     ASSERT_TRUE_MSG(vImageTestCompare8888Buffers(&unpremultipliedBufferSimd, &unpremultipliedBufferNormal),
                     "SIMD and non-SIMD output of AlphaUnpremultiply do not match");


### PR DESCRIPTION
Fixes #1285.

Everything worked once the vImage buffer was RGBA. No framework changes, only test changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1680)
<!-- Reviewable:end -->
