### PR TITLE
Fixing more UIKit memory leaks

### DIFF
--- a/Frameworks/UIKit.Xaml/Button.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Button.xaml.cpp
@@ -189,9 +189,9 @@ void Button::OnApplyTemplate() {
 ////////////////////////////////////////////////////////////////////////////////////
 // ObjectiveC Interop
 ////////////////////////////////////////////////////////////////////////////////////
-UIKIT_XAML_EXPORT IInspectable* XamlCreateButton() {
-    auto button = ref new UIKit::Xaml::Button();
-    return InspectableFromObject(button).Detach();
+UIKIT_XAML_EXPORT void XamlCreateButton(IInspectable** created) {
+    ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::Button());
+    *created = inspectable.Detach();
 }
 
 UIKIT_XAML_EXPORT void XamlRemovePointerEvents(const ComPtr<IInspectable>& inspectableButton) {

--- a/Frameworks/UIKit.Xaml/ContentDialog.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/ContentDialog.xaml.cpp
@@ -60,8 +60,9 @@ void ContentDialog::OnSelectionChanged(Platform::Object ^sender, SelectionChange
 // ObjectiveC Interop
 ////////////////////////////////////////////////////////////////////////////////////
 
-UIKIT_XAML_EXPORT IInspectable* XamlCreateContentDialog() {
-    return InspectableFromObject(ref new UIKit::Xaml::ContentDialog()).Detach();
+UIKIT_XAML_EXPORT void XamlCreateContentDialog(IInspectable** created) {
+    ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::ContentDialog());
+    *created = inspectable.Detach();
 }
 
 UIKIT_XAML_EXPORT int XamlContentDialogPressedIndex(const ComPtr<IInspectable>& inspectableContentDialog) {

--- a/Frameworks/UIKit.Xaml/Label.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Label.xaml.cpp
@@ -83,8 +83,9 @@ TextBlock^ Label::TextBlock::get() {
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::Label as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateLabel() {
-    return InspectableFromObject(ref new UIKit::Xaml::Label()).Detach();
+UIKIT_XAML_EXPORT void XamlCreateLabel(IInspectable** created) {
+    ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::Label());
+    *created = inspectable.Detach();
 }
 
 // Retrieves the UIKit::Label's backing TextBlock as an IInspectable

--- a/Frameworks/UIKit.Xaml/ObjCXamlControls.h
+++ b/Frameworks/UIKit.Xaml/ObjCXamlControls.h
@@ -29,7 +29,7 @@ enum ControlStates { ControlStateNormal = 0, ControlStateHighlighted = 1 << 0, C
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::Button as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateButton();
+UIKIT_XAML_EXPORT void XamlCreateButton(IInspectable** created);
 
 UIKIT_XAML_EXPORT void XamlButtonApplyVisuals(const Microsoft::WRL::ComPtr<IInspectable>& inspectableButton,
                                               const Microsoft::WRL::ComPtr<IInspectable>& inspectableText,
@@ -57,7 +57,7 @@ UIKIT_XAML_EXPORT void XamlRemoveLayoutEvent(const Microsoft::WRL::ComPtr<IInspe
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::Label as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateLabel();
+UIKIT_XAML_EXPORT void XamlCreateLabel(IInspectable** created);
 
 // Retrieves the UIKit::Label's backing TextBlock as an IInspectable
 UIKIT_XAML_EXPORT IInspectable* XamlGetLabelTextBox(const Microsoft::WRL::ComPtr<IInspectable>& label);
@@ -82,35 +82,35 @@ UIKIT_XAML_EXPORT IInspectable* XamlGetFrameworkElementSublayerCanvasProperty(co
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::ProgressRing as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateProgressRing();
+UIKIT_XAML_EXPORT void XamlCreateProgressRing(IInspectable** created);
 
 ////////////////////////////////////////////////////////////////////////////////////
 // ScrollViewer.xaml.cpp
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::ScrollViewer as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateScrollViewer();
+UIKIT_XAML_EXPORT void XamlCreateScrollViewer(IInspectable** created);
 
 ////////////////////////////////////////////////////////////////////////////////////
 // Slider.xaml.cpp
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::Slider as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateSlider();
+UIKIT_XAML_EXPORT void XamlCreateSlider(IInspectable** created);
 
 ////////////////////////////////////////////////////////////////////////////////////
 // TextBox.xaml.cpp
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::TextBox as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateTextBox();
+UIKIT_XAML_EXPORT void XamlCreateTextBox(IInspectable** created);
 
 ////////////////////////////////////////////////////////////////////////////////////
 // ContentDialog.xaml.cpp
 ////////////////////////////////////////////////////////////////////////////////////
 
 // Returns a UIKit::ContentDialog as an IInspectable
-UIKIT_XAML_EXPORT IInspectable* XamlCreateContentDialog();
+UIKIT_XAML_EXPORT void XamlCreateContentDialog(IInspectable** created);
 
 // Get the index of the button pressed
 UIKIT_XAML_EXPORT int XamlContentDialogPressedIndex(const Microsoft::WRL::ComPtr<IInspectable>& inspectableContentDialog);

--- a/Frameworks/UIKit.Xaml/ProgressRing.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/ProgressRing.xaml.cpp
@@ -31,8 +31,9 @@ ProgressRing::ProgressRing() {
 ////////////////////////////////////////////////////////////////////////////////////
 // ObjectiveC Interop
 ////////////////////////////////////////////////////////////////////////////////////
-UIKIT_XAML_EXPORT IInspectable* XamlCreateProgressRing() {
-    return InspectableFromObject(ref new UIKit::Xaml::ProgressRing()).Detach();
+UIKIT_XAML_EXPORT void XamlCreateProgressRing(IInspectable** created) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::ProgressRing());
+    *created = inspectable.Detach();
 }
 
 // clang-format on

--- a/Frameworks/UIKit.Xaml/ScrollViewer.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/ScrollViewer.xaml.cpp
@@ -31,8 +31,9 @@ ScrollViewer::ScrollViewer() {
 ////////////////////////////////////////////////////////////////////////////////////
 // ObjectiveC Interop
 ////////////////////////////////////////////////////////////////////////////////////
-UIKIT_XAML_EXPORT IInspectable* XamlCreateScrollViewer() {
-    return InspectableFromObject(ref new UIKit::Xaml::ScrollViewer()).Detach();
+UIKIT_XAML_EXPORT void XamlCreateScrollViewer(IInspectable** created) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::ScrollViewer());
+    *created = inspectable.Detach();
 }
 
 // clang-format on

--- a/Frameworks/UIKit.Xaml/Slider.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Slider.xaml.cpp
@@ -36,8 +36,9 @@ void Slider::OnApplyTemplate() {
 ////////////////////////////////////////////////////////////////////////////////////
 // ObjectiveC Interop
 ////////////////////////////////////////////////////////////////////////////////////
-UIKIT_XAML_EXPORT IInspectable* XamlCreateSlider() {
-    return InspectableFromObject(ref new UIKit::Xaml::Slider()).Detach();
+UIKIT_XAML_EXPORT void XamlCreateSlider(IInspectable** created) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::Slider());
+    *created = inspectable.Detach();
 }
 
 // clang-format on

--- a/Frameworks/UIKit.Xaml/TextBox.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/TextBox.xaml.cpp
@@ -36,8 +36,9 @@ void TextBox::OnApplyTemplate() {
 ////////////////////////////////////////////////////////////////////////////////////
 // ObjectiveC Interop
 ////////////////////////////////////////////////////////////////////////////////////
-UIKIT_XAML_EXPORT IInspectable* XamlCreateTextBox() {
-    return InspectableFromObject(ref new UIKit::Xaml::TextBox()).Detach();
+UIKIT_XAML_EXPORT void XamlCreateTextBox(IInspectable** created) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::TextBox());
+    *created = inspectable.Detach();
 }
 
 // clang-format on

--- a/Frameworks/UIKit/UIButton.mm
+++ b/Frameworks/UIKit/UIButton.mm
@@ -184,7 +184,7 @@ struct ButtonState {
     _contentVerticalAlignment = UIControlContentVerticalAlignmentCenter;
     _contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
 
-    __block UIButton* weakSelf = self;
+    __weak UIButton* weakSelf = self;
     XamlControls::HookButtonPointerEvents(_xamlButton,
                                           ^(RTObject* sender, WUXIPointerRoutedEventArgs* e) {
                                               // We mark the event as handled here. The method _processPointerPressedCallback

--- a/Frameworks/UIKit/XamlControls.mm
+++ b/Frameworks/UIKit/XamlControls.mm
@@ -27,7 +27,9 @@ namespace XamlControls {
 // Button
 ////////////////////////////////////////////////////////////////////////////////////
 WXCButton* CreateButton() {
-    ComPtr<IInspectable> inspectable(XamlCreateButton());
+    ComPtr<IInspectable> inspectable;
+    // Use Attach for transfer-ownership semantics, else we +1 and leak
+    inspectable.Attach(XamlCreateButton());
     return _createRtProxy([WXCButton class], inspectable.Get());
 }
 
@@ -53,7 +55,9 @@ void HookLayoutEvent(WXCButton* button, WUXIPointerEventHandler layoutHook) {
 // ContentDialog
 ////////////////////////////////////////////////////////////////////////////////////
 WXCContentDialog* CreateContentDialog() {
-    ComPtr<IInspectable> inspectable(XamlCreateContentDialog());
+    ComPtr<IInspectable> inspectable;
+    // Use Attach for transfer-ownership semantics, else we +1 and leak
+    inspectable.Attach(XamlCreateContentDialog());
     return _createRtProxy([WXCContentDialog class], inspectable.Get());
 }
 
@@ -95,7 +99,9 @@ void XamlContentDialogSetDestructiveButtonIndex(WXCContentDialog* contentDialog,
 // Label
 ////////////////////////////////////////////////////////////////////////////////////
 WXCGrid* CreateLabel() {
-    Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlCreateLabel());
+    Microsoft::WRL::ComPtr<IInspectable> inspectable;
+    // Use Attach for transfer-ownership semantics, else we +1 and leak
+    inspectable.Attach(XamlCreateLabel());
     return _createRtProxy([WXCGrid class], inspectable.Get());
 }
 

--- a/Frameworks/UIKit/XamlControls.mm
+++ b/Frameworks/UIKit/XamlControls.mm
@@ -28,8 +28,7 @@ namespace XamlControls {
 ////////////////////////////////////////////////////////////////////////////////////
 WXCButton* CreateButton() {
     ComPtr<IInspectable> inspectable;
-    // Use Attach for transfer-ownership semantics, else we +1 and leak
-    inspectable.Attach(XamlCreateButton());
+    XamlCreateButton(&inspectable);
     return _createRtProxy([WXCButton class], inspectable.Get());
 }
 
@@ -56,8 +55,7 @@ void HookLayoutEvent(WXCButton* button, WUXIPointerEventHandler layoutHook) {
 ////////////////////////////////////////////////////////////////////////////////////
 WXCContentDialog* CreateContentDialog() {
     ComPtr<IInspectable> inspectable;
-    // Use Attach for transfer-ownership semantics, else we +1 and leak
-    inspectable.Attach(XamlCreateContentDialog());
+    XamlCreateContentDialog(&inspectable);
     return _createRtProxy([WXCContentDialog class], inspectable.Get());
 }
 
@@ -100,8 +98,7 @@ void XamlContentDialogSetDestructiveButtonIndex(WXCContentDialog* contentDialog,
 ////////////////////////////////////////////////////////////////////////////////////
 WXCGrid* CreateLabel() {
     Microsoft::WRL::ComPtr<IInspectable> inspectable;
-    // Use Attach for transfer-ownership semantics, else we +1 and leak
-    inspectable.Attach(XamlCreateLabel());
+    XamlCreateLabel(&inspectable);
     return _createRtProxy([WXCGrid class], inspectable.Get());
 }
 

--- a/tests/functionaltests/FunctionalTests.cpp
+++ b/tests/functionaltests/FunctionalTests.cpp
@@ -476,6 +476,7 @@ extern void UIActivityIndicatorViewGetXamlElement();
 
 extern void UIButtonCreateXamlElement();
 extern void UIButtonGetXamlElement();
+extern void UIButtonCheckForLeaks();
 extern void UIButtonTitleColorChanged();
 extern void UIButtonTextChanged();
 
@@ -604,6 +605,10 @@ public:
 
     TEST_METHOD(UIButton_GetXamlElement) {
         FrameworkHelper::RunOnUIThread(&UIButtonGetXamlElement);
+    }
+
+    TEST_METHOD(UIButton_CheckForLeaks) {
+        UIButtonCheckForLeaks();
     }
 
     TEST_METHOD(UIButton_TitleColorChanged) {

--- a/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
@@ -32,7 +32,8 @@
 
 TEST(UIActionSheet, CreateXamlElement) {
     // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateContentDialog());
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    XamlCreateContentDialog(&xamlElement);
     ASSERT_TRUE(xamlElement);
 }
 

--- a/tests/functionaltests/Tests/UIKitTests/UIActivityIndicatorTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIActivityIndicatorTests.mm
@@ -32,7 +32,8 @@
 
 TEST(UIActivityIndicatorView, CreateXamlElement) {
     // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateProgressRing());
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    XamlCreateProgressRing(&xamlElement);
     ASSERT_TRUE(xamlElement);
 }
 

--- a/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
@@ -58,7 +58,8 @@ TEST(UIButton, GetXamlElement) {
 TEST(UIButton, CheckForLeaks) {
     Microsoft::WRL::WeakRef weakXamlElement;
     {
-        __block UIButtonWithControlsViewController* buttonVC = [[UIButtonWithControlsViewController alloc] init];
+        StrongId<UIButtonWithControlsViewController> buttonVC;
+        buttonVC.attach([[UIButtonWithControlsViewController alloc] init]);
         UXTestAPI::ViewControllerPresenter testHelper(buttonVC);
 
         __block UIDeallocTestButton* testButton = nil;
@@ -69,7 +70,7 @@ TEST(UIButton, CheckForLeaks) {
             testButton = [[UIDeallocTestButton alloc] initWithFrame:CGRectMake(100, 100, 100, 100)];
             testButton.backgroundColor = [UIColor redColor];
             [testButton setDeallocEvent:event];
-            [buttonVC.view addSubview:testButton];
+            [[buttonVC view] addSubview:testButton];
         });
 
         // Grab a weak reference to the backing Xaml element

--- a/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
@@ -25,7 +25,8 @@ using namespace UXTestAPI;
 
 TEST(UIButton, CreateXamlElement) {
     // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateButton());
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    XamlCreateButton(&xamlElement);
     ASSERT_TRUE(xamlElement);
 }
 

--- a/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
@@ -89,6 +89,9 @@ TEST(UIButton, CheckForLeaks) {
         ASSERT_TRUE_MSG(event->Wait(c_testTimeoutInSec), "FAILED: Waiting for dealloc call failed!");
     }
 
+    // Unfortunately we have to wait a bit for the button to actually finish deallocation
+    [NSThread sleepForTimeInterval:.25];
+
     // Validate that we can no longer acquire a strong reference to the UIButton's backing Xaml element
     Microsoft::WRL::ComPtr<IInspectable> xamlElement;
     weakXamlElement.As(&xamlElement);

--- a/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIButtonTests.mm
@@ -38,6 +38,72 @@ TEST(UIButton, GetXamlElement) {
     ASSERT_TRUE([backingElement isKindOfClass:[WXFrameworkElement class]]);
 }
 
+@interface UIDeallocTestButton : UIButton {
+    NSCondition* _condition;
+    BOOL* _signaled;
+}
+@end
+
+@implementation UIDeallocTestButton
+
+- (void)setDeallocEvent:(NSCondition*)condition signaledFlag:(BOOL*)signaled {
+    _condition = condition;
+    _signaled = signaled;
+}
+
+-(void)dealloc {
+    [_condition lock];
+    *_signaled = YES;
+    [_condition signal];
+    [_condition unlock];
+    [super dealloc];
+}
+@end
+
+TEST(UIButton, CheckForLeaks) {
+    Microsoft::WRL::WeakRef weakXamlElement;
+    {
+        __block UIButtonWithControlsViewController* buttonVC = [[UIButtonWithControlsViewController alloc] init];
+        UXTestAPI::ViewControllerPresenter testHelper(buttonVC);
+
+        __block UIDeallocTestButton* testButton = nil;
+        __block BOOL signaled = NO;
+        __block NSCondition* condition = [[NSCondition alloc] init];
+
+        // Create and render the button
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            testButton = [[UIDeallocTestButton alloc] initWithFrame:CGRectMake(100, 100, 100, 100)];
+            testButton.backgroundColor = [UIColor redColor];
+            [testButton setDeallocEvent:condition signaledFlag:&signaled];
+            [buttonVC.view addSubview:testButton];
+        });
+
+        // Grab a weak reference to the backing Xaml element
+        Microsoft::WRL::ComPtr<IInspectable> xamlElement([[testButton xamlElement] comObj]);
+        ASSERT_TRUE_MSG(SUCCEEDED(xamlElement.AsWeak(&weakXamlElement)), "Failed to acquire a weak reference to the backing Xaml element.");
+        xamlElement = nullptr;
+
+        // Free the button
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // Nil out testButton and remove it from its superview
+            [testButton removeFromSuperview];
+            [testButton release];
+            testButton = nil;
+        });
+
+        // Validate that dealloc was called
+        [condition lock];
+        ASSERT_TRUE_MSG(signaled || [condition waitUntilDate:[NSDate dateWithTimeIntervalSinceNow:c_testTimeoutInSec]],
+                        "FAILED: Waiting for dealloc call failed!");
+        [condition unlock];
+    }
+
+    // Validate that we can no longer acquire a strong reference to the UIButton's backing Xaml element
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    weakXamlElement.As(&xamlElement);
+    ASSERT_EQ_MSG(xamlElement.Get(), nullptr, "Unexpectedly able to reacquire a strong reference to the backing Xaml element.");
+}
+
 TEST(UIButton, TitleColorChanged) {
     __block auto uxEvent = UXEvent::CreateManual();
     __block auto xamlSubscriber = std::make_shared<XamlEventSubscription>();

--- a/tests/functionaltests/Tests/UIKitTests/UIScrollViewTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIScrollViewTests.mm
@@ -32,7 +32,8 @@
 
 TEST(UIScrollView, CreateXamlElement) {
     // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateScrollViewer());
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    XamlCreateScrollViewer(&xamlElement);
     ASSERT_TRUE(xamlElement);
 }
 

--- a/tests/functionaltests/Tests/UIKitTests/UISliderTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UISliderTests.mm
@@ -32,7 +32,8 @@
 
 TEST(UISlider, CreateXamlElement) {
     // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateSlider());
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    XamlCreateSlider(&xamlElement);
     ASSERT_TRUE(xamlElement);
 }
 

--- a/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
@@ -32,7 +32,8 @@
 
 TEST(UITextField, CreateXamlElement) {
     // TODO: Switch to UIKit.Xaml projections when they're available.
-    Microsoft::WRL::ComPtr<IInspectable> xamlElement(XamlCreateTextBox());
+    Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+    XamlCreateTextBox(&xamlElement);
     ASSERT_TRUE(xamlElement);
 }
 


### PR DESCRIPTION
Oops; accidentally deleted the branch; re-submitting PR.  

Fixing a leak in the Create* path for our UIKit.Xaml controls, and a leak in UIButton's use of 'weakSelf'.

Fixes #1858.
Fixes #1859 .