### PR TITLE
Use _CGContextPushBegin/PopEndDraw for Drawing Tests

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -2126,11 +2126,11 @@ void CGContextClearRect(CGContextRef context, CGRect rect) {
     NOISY_RETURN_IF_NULL(context);
     ComPtr<ID2D1DeviceContext> deviceContext = context->DeviceContext();
     if (!context->CurrentGState().clippingGeometry) {
-        deviceContext->BeginDraw();
+        _CGContextPushBeginDraw(context);
         deviceContext->PushAxisAlignedClip(__CGRectToD2D_F(rect), D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
         deviceContext->Clear(nullptr); // transparent black clear
         deviceContext->PopAxisAlignedClip();
-        deviceContext->EndDraw();
+        _CGContextPopEndDraw(context);
     }
 }
 
@@ -2830,7 +2830,8 @@ CGContextRef CGBitmapContextCreate(void* data,
 
 /**
  @Status Caveat
- @Notes If data is provided, it can only be in one of the few pixel formats Direct2D can render to in system memory: (P)RGBA, (P)BGRA, or Alpha8. If a buffer is
+ @Notes If data is provided, it can only be in one of the few pixel formats Direct2D can render to in system memory: (P)RGBA, (P)BGRA, or
+ Alpha8. If a buffer is
         provided for a grayscale image, render operations will be carried out into an Alpha8 buffer instead.
         Luminance values will be discarded in favour of alpha values.
 */

--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -2830,9 +2830,9 @@ CGContextRef CGBitmapContextCreate(void* data,
 
 /**
  @Status Caveat
- @Notes If data is provided, it can only be in one of the few pixel formats Direct2D can render to in system memory: (P)RGBA, (P)BGRA, or
- Alpha8. If a buffer is
-        provided for a grayscale image, render operations will be carried out into an Alpha8 buffer instead.
+ @Notes If data is provided, it can only be in one of the few pixel formats Direct2D can render to in system memory:
+        (P)RGBA, (P)BGRA, or Alpha8.
+        If a buffer is provided for a grayscale image, render operations will be carried out into an Alpha8 buffer instead.
         Luminance values will be discarded in favour of alpha values.
 */
 CGContextRef CGBitmapContextCreateWithData(void* data,


### PR DESCRIPTION
 - Since we generally expect real use-cases to use these functions for perf purposes,
   we should also validate that our drawing is correct when using them.
 - Fixed a stray raw ->BeginDraw() ->EndDraw() in CGContext.mm that was missed
   and could cause crashes if used under PushBegin/PopEndDraw

Fixes #1869