### PR TITLE
Fix the upside-down UIImage drawing encountered in IslandwoodNews.

### DIFF
--- a/Frameworks/UIKit/UIImage.mm
+++ b/Frameworks/UIKit/UIImage.mm
@@ -494,11 +494,16 @@ static inline CGImageRef getImage(UIImage* uiImage) {
     pos.size.height = (img_width / _scale);
 
     srcRect.origin.x = 0;
-    srcRect.origin.y = img_height;
+    srcRect.origin.y = 0;
     srcRect.size.width = img_width;
-    srcRect.size.height = -img_height;
+    srcRect.size.height = img_height;
 
-    _CGContextDrawImageRect(cur, img, srcRect, pos);
+    // |1  0 0| is the transformation matrix for flipping a rect about its Y midpoint m. (m = (y + h/2))
+    // |0 -1 0|
+    // |0 2m 1|
+    CGContextConcatCTM(cur, CGAffineTransformMake(1, 0, 0, -1, 0, 2 * (pos.origin.y + (pos.size.height / 2))));
+
+    CGContextDrawImage(cur, pos, img);
 }
 
 /**
@@ -544,6 +549,11 @@ static inline void drawPatches(CGContextRef context, UIImage* img, CGRect* dst) 
     const float dstBotCap = img->_imageInsets.bottom;
     const float dstLeftCap = img->_imageInsets.left;
     const float dstRightCap = img->_imageInsets.right;
+
+    // |1  0 0| is the transformation matrix for flipping a rect about its Y midpoint m. (m = (y + h/2))
+    // |0 -1 0|
+    // |0 2m 1|
+    CGContextConcatCTM(context, CGAffineTransformMake(1, 0, 0, -1, 0, 2 * (dstY + (dstHeight / 2))));
 
     // Center strip
     if (dstHeight - dstTopCap - dstBotCap > 0) {


### PR DESCRIPTION
This pull request comprises two commits:
* One commit that fixes our upside-down image drawing. Cairo was taking a negative-height image to mean "draw upside-down", but D2D took that to mean "LOL everything is fine"...
    * On the reference platform, height -300 actually means "draw 300 points above the origin".
* One commit that reimplements _CGContextDrawImageRect, the workhorse for out 9patch image drawing code. This was validated independently.

Test 9patch image:
![test9patch](https://cloud.githubusercontent.com/assets/14316954/22358140/c7d2e990-e3f1-11e6-8353-01bb27ed9d2e.png)

UIImage rendering:
![image](https://cloud.githubusercontent.com/assets/14316954/22358150/d81ed048-e3f1-11e6-8837-2343f91edcfa.png)

Fixes #1827.