### PR TITLE
Firing UIScrollView's scrollViewDidScroll: delegate call from within …

### DIFF
--- a/Frameworks/UIKit/UIScrollView.mm
+++ b/Frameworks/UIKit/UIScrollView.mm
@@ -894,7 +894,11 @@ static void clipPoint(UIScrollView* o, CGPoint& p, bool bounce = true) {
     [self setNeedsLayout];
 
     if ([self.delegate respondsToSelector:@selector(scrollViewDidScroll:)]) {
-        [self.delegate scrollViewDidScroll:self];
+        // NOTE: We have to push this off of the ScrollViewer's callback thread to work around
+        // issue #1865.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.delegate scrollViewDidScroll:self];
+        });
     }
 }
 


### PR DESCRIPTION
…Xaml ScrollViewer's ScrollViewerViewChanged event leads to an AV in Xaml if the delegate removes the UIScrollView from the Xaml UIElement tree.  To work around the issue, push the delegate call to a subsequent run of the UI thread.

Fixes #1865.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1877)
<!-- Reviewable:end -->
