### PR TITLE
Fixing WocCatalog test app layout issue in Controls view controller on phone and crash on iOS in TextDislayView Controller.

### DIFF
--- a/samples/WOCCatalog/WOCCatalog/ControlsViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/ControlsViewController.m
@@ -51,7 +51,7 @@ static const int MULTIPLEPRESENTDISMISS_ROW = 5;
 
     const CGFloat buttonHeight = 50;
     const CGFloat buttonWidth = 175;
-    const CGFloat originOffset = 25;
+    const CGFloat originOffset = 15;
 
     self.leftPopoverButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     self.leftPopoverButton.titleLabel.font = [UIFont systemFontOfSize:11];
@@ -63,7 +63,8 @@ static const int MULTIPLEPRESENTDISMISS_ROW = 5;
     self.rightPopoverButton = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     self.rightPopoverButton.titleLabel.font = [UIFont systemFontOfSize:11];
     [self.rightPopoverButton setTitle:@"Popover (up arrow direction)" forState:UIControlStateNormal];
-    [self.rightPopoverButton setFrame:CGRectMake(self.view.bounds.size.width - originOffset - buttonWidth, originOffset, buttonWidth, buttonHeight)];
+    [self.rightPopoverButton
+        setFrame:CGRectMake(self.view.bounds.size.width - originOffset - buttonWidth, originOffset, buttonWidth, buttonHeight)];
     [self.rightPopoverButton addTarget:self action:@selector(pressedPopoverButton:) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:self.rightPopoverButton];
 }
@@ -185,19 +186,28 @@ static const int MULTIPLEPRESENTDISMISS_ROW = 5;
         UIViewController* viewController = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
         viewController.modalPresentationStyle = UIModalPresentationFormSheet;
 
-        [self presentViewController:viewController animated:YES completion:^{
-            UIViewController* another = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
-            another.modalPresentationStyle = UIModalPresentationFormSheet;
-            [viewController presentViewController:another animated:YES completion:^{
-                UIViewController* yetAnother = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
-                yetAnother.modalPresentationStyle = UIModalPresentationFormSheet;
-                [another presentViewController:yetAnother animated:YES completion:^{
-                    // This should dismiss all children (only topmost should be dismissed with animation).
-                    [self dismissViewControllerAnimated:YES completion:^{
-                    }];
-                }];
-            }];
-        }];
+        [self presentViewController:viewController
+                           animated:YES
+                         completion:^{
+                             UIViewController* another = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
+                             another.modalPresentationStyle = UIModalPresentationFormSheet;
+                             [viewController presentViewController:another
+                                                          animated:YES
+                                                        completion:^{
+                                                            UIViewController* yetAnother = [[PopoverViewController alloc]
+                                                                initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
+                                                            yetAnother.modalPresentationStyle = UIModalPresentationFormSheet;
+                                                            [another presentViewController:yetAnother
+                                                                                  animated:YES
+                                                                                completion:^{
+                                                                                    // This should dismiss all children (only topmost should
+                                                                                    // be dismissed with animation).
+                                                                                    [self dismissViewControllerAnimated:YES
+                                                                                                             completion:^{
+                                                                                                             }];
+                                                                                }];
+                                                        }];
+                         }];
     }
 }
 

--- a/samples/WOCCatalog/WOCCatalog/TextDisplayViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/TextDisplayViewController.m
@@ -480,27 +480,32 @@ typedef enum { shapeRectangle, shapeTriangle } ShapeType;
     // font 1
     NSURL* url = [NSURL fileURLWithPath:@"C:/Windows/Fonts/gadugi.ttf"];
     bool result = CTFontManagerRegisterFontsForURL((__bridge CFURLRef)(url), kCTFontManagerScopeProcess, NULL);
-    UIFont* font = [UIFont fontWithName:@"Gadugi" size:22.0];
-    CTTypesetterRef typesetter =
-        CTTypesetterCreateWithAttributedString((__bridge CFAttributedStringRef)[self getAttributedStringForFont:font]);
-    CFRange range = { 0, 11 };
-    CTLineRef line = CTTypesetterCreateLineWithOffset(typesetter, range, 0.0f);
-    CTLineDraw(line, context);
-    CFRelease(typesetter);
-    CFRelease(line);
+    if (result) {
+        UIFont* font = [UIFont fontWithName:@"Gadugi" size:22.0];
+        CTTypesetterRef typesetter =
+            CTTypesetterCreateWithAttributedString((__bridge CFAttributedStringRef)[self getAttributedStringForFont:font]);
+        CFRange range = { 0, 11 };
+        CTLineRef line = CTTypesetterCreateLineWithOffset(typesetter, range, 0.0f);
+        CTLineDraw(line, context);
+        CFRelease(typesetter);
+        CFRelease(line);
+    }
 
     // font 2
     url = [NSURL fileURLWithPath:@"C:/Windows/Fonts/times.ttf"];
     result = CTFontManagerRegisterFontsForURL((__bridge CFURLRef)(url), kCTFontManagerScopeProcess, NULL);
-    font = [UIFont fontWithName:@"Times New Roman" size:22.0];
-    typesetter = CTTypesetterCreateWithAttributedString((__bridge CFAttributedStringRef)[self getAttributedStringForFont:font]);
-    range = CFRangeMake(0, 11);
-    line = CTTypesetterCreateLineWithOffset(typesetter, range, 0.0f);
-    CGContextSetTextPosition(context, 0.0, 25.0);
+    if (result) {
+        UIFont* font = [UIFont fontWithName:@"Times New Roman" size:22.0];
+        CTTypesetterRef typesetter =
+            CTTypesetterCreateWithAttributedString((__bridge CFAttributedStringRef)[self getAttributedStringForFont:font]);
+        CFRange range = CFRangeMake(0, 11);
+        CTLineRef line = CTTypesetterCreateLineWithOffset(typesetter, range, 0.0f);
+        CGContextSetTextPosition(context, 0.0, 25.0);
 
-    CTLineDraw(line, context);
-    CFRelease(typesetter);
-    CFRelease(line);
+        CTLineDraw(line, context);
+        CFRelease(typesetter);
+        CFRelease(line);
+    }
 }
 
 - (NSAttributedString*)getAttributedStringForFont:(UIFont*)font {


### PR DESCRIPTION
The two button lay out on phone is overlapped because the fixed margin that we set is too big on the phone which pushes two buttons toward the center and then they overlapped.

The crash only happen on iOS. It is because we didn't check the result (those two tests applies only on windows platform given the native font path used), which we used to do but got accidentally removed by earlier commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1773)
<!-- Reviewable:end -->
