### PR TITLE
Adding Pasteboard image support + UIImage JPEG & PNG representation support

### DIFF
--- a/Frameworks/UIKit/UIPasteboard.mm
+++ b/Frameworks/UIKit/UIPasteboard.mm
@@ -393,15 +393,9 @@ WADDataPackageView* _getClipboardContent() {
 }
 
 + (WSSInMemoryRandomAccessStream*)_grabStreamFromUIImage:(UIImage*)image {
-    CGImageRef img = [image CGImage];
-
-    // TODO #1338 - Support via encoded data from IWIC
-    woc::unique_cf<CGImageRef> imgRef(_CGImageCreateCopyWithPixelFormat(img, GUID_WICPixelFormat32bppPBGRA));
-    // TODO #1450 - CGDataProvider should not be an NSData.
-    NSData* data = static_cast<NSData*>(CGImageGetDataProvider(imgRef.get()));
-
     StrongId<WSSInMemoryRandomAccessStream> stream;
     stream.attach([WSSInMemoryRandomAccessStream make]);
+    NSData* data = UIImagePNGRepresentation(image);
     [UIPasteboard _populateStream:stream withData:[data bytes] withLength:[data length]];
     return stream;
 }

--- a/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/UIKit/UIKit.UnitTests.vcxproj
@@ -270,6 +270,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSParagraphStyleTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSString+UIKitAdditionsTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\NSTextContainerTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\UIKit\UIImageTests.mm" />
   </ItemGroup>
   <Target Name="CopyTestResourcesToOutput" AfterTargets="AfterBuild">
     <ItemGroup>

--- a/build/UIKit/dll/UIKit.vcxproj
+++ b/build/UIKit/dll/UIKit.vcxproj
@@ -28,6 +28,9 @@
     <ProjectReference Include="..\..\CoreGraphics\dll\CoreGraphics.vcxproj">
       <Project>{26DA08DA-D0B9-4579-B168-E7F0A5F20E57}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\ImageIO\dll\ImageIO.vcxproj">
+      <Project>{81B44F5A-DA8C-4699-BB4D-2C6DA20DD324}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\MobileCoreServices\dll\MobileCoreServicesdll.vcxproj">
       <Project>{f1c44e27-6599-49c3-b4c2-d812c114b166}</Project>
     </ProjectReference>

--- a/include/UIKit/UIImage.h
+++ b/include/UIKit/UIImage.h
@@ -127,7 +127,7 @@ UIKIT_EXPORT BOOL UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(NSString* videoP
 
 // both of these use .CGImage to generate the image data - note what this means
 // for multi-scale images!
-UIKIT_EXPORT NSData* UIImageJPEGRepresentation(UIImage* image, CGFloat compressionQuality) STUB_METHOD;
-UIKIT_EXPORT NSData* UIImagePNGRepresentation(UIImage* image) STUB_METHOD;
+UIKIT_EXPORT NSData* UIImageJPEGRepresentation(UIImage* image, CGFloat compressionQuality);
+UIKIT_EXPORT NSData* UIImagePNGRepresentation(UIImage* image);
 
 void UIImageSetLayerContents(CALayer* layer, UIImage* image);

--- a/tests/UnitTests/UIKit/UIImageTests.mm
+++ b/tests/UnitTests/UIKit/UIImageTests.mm
@@ -1,0 +1,82 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <Starboard/SmartTypes.h>
+#import <TestFramework.h>
+#import <UIKit/UIImage.h>
+
+static NSString* getPathToFile(NSString* fileName) {
+    static StrongId<NSString*> refPath = []() {
+        char fullPath[_MAX_PATH];
+        GetModuleFileNameA(NULL, fullPath, _MAX_PATH);
+        return [@(fullPath) stringByDeletingLastPathComponent];
+    }();
+    return [refPath stringByAppendingPathComponent:fileName];
+}
+
+template <typename VerifierLambda> // Takes the form void(*)(UIImage*,UIImage*)
+static void testRepresentationOfCroppedImage(NSString* source1, NSString* source2, CGRect cropRegion, VerifierLambda&& verify) {
+    UIImage* photo = [UIImage imageNamed:source1];
+    ASSERT_OBJCNE(nil, photo);
+
+    // crop it
+    woc::unique_cf<CGImageRef> imageRef{ CGImageCreateWithImageInRect([photo CGImage], cropRegion) };
+    ASSERT_NE(nullptr, imageRef);
+
+    photo = [UIImage imageWithCGImage:imageRef.get()];
+    ASSERT_OBJCNE(nil, photo);
+
+    UIImage* croppedRef = [UIImage imageNamed:source2];
+    ASSERT_OBJCNE(nil, croppedRef);
+
+    verify(photo, croppedRef);
+}
+
+TEST(UIImage, JPEGRepresentation) {
+    CGFloat quality = 1;
+    auto verifier = [&quality](UIImage* source, UIImage* testImage) {
+        NSData* OrgCroppedData = UIImageJPEGRepresentation(source, quality);
+        ASSERT_OBJCNE(nil, OrgCroppedData);
+
+        NSData* croppedData = UIImageJPEGRepresentation(testImage, quality);
+        ASSERT_OBJCNE(nil, croppedData);
+
+        ASSERT_OBJCEQ(croppedData, OrgCroppedData);
+    };
+    NSString* source1 = getPathToFile(@"data/Photo2.jpg");
+    NSString* source2 = getPathToFile(@"data/CroppedPhoto2.jpg");
+    CGRect region = CGRectMake(300, 600, 200, 200);
+
+    testRepresentationOfCroppedImage(source1, source2, region, verifier);
+
+    quality = 0.5;
+    testRepresentationOfCroppedImage(source1, source2, region, verifier);
+}
+
+TEST(UIImage, PNGRepresentation) {
+    auto verifier = [](UIImage* source, UIImage* testImage) {
+        NSData* OrgCroppedData = UIImagePNGRepresentation(source);
+        ASSERT_OBJCNE(nil, OrgCroppedData);
+
+        NSData* croppedData = UIImagePNGRepresentation(testImage);
+        ASSERT_OBJCNE(nil, croppedData);
+        ASSERT_OBJCEQ(croppedData, OrgCroppedData);
+    };
+    testRepresentationOfCroppedImage(getPathToFile(@"data/png1.png"),
+                                     getPathToFile(@"data/CroppedPhoto1.png"),
+                                     CGRectMake(200, 200, 800, 600),
+                                     verifier);
+}

--- a/tests/UnitTests/UIKit/data/CroppedPhoto1.png
+++ b/tests/UnitTests/UIKit/data/CroppedPhoto1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ab495b99fc02eb882af14ed931c25afd62414f162ffa753bc42287ab71fcb52
+size 494330

--- a/tests/UnitTests/UIKit/data/CroppedPhoto2.jpg
+++ b/tests/UnitTests/UIKit/data/CroppedPhoto2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61aba11114561568737c95156de664b0a28bac38d2110cb04f4c045b21d19c2e
+size 86439

--- a/tests/UnitTests/UIKit/data/Photo2.jpg
+++ b/tests/UnitTests/UIKit/data/Photo2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7cff08aa03c90b0ad62a1cdf0bcee9db66329c2be8a310f51968dea1d62b259
+size 2101302

--- a/tests/UnitTests/UIKit/data/png1.png
+++ b/tests/UnitTests/UIKit/data/png1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90c94f695c4e69f286fa7486d05ea045fd9cb8a6b6ae77647071c71d68ab6ff0
+size 1251692


### PR DESCRIPTION
Tested via WOCCatalogue.
We can copy an image into the windows pasteboard and past it into the WinOBJC application. 

#1338

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1704)
<!-- Reviewable:end -->
