### PR TITLE
Fix CT drawing tests on ARM

### DIFF
--- a/tests/UnitTests/CoreGraphics.drawing/DrawingTest.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/DrawingTest.cpp
@@ -123,7 +123,7 @@ void testing::DrawTest<TComparator>::TearDown() {
             if (delta.result == ImageComparisonResult::Incomparable) {
                 ADD_FAILURE() << "images are incomparable due to a mismatch in dimensions, presence, or byte length";
             } else {
-                ADD_FAILURE() << "images differ nontrivially";
+                ADD_FAILURE() << "images differ nontrivially with " << delta.differences << " registered differences";
             }
 
             woc::unique_cf<CFStringRef> deltaFilename{
@@ -205,9 +205,18 @@ void UIKitMimicTest<TComparator>::SetUpContext() {
 template class ::testing::DrawTest<>;
 template class WhiteBackgroundTest<>;
 template class UIKitMimicTest<>;
-template class ::testing::DrawTest<PixelByPixelImageComparator<ComparisonMode::Mask>>;
-template class WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>;
-template class UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>;
-template class ::testing::DrawTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>;
-template class WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>;
-template class UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<PixelComparisonModeMask<2300>>>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<PixelComparisonModeMask<1024>>>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<PixelComparisonModeMask<512>>>;
+template class ::testing::DrawTest<PixelByPixelImageComparator<PixelComparisonModeMask<64>>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<2300>>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<1024>>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<512>>>;
+template class WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<64>>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<2300>>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<1024>>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<512>>>;
+template class UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<64>>>;

--- a/tests/UnitTests/CoreGraphics.drawing/DrawingTest.h
+++ b/tests/UnitTests/CoreGraphics.drawing/DrawingTest.h
@@ -25,7 +25,7 @@
 // Due to how templates are compiled as needed, any new usage of templates needs to be "forced" in DrawingTest.cpp
 
 namespace testing {
-template <typename TComparator = PixelByPixelImageComparator<ComparisonMode::Exact>>
+template <typename TComparator = PixelByPixelImageComparator<>>
 class DrawTest : public ::testing::Test {
 private:
     woc::unique_cf<CGContextRef> _context;

--- a/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGTextDrawing.cpp
@@ -32,7 +32,7 @@ static void __SetFontForContext(CGContextRef context) {
     CGContextSetFontSize(context, 144);
 }
 
-TEXT_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
@@ -40,14 +40,14 @@ TEXT_DRAW_TEST_F(CGContext, ShowGlyphs, WhiteBackgroundTest<PixelByPixelImageCom
     CGContextShowGlyphs(context, glyphs.data(), glyphs.size());
 }
 
-TEXT_DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CGContext, ShowGlyphsAtPoint, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
     CGContextShowGlyphsAtPoint(context, 25, 50, glyphs.data(), glyphs.size());
 }
 
-TEXT_DRAW_TEST_F(CGContext, DrawWithRotatedTextMatrix, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CGContext, DrawWithRotatedTextMatrix, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     std::vector<CGGlyph> glyphs{ __CreateGlyphs() };
     __SetFontForContext(context);
@@ -68,7 +68,7 @@ static const CGAffineTransform c_transforms[] = { CGAffineTransformMakeRotation(
                                                   { 2, 2, 1.75, 2, 0, 0 },
                                                   CGAffineTransformIdentity };
 
-class CGTransform : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class CGTransform : public WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>,
                     public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
 TEXT_DRAW_TEST_P(CGTransform, TestMatrices) {
@@ -87,7 +87,7 @@ INSTANTIATE_TEST_CASE_P(TestDrawingTextWithTransformedMatrices,
                         CGTransform,
                         ::testing::Combine(::testing::ValuesIn(c_transforms), ::testing::ValuesIn(c_transforms)));
 
-class CGUIKitTransform : public UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class CGUIKitTransform : public UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>,
                          public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
 TEXT_DRAW_TEST_P(CGUIKitTransform, TestMatrices) {
@@ -109,7 +109,7 @@ INSTANTIATE_TEST_CASE_P(TestDrawingTextWithTransformedMatrices,
 // On reference platform, CGContextShowText* can only be used with CGContextSelectFont
 // Which we do not currently support.
 #ifdef WINOBJC
-TEXT_DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CGContext, ShowTextAtPoint, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     __SetFontForContext(context);
     CGContextShowTextAtPoint(context, 25, 50, "TEST", 4);

--- a/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CTDrawingTests.cpp
@@ -26,7 +26,7 @@ static NSURL* __GetURLFromPathRelativeToModuleDirectory(NSString* relativePath) 
 }
 #endif // WINOBJC
 
-TEXT_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -65,7 +65,7 @@ TEXT_DRAW_TEST_F(CTFrame, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImag
     CTFrameDraw(frame.get(), context);
 }
 
-TEXT_DRAW_TEST_F(CTFrame, BasicUIKitMimicDrawingTest, UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTFrame, BasicUIKitMimicDrawingTest, UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -104,7 +104,7 @@ TEXT_DRAW_TEST_F(CTFrame, BasicUIKitMimicDrawingTest, UIKitMimicTest<PixelByPixe
     CTFrameDraw(frame.get(), context);
 }
 
-TEXT_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -133,7 +133,7 @@ TEXT_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest<PixelByPixelImag
                                                              &kCFTypeDictionaryValueCallBacks) };
 
     woc::unique_cf<CFAttributedStringRef> attrString{
-        CFAttributedStringCreate(nullptr, CFSTR("он прошел այն անցավ ມັນຜ່ານໄປ ਇਸ ਨੂੰ ਪਾਸ ਕੀਤਾ 它通過了 그것이 통과했다 minęło"), dict.get())
+        CFAttributedStringCreate(nullptr, CFSTR("он прошел այն անցավ ມັນຜ່ານໄປ minęło"), dict.get())
     };
 
     woc::unique_cf<CTFramesetterRef> framesetter{ CTFramesetterCreateWithAttributedString(attrString.get()) };
@@ -145,7 +145,7 @@ TEXT_DRAW_TEST_F(CTFrame, BasicUnicodeTest, WhiteBackgroundTest<PixelByPixelImag
     CTFrameDraw(frame.get(), context);
 }
 
-class CTFrame : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class CTFrame : public WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>,
                 public ::testing::WithParamInterface<::testing::tuple<CTTextAlignment, CTLineBreakMode, CTWritingDirection, CGFloat>> {
     CFStringRef CreateOutputFilename() {
         CTTextAlignment alignment = ::testing::get<0>(GetParam());
@@ -237,7 +237,7 @@ INSTANTIATE_TEST_CASE_P(TestAlignmentLineBreakMode,
                                            ::testing::ValuesIn(c_writingDirections),
                                            ::testing::ValuesIn(c_fontSizes)));
 
-class Transform : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask, 1024>>,
+class Transform : public WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<1024>>>,
                   public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
 TEXT_DRAW_TEST_P(Transform, TestMatrices) {
@@ -292,7 +292,7 @@ INSTANTIATE_TEST_CASE_P(TestDrawingTextWithTransformedMatrices,
                         Transform,
                         ::testing::Combine(::testing::ValuesIn(c_transforms), ::testing::ValuesIn(c_transforms)));
 
-class UIKitTransform : public UIKitMimicTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class UIKitTransform : public UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>,
                        public ::testing::WithParamInterface<::testing::tuple<CGAffineTransform, CGAffineTransform>> {};
 
 TEXT_DRAW_TEST_P(UIKitTransform, TestMatrices) {
@@ -335,7 +335,7 @@ INSTANTIATE_TEST_CASE_P(TestDrawingUITransforms,
                         UIKitTransform,
                         ::testing::Combine(::testing::ValuesIn(c_transforms), ::testing::ValuesIn(c_transforms)));
 
-class ExtraKerning : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class ExtraKerning : public WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>,
                      public ::testing::WithParamInterface<CGFloat> {
     CFStringRef CreateOutputFilename() {
         CGFloat extraKerning = GetParam();
@@ -373,7 +373,7 @@ TEXT_DRAW_TEST_P(ExtraKerning, TestExtraKerning) {
 static constexpr CGFloat c_extraKernings[] = { -1.0, 1.0, 5.25, 25.75 };
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInExtraKerning, ExtraKerning, ::testing::ValuesIn(c_extraKernings));
 
-class LineHeightMultiple : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class LineHeightMultiple : public WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>,
                            public ::testing::WithParamInterface<CGFloat> {
     CFStringRef CreateOutputFilename() {
         CGFloat lineHeightMultiple = GetParam();
@@ -412,7 +412,7 @@ TEXT_DRAW_TEST_P(LineHeightMultiple, TestLineHeightMultiple) {
 static constexpr CGFloat c_lineHeightMultiples[] = { -1.0, .75, 1.25 };
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInLineHeightMultiple, LineHeightMultiple, ::testing::ValuesIn(c_lineHeightMultiples));
 
-TEXT_DRAW_TEST_F(CTRun, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTRun, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -440,7 +440,7 @@ TEXT_DRAW_TEST_F(CTRun, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageC
     CTLineDraw(line.get(), context);
 }
 
-TEXT_DRAW_TEST_F(CTLine, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTLine, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -470,7 +470,7 @@ TEXT_DRAW_TEST_F(CTLine, BasicDrawingTest, WhiteBackgroundTest<PixelByPixelImage
     CTRunDraw(run, context, {});
 }
 
-class Fonts : public WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>,
+class Fonts : public WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<2300>>>,
               public ::testing::WithParamInterface<CFStringRef> {
     CFStringRef CreateOutputFilename() {
         CFStringRef fontName = GetParam();
@@ -508,7 +508,7 @@ static CFStringRef c_fontNames[] = { CFSTR("Arial"), CFSTR("Times New Roman"), C
 INSTANTIATE_TEST_CASE_P(TestDrawingTextInFonts, Fonts, ::testing::ValuesIn(c_fontNames));
 
 #ifdef WINOBJC
-TEXT_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<512>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 
@@ -555,7 +555,7 @@ TEXT_DRAW_TEST_F(CTFontManager, DrawWithCustomFont, WhiteBackgroundTest<PixelByP
 }
 #endif // WINOBJC
 
-TEXT_DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest<PixelByPixelImageComparator<ComparisonMode::Mask>>) {
+TEXT_DRAW_TEST_F(CTFont, DrawGlyphs, WhiteBackgroundTest<PixelByPixelImageComparator<PixelComparisonModeMask<64>>>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
 

--- a/tests/unittests/CoreGraphics.drawing/ImageComparison.h
+++ b/tests/unittests/CoreGraphics.drawing/ImageComparison.h
@@ -21,7 +21,23 @@
 
 enum class ImageComparisonResult : unsigned int { Unknown = 0, Incomparable, Different, Same };
 
-enum struct ComparisonMode { Exact, Mask };
+struct rgbaPixel {
+    uint8_t r, g, b, a;
+};
+
+template <size_t FailureThreshold = 1>
+struct PixelComparisonModeExact {
+    static constexpr size_t Threshold = FailureThreshold;
+    template <typename LP, typename RP>
+    rgbaPixel ComparePixels(const LP& background, const LP& bp, const RP& cp, size_t& npxchg);
+};
+
+template <size_t FailureThreshold = 1>
+struct PixelComparisonModeMask {
+    static constexpr size_t Threshold = FailureThreshold;
+    template <typename LP, typename RP>
+    rgbaPixel ComparePixels(const LP& background, const LP& bp, const RP& cp, size_t& npxchg);
+};
 
 struct ImageDelta {
     ImageComparisonResult result;
@@ -41,7 +57,7 @@ public:
     virtual ImageDelta CompareImages(CGImageRef left, CGImageRef right) = 0;
 };
 
-template <ComparisonMode Mode = ComparisonMode::Exact, size_t FailureThreshold = 1>
+template <typename PixelComparisonMode = PixelComparisonModeExact<1>>
 class PixelByPixelImageComparator : public ImageComparator {
 public:
     ImageDelta CompareImages(CGImageRef left, CGImageRef right) override;

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CTFrame.BasicUnicodeTest.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CTFrame.BasicUnicodeTest.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b63a0fa546794e968c3f593ffd17646dbfe19bc7fe1074ab74ab41858cbd68c
-size 7974
+oid sha256:0a5cd002e98d0b48c570debe2cc1adbb610728d21a4de04db99b33fef88c1b6c
+size 4543


### PR DESCRIPTION
Changes more tests to be more lenient, and changes the templates for the image comparison to work with the Gtest macros
Fixes #1772

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1780)
<!-- Reviewable:end -->
