### PR TITLE
Make text drawing tests more lenient

### DIFF
--- a/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DISABLED_DRAW_TEST_F(CGContext, RedBox, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGContext, RedBox, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -24,7 +24,7 @@ DISABLED_DRAW_TEST_F(CGContext, RedBox, UIKitMimicTest) {
     CGContextFillRect(context, CGRectInset(bounds, 10, 10));
 }
 
-DISABLED_DRAW_TEST_F(CGContext, FillThenStrokeIsSameAsDrawFillStroke, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, FillThenStrokeIsSameAsDrawFillStroke, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -62,7 +62,7 @@ static void _drawThreeCirclesInContext(CGContextRef context, CGRect bounds) {
     }
 }
 
-DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesColorAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesColorAlpha, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -73,7 +73,7 @@ DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesColorAlpha, WhiteBackgroundTes
     _drawThreeCirclesInContext(context, bounds);
 }
 
-DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlpha, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -86,7 +86,7 @@ DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlpha, WhiteBackgroundTe
     _drawThreeCirclesInContext(context, bounds);
 }
 
-DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlphaStackedWithColorAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlphaStackedWithColorAlpha, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -99,7 +99,7 @@ DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesGlobalAlphaStackedWithColorAlp
     _drawThreeCirclesInContext(context, bounds);
 }
 
-DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesTransparencyLayerAlpha, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesTransparencyLayerAlpha, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -119,7 +119,7 @@ DISABLED_DRAW_TEST_F(CGContext, OverlappingCirclesTransparencyLayerAlpha, WhiteB
 // This test proves that the path is stored fully transformed;
 // changing the CTM before stroking it does not cause it to scale!
 // However, the stroke width _is_ scaled (!)
-DISABLED_DRAW_TEST_F(CGContext, ChangeCTMAfterCreatingPath, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, ChangeCTMAfterCreatingPath, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/UnitTests/CoreGraphics.drawing/DrawingTest.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/DrawingTest.cpp
@@ -24,21 +24,26 @@
 
 static const CGSize g_defaultCanvasSize{ 512.f, 256.f };
 
-woc::unique_cf<CGColorSpaceRef> testing::DrawTest::s_deviceColorSpace;
+template <typename TComparator>
+woc::unique_cf<CGColorSpaceRef> testing::DrawTest<TComparator>::s_deviceColorSpace;
 
-void testing::DrawTest::SetUpTestCase() {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::SetUpTestCase() {
     s_deviceColorSpace.reset(CGColorSpaceCreateDeviceRGB());
 }
 
-void testing::DrawTest::TearDownTestCase() {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::TearDownTestCase() {
     s_deviceColorSpace.release();
 }
 
-CGSize testing::DrawTest::CanvasSize() {
+template <typename TComparator>
+CGSize testing::DrawTest<TComparator>::CanvasSize() {
     return g_defaultCanvasSize;
 }
 
-void testing::DrawTest::SetUp() {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::SetUp() {
     CGSize size = CanvasSize();
 
     _context.reset(CGBitmapContextCreate(
@@ -50,11 +55,13 @@ void testing::DrawTest::SetUp() {
     SetUpContext();
 }
 
-CFStringRef testing::DrawTest::CreateAdditionalTestDescription() {
+template <typename TComparator>
+CFStringRef testing::DrawTest<TComparator>::CreateAdditionalTestDescription() {
     return nullptr;
 }
 
-CFStringRef testing::DrawTest::CreateOutputFilename() {
+template <typename TComparator>
+CFStringRef testing::DrawTest<TComparator>::CreateOutputFilename() {
     const ::testing::TestInfo* const test_info = ::testing::UnitTest::GetInstance()->current_test_info();
     woc::unique_cf<CFStringRef> additionalDesc{ CreateAdditionalTestDescription() };
     woc::unique_cf<CFStringRef> filename{ CFStringCreateWithFormat(nullptr,
@@ -67,7 +74,8 @@ CFStringRef testing::DrawTest::CreateOutputFilename() {
     return filename.release();
 }
 
-void testing::DrawTest::TearDown() {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::TearDown() {
     CGContextRef context = GetDrawingContext();
 
     // Generate image from context.
@@ -108,7 +116,7 @@ void testing::DrawTest::TearDown() {
         ASSERT_NE(nullptr, referenceImage);
 
         // And fire off a comparator.
-        PixelByPixelImageComparator comparator;
+        TComparator comparator;
         auto delta = comparator.CompareImages(referenceImage.get(), image.get());
 
         if (delta.result != ImageComparisonResult::Same) {
@@ -134,29 +142,35 @@ void testing::DrawTest::TearDown() {
     }
 }
 
-void testing::DrawTest::SetUpContext() {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::SetUpContext() {
     // The default context is fine as-is.
 }
 
-void testing::DrawTest::TestBody() {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::TestBody() {
     // Nothing.
 }
 
-CGContextRef testing::DrawTest::GetDrawingContext() {
+template <typename TComparator>
+CGContextRef testing::DrawTest<TComparator>::GetDrawingContext() {
     return _context.get();
 }
 
-void testing::DrawTest::SetDrawingBounds(CGRect bounds) {
+template <typename TComparator>
+void testing::DrawTest<TComparator>::SetDrawingBounds(CGRect bounds) {
     _bounds = bounds;
 }
 
-CGRect testing::DrawTest::GetDrawingBounds() {
+template <typename TComparator>
+CGRect testing::DrawTest<TComparator>::GetDrawingBounds() {
     return _bounds;
 }
 
-void WhiteBackgroundTest::SetUpContext() {
-    CGContextRef context = GetDrawingContext();
-    CGRect bounds = GetDrawingBounds();
+template <typename TComparator>
+void WhiteBackgroundTest<TComparator>::SetUpContext() {
+    CGContextRef context = this->GetDrawingContext();
+    CGRect bounds = this->GetDrawingBounds();
 
     CGContextSaveGState(context);
     CGContextSetRGBFillColor(context, 1.0, 1.0, 1.0, 1.0);
@@ -166,21 +180,34 @@ void WhiteBackgroundTest::SetUpContext() {
     CGContextSetRGBStrokeColor(context, 0.0, 0.0, 0.0, 1.0);
 }
 
-CGSize UIKitMimicTest::CanvasSize() {
-    CGSize parent = WhiteBackgroundTest::CanvasSize();
+template <typename TComparator>
+CGSize UIKitMimicTest<TComparator>::CanvasSize() {
+    CGSize parent = WhiteBackgroundTest<TComparator>::CanvasSize();
     return { parent.width * 2., parent.height * 2. };
 }
 
-void UIKitMimicTest::SetUpContext() {
-    WhiteBackgroundTest::SetUpContext();
+template <typename TComparator>
+void UIKitMimicTest<TComparator>::SetUpContext() {
+    WhiteBackgroundTest<TComparator>::SetUpContext();
 
-    CGContextRef context = GetDrawingContext();
-    CGRect bounds = GetDrawingBounds();
+    CGContextRef context = this->GetDrawingContext();
+    CGRect bounds = this->GetDrawingBounds();
 
     CGContextScaleCTM(context, 1.0, -1.0);
     CGContextTranslateCTM(context, 0, -bounds.size.height);
     CGContextScaleCTM(context, 2.0, 2.0);
     bounds = CGRectApplyAffineTransform(bounds, CGAffineTransformMakeScale(.5, .5));
 
-    SetDrawingBounds(bounds);
+    this->SetDrawingBounds(bounds);
 }
+
+// Force templates so they compile
+template class ::testing::DrawTest<>;
+template class WhiteBackgroundTest<>;
+template class UIKitMimicTest<>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<ComparisonMode::Mask>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>;

--- a/tests/UnitTests/CoreGraphics.drawing/DrawingTest.h
+++ b/tests/UnitTests/CoreGraphics.drawing/DrawingTest.h
@@ -20,8 +20,12 @@
 #include <CoreGraphics/CoreGraphics.h>
 
 #include <Starboard/SmartTypes.h>
+#include "ImageComparison.h"
+
+// Due to how templates are compiled as needed, any new usage of templates needs to be "forced" in DrawingTest.cpp
 
 namespace testing {
+template <typename TComparator = PixelByPixelImageComparator<ComparisonMode::Exact>>
 class DrawTest : public ::testing::Test {
 private:
     woc::unique_cf<CGContextRef> _context;
@@ -63,19 +67,21 @@ inline CGRect _CGRectCenteredOnPoint(CGSize size, CGPoint point) {
     };
 }
 
-class WhiteBackgroundTest : public ::testing::DrawTest {
+template <typename TComparator = PixelByPixelImageComparator<>>
+class WhiteBackgroundTest : public ::testing::DrawTest<TComparator> {
 protected:
     virtual void SetUpContext();
 };
 
-class UIKitMimicTest : public WhiteBackgroundTest {
+template <typename TComparator = PixelByPixelImageComparator<>>
+class UIKitMimicTest : public WhiteBackgroundTest<TComparator> {
 protected:
     virtual CGSize CanvasSize();
     virtual void SetUpContext();
 };
 
 #define DRAW_TEST(test_case_name, test_name) \
-    GTEST_TEST_(test_case_name, test_name, ::testing::DrawTest, ::testing::internal::GetTestTypeId())
+    GTEST_TEST_(test_case_name, test_name, ::testing::DrawTest<>, ::testing::internal::GetTestTypeId())
 #define DRAW_TEST_F(test_case_name, test_name, test_fixture) \
     GTEST_TEST_(test_case_name, test_name, test_fixture, ::testing::internal::GetTestTypeId())
 
@@ -84,3 +90,18 @@ protected:
 
 #define DRAW_TEST_P(test_case_name, test_name) TEST_P(test_case_name, test_name)
 #define DISABLED_DRAW_TEST_P(test_case_name, test_name) DRAW_TEST_P(test_case_name, DISABLED_##test_name)
+
+#define TEXT_DRAW_TEST(test_case_name, test_name)                                       \
+    GTEST_TEST_(test_case_name,                                                         \
+                test_name,                                                              \
+                ::testing::DrawTest<PixelByPixelImageComparator<ComparisonMode::Mask>>, \
+                ::testing::internal::GetTestTypeId())
+#define TEXT_DRAW_TEST_F(test_case_name, test_name, test_fixture) \
+    GTEST_TEST_(test_case_name, test_name, test_fixture, ::testing::internal::GetTestTypeId())
+
+#define DISABLED_TEXT_DRAW_TEST(test_case_name, test_name) TEXT_DRAW_TEST(test_case_name, DISABLED_##test_name)
+#define DISABLED_TEXT_DRAW_TEST_F(test_case_name, test_name, test_fixture) \
+    TEXT_DRAW_TEST_F(test_case_name, DISABLED_##test_name, test_fixture)
+
+#define TEXT_DRAW_TEST_P(test_case_name, test_name) TEST_P(test_case_name, test_name)
+#define DISABLED_TEXT_DRAW_TEST_P(test_case_name, test_name) TEXT_DRAW_TEST_P(test_case_name, DISABLED_##test_name)

--- a/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_FillTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_FillTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesWinding, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesWinding, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -38,7 +38,7 @@ DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesWinding, WhiteBackgroundTes
     CGPathRelease(concentricCirclesPath);
 }
 
-DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesEvenOdd, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesEvenOdd, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -60,7 +60,7 @@ DISABLED_DRAW_TEST_F(CGContextFill, ConcentricCirclesEvenOdd, WhiteBackgroundTes
     CGPathRelease(concentricCirclesPath);
 }
 
-DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsWinding, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsWinding, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -82,7 +82,7 @@ DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsWinding, WhiteBackgroundTest)
     CGPathRelease(path);
 }
 
-DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsEvenOdd, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContextFill, ConcentricRectsEvenOdd, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_ShadowTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGContextDrawing_ShadowTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DISABLED_DRAW_TEST_F(CGContext, Shadow, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, Shadow, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -31,7 +31,7 @@ DISABLED_DRAW_TEST_F(CGContext, Shadow, WhiteBackgroundTest) {
     CGContextStrokeRect(context, rect);
 }
 
-DISABLED_DRAW_TEST_F(CGContext, ShadowWithRotatedCTM, WhiteBackgroundTest) {
+DISABLED_DRAW_TEST_F(CGContext, ShadowWithRotatedCTM, WhiteBackgroundTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -16,7 +16,7 @@
 
 #include "DrawingTest.h"
 
-DISABLED_DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -36,7 +36,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -58,7 +58,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddEllipse, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -84,7 +84,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddLineToPoint, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -116,7 +116,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddPath, UIKitMimicTest) {
     CGPathRelease(theSecondPath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -141,7 +141,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddQuadCurveToPoint, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -159,7 +159,7 @@ DISABLED_DRAW_TEST_F(CGPath, AddRect, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, Apply, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -196,7 +196,7 @@ DISABLED_DRAW_TEST_F(CGPath, Apply, UIKitMimicTest) {
     CGPathRelease(thepath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -223,7 +223,7 @@ DISABLED_DRAW_TEST_F(CGPath, CloseSubpath, UIKitMimicTest) {
     CGPathRelease(thePath);
 }
 
-DISABLED_DRAW_TEST_F(CGPath, GetBoundingBox, UIKitMimicTest) {
+DISABLED_DRAW_TEST_F(CGPath, GetBoundingBox, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
@@ -50,7 +50,7 @@ CGNamedBlendMode compositionModes[] = {
 
 CGFloat alphas[] = { 0.5f, 1.f };
 
-class CGContextBlendMode : public WhiteBackgroundTest, public ::testing::WithParamInterface<::testing::tuple<CGFloat, CGNamedBlendMode>> {
+class CGContextBlendMode : public WhiteBackgroundTest<>, public ::testing::WithParamInterface<::testing::tuple<CGFloat, CGNamedBlendMode>> {
     CFStringRef CreateOutputFilename() {
         const char* blendModeName = ::testing::get<1>(GetParam()).name;
         CGFloat alpha = ::testing::get<0>(GetParam());

--- a/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
@@ -32,7 +32,7 @@ static void __SetFontForContext(CGContextRef context) {
     CGContextSetFontSize(context, 144);
 }
 
-DISABLED_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
@@ -40,14 +40,14 @@ DISABLED_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest) {
     CGContextShowGlyphs(context, glyphs.data(), glyphs.size());
 }
 
-DISABLED_DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
     CGContextShowGlyphsAtPoint(context, 25, 50, glyphs.data(), glyphs.size());
 }
 
-DISABLED_DRAW_TEST_F(CGContext, DrawWithRotatedTextMatrix, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CGContext, DrawWithRotatedTextMatrix, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
@@ -68,10 +68,10 @@ static const CGAffineTransform c_transforms[] = { CGAffineTransformMakeRotation(
                                                   { 2, 2, 1.75, 2, 0, 0 },
                                                   CGAffineTransformIdentity };
 
-class CGTransform : public WhiteBackgroundTest,
+class CGTransform : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
                     public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
-DISABLED_DRAW_TEST_P(CGTransform, TestMatrices) {
+TEXT_DRAW_TEST_P(CGTransform, TestMatrices) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -87,10 +87,10 @@ INSTANTIATE_TEST_CASE_P(TestDrawingTextWithTransformedMatrices,
                         CGTransform,
                         ::testing::Combine(::testing::ValuesIn(c_transforms), ::testing::ValuesIn(c_transforms)));
 
-class CGUIKitTransform : public UIKitMimicTest,
+class CGUIKitTransform : public UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
                          public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
-DISABLED_DRAW_TEST_P(CGUIKitTransform, TestMatrices) {
+TEXT_DRAW_TEST_P(CGUIKitTransform, TestMatrices) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -109,7 +109,7 @@ INSTANTIATE_TEST_CASE_P(TestDrawingTextWithTransformedMatrices,
 // On reference platform, CGContextShowText* can only be used with CGContextSelectFont
 // Which we do not currently support.
 #ifdef WINOBJC
-DISABLED_DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     __SetFontForContext(context);
     CGContextShowTextAtPoint(context, 25, 50, "TEST", 4);

--- a/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
@@ -26,7 +26,7 @@ static NSURL* __GetURLFromPathRelativeToModuleDirectory(NSString* relativePath) 
 }
 #endif // WINOBJC
 
-DISABLED_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -65,7 +65,7 @@ DISABLED_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest) {
     CTFrameDraw(frame.get(), context);
 }
 
-DISABLED_DRAW_TEST_F(CTFrame, BasicUIKitMimicDrawingTest, UIKitMimicTest) {
+TEXT_DRAW_TEST_F(CTFrame, BasicUIKitMimicDrawingTest, UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -104,7 +104,7 @@ DISABLED_DRAW_TEST_F(CTFrame, BasicUIKitMimicDrawingTest, UIKitMimicTest) {
     CTFrameDraw(frame.get(), context);
 }
 
-DISABLED_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -145,7 +145,7 @@ DISABLED_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest) {
     CTFrameDraw(frame.get(), context);
 }
 
-class CTFrame : public WhiteBackgroundTest,
+class CTFrame : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
                 public ::testing::WithParamInterface<::testing::tuple<CTTextAlignment, CTLineBreakMode, CTWritingDirection, CGFloat>> {
     CFStringRef CreateOutputFilename() {
         CTTextAlignment alignment = ::testing::get<0>(GetParam());
@@ -186,7 +186,7 @@ static void __DrawLoremIpsum(CGContextRef context, CGPathRef path, const CFStrin
     CTFrameDraw(frame.get(), context);
 }
 
-DISABLED_DRAW_TEST_P(CTFrame, AlignLBMFontSize) {
+TEXT_DRAW_TEST_P(CTFrame, AlignLBMFontSize) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -237,10 +237,10 @@ INSTANTIATE_TEST_CASE_P(TestAlignmentLineBreakMode,
                                            ::testing::ValuesIn(c_writingDirections),
                                            ::testing::ValuesIn(c_fontSizes)));
 
-class Transform : public WhiteBackgroundTest,
+class Transform : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>,
                   public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
-DISABLED_DRAW_TEST_P(Transform, TestMatrices) {
+TEXT_DRAW_TEST_P(Transform, TestMatrices) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -292,10 +292,10 @@ INSTANTIATE_TEST_CASE_P(TestDrawingTextWithTransformedMatrices,
                         Transform,
                         ::testing::Combine(::testing::ValuesIn(c_transforms), ::testing::ValuesIn(c_transforms)));
 
-class UIKitTransform : public UIKitMimicTest,
+class UIKitTransform : public UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
                        public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
-DISABLED_DRAW_TEST_P(UIKitTransform, TestMatrices) {
+TEXT_DRAW_TEST_P(UIKitTransform, TestMatrices) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -335,14 +335,16 @@ INSTANTIATE_TEST_CASE_P(TestDrawingUITransforms,
                         UIKitTransform,
                         ::testing::Combine(::testing::ValuesIn(c_transforms), ::testing::ValuesIn(c_transforms)));
 
-class ExtraKerning : public WhiteBackgroundTest, public ::testing::WithParamInterface<CGFloat> {
+class ExtraKerning : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+                     public ::testing::WithParamInterface<CGFloat> {
     CFStringRef CreateOutputFilename() {
         CGFloat extraKerning = GetParam();
         return CFStringCreateWithFormat(nullptr, nullptr, CFSTR("TestImage.ExtraKerning.%.02f.png"), extraKerning);
     }
 };
 
-DISABLED_DRAW_TEST_P(ExtraKerning, TestExtraKerning) {
+// TODO 1696: Re-enable
+DISABLED_TEXT_DRAW_TEST_P(ExtraKerning, TestExtraKerning) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -372,14 +374,15 @@ DISABLED_DRAW_TEST_P(ExtraKerning, TestExtraKerning) {
 static constexpr CGFloat c_extraKernings[] = { -1.0, 1.0, 5.25, 25.75 };
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInExtraKerning, ExtraKerning, ::testing::ValuesIn(c_extraKernings));
 
-class LineHeightMultiple : public WhiteBackgroundTest, public ::testing::WithParamInterface<CGFloat> {
+class LineHeightMultiple : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+                           public ::testing::WithParamInterface<CGFloat> {
     CFStringRef CreateOutputFilename() {
         CGFloat lineHeightMultiple = GetParam();
         return CFStringCreateWithFormat(nullptr, nullptr, CFSTR("TestImage.LineHeightMultiple.%.02f.png"), lineHeightMultiple);
     }
 };
 
-DISABLED_DRAW_TEST_P(LineHeightMultiple, TestLineHeightMultiple) {
+TEXT_DRAW_TEST_P(LineHeightMultiple, TestLineHeightMultiple) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -410,7 +413,7 @@ DISABLED_DRAW_TEST_P(LineHeightMultiple, TestLineHeightMultiple) {
 static constexpr CGFloat c_lineHeightMultiples[] = { -1.0, .75, 1.25 };
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInLineHeightMultiple, LineHeightMultiple, ::testing::ValuesIn(c_lineHeightMultiples));
 
-DISABLED_DRAW_TEST_F(CTRun, BasicDrawingTest, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CTRun, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -438,7 +441,7 @@ DISABLED_DRAW_TEST_F(CTRun, BasicDrawingTest, WhiteBackgroundTest) {
     CTLineDraw(line.get(), context);
 }
 
-DISABLED_DRAW_TEST_F(CTLine, BasicDrawingTest, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CTLine, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -468,14 +471,15 @@ DISABLED_DRAW_TEST_F(CTLine, BasicDrawingTest, WhiteBackgroundTest) {
     CTRunDraw(run, context, {});
 }
 
-class Fonts : public WhiteBackgroundTest, public ::testing::WithParamInterface<CFStringRef> {
+class Fonts : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+              public ::testing::WithParamInterface<CFStringRef> {
     CFStringRef CreateOutputFilename() {
         CFStringRef fontName = GetParam();
         return CFStringCreateWithFormat(nullptr, nullptr, CFSTR("TestImage.Fonts.%@.png"), fontName);
     }
 };
 
-DISABLED_DRAW_TEST_P(Fonts, TestFonts) {
+TEXT_DRAW_TEST_P(Fonts, TestFonts) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -505,7 +509,7 @@ static CFStringRef c_fontNames[] = { CFSTR("Arial"), CFSTR("Times New Roman"), C
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInFonts, Fonts, ::testing::ValuesIn(c_fontNames));
 
 #ifdef WINOBJC
-DISABLED_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -552,7 +556,7 @@ DISABLED_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest) {
 }
 #endif // WINOBJC
 
-DISABLED_DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest) {
+TEXT_DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.drawing/DrawingTestConfig.h
+++ b/tests/unittests/CoreGraphics.drawing/DrawingTestConfig.h
@@ -15,6 +15,7 @@
 //******************************************************************************
 
 #pragma once
+#include <string>
 
 enum class DrawingTestMode : int { Generate, Compare };
 

--- a/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
+++ b/tests/unittests/CoreGraphics.drawing/ImageComparison.cpp
@@ -32,7 +32,69 @@ bool operator==(const T& t, const U& u) {
     return t.r == u.r && t.g == u.g && t.b == u.b && t.a == u.a;
 }
 
-ImageDelta PixelByPixelImageComparator::CompareImages(CGImageRef left, CGImageRef right) {
+template <ComparisonMode Mode>
+struct __comparePixels {
+    template <typename LP, typename RP>
+    rgbaPixel operator()(const LP& background, const LP& bp, const RP& cp, size_t& npxchg);
+};
+
+template <>
+struct __comparePixels<ComparisonMode::Exact> {
+    template <typename LP, typename RP>
+    rgbaPixel operator()(const LP& background, const LP& bp, const RP& cp, size_t& npxchg) {
+        rgbaPixel gp{};
+        if (!(bp == cp)) {
+            ++npxchg;
+            if (cp == background) {
+                // Pixel is in EXPECTED but not ACTUAL
+                gp.r = gp.a = 255;
+            } else if (bp == background) {
+                // Pixel is in ACTUAL but not EXPECTED
+                gp.g = gp.a = 255;
+            } else {
+                // Pixel is in BOTH but DIFFERENT
+                gp.r = gp.g = gp.a = 255;
+            }
+        } else {
+            gp.r = gp.g = gp.b = 0;
+            gp.a = 255;
+        }
+
+        return gp;
+    }
+};
+
+template <>
+struct __comparePixels<ComparisonMode::Mask> {
+    template <typename LP, typename RP>
+    rgbaPixel operator()(const LP& background, const LP& bp, const RP& cp, size_t& npxchg) {
+        rgbaPixel gp{};
+        if (!(bp == cp)) {
+            ++npxchg;
+            if (cp == background) {
+                // Pixel is in EXPECTED but not ACTUAL
+                gp.r = gp.a = 255;
+            } else if (bp == background) {
+                // Pixel is in ACTUAL but not EXPECTED
+                gp.g = gp.a = 255;
+            } else {
+                // Pixel is in BOTH but DIFFERENT
+                // Only comparing as mask so counts as match
+                gp.r = gp.g = gp.b = 0;
+                gp.a = 255;
+                --npxchg;
+            }
+        } else {
+            gp.r = gp.g = gp.b = 0;
+            gp.a = 255;
+        }
+
+        return gp;
+    }
+};
+
+template <ComparisonMode Mode, size_t FailureThreshold>
+ImageDelta PixelByPixelImageComparator<Mode, FailureThreshold>::CompareImages(CGImageRef left, CGImageRef right) {
     if (!left || !right) {
         return { ImageComparisonResult::Incomparable };
     }
@@ -71,26 +133,12 @@ ImageDelta PixelByPixelImageComparator::CompareImages(CGImageRef left, CGImageRe
     auto background = leftPixels[0];
 
     size_t npxchg = 0;
+    __comparePixels<Mode> pixelComparitor{};
     for (off_t i = 0; i < leftLength / sizeof(rgbaPixel); ++i) {
         auto& bp = leftPixels[i];
         auto& cp = rightPixels[i];
         auto& gp = deltaPixels[i];
-        if (!(bp == cp)) {
-            ++npxchg;
-            if (cp == background) {
-                // Pixel is in EXPECTED but not ACTUAL
-                gp.r = gp.a = 255;
-            } else if (bp == background) {
-                // Pixel is in ACTUAL but not EXPECTED
-                gp.g = gp.a = 255;
-            } else {
-                // Pixel is in BOTH but DIFFERENT
-                gp.r = gp.g = gp.a = 255;
-            }
-        } else {
-            gp.r = gp.g = gp.b = 0;
-            gp.a = 255;
-        }
+        gp = pixelComparitor(background, bp, cp, npxchg);
     }
 
     woc::unique_cf<CFDataRef> deltaData{ CFDataCreateWithBytesNoCopy(nullptr, deltaBuffer.release(), leftLength, kCFAllocatorDefault) };
@@ -109,6 +157,11 @@ ImageDelta PixelByPixelImageComparator::CompareImages(CGImageRef left, CGImageRe
                                                          kCGRenderingIntentDefault) };
 
     return {
-        (npxchg == 0 ? ImageComparisonResult::Same : ImageComparisonResult::Different), npxchg, deltaImage.get(),
+        (npxchg < FailureThreshold ? ImageComparisonResult::Same : ImageComparisonResult::Different), npxchg, deltaImage.get(),
     };
 }
+
+// Force templates so they compile
+template class PixelByPixelImageComparator<>;
+template class PixelByPixelImageComparator<ComparisonMode::Mask>;
+template class PixelByPixelImageComparator<ComparisonMode::Mask, 1024>;

--- a/tests/unittests/CoreGraphics.drawing/ImageComparison.h
+++ b/tests/unittests/CoreGraphics.drawing/ImageComparison.h
@@ -21,6 +21,8 @@
 
 enum class ImageComparisonResult : unsigned int { Unknown = 0, Incomparable, Different, Same };
 
+enum struct ComparisonMode { Exact, Mask };
+
 struct ImageDelta {
     ImageComparisonResult result;
     size_t differences;
@@ -39,6 +41,7 @@ public:
     virtual ImageDelta CompareImages(CGImageRef left, CGImageRef right) = 0;
 };
 
+template <ComparisonMode Mode = ComparisonMode::Exact, size_t FailureThreshold = 1>
 class PixelByPixelImageComparator : public ImageComparator {
 public:
     ImageDelta CompareImages(CGImageRef left, CGImageRef right) override;


### PR DESCRIPTION
Allow tests to handle cleartype differences more leniently to pass on different machines.  Fixes failing tests.

Fixes #1646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1692)
<!-- Reviewable:end -->
