### PR TITLE
Fix our WIC<->CG color format table again.

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -2775,8 +2775,8 @@ CGContextRef CGBitmapContextCreateWithData(void* data,
 
     // bitsperpixel = ((bytesPerRow/width) * 8bits/byte)
     size_t bitsPerPixel = ((bytesPerRow / width) << 3);
-    REFWICPixelFormatGUID outputPixelFormat =
-        _CGImageGetWICPixelFormatFromImageProperties(bitsPerComponent, bitsPerPixel, space, bitmapInfo);
+    WICPixelFormatGUID outputPixelFormat;
+    RETURN_NULL_IF_FAILED(_CGImageGetWICPixelFormatFromImageProperties(bitsPerComponent, bitsPerPixel, space, bitmapInfo, &outputPixelFormat));
     WICPixelFormatGUID pixelFormat = outputPixelFormat;
 
     if (!_CGIsValidRenderTargetPixelFormat(pixelFormat)) {

--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -56,44 +56,106 @@ static const std::map<GUID, int, GuidPixelLess> s_ValidRenderTargetPixelFormat =
                                                                                    { GUID_WICPixelFormat32bppPBGRA, 1 } }; // BGRX Premultiplied
 
 static const std::map<GUID, __CGImagePixelProperties, GuidPixelLess> s_PixelFormats = {
-    // Last = RGBA, 32Little = forward: RGBA
-    // First = ARGB, 32Big = backward: BGRA
-    { GUID_WICPixelFormat32bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrder32Little), 8, 32 } },
-    { GUID_WICPixelFormat32bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaFirst | kCGBitmapByteOrder32Big), 8, 32 } },
-    { GUID_WICPixelFormat32bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Little), 8, 32 } },
-    { GUID_WICPixelFormat32bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Big), 8, 32 } },
+    // RGB(A) formats
 
-    // 64bpp formats (CoreGraphics has limited support for these.)
-    { GUID_WICPixelFormat64bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
-    { GUID_WICPixelFormat64bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
-    { GUID_WICPixelFormat64bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 16, 64 } },
-    { GUID_WICPixelFormat64bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 16, 64 } },
+    // + 16bpp
+    // IN-MEMORY PIXEL LAYOUTS
+    //                  | Alpha First         | Alpha Last
+    //                  +---------------------+------------
+    // Conceptual Model | A RRRRR GGGGG BBBBB | DOES NOT EXIST
+    //                  +---------------------+------------
+    //                  | Stored As
+    //                  +---------------------+------------
+    // Little Endian    | GGGBBBBB ARRRRRGG   | -
+    // Big Endian       | ARRRRRGG GGGBBBBB   | -
+    //                  +---------------------+------------
+    //                    A = X where skipped.
+    // -+ No alpha
+    // There are no mappable 16bpp formats. CoreGraphics supports ARGB in big and little endian.
+    // WIC only supports BGRA in one endianness. Since this isn't like 32bpp RGB(A) where component
+    // values divide clearly along byte boundaries, we can't tolerate the RGB<->BGR swap.
+    // Where WIC would store    BBBBBGGG GGRRRRRA,
+    // CoreGraphics would store ARRRRRGG GGGBBBBB.
 
-    // Non-alpha formats.
+    // + 24bpp (CoreGraphics has limited support for these.)
+    // -+ Skipped alpha
     { GUID_WICPixelFormat24bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 24 } },
     { GUID_WICPixelFormat24bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 24 } },
-    // Alpha-Skip formats (32bpp, but has alpha)
-    { GUID_WICPixelFormat32bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNoneSkipLast | kCGBitmapByteOrder32Little), 8, 32 } },
-    { GUID_WICPixelFormat32bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big), 8, 32 } },
+
+    // + 32bpp
+    // IN-MEMORY PIXEL LAYOUTS
+    //                  | Alpha First | Alpha Last
+    //                  +-------------+------------
+    // Conceptual Model | A R G B     | R G B A
+    //                  +-------------+------------
+    //                  | Stored As
+    //                  +-------------+------------
+    // Little Endian    | B G R A     | A B G R
+    // Big Endian       | A R G B     | R G B A
+    //                  +-------------+------------
+    //                    A = X where skipped.
+    // -+ Non-premultiplied alpha (not natively supported by D2D)
+    { GUID_WICPixelFormat32bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrder32Big), 8, 32 } },
+    { GUID_WICPixelFormat32bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaFirst | kCGBitmapByteOrder32Little), 8, 32 } },
+    // -+ Premultiplied alpha
+    { GUID_WICPixelFormat32bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big), 8, 32 } },
+    { GUID_WICPixelFormat32bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little), 8, 32 } },
+    // -+ Skipped alpha
+    { GUID_WICPixelFormat32bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNoneSkipLast | kCGBitmapByteOrder32Big), 8, 32 } },
+    { GUID_WICPixelFormat32bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Little), 8, 32 } },
+
+    // + 48bpp (CoreGraphics has limited support for these.)
+    // -+ No alpha
     { GUID_WICPixelFormat48bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 48 } },
     { GUID_WICPixelFormat48bppBGR, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 48 } },
+
+    // 64bpp (CoreGraphics has limited support for these.)
+    // -+ Non-premultiplied alpha (not natively supported by D2D)
+    { GUID_WICPixelFormat64bppRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
+    { GUID_WICPixelFormat64bppBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
+    // -+ Premultiplied alpha
+    { GUID_WICPixelFormat64bppPRGBA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 16, 64 } },
+    { GUID_WICPixelFormat64bppPBGRA, { kCGColorSpaceModelRGB, (kCGImageAlphaPremultipliedLast | kCGBitmapByteOrderDefault), 16, 64 } },
+    // -+ Skipped alpha
     { GUID_WICPixelFormat64bppRGB, { kCGColorSpaceModelRGB, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 64 } },
-    /*Alpha Only */
-    { GUID_WICPixelFormat8bppAlpha, { kCGColorSpaceModelRGB, (kCGImageAlphaOnly | kCGBitmapByteOrderDefault), 8, 32 } },
-    /* CYMK */
-    { GUID_WICPixelFormat32bppCMYK, { kCGColorSpaceModelCMYK, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 32 } },
-    { GUID_WICPixelFormat64bppCMYK, { kCGColorSpaceModelCMYK, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 64 } },
-    { GUID_WICPixelFormat40bppCMYKAlpha, { kCGColorSpaceModelCMYK, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 8, 40 } },
-    { GUID_WICPixelFormat80bppCMYKAlpha, { kCGColorSpaceModelCMYK, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 64 } },
-    /*Monochrome*/
+
+    // A formats
+    // + 8bpp
+    // -+ Alpha only
+    { GUID_WICPixelFormat8bppAlpha, { kCGColorSpaceModelMonochrome, (kCGImageAlphaOnly | kCGBitmapByteOrderDefault), 8, 8 } },
+
+    // G formats
+    // + 1bpp
+    { GUID_WICPixelFormatBlackWhite, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 1, 1 } },
+    // + 2bpp
+    { GUID_WICPixelFormat2bppGray, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 2, 2 } },
+    // + 4bpp
     { GUID_WICPixelFormat4bppGray, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 4, 4 } },
+    // + 8bpp
     { GUID_WICPixelFormat8bppGray, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 8 } },
+    // + 16bpp
     { GUID_WICPixelFormat16bppGray, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 16 } },
+    // + 32bpp (float)
     { GUID_WICPixelFormat32bppGrayFloat, { kCGColorSpaceModelMonochrome, (kCGImageAlphaNone | kCGBitmapFloatComponents), 32, 32 } },
-    /*Indexed*/
+
+    // CMYK formats
+    // + 32bpp
+    { GUID_WICPixelFormat32bppCMYK, { kCGColorSpaceModelCMYK, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 32 } },
+    // + 40bpp
+    { GUID_WICPixelFormat40bppCMYKAlpha, { kCGColorSpaceModelCMYK, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 8, 40 } },
+    // + 64bpp
+    { GUID_WICPixelFormat64bppCMYK, { kCGColorSpaceModelCMYK, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 16, 64 } },
+    // + 80bpp
+    { GUID_WICPixelFormat80bppCMYKAlpha, { kCGColorSpaceModelCMYK, (kCGImageAlphaLast | kCGBitmapByteOrderDefault), 16, 80 } },
+
+    // Indexed formats
+    // + 1bpp
     { GUID_WICPixelFormat1bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 1, 1 } },
+    // + 2bpp
     { GUID_WICPixelFormat2bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 2, 2 } },
+    // + 4bpp
     { GUID_WICPixelFormat4bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 4, 4 } },
+    // + 8bpp
     { GUID_WICPixelFormat8bppIndexed, { kCGColorSpaceModelIndexed, (kCGImageAlphaNone | kCGBitmapByteOrderDefault), 8, 8 } }
 };
 
@@ -130,10 +192,11 @@ COREGRAPHICS_EXPORT void* _CGImageGetRawBytes(CGImageRef image);
 // Obtain the associated DisplayTexture
 __declspec(dllexport) std::shared_ptr<IDisplayTexture> _CGImageGetDisplayTexture(CGImageRef image);
 
-REFGUID _CGImageGetWICPixelFormatFromImageProperties(unsigned int bitsPerComponent,
+HRESULT _CGImageGetWICPixelFormatFromImageProperties(unsigned int bitsPerComponent,
                                                      unsigned int bitsPerPixel,
                                                      CGColorSpaceRef colorSpace,
-                                                     CGBitmapInfo bitmapInfo);
+                                                     CGBitmapInfo bitmapInfo,
+                                                     GUID* pixelFormat);
 
 // If the image is of the same format, the image is retained and returned.
 COREGRAPHICS_EXPORT CGImageRef _CGImageCreateCopyWithPixelFormat(CGImageRef image, WICPixelFormatGUID pixelFormat);

--- a/tests/unittests/CoreGraphics/CGContextTests.mm
+++ b/tests/unittests/CoreGraphics/CGContextTests.mm
@@ -407,7 +407,7 @@ TEST(CGContext, DrawAnImageIntoContext) {
 
     // Create a canvas context
     woc::unique_cf<CGContextRef> context(CGBitmapContextCreate(
-        nullptr, 512, 256, 8, 4 * 512 /* bytesPerRow = bytesPerPixel*width*/, rgbColorSpace.get(), kCGImageAlphaPremultipliedFirst));
+        nullptr, 512, 256, 8, 4 * 512 /* bytesPerRow = bytesPerPixel*width*/, rgbColorSpace.get(), kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big));
 
     // Load an image from file
     CFDataRef data = (CFDataRef)[NSData dataWithContentsOfFile:getPathToFile(@"data/jpg1.jpg")];
@@ -453,7 +453,7 @@ TEST(CGContext, DrawAContextImageIntoAContext) {
 
     // This will be the pseudo canvas context which we will draw into
     woc::unique_cf<CGContextRef> context(CGBitmapContextCreate(
-        nullptr, 512, 256, 8, 4 * 512 /* bytesPerRow = bytesPerPixel*width*/, rgbColorSpace.get(), kCGImageAlphaPremultipliedFirst));
+        nullptr, 512, 256, 8, 4 * 512 /* bytesPerRow = bytesPerPixel*width*/, rgbColorSpace.get(), kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big));
 
     CGRect bounds = { 0, 0, 512, 256 };
 
@@ -475,8 +475,8 @@ TEST(CGContext, DrawAContextImageIntoAContext) {
 }
 
 TEST(CGContext, TextPositionShouldBeInMatrix) {
-    woc::unique_cf<CGColorSpaceRef> rgbColorSpace{ CGColorSpaceCreateDeviceRGB() };
-    woc::unique_cf<CGContextRef> context{ CGBitmapContextCreate(0, 1, 1, 8, 4, rgbColorSpace.get(), kCGImageAlphaOnly) };
+    woc::unique_cf<CGColorSpaceRef> grayColorSpace{ CGColorSpaceCreateDeviceGray() };
+    woc::unique_cf<CGContextRef> context{ CGBitmapContextCreate(0, 1, 1, 8, 1, grayColorSpace.get(), kCGImageAlphaOnly) };
     EXPECT_EQ(CGAffineTransformIdentity, CGContextGetTextMatrix(context.get()));
     EXPECT_EQ(CGPointMake(0, 0), CGContextGetTextPosition(context.get()));
     CGContextSetTextPosition(context.get(), 25, 50);

--- a/tests/unittests/ImageIO/ImageIOTest.mm
+++ b/tests/unittests/ImageIO/ImageIOTest.mm
@@ -357,7 +357,7 @@ TEST(ImageIO, BMP_ICO_PNG_SingleFrameSourceTest) {
     frameCount = CGImageSourceGetCount(imageSource);
     EXPECT_EQ(1, frameCount);
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRef));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRef));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRef));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRef));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRef));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
@@ -718,7 +718,7 @@ TEST(ImageIO, DestinationTest) {
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -799,7 +799,7 @@ TEST(ImageIO, DestinationTest) {
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaNoneSkipFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -861,7 +861,7 @@ TEST(ImageIO, DestinationFromSourceTest) {
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -942,7 +942,7 @@ TEST(ImageIO, DestinationFromSourceTest) {
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaNoneSkipFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -988,7 +988,7 @@ TEST(ImageIO, DestinationMultiFrameTest) {
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -998,7 +998,7 @@ TEST(ImageIO, DestinationMultiFrameTest) {
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -1008,7 +1008,7 @@ TEST(ImageIO, DestinationMultiFrameTest) {
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -1105,7 +1105,7 @@ TEST(ImageIO, DestinationDataTest) {
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRef)));
@@ -1145,7 +1145,7 @@ TEST(ImageIO, DestinationMultiFrameDataTest) {
     CGImageRef imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -1155,7 +1155,7 @@ TEST(ImageIO, DestinationMultiFrameDataTest) {
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 1, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));
@@ -1165,7 +1165,7 @@ TEST(ImageIO, DestinationMultiFrameDataTest) {
     imageRefOut = CGImageSourceCreateImageAtIndex(imageSource, 2, NULL);
     ASSERT_NE_MSG(nil, imageRefOut, "FAILED: ImageIOTest::CGImageSourceCreateImageAtIndex returned nullptr");
     EXPECT_EQ(kCGImageAlphaFirst, CGImageGetAlphaInfo(imageRefOut));
-    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Big, CGImageGetBitmapInfo(imageRefOut));
+    EXPECT_EQ(kCGImageAlphaFirst | kCGBitmapByteOrder32Little, CGImageGetBitmapInfo(imageRefOut));
     EXPECT_EQ(8, CGImageGetBitsPerComponent(imageRefOut));
     EXPECT_EQ(32, CGImageGetBitsPerPixel(imageRefOut));
     EXPECT_EQ(3, CGColorSpaceGetNumberOfComponents(CGImageGetColorSpace(imageRefOut)));


### PR DESCRIPTION
Fixes #1694.

This pull request fixes a few issues:
* Bitmap context creation (and image creation) never respected byte order.
* Our little/big endian pixel buffers were swapped.
* The bitmap context test didn't think alpha was premultiplied on the **skip** alpha formats. It turns out that it is!
* A few of our tests were relying on the "default" byte order with an RGBA fallback.
* The RGBA fallback would have led to memory corruption down the line.
* Our "default" endianness specifier was being ignored.
  * Now we make it match a WIC-appropriate endianness. Any consumers relying on "default" to be any particular format should not have been doing so. Including us!
* Some of our WIC->CG pixel formats _still_ had incorrect bpp values.
* It turns out that the reference platform will return a "Default" pixel format even though it never should. For 32bpp RGB, that means "ARGB".
* The format flips were backwards in the testing harness too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1748)
<!-- Reviewable:end -->
