### PR TITLE
getNetworkConnectivityLevel can throw under some circumstances.  Handle

### DIFF
--- a/Frameworks/SystemConfiguration/SCNetworkReachability.mm
+++ b/Frameworks/SystemConfiguration/SCNetworkReachability.mm
@@ -146,7 +146,7 @@ static NSLock* _allReachabilityOperationsLock;
         } else {
             _globalReachableFlags = 0;
         }
-    } @catch (NSException* exception) {
+    } @catch (...) {
         _globalReachableFlags = 0;
     }
 }


### PR DESCRIPTION
these and treat the connection status as 'not connected'.

Fixes #1786

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1795)
<!-- Reviewable:end -->
