### PR TITLE
Fix cases where NSDictionary setObject:forKey: was given nil objects

### DIFF
--- a/Frameworks/Foundation/NSNotificationCenter.mm
+++ b/Frameworks/Foundation/NSNotificationCenter.mm
@@ -223,7 +223,7 @@ static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* k
     }
 
     if (CFArrayGetCount((CFArrayRef)arr) == 0) {
-        [observers setObject:nil forKey:name];
+        [observers removeObjectForKey:name];
     }
 }
 

--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -1389,7 +1389,7 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
 
 - (void)_removeAnimation:(CAAnimation*)animation {
     CAAnimation* objForKey = [priv->_animations objectForKey:animation->_keyName];
-    [priv->_animations setObject:nil forKey:animation->_keyName];
+    [priv->_animations removeObjectForKey:animation->_keyName];
 }
 
 /**

--- a/Frameworks/UIKit/UIViewController.mm
+++ b/Frameworks/UIKit/UIViewController.mm
@@ -893,13 +893,14 @@ NSMutableDictionary* _pageMappings;
         TraceVerbose(TAG, L"Loading view %hs with owner=%hs", name ? name : "nil", object_getClassName(self));
 
         if (EbrAccess(openname, 0) != -1) {
-            UIStoryboard* proxyObjects[1];
-            NSString* proxyNames[1];
+            UIStoryboard* proxyObject = [self storyboard];
+            NSString* proxyName = @"UIStoryboardPlaceholder";
 
-            proxyObjects[0] = [self storyboard];
-            proxyNames[0] = @"UIStoryboardPlaceholder";
+            NSMutableDictionary* proxyObjectsDict = [NSMutableDictionary dictionary];
+            if (proxyObject != nil) {
+                [proxyObjectsDict setObject:proxyObject forKey:proxyName];
+            }
 
-            NSMutableDictionary* proxyObjectsDict = [NSMutableDictionary dictionaryWithObjects:proxyObjects forKeys:proxyNames count:1];
             [proxyObjectsDict addEntriesFromDictionary:priv->_externalObjects];
 
             UINib* nib = [UINib nibWithNibName:[NSString stringWithCString:openname] bundle:priv->nibBundle];


### PR DESCRIPTION
CALayer was using setObject:nil to remove an object, but as of dad3c32 ( #1698 ) this will throw an NSException.  This was causing CTCatalog to crash when navigating past the first page.


Fixes #1713

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1711)
<!-- Reviewable:end -->
