### PR TITLE
Fix leak calling [NSThread currentThread] when underlying thread created outside NSThread API

### DIFF
--- a/Frameworks/Foundation/NSThread.mm
+++ b/Frameworks/Foundation/NSThread.mm
@@ -363,7 +363,7 @@ static void* _threadBody(void* context) {
 @Status Interoperable
 */
 - (NSString*)name {
-    return _name;
+    return [[_name retain] autorelease];
 }
 
 /**

--- a/Frameworks/Foundation/NSThread.mm
+++ b/Frameworks/Foundation/NSThread.mm
@@ -37,7 +37,7 @@ static StrongId<NSThread> s_mainThread;
 static BOOL s_isMultiThreaded = NO;
 
 static NSThread* setOrGetCurrentThread(NSThread* thread) {
-    // Use a lazy initialized block scope thread_local to manage the liftime of currentThread.
+    // Use a lazy initialized block scope thread_local to manage the lifetime of currentThread.
     // Note that non-trivial file scope thread_locals are apparently not supported in current clang version.
     thread_local static StrongId<NSThread> tlsCurrentThread;
 
@@ -276,7 +276,7 @@ the default thread priority. Utilizes win32 thread priority.
 }
 
 static void* threadBody(void* context) {
-    NSThread* self = reinterpret_cast<NSThread*>(context);
+    NSThread* self = static_cast<NSThread*>(context);
 
     // Let current thread mechanism assume ownership.
     setCurrentThread(self);
@@ -320,7 +320,7 @@ static void* threadBody(void* context) {
     // Stay alive while underlying thread of execution starts.
     [self retain];
 
-    pthread_create(&_pthread, &attrs, threadBody, reinterpret_cast<void*>(self));
+    pthread_create(&_pthread, &attrs, threadBody, self);
 }
 
 /**


### PR DESCRIPTION
This is an alternative for the naive leak fix in #1834 (which introduces a use after free).

I took a look at supporting the cdecl destructor argument of pthread_key_create but it looks like any fixes there would complicate the implementation of pthread_setspecific/pthread_getspecific. So this commit just calls the Fls functions directly from NSThread.