### PR TITLE
Ensure subviews can be added to UIScrollView during the nib-loading phase

### DIFF
--- a/Frameworks/UIKit.Xaml/Layer.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Layer.xaml.cpp
@@ -122,3 +122,15 @@ UIKIT_XAML_EXPORT void XamlSetFrameworkElementLayerProperties(
         frameworkElement->SetValue(UIKit::Xaml::Private::CoreAnimation::Layer::SublayerCanvasProperty, sublayerCanvas);
     }
 }
+
+// Get the layerContentProperty for the specified target xaml element
+UIKIT_XAML_EXPORT IInspectable* XamlGetFrameworkElementLayerContentProperty(const Microsoft::WRL::ComPtr<IInspectable>& targetElement) {
+    auto frameworkElement = safe_cast<FrameworkElement^>(reinterpret_cast<Object^>(targetElement.Get()));
+    return InspectableFromObject(frameworkElement->GetValue(UIKit::Xaml::Private::CoreAnimation::Layer::LayerContentProperty)).Detach();
+}
+
+// Get the sublayerCanvasProperty for the specified target xaml element
+UIKIT_XAML_EXPORT IInspectable* XamlGetFrameworkElementSublayerCanvasProperty(const Microsoft::WRL::ComPtr<IInspectable>& targetElement) {
+    auto frameworkElement = safe_cast<FrameworkElement^>(reinterpret_cast<Object^>(targetElement.Get()));
+    return InspectableFromObject(frameworkElement->GetValue(UIKit::Xaml::Private::CoreAnimation::Layer::SublayerCanvasProperty)).Detach();
+}

--- a/Frameworks/UIKit.Xaml/ObjCXamlControls.h
+++ b/Frameworks/UIKit.Xaml/ObjCXamlControls.h
@@ -70,6 +70,12 @@ UIKIT_XAML_EXPORT IInspectable* XamlGetLabelTextBox(const Microsoft::WRL::ComPtr
 UIKIT_XAML_EXPORT void XamlSetFrameworkElementLayerProperties(const Microsoft::WRL::ComPtr<IInspectable>& targetElement,
                                                               const Microsoft::WRL::ComPtr<IInspectable>& sublayerCanvasProperty,
                                                               const Microsoft::WRL::ComPtr<IInspectable>& layerContentProperty);
+                                                              
+// Get the layerContentProperty for the specified target xaml element
+UIKIT_XAML_EXPORT IInspectable* XamlGetFrameworkElementLayerContentProperty(const Microsoft::WRL::ComPtr<IInspectable>& targetElement);
+
+// Get the sublayerCanvasProperty for the specified target xaml element
+UIKIT_XAML_EXPORT IInspectable* XamlGetFrameworkElementSublayerCanvasProperty(const Microsoft::WRL::ComPtr<IInspectable>& targetElement);
 
 ////////////////////////////////////////////////////////////////////////////////////
 // ProgressRing.xaml.cpp

--- a/Frameworks/UIKit/StarboardXaml/LayerProxy.cpp
+++ b/Frameworks/UIKit/StarboardXaml/LayerProxy.cpp
@@ -32,6 +32,9 @@ using namespace Windows::UI::Xaml::Media;
 
 static const wchar_t* TAG = L"LayerProxy";
 
+static const bool DEBUG_ALL = false;
+static const bool DEBUG_HIERARCHY = DEBUG_ALL | false;
+
 // TODO: We should formally expose this off of XamlCompositor for our use here.
 extern Canvas^ s_windowCollection;
 
@@ -45,17 +48,33 @@ __inline Panel^ _SubLayerPanelFromInspectable(const ComPtr<IInspectable>& elemen
     // First check if the element implements ILayer
     ILayer^ layerElement = dynamic_cast<ILayer^>(xamlElement);
     if (layerElement) {
+        if (DEBUG_HIERARCHY) {
+            TraceVerbose(
+                TAG,
+                L"_SubLayerPanelFromInspectable for [%ws] returning layerElement->SublayerCanvas [%ws].",
+                layerElement->GetType()->FullName->Data(),
+                layerElement->SublayerCanvas->GetType()->FullName->Data());
+        }
+
         return layerElement->SublayerCanvas;
     }
 
     // Not an ILayer, so default to grabbing the xamlElement's SublayerCanvasProperty (if it exists)
-    return dynamic_cast<Canvas^>(_FrameworkElementFromInspectable(element)->GetValue(Layer::SublayerCanvasProperty));
+    Platform::Object^ value = xamlElement->GetValue(Layer::SublayerCanvasProperty);
+    if (DEBUG_HIERARCHY) {
+        TraceVerbose(
+            TAG,
+            L"GetValue(Layer::SublayerCanvasProperty) for [%ws] returned layerElement->SublayerCanvas [%ws].",
+            xamlElement->GetType()->FullName->Data(),
+            (value ? value->GetType()->FullName->Data() : L"nullptr"));
+    }
+
+    return dynamic_cast<Canvas^>(value);
 };
 
 LayerProxy::LayerProxy(IInspectable* xamlElement) :
     _xamlElement(nullptr),
     _isRoot(false),
-    _parent(nullptr),
     _currentTexture(nullptr),
     _topMost(false) {
 
@@ -68,12 +87,6 @@ LayerProxy::LayerProxy(IInspectable* xamlElement) :
 
     // Initialize the UIElement with CoreAnimation
     CoreAnimation::LayerCoordinator::InitializeFrameworkElement(_FrameworkElementFromInspectable(_xamlElement));
-}
-
-LayerProxy::~LayerProxy() {
-    for (auto layer : _subLayers) {
-        layer->_parent = nullptr;
-    }
 }
 
 Microsoft::WRL::ComPtr<IInspectable> LayerProxy::GetXamlElement() {
@@ -192,8 +205,14 @@ void LayerProxy::AddToRoot() {
 }
 
 void LayerProxy::AddSubLayer(const std::shared_ptr<LayerProxy>& subLayer, const std::shared_ptr<LayerProxy>& before, const std::shared_ptr<LayerProxy>& after) {
-    assert(subLayer->_parent == NULL);
-    subLayer->_parent = this;
+    // Make sure the sublayer isn't already parented
+    {
+        auto strongParent = subLayer->_parent.lock();
+        assert(!strongParent);
+    }
+
+    // Set ourselves as the sublayer's parent
+    subLayer->_parent = shared_from_this();
     _subLayers.insert(subLayer);
 
     FrameworkElement^ xamlElementForSubLayer = _FrameworkElementFromInspectable(subLayer->_xamlElement);
@@ -229,12 +248,14 @@ void LayerProxy::AddSubLayer(const std::shared_ptr<LayerProxy>& subLayer, const 
 }
 
 void LayerProxy::MoveLayer(const std::shared_ptr<LayerProxy>& before, const std::shared_ptr<LayerProxy>& after) {
-    assert(_parent != NULL);
+    // Grab a strong reference to our parent
+    auto strongParent = _parent.lock();
+    assert(strongParent);
 
     FrameworkElement^ xamlElementForThisLayer = _FrameworkElementFromInspectable(_xamlElement);
-    Panel^ subLayerPanelForParentLayer = _SubLayerPanelFromInspectable(_parent->_xamlElement);
+    Panel^ subLayerPanelForParentLayer = _SubLayerPanelFromInspectable(strongParent->_xamlElement);
     if (!subLayerPanelForParentLayer) {
-        FrameworkElement^ xamlElementForParentLayer = _FrameworkElementFromInspectable(_parent->_xamlElement);
+        FrameworkElement^ xamlElementForParentLayer = _FrameworkElementFromInspectable(strongParent->_xamlElement);
         UNIMPLEMENTED_WITH_MSG(
             "MoveLayer for [%ws] not supported on parent [%ws].",
             xamlElementForThisLayer->GetType()->FullName->Data(),
@@ -242,7 +263,7 @@ void LayerProxy::MoveLayer(const std::shared_ptr<LayerProxy>& before, const std:
         return;
     }
 
-    if (before != NULL) {
+    if (before) {
         FrameworkElement^ xamlBeforeLayer = _FrameworkElementFromInspectable(before->_xamlElement);
 
         unsigned int srcIdx = 0;
@@ -264,7 +285,7 @@ void LayerProxy::MoveLayer(const std::shared_ptr<LayerProxy>& before, const std:
             FAIL_FAST();
         }
     } else {
-        assert(after != NULL);
+        assert(after);
 
         FrameworkElement^ xamlAfterLayer = _FrameworkElementFromInspectable(after->_xamlElement);
         unsigned int srcIdx = 0;
@@ -289,21 +310,39 @@ void LayerProxy::MoveLayer(const std::shared_ptr<LayerProxy>& before, const std:
 }
 
 void LayerProxy::RemoveFromSuperLayer() {
+    // Grab a strong reference to our parent (if one exists)
+    auto strongParent = _parent.lock();
+
     FrameworkElement^ xamlElementForThisLayer = _FrameworkElementFromInspectable(_xamlElement);
     Panel^ subLayerPanelForParentLayer;
     if (_isRoot) {
         subLayerPanelForParentLayer = s_windowCollection;
     } else {
-        if (!_parent) {
+        if (!strongParent) {
+            if (DEBUG_HIERARCHY) {
+                TraceVerbose(
+                    TAG, 
+                    L"RemoveFromSuperLayer for [%ws] doesn't have a parent; nothing left to do.", 
+                    xamlElementForThisLayer->GetType()->FullName->Data());
+            }
+
             return;
         }
 
-        subLayerPanelForParentLayer = _SubLayerPanelFromInspectable(_parent->_xamlElement);
-        _parent->_subLayers.erase(shared_from_this());
+        subLayerPanelForParentLayer = _SubLayerPanelFromInspectable(strongParent->_xamlElement);
+        strongParent->_subLayers.erase(shared_from_this());
+    }
+
+    if (DEBUG_HIERARCHY) {
+        TraceVerbose(
+            TAG,
+            L"RemoveFromSuperLayer xamlElementForThisLayer = [%ws]; subLayerPanelForParentLayer = [%ws].",
+            xamlElementForThisLayer->GetType()->FullName->Data(),
+            subLayerPanelForParentLayer->GetType()->FullName->Data());
     }
 
     if (!subLayerPanelForParentLayer) {
-        FrameworkElement^ xamlElementForParentLayer = _FrameworkElementFromInspectable(_parent->_xamlElement);
+        FrameworkElement^ xamlElementForParentLayer = _FrameworkElementFromInspectable(strongParent->_xamlElement);
         UNIMPLEMENTED_WITH_MSG(
             "RemoveFromSuperLayer for [%ws] not supported on parent [%ws].",
             xamlElementForThisLayer->GetType()->FullName->Data(),
@@ -312,12 +351,12 @@ void LayerProxy::RemoveFromSuperLayer() {
         return;
     }
 
-    _parent = nullptr;
-
     unsigned int idx = 0;
     if (subLayerPanelForParentLayer->Children->IndexOf(xamlElementForThisLayer, &idx) == true) {
         subLayerPanelForParentLayer->Children->RemoveAt(idx);
     } else {
         FAIL_FAST();
     }
+
+    _parent.reset();
 }

--- a/Frameworks/UIKit/StarboardXaml/LayerProxy.h
+++ b/Frameworks/UIKit/StarboardXaml/LayerProxy.h
@@ -28,7 +28,6 @@
 class LayerProxy : public ILayerProxy, public std::enable_shared_from_this<LayerProxy> {
 public:
     explicit LayerProxy(IInspectable* xamlElement);
-    ~LayerProxy();
 
     // ILayerProxy
     Microsoft::WRL::ComPtr<IInspectable> GetXamlElement() override;
@@ -68,8 +67,7 @@ private:
     float _GetPresentationPropertyValue(const char* name);
 
     bool _isRoot;
-    // TODO: weak_ptr or reference??
-    LayerProxy* _parent;
+    std::weak_ptr<LayerProxy> _parent;
     std::set<std::shared_ptr<LayerProxy>> _subLayers;
     std::shared_ptr<IDisplayTexture> _currentTexture;
     bool _topMost;

--- a/Frameworks/UIKit/UIScrollView.mm
+++ b/Frameworks/UIKit/UIScrollView.mm
@@ -189,19 +189,11 @@ const float UIScrollViewDecelerationRateFast = StubConstant();
     _leftInset = [WUXSRectangle make];
     _leftInset.name = @"left";
 
-    // Create a content canvas for our subviews
-    _contentCanvas = [WXCCanvas make];
-    _contentCanvas.name = @"Content Canvas";
+    // Grab the content canvas for our subviews - we created it in createXamlElement
+    _contentCanvas = XamlControls::GetFrameworkElementSublayerCanvasProperty(_scrollViewer);
 
-    // Create an image for our rendered content
-    _contentImage = [WXCImage make];
-    _contentImage.name = @"Content Element";
-
-    // Set up the CALayer properties for our backing Xaml element so
-    // our subviews are placed within our _contentCanvas
-    XamlControls::SetFrameworkElementLayerProperties(_scrollViewer,
-                                                     _contentImage, // content element
-                                                     _contentCanvas); // sublayer canvas
+    // Grab the image for our rendered content - we created it in createXamlElement
+    _contentImage = XamlControls::GetFrameworkElementLayerContentProperty(_scrollViewer);
 
     // creating and build 3 X 3 content grid
     _contentGrid = [WXCGrid make];
@@ -691,8 +683,26 @@ const float UIScrollViewDecelerationRateFast = StubConstant();
  Microsoft Extension
 */
 + (WXFrameworkElement*)createXamlElement {
+    WXCScrollViewer* scrollViewer = [WXCScrollViewer make];
+
+    // Create an image for our rendered content
+    WXCImage* contentImage = [WXCImage make];
+    contentImage.name = @"Content Element";
+
+    // Create a content canvas for our subviews
+    WXCCanvas* contentCanvas = [WXCCanvas make];
+    contentCanvas.name = @"Content Canvas";
+
+    // Set up the CALayer properties for our backing Xaml element so
+    // our subviews are placed within our contentCanvas
+    // Note: It's critical that we do this here in case subviews are added before _initUIScrollView has a chance
+    // to run (during initWithCoder, for example).
+    XamlControls::SetFrameworkElementLayerProperties(scrollViewer,
+        contentImage, // content element
+        contentCanvas); // sublayer canvas
+
     // No autorelease needed because we compile with ARC
-    return [WXCScrollViewer make];
+    return scrollViewer;
 }
 
 /**

--- a/Frameworks/UIKit/XamlControls.h
+++ b/Frameworks/UIKit/XamlControls.h
@@ -128,4 +128,11 @@ WXCTextBlock* GetLabelTextBlock(WXCGrid* labelGrid);
 void SetFrameworkElementLayerProperties(WXFrameworkElement* targetElement,
                                         WXCImage* layerContentProperty,
                                         WXCCanvas* sublayerCanvasProperty);
+
+// Get the layerContentProperty for the specified target xaml element
+WXCImage* GetFrameworkElementLayerContentProperty(WXFrameworkElement* targetElement);
+
+// Get the sublayerCanvasProperty for the specified target xaml element
+WXCCanvas* GetFrameworkElementSublayerCanvasProperty(WXFrameworkElement* targetElement);
+
 } // namespace XamlControls

--- a/Frameworks/UIKit/XamlControls.mm
+++ b/Frameworks/UIKit/XamlControls.mm
@@ -115,4 +115,14 @@ void SetFrameworkElementLayerProperties(WXFrameworkElement* targetElement,
                                            sublayerCanvasProperty ? [sublayerCanvasProperty comObj] : nullptr);
 }
 
+WXCImage* GetFrameworkElementLayerContentProperty(WXFrameworkElement* targetElement) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetFrameworkElementLayerContentProperty([targetElement comObj]));
+    return _createRtProxy([WXCImage class], inspectable.Get());
+}
+
+WXCCanvas* GetFrameworkElementSublayerCanvasProperty(WXFrameworkElement* targetElement) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetFrameworkElementSublayerCanvasProperty([targetElement comObj]));
+    return _createRtProxy([WXCCanvas class], inspectable.Get());
+}
+
 } // namespace XamlControls


### PR DESCRIPTION
We need to 'enlighten' the compositor about the UIScrollView's content element and sublayer canvas element *before* UIScrollView's _initUIScrollView method is called, so that the initWithCoder path can add subviews to the correct Xaml element.  Without this fix, labels, etc. added to the UIScrollView are dropped and don't make it into the UIElement tree.  This will go away when we move UIScrollView down to a fully-backed Xaml element. Fixes #1706.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1714)
<!-- Reviewable:end -->
