### PR TITLE
Fixing more UIKit memory leaks

### DIFF
--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -184,7 +184,7 @@ struct ButtonState {
     _contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
     _contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
 
-    __block UIButton* weakSelf = self;
+    __weak UIButton* weakSelf = self;
     XamlControls::HookButtonPointerEvents(_xamlButton,
                                           ^(RTObject* sender, WUXIPointerRoutedEventArgs* e) {
                                               // We mark the event as handled here. The method _processPointerPressedCallback

--- a/Frameworks/UIKit/XamlControls.mm
+++ b/Frameworks/UIKit/XamlControls.mm
@@ -27,7 +27,9 @@ namespace XamlControls {
 // Button
 ////////////////////////////////////////////////////////////////////////////////////
 WXCButton* CreateButton() {
-    ComPtr<IInspectable> inspectable(XamlCreateButton());
+    ComPtr<IInspectable> inspectable;
+    // Use Attach for transfer-ownership semantics, else we +1 and leak
+    inspectable.Attach(XamlCreateButton());
     return _createRtProxy([WXCButton class], inspectable.Get());
 }
 
@@ -53,7 +55,9 @@ void HookLayoutEvent(WXCButton* button, WUXIPointerEventHandler layoutHook) {
 // ContentDialog
 ////////////////////////////////////////////////////////////////////////////////////
 WXCContentDialog* CreateContentDialog() {
-    ComPtr<IInspectable> inspectable(XamlCreateContentDialog());
+    ComPtr<IInspectable> inspectable;
+    // Use Attach for transfer-ownership semantics, else we +1 and leak
+    inspectable.Attach(XamlCreateContentDialog());
     return _createRtProxy([WXCContentDialog class], inspectable.Get());
 }
 
@@ -95,7 +99,9 @@ void XamlContentDialogSetDestructiveButtonIndex(WXCContentDialog* contentDialog,
 // Label
 ////////////////////////////////////////////////////////////////////////////////////
 WXCGrid* CreateLabel() {
-    Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlCreateLabel());
+    Microsoft::WRL::ComPtr<IInspectable> inspectable;
+    // Use Attach for transfer-ownership semantics, else we +1 and leak
+    inspectable.Attach(XamlCreateLabel());
     return _createRtProxy([WXCGrid class], inspectable.Get());
 }
 

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -476,6 +476,7 @@ extern void UIActivityIndicatorViewGetXamlElement();
 
 extern void UIButtonCreateXamlElement();
 extern void UIButtonGetXamlElement();
+extern void UIButtonCheckForLeaks();
 extern void UIButtonTitleColorChanged();
 extern void UIButtonTextChanged();
 
@@ -604,6 +605,10 @@ public:
 
     TEST_METHOD(UIButton_GetXamlElement) {
         FrameworkHelper::RunOnUIThread(&UIButtonGetXamlElement);
+    }
+
+    TEST_METHOD(UIButton_CheckForLeaks) {
+        UIButtonCheckForLeaks();
     }
 
     TEST_METHOD(UIButton_TitleColorChanged) {


### PR DESCRIPTION
Fixing a leak in the Create* path for our UIKit.Xaml controls, and a leak in UIButton's use of 'weakSelf'.

Fixes #1858.
Fixes #1859 .