### PR TITLE
Fix starting position of arc in bezierPathWithArcCenter

### DIFF
--- a/Frameworks/UIKit/UIBezierPath.mm
+++ b/Frameworks/UIKit/UIBezierPath.mm
@@ -128,6 +128,9 @@ CGAffineTransform* getTransform(UIBezierPath* path) {
                               clockwise:(BOOL)clockwise {
     UIBezierPath* ret = [self new];
 
+    // Path needs to move to the actual start of the arc location otherwise CGPathAddArc will draw a line to this
+    // start point instead.
+    CGPathMoveToPoint(ret->_path, NULL, center.x + cos(startAngle) * radius, center.y + sin(startAngle) * radius);
     CGPathAddArc(ret->_path, NULL, center.x, center.y, radius, startAngle, endAngle, clockwise == FALSE);
 
     return [ret autorelease];


### PR DESCRIPTION
The arc API in CoreGraphics will add a line to the start point if the current point is not already there. Thus we were getting the line from the origin point to the start location of the arc before creating the rest of the shape.

Fixes #1828 