### PR TITLE
Fixing up functional test failure cuased by mismatched UIApplication setup/cleanup calls

### DIFF
--- a/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
+++ b/Frameworks/UIKit/StarboardXaml/StarboardXaml.cpp
@@ -353,7 +353,7 @@ int UIApplicationMain(int argc, char* argv[], void* principalClassName, void* de
 }
 
 // This is the initialization function for non-Islandwood apps that intend to call into Islandwood:
-// test executables and general WinRT apps that want to call Islandwood libraries
+// general WinRT apps that want to call Islandwood libraries
 UIKIT_EXPORT
 void UIApplicationInitialize(const wchar_t* principalClassName, const wchar_t* delegateClassName) {
     // Register tracelogging
@@ -372,6 +372,28 @@ void UIApplicationInitialize(const wchar_t* principalClassName, const wchar_t* d
     }
 
     _ApplicationLaunch(ActivationTypeLibrary, nullptr);
+}
+
+// This is the initialization function for functional tests
+UIKIT_EXPORT
+void UIApplicationInitializeFunctionalTest(const wchar_t* principalClassName, const wchar_t* delegateClassName) {
+    // Register tracelogging
+    TraceRegister();
+
+    if (principalClassName != nullptr) {
+        g_principalClassName = ref new Platform::String(principalClassName);
+    } else {
+        g_principalClassName = ref new Platform::String();
+    }
+
+    if (delegateClassName != nullptr) {
+        g_delegateClassName = ref new Platform::String(delegateClassName);
+    } else {
+        g_delegateClassName = ref new Platform::String();
+    }
+
+    // Perform a default app launch
+    _ApplicationLaunch(ActivationTypeNone, nullptr);
 }
 
 // Note: Like UIApplicationMain, delegateClassName is actually an NSString*.

--- a/Frameworks/include/LinkedList.h
+++ b/Frameworks/include/LinkedList.h
@@ -18,6 +18,7 @@
 #define __UTILS_LINKEDLIST_H
 
 #include <malloc.h>
+#include <type_traits>
 #ifdef EBRIUS
 #include "Foundation/NSArray.h"
 #endif

--- a/Frameworks/include/UIViewInternal.h
+++ b/Frameworks/include/UIViewInternal.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #import "LinkedList.h"
+#import <Starboard/SmartTypes.h>
 #import <UIKit/NSLayoutAnchor.h>
 #import <UIKit/NSLayoutXAxisAnchor.h>
 #import <UIKit/NSLayoutYAxisAnchor.h>

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -240,12 +240,20 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Logger.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\pch.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\targetver.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\AppDelegate.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\MainViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\FunctionalTestHelpers.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\AssetsLibraryTests\AssetsLibraryTestHelpers.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\MenuTableViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIButtonViewController.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\AppDelegate.mm">
+      <ObjectiveCARC>true</ObjectiveCARC>
+    </ClangCompile>
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\MainViewController.mm">
+      <ObjectiveCARC>true</ObjectiveCARC>
+    </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\FunctionalTestHelpers.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\NSURLConnection.mm">
       <ObjectiveCARC>true</ObjectiveCARC>

--- a/build/UIKit/dll/UIKit.def
+++ b/build/UIKit/dll/UIKit.def
@@ -3,6 +3,7 @@ LIBRARY UIKit
         ; Application entry points (StarboardXAML)
         UIApplicationMain
         UIApplicationInitialize
+        UIApplicationInitializeFunctionalTest
         UIApplicationActivationTest
         UIApplicationLaunched
         UIApplicationActivated

--- a/tests/functionaltests/AppDelegate.h
+++ b/tests/functionaltests/AppDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/AppDelegate.h
+++ b/tests/functionaltests/AppDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -14,16 +14,11 @@
 //
 //******************************************************************************
 
-#pragma once
+#import <UIKit/UIKit.h>
 
-// Setup method to call before every test class to initialize the UIApplication
-void FunctionalTestSetupUIApplication();
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-// Cleanup method to call after every test class to free the UIApplication
-void FunctionalTestCleanupUIApplication();
+@property (strong, nonatomic) UIWindow* window;
+@property (strong, nonatomic) UIViewController* viewController;
 
-#ifdef __OBJC__
-#import <Foundation/NSString.h>
-NSString* appendPathRelativeToFTModule(NSString* pathAppendage);
-NSString* getModulePath();
-#endif
+@end

--- a/tests/functionaltests/AppDelegate.mm
+++ b/tests/functionaltests/AppDelegate.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/AppDelegate.mm
+++ b/tests/functionaltests/AppDelegate.mm
@@ -1,0 +1,64 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <AppDelegate.h>
+#import <MainViewController.h>
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+    MainViewController* mainViewController = [[MainViewController alloc] init];
+    self.viewController = (UIViewController*)[[UINavigationController alloc] initWithRootViewController:mainViewController];
+    self.window.rootViewController = self.viewController;
+    [self.window makeKeyAndVisible];
+
+    return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication*)application {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions
+    // (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background
+    // state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to
+    // pause the game.
+}
+
+- (void)applicationDidEnterBackground:(UIApplication*)application {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to
+    // restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+}
+
+- (void)applicationWillEnterForeground:(UIApplication*)application {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering
+    // the background.
+}
+
+- (void)applicationDidBecomeActive:(UIApplication*)application {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the
+    // background, optionally refresh the user interface.
+}
+
+- (void)applicationWillTerminate:(UIApplication*)application {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+}
+
+@end

--- a/tests/functionaltests/FunctionalTestHelpers.h
+++ b/tests/functionaltests/FunctionalTestHelpers.h
@@ -17,10 +17,10 @@
 #pragma once
 
 // Setup method to call before every test class to initialize the UIApplication
-void FunctionalTestSetupUIApplication();
+bool FunctionalTestSetupUIApplication();
 
 // Cleanup method to call after every test class to free the UIApplication
-void FunctionalTestCleanupUIApplication();
+bool FunctionalTestCleanupUIApplication();
 
 #ifdef __OBJC__
 #import <Foundation/NSString.h>

--- a/tests/functionaltests/FunctionalTestHelpers.mm
+++ b/tests/functionaltests/FunctionalTestHelpers.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -27,31 +27,23 @@
 // This is a method that UIKit exposes for the test frameworks to use.
 extern "C" void UIApplicationInitialize(const wchar_t*, const wchar_t*);
 
-static bool g_appRunning = false;
-
 // Launches the functional test app
-void FunctionalTestSetupUIApplication() {
-    if (g_appRunning) {
-        FunctionalTestLog::LogErrorAndAbort(
-            "Mismatched calls to FunctionalTestSetupUIApplication/FunctionalTestCleanupUIApplication!", 
-            __FILE__, 
-            __FUNCTION__, 
-            __LINE__);
-    }
-
+bool FunctionalTestSetupUIApplication() {
     RunSynchronouslyOnMainThread(^{
         // The name of our default 'AppDelegate' class
         UIApplicationInitialize(nullptr, Strings::NarrowToWide<std::wstring>(NSStringFromClass([AppDelegate class])).c_str());
-        g_appRunning = true;
     });
+
+    return true;
 }
 
 // Terminates the functional test app
-void FunctionalTestCleanupUIApplication() {
+bool FunctionalTestCleanupUIApplication() {
     RunSynchronouslyOnMainThread(^{
         [[UIApplication sharedApplication] _destroy];
-        g_appRunning = false;
     });
+
+    return true;
 }
 
 // Gets the path to the app installation location

--- a/tests/functionaltests/FunctionalTestHelpers.mm
+++ b/tests/functionaltests/FunctionalTestHelpers.mm
@@ -25,13 +25,13 @@
 #import <UWP/WindowsApplicationModel.h>
 
 // This is a method that UIKit exposes for the test frameworks to use.
-extern "C" void UIApplicationInitialize(const wchar_t*, const wchar_t*);
+extern "C" void UIApplicationInitializeFunctionalTest(const wchar_t*, const wchar_t*);
 
 // Launches the functional test app
 bool FunctionalTestSetupUIApplication() {
     RunSynchronouslyOnMainThread(^{
         // The name of our default 'AppDelegate' class
-        UIApplicationInitialize(nullptr, Strings::NarrowToWide<std::wstring>(NSStringFromClass([AppDelegate class])).c_str());
+        UIApplicationInitializeFunctionalTest(nullptr, Strings::NarrowToWide<std::wstring>(NSStringFromClass([AppDelegate class])).c_str());
     });
 
     return true;

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -28,14 +28,6 @@ MODULE_PROPERTY(L"UAP:Host", L"Xaml")
 MODULE_PROPERTY(L"UAP:AppXManifest", L"Default.AppxManifest.xml")
 END_MODULE()
 
-// This is a method that UIKit exposes for the test frameworks to use.
-extern "C" void UIApplicationInitialize(const wchar_t*, const wchar_t*);
-
-static void UIApplicationDefaultInitialize() {
-    // Pass null to indicate default app and app delegate classes
-    UIApplicationInitialize(nullptr, nullptr);
-}
-
 //
 // How is functional test organized?
 //
@@ -100,7 +92,8 @@ public:
     //     2. Use the same mechanism as in TEST_METHOD below to export a method from the WinObjC test file and call it here.
     //     3. If you do not need this functionality feel free to remove this for your test class.
     TEST_CLASS_SETUP(SampleTestClassSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
     // SampleTest test class cleanup.
@@ -109,6 +102,7 @@ public:
     //     2. Use the same mechanism as in TEST_METHOD below to export a method from the WinObjC test file and call it here.
     //     3. If you do not need this functionality feel free to remove this for your test class.
     TEST_CLASS_CLEANUP(SampleTestClassCleanup) {
+        FunctionalTestCleanupUIApplication();
         return true;
     }
 
@@ -181,11 +175,13 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSURLClassSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(NSURLCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(NSURLClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     //
@@ -268,12 +264,14 @@ public:
     BEGIN_TEST_CLASS(NSUserDefaults)
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(NSURLClassSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    TEST_CLASS_SETUP(NSUserDefaultsClassSetup) {
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(NSUserDefaultsCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(NSUserDefaultsClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(NSUserDefaults_Basic) {
@@ -304,12 +302,14 @@ public:
     BEGIN_TEST_CLASS(NSBundle)
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(NSURLClassSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    TEST_CLASS_SETUP(NSBundleClassSetup) {
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(NSBundleCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(NSBundleClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(NSBundle_MSAppxURL) {
@@ -330,15 +330,14 @@ public:
 
     TEST_CLASS_SETUP(AssetsLibraryClassSetup) {
         bool success = AssetsLibraryTestVideoSetup("AssetsLibraryTestVideo.mp4");
-        return (success & SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize)));
+        FunctionalTestSetupUIApplication();
+        return success;
     }
 
     TEST_CLASS_CLEANUP(AssetsLibraryClassCleanup) {
-        return AssetsLibraryTestVideoCleanup("AssetsLibraryTestVideo.mp4");
-    }
-
-    TEST_METHOD_CLEANUP(AssetsLibraryCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+        bool success = AssetsLibraryTestVideoCleanup("AssetsLibraryTestVideo.mp4");
+        FunctionalTestCleanupUIApplication();
+        return success;
     }
 
     TEST_METHOD(AssetsLibrary_GetVideoAsset) {
@@ -362,8 +361,9 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestVoiceCommandForegroundActivation));
     }
 
-    TEST_METHOD_CLEANUP(CortanaVoiceCommandForegroundCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(CortanaVoiceCommandForegroundTestClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(Cortana_VoiceCommandForegroundActivationDelegateMethodsCalled) {
@@ -384,8 +384,9 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&CortanaTestProtocolForegroundActivation));
     }
 
-    TEST_METHOD_CLEANUP(CortanaProtocolForegroundCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(CortanaProtocolForegroundTestClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(Cortana_ProtocolForegroundActivationDelegateMethodsCalled) {
@@ -405,8 +406,9 @@ class ToastNotificationForegroundActivation {
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&ToastNotificationTestForegroundActivation));
     }
 
-    TEST_METHOD_CLEANUP(ToastNotificationForegroundCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(ToastNotificationForegroundTestClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(ToastNotification_ForegroundActivationDelegateMethodsCalled) {
@@ -422,11 +424,13 @@ class ActivatedAppReceivesToastNotification {
 
     TEST_CLASS_SETUP(ActivatedAppReceivesToastNotificationTestClassSetup) {
         // The class setup allows us to activate the app in our test method, but can only be done once per class
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(ActivatedAppReceivesToastNotificationCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(ActivatedAppReceivesToastNotificationTestClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(ToastNotification_ActivatedAppReceivesToastNotification) {
@@ -451,8 +455,9 @@ public:
         return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FileActivatedTestForegroundActivation));
     }
 
-    TEST_METHOD_CLEANUP(FileActivationForegroundActivationCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(FileActivationForegroundActivationClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(FileActivation_TestForegroundActivationDelegateMethodsCalled) {
@@ -510,12 +515,14 @@ public:
     BEGIN_TEST_CLASS(UIKitTests)
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(UIKitTestsSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    TEST_CLASS_SETUP(UIKitTestsClassSetup) {
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(UIKitTestsCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(UIKitTestsClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(UIView_Create) {
@@ -683,11 +690,13 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(ProjectionTestClassSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(ProjectionTestCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(ProjectionTestClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(ProjectionTest_WUCCoreDispatcherSanity) {
@@ -730,8 +739,14 @@ public:
     BEGIN_TEST_CLASS(UIApplicationTests)
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(UIApplicationTestsSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    TEST_CLASS_SETUP(UIApplicationTestsClassSetup) {
+        FunctionalTestSetupUIApplication();
+        return true;
+    }
+
+    TEST_CLASS_CLEANUP(UIApplicationTestsClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(UIApplicationTests_OpenURL) {
@@ -749,12 +764,14 @@ public:
     BEGIN_TEST_CLASS(NSURLStorageFileTests)
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(NSURLStorageFileTestsSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    TEST_CLASS_SETUP(NSURLStorageFileTestsClassSetup) {
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(NSURLStorageFileTestsCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(NSURLStorageFileTestsClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(NSURLTests_StorageFileURL) {
@@ -773,12 +790,14 @@ public:
     BEGIN_TEST_CLASS(CoreAnimationTests)
     END_TEST_CLASS()
 
-    TEST_CLASS_SETUP(CoreAnimationTestsSetup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&UIApplicationDefaultInitialize));
+    TEST_CLASS_SETUP(CoreAnimationTestsClassSetup) {
+        FunctionalTestSetupUIApplication();
+        return true;
     }
 
-    TEST_METHOD_CLEANUP(CoreAnimationTestsCleanup) {
-        return SUCCEEDED(FrameworkHelper::RunOnUIThread(&FunctionalTestCleanupUIApplication));
+    TEST_CLASS_CLEANUP(CoreAnimationTestsClassCleanup) {
+        FunctionalTestCleanupUIApplication();
+        return true;
     }
 
     TEST_METHOD(CALayerAppearance_OpacityChanged) {

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -92,8 +92,7 @@ public:
     //     2. Use the same mechanism as in TEST_METHOD below to export a method from the WinObjC test file and call it here.
     //     3. If you do not need this functionality feel free to remove this for your test class.
     TEST_CLASS_SETUP(SampleTestClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     // SampleTest test class cleanup.
@@ -102,8 +101,7 @@ public:
     //     2. Use the same mechanism as in TEST_METHOD below to export a method from the WinObjC test file and call it here.
     //     3. If you do not need this functionality feel free to remove this for your test class.
     TEST_CLASS_CLEANUP(SampleTestClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     // SampleTest test method setup.
@@ -175,13 +173,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSURLClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(NSURLClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     //
@@ -265,13 +261,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSUserDefaultsClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(NSUserDefaultsClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(NSUserDefaults_Basic) {
@@ -303,13 +297,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSBundleClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(NSBundleClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(NSBundle_MSAppxURL) {
@@ -330,13 +322,13 @@ public:
 
     TEST_CLASS_SETUP(AssetsLibraryClassSetup) {
         bool success = AssetsLibraryTestVideoSetup("AssetsLibraryTestVideo.mp4");
-        FunctionalTestSetupUIApplication();
+        success &= FunctionalTestSetupUIApplication();
         return success;
     }
 
     TEST_CLASS_CLEANUP(AssetsLibraryClassCleanup) {
         bool success = AssetsLibraryTestVideoCleanup("AssetsLibraryTestVideo.mp4");
-        FunctionalTestCleanupUIApplication();
+        success &= FunctionalTestCleanupUIApplication();
         return success;
     }
 
@@ -362,8 +354,7 @@ public:
     }
 
     TEST_CLASS_CLEANUP(CortanaVoiceCommandForegroundTestClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(Cortana_VoiceCommandForegroundActivationDelegateMethodsCalled) {
@@ -385,8 +376,7 @@ public:
     }
 
     TEST_CLASS_CLEANUP(CortanaProtocolForegroundTestClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(Cortana_ProtocolForegroundActivationDelegateMethodsCalled) {
@@ -407,8 +397,7 @@ class ToastNotificationForegroundActivation {
     }
 
     TEST_CLASS_CLEANUP(ToastNotificationForegroundTestClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(ToastNotification_ForegroundActivationDelegateMethodsCalled) {
@@ -424,13 +413,11 @@ class ActivatedAppReceivesToastNotification {
 
     TEST_CLASS_SETUP(ActivatedAppReceivesToastNotificationTestClassSetup) {
         // The class setup allows us to activate the app in our test method, but can only be done once per class
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(ActivatedAppReceivesToastNotificationTestClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(ToastNotification_ActivatedAppReceivesToastNotification) {
@@ -456,8 +443,7 @@ public:
     }
 
     TEST_CLASS_CLEANUP(FileActivationForegroundActivationClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(FileActivation_TestForegroundActivationDelegateMethodsCalled) {
@@ -516,13 +502,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(UIKitTestsClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(UIKitTestsClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(UIView_Create) {
@@ -690,13 +674,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(ProjectionTestClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(ProjectionTestClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(ProjectionTest_WUCCoreDispatcherSanity) {
@@ -740,13 +722,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(UIApplicationTestsClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(UIApplicationTestsClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(UIApplicationTests_OpenURL) {
@@ -765,13 +745,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSURLStorageFileTestsClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(NSURLStorageFileTestsClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(NSURLTests_StorageFileURL) {
@@ -791,13 +769,11 @@ public:
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(CoreAnimationTestsClassSetup) {
-        FunctionalTestSetupUIApplication();
-        return true;
+        return FunctionalTestSetupUIApplication();
     }
 
     TEST_CLASS_CLEANUP(CoreAnimationTestsClassCleanup) {
-        FunctionalTestCleanupUIApplication();
-        return true;
+        return FunctionalTestCleanupUIApplication();
     }
 
     TEST_METHOD(CALayerAppearance_OpacityChanged) {

--- a/tests/functionaltests/Logger.cpp
+++ b/tests/functionaltests/Logger.cpp
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/Logger.h
+++ b/tests/functionaltests/Logger.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/MainViewController.h
+++ b/tests/functionaltests/MainViewController.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/MainViewController.h
+++ b/tests/functionaltests/MainViewController.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -14,16 +14,8 @@
 //
 //******************************************************************************
 
-#pragma once
+#import "UIKit/UIViewController.h"
 
-// Setup method to call before every test class to initialize the UIApplication
-void FunctionalTestSetupUIApplication();
+@interface MainViewController : UIViewController
 
-// Cleanup method to call after every test class to free the UIApplication
-void FunctionalTestCleanupUIApplication();
-
-#ifdef __OBJC__
-#import <Foundation/NSString.h>
-NSString* appendPathRelativeToFTModule(NSString* pathAppendage);
-NSString* getModulePath();
-#endif
+@end

--- a/tests/functionaltests/MainViewController.mm
+++ b/tests/functionaltests/MainViewController.mm
@@ -1,6 +1,7 @@
 //******************************************************************************
 //
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) 2016 Intel Corporation. All rights reserved.
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -14,16 +15,26 @@
 //
 //******************************************************************************
 
-#pragma once
+#import <MainViewController.h>
 
-// Setup method to call before every test class to initialize the UIApplication
-void FunctionalTestSetupUIApplication();
+#import "UIKit/UIColor.h"
+#import "UIKit/UIView.h"
 
-// Cleanup method to call after every test class to free the UIApplication
-void FunctionalTestCleanupUIApplication();
+@interface MainViewController ()
 
-#ifdef __OBJC__
-#import <Foundation/NSString.h>
-NSString* appendPathRelativeToFTModule(NSString* pathAppendage);
-NSString* getModulePath();
-#endif
+@end
+
+@implementation MainViewController
+
+- (void)viewDidLoad {
+    self.view.backgroundColor = [UIColor lightGrayColor];
+
+    [super viewDidLoad];
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/tests/functionaltests/MainViewController.mm
+++ b/tests/functionaltests/MainViewController.mm
@@ -1,7 +1,7 @@
 //******************************************************************************
 //
 // Copyright (c) 2016 Intel Corporation. All rights reserved.
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/functionaltest-api.h
+++ b/tests/functionaltests/functionaltest-api.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/pch.h
+++ b/tests/functionaltests/pch.h
@@ -1,6 +1,6 @@
 ﻿//******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/tests/functionaltests/targetver.h
+++ b/tests/functionaltests/targetver.h
@@ -1,6 +1,6 @@
 ﻿//******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //


### PR DESCRIPTION
Also hooking up in-test rendering, and moving UIThread usage into formal FunctionalTestSetupUIApplication/FunctionalTestCleanupUIApplication methods..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1716)
<!-- Reviewable:end -->
