### PR TITLE
Fix CoreText extra kerning for the first run in a frame

### DIFF
--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -265,13 +265,7 @@ static HRESULT __DWriteTextLayoutCreate(CFAttributedStringRef string, CFRange ra
     // Used to separate runs for attributes which DWrite does not handle until drawing (e.g. Foreground Color)
     uint32_t incompatibleAttributeFlag = 0;
     CFRange attributeRange;
-
-    // Find the range of the first set of attributes and skip it, since the underlying DWriteTextFormat has already internalized it
-    // If this first set of attributes lasts the entire range, the below for loop is not executed at all
-    // attributeRange is populated even if this attribute is not found
-    CFAttributedStringGetAttribute(string, range.location, kCTFontAttributeName, &attributeRange);
-
-    for (CFIndex index = attributeRange.location + attributeRange.length; index < rangeEnd; index += attributeRange.length) {
+    for (CFIndex index = range.location; index < rangeEnd; index += attributeRange.length) {
         CTFontRef font = static_cast<CTFontRef>(CFAttributedStringGetAttribute(string, index, kCTFontAttributeName, &attributeRange));
 
         // attributeRange is populated even if this attribute is not found

--- a/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
@@ -343,8 +343,7 @@ class ExtraKerning : public WhiteBackgroundTest<PixelByPixelImageComparator<Comp
     }
 };
 
-// TODO 1696: Re-enable
-DISABLED_TEXT_DRAW_TEST_P(ExtraKerning, TestExtraKerning) {
+TEXT_DRAW_TEST_P(ExtraKerning, TestExtraKerning) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.-1.00.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.-1.00.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92c9b3acfd75b18d31a85ee3f4d62529f70963fac2254a5ae3526dbb749056f2
-size 28936
+oid sha256:0d5702c014682d24b48fb34d4f8a3ec00ff9f6032e81ec9005097eb1ed8789ee
+size 25231

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.1.00.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.1.00.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14c187fb0ce2fc875ca780f580fac3a79fa3b9dfb3cd0010f6f991d1e86e0782
-size 31524
+oid sha256:a590bb9a579134b9fd4afdff77d435d9f8830d933bfeeef85401ab77731b9092
+size 27587

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.25.75.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.25.75.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65b4729e3c44d7f1656adc9bbe2e3abebb051c5bf5beb09e338dd046af2feeab
-size 15228
+oid sha256:95ca8bb087115c177223e9b9f68da4b9f5e6aba838e912e8f50ded67642c1f8a
+size 13244

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.5.25.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.ExtraKerning.5.25.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87043d68af30b7298dc27823dc7d5cd3f6e0dacc03747f1402b3be542679aa27
-size 28946
+oid sha256:32f876608fe966de283ec17a63a22e3bdf488ff221345d3da1024a3ce5f58008
+size 25107


### PR DESCRIPTION
When we changed the Core Text code to optimize out setting the font twice on a frame I forgot that kerning was also set in the loop.  Updates images for post #1723 drawing.

Fixes #1696

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1742)
<!-- Reviewable:end -->
