### PR TITLE
Fix leak of image data in CGImageGetDataProvider

### DIFF
--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -490,10 +490,8 @@ CGImageAlphaInfo CGImageGetAlphaInfo(CGImageRef img) {
 CGDataProviderRef CGImageGetDataProvider(CGImageRef img) {
     const UInt8* pPtr = (const UInt8*)img->Backing()->LockImageData();
     CFIndex length = img->Backing()->Height() * img->Backing()->BytesPerRow();
-
-    //TODO 1709:: Autorelease dataProvider so it won't leak for consumers expecting a non-owning reference
     CGDataProviderRef dataProvider = CGDataProviderCreateWithData(nullptr, pPtr, length, nullptr);
-    return dataProvider;
+    return (CGDataProviderRef)CFAutorelease(dataProvider);
 }
 
 void* _CGImageGetData(CGImageRef img) {

--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -490,8 +490,7 @@ CGImageAlphaInfo CGImageGetAlphaInfo(CGImageRef img) {
 CGDataProviderRef CGImageGetDataProvider(CGImageRef img) {
     const UInt8* pPtr = (const UInt8*)img->Backing()->LockImageData();
     CFIndex length = img->Backing()->Height() * img->Backing()->BytesPerRow();
-    woc::unique_cf<CFDataRef> data{ CFDataCreateWithBytesNoCopy(nullptr, pPtr, length, kCFAllocatorNull) };
-    CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData(data.get());
+    CGDataProviderRef dataProvider = CGDataProviderCreateWithData(nullptr, pPtr, length, nullptr);
     return dataProvider;
 }
 

--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -490,6 +490,8 @@ CGImageAlphaInfo CGImageGetAlphaInfo(CGImageRef img) {
 CGDataProviderRef CGImageGetDataProvider(CGImageRef img) {
     const UInt8* pPtr = (const UInt8*)img->Backing()->LockImageData();
     CFIndex length = img->Backing()->Height() * img->Backing()->BytesPerRow();
+
+    //TODO 1709:: Autorelease dataProvider so it won't leak for consumers expecting a non-owning reference
     CGDataProviderRef dataProvider = CGDataProviderCreateWithData(nullptr, pPtr, length, nullptr);
     return dataProvider;
 }

--- a/Frameworks/ImageIO/CGImageDestination.mm
+++ b/Frameworks/ImageIO/CGImageDestination.mm
@@ -1031,7 +1031,6 @@ void CGImageDestinationAddImage(CGImageDestinationRef idst, CGImageRef image, CF
                                                   (unsigned char*)[imageByteData bytes],
                                                   &inputImage);
     [imageByteData release];
-    CGDataProviderRelease(provider);
     if (!SUCCEEDED(status)) {
         NSTraceInfo(TAG, @"CreateBitmapFromMemory failed with status=%x\n", status);
         return;


### PR DESCRIPTION
CGImageGetDataProvider was copying the CFData rather than accessing it directly, and would leak the data for consumers expecting a +0 reference.


Blocks #1692

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1710)
<!-- Reviewable:end -->
