### PR TITLE
Make sure our touch/point conversion works in middleware (C#-hosted, …

### DIFF
--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -17,6 +17,7 @@
 #import <StubReturn.h>
 #import "Starboard.h"
 
+#import <UIKit/UIApplication.h>
 #import <UIKit/UIGraphics.h>
 #import <UIKit/UIImage.h>
 #import <UIKit/UIImageView.h>
@@ -39,6 +40,7 @@
 #import "UIWindowInternal.h"
 #import "UIViewControllerInternal.h"
 #import "UIGestureRecognizerInternal.h"
+#import "CACompositor.h"
 #import "CALayerInternal.h"
 #import "CAAnimationInternal.h"
 #import "CGContextInternal.h"
@@ -2299,6 +2301,13 @@ static float doRound(float f) {
     }
 
     if (!priv->superview) {
+        // This is probably safe to do in all cases, but for now, let's constrain 
+        // this to middleware scenarios.  We need to return a window in such cases
+        // so point/rect/etc. conversion works properly.
+        if (GetCACompositor()->IsRunningAsFramework()) {
+            return [[UIApplication sharedApplication] keyWindow];
+        }
+
         return nil;
     }
 


### PR DESCRIPTION
…etc.) scenarios.  Controls that are placed within arbitrary Xaml scenes don't have a superview chain up to a valid UIWindow, so touch point conversion is failing.  The fix is to - in middleware scenarios - use the app's main UIWindow for any UIView that doesn't have a superview.

Fixes #1818.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1821)
<!-- Reviewable:end -->
