### PR TITLE
SC callbacks must by default happen on the main thread unless the app

### DIFF
--- a/Frameworks/SystemConfiguration/SCNetworkReachability.mm
+++ b/Frameworks/SystemConfiguration/SCNetworkReachability.mm
@@ -165,7 +165,7 @@ static NSLock* _allReachabilityOperationsLock;
         _runLoopsScheduled.attach([NSMutableDictionary new]);
         _reachabilityFlagsValid.attach([NSConditionLock new]);
         _weakRef.attach([[SCNetworkReachabilityWeakRef alloc] initWithObject:self]);
-        _callbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0);
+        _callbackQueue = dispatch_get_main_queue();
 
         // clang-format off
         CFRunLoopSourceContext ctxt{


### PR DESCRIPTION
specifies a different queue.  This fixes a crash in reachability sample.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1801)
<!-- Reviewable:end -->
