### PR TITLE
Fix the Accelerate page in WOCCatalog to not depend on RGBA buffers.

### DIFF
--- a/Frameworks/Accelerate/vImage.mm
+++ b/Frameworks/Accelerate/vImage.mm
@@ -173,49 +173,33 @@ CGImageRef vImageCreateCGImageFromBuffer(vImage_Buffer* buffer,
         packedBufferAllocated = false;
     }
 
-    CGImageRef imageRef;
-
-    if ((flags & kvImageNoAllocate) != 0) {
-        const size_t bufferSize = packedWidthInBytes * buffer->height;
+    if ((flags & kvImageNoAllocate) != 0) { // Client is self-allocating buffer.
         if (packedBufferAllocated) {
             TraceWarning(TAG,
                          L"kvImageNoAllocate flag ignored since padded buffer passed in. Packed buffer allocated and used since padded "
                          L"buffers can't be used in CGImage.");
         }
+    }
 
-        NSData* data = [NSData dataWithBytesNoCopy:packedBuffer length:bufferSize freeWhenDone:YES];
+    const size_t bufferSize = packedWidthInBytes * buffer->height;
+    CGDataProviderRef dataProvider = CGDataProviderCreateWithData(nullptr, packedBuffer, bufferSize, nullptr);
 
-        CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((CFDataRef)data);
+    CGImageRef imageRef = CGImageCreate((size_t)buffer->width,
+                                        (size_t)buffer->height,
+                                        (size_t)format->bitsPerComponent,
+                                        (size_t)format->bitsPerPixel,
+                                        (size_t)packedWidthInBytes,
+                                        format->colorSpace,
+                                        format->bitmapInfo,
+                                        dataProvider,
+                                        NULL,
+                                        false,
+                                        format->renderingIntent);
 
-        imageRef = CGImageCreate((size_t)buffer->width,
-                                 (size_t)buffer->height,
-                                 (size_t)format->bitsPerComponent,
-                                 (size_t)format->bitsPerPixel,
-                                 (size_t)packedWidthInBytes,
-                                 format->colorSpace,
-                                 format->bitmapInfo,
-                                 dataProvider,
-                                 NULL,
-                                 false,
-                                 format->renderingIntent);
+    CGDataProviderRelease(dataProvider);
 
-        CGDataProviderRelease(dataProvider);
-    } else {
-        CGContextRef ctx = CGBitmapContextCreate(packedBuffer,
-                                                 (size_t)buffer->width,
-                                                 (size_t)buffer->height,
-                                                 (size_t)format->bitsPerComponent,
-                                                 packedWidthInBytes,
-                                                 format->colorSpace,
-                                                 format->bitmapInfo);
-
-        imageRef = CGBitmapContextCreateImage(ctx);
-
-        CGContextRelease(ctx);
-
-        if (packedBufferAllocated == true) {
-            IwFree(packedBuffer);
-        }
+    if (packedBufferAllocated == true) {
+        IwFree(packedBuffer);
     }
 
     if (imageRef == nullptr) {

--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -2982,8 +2982,14 @@ CGImageRef CGBitmapContextCreateImage(CGContextRef context) {
         return nullptr;
     }
 
-    // This copy is a no-op if the output format requested matches the backing image format.
     __CGBitmapContext* bitmapContext = (__CGBitmapContext*)context;
+    // If the bitmap context was provided with its own data buffer, *we must not share it*
+    // because the caller may free it at any time.
+    if (bitmapContext->_data) {
+        return CGImageCreateCopy(bitmapContext->_image);
+    }
+
+    // This copy is a no-op if the output format requested matches the backing image format.
     return _CGImageCreateCopyWithPixelFormat(bitmapContext->_image.get(), bitmapContext->GetOutputPixelFormat());
 }
 

--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -733,7 +733,7 @@ HRESULT _CGImageGetWICPixelFormatFromImageProperties(
 
         { CG_FORMAT_KEY(kCGColorSpaceModelRGB       , 32, kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst     ), GUID_WICPixelFormat32bppBGR       },
         { CG_FORMAT_KEY(kCGColorSpaceModelRGB       , 32, kCGBitmapByteOrder32Little, kCGImageAlphaPremultipliedFirst), GUID_WICPixelFormat32bppPBGRA     },
-        { CG_FORMAT_KEY(kCGColorSpaceModelRGB       , 32, kCGBitmapByteOrder32Little, kCGImageAlphaFirst             ), GUID_WICPixelFormat32bppRGBA      },
+        { CG_FORMAT_KEY(kCGColorSpaceModelRGB       , 32, kCGBitmapByteOrder32Little, kCGImageAlphaFirst             ), GUID_WICPixelFormat32bppBGRA      },
 
         { CG_FORMAT_KEY(kCGColorSpaceModelRGB       , 32, kCGBitmapByteOrder32Big,    kCGImageAlphaNoneSkipLast      ), GUID_WICPixelFormat32bppRGB       },
         { CG_FORMAT_KEY(kCGColorSpaceModelRGB       , 32, kCGBitmapByteOrder32Big,    kCGImageAlphaPremultipliedLast ), GUID_WICPixelFormat32bppPRGBA     },

--- a/Frameworks/UIKit/UIImage.mm
+++ b/Frameworks/UIKit/UIImage.mm
@@ -487,16 +487,10 @@ static inline CGImageRef getImage(UIImage* uiImage) {
     float img_height = CGImageGetHeight(img);
     float img_width = CGImageGetWidth(img);
 
-    CGRect srcRect;
     CGRect pos;
     pos.origin = point;
     pos.size.width = (img_height / _scale);
     pos.size.height = (img_width / _scale);
-
-    srcRect.origin.x = 0;
-    srcRect.origin.y = 0;
-    srcRect.size.width = img_width;
-    srcRect.size.height = img_height;
 
     // |1  0 0| is the transformation matrix for flipping a rect about its Y midpoint m. (m = (y + h/2))
     // |0 -1 0|

--- a/samples/WOCCatalog/WOCCatalog/AccelerateViewController2.m
+++ b/samples/WOCCatalog/WOCCatalog/AccelerateViewController2.m
@@ -56,32 +56,50 @@
     // Use the byteorder and alpha info of the input image to get the byte index of each component
     // Note: vImage uses little endian notation for byte order as opposed to CoreGraphics which uses big endian or networkByte order
     // notation
-    if (byteOrder == kCGBitmapByteOrder32Big) {
-        // XBGR_le or BGRX_le
-        if (alphaInfo == kCGImageAlphaLast || alphaInfo == kCGImageAlphaNoneSkipLast) {
-            indexA = 0;
-            indexB = 1;
-            indexG = 2;
+    // Unlike the example from AccelerateViewController(1), we must flip the orders of the channels before we push them into
+    // vImage_Convert.
+    switch (byteOrder) {
+    case kCGBitmapByteOrder32Little: // ABGR or BGRA
+        switch (alphaInfo) {
+        case kCGImageAlphaLast:
+        case kCGImageAlphaPremultipliedLast:
+        case kCGImageAlphaNoneSkipLast:
             indexR = 3;
-        } else {
-            indexB = 0;
-            indexG = 1;
+            indexG = 2;
+            indexB = 1;
+            indexA = 0;
+            break;
+        case kCGImageAlphaFirst:
+        case kCGImageAlphaPremultipliedFirst:
+        case kCGImageAlphaNoneSkipFirst:
             indexR = 2;
+            indexG = 1;
+            indexB = 0;
             indexA = 3;
+            break;
         }
-    } else {
-        // RGBX_le or XRGB_le
-        if (alphaInfo == kCGImageAlphaLast || alphaInfo == kCGImageAlphaNoneSkipLast) {
+        break;
+    case kCGBitmapByteOrder32Big: // RGBA or ARGB
+    case kCGBitmapByteOrderDefault: // On the reference platform, "default" for a 32bpp image is RGBA or ARGB. WinObjC will never return Default.
+        switch (alphaInfo) {
+        case kCGImageAlphaLast:
+        case kCGImageAlphaPremultipliedLast:
+        case kCGImageAlphaNoneSkipLast:
             indexR = 0;
             indexG = 1;
             indexB = 2;
             indexA = 3;
-        } else {
-            indexA = 0;
+            break;
+        case kCGImageAlphaFirst:
+        case kCGImageAlphaPremultipliedFirst:
+        case kCGImageAlphaNoneSkipFirst:
             indexR = 1;
             indexG = 2;
             indexB = 3;
+            indexA = 0;
+            break;
         }
+        break;
     }
     
     vImage_Error result;


### PR DESCRIPTION
 This fixes #1829 and partially addresses some of our format conversion issues.

We will need to evaluate our image loader and the formats it outputs to ensure that UIImage will always (or almost always) return an expected format for vImage users. This pull request does not do that.

Additionally, it removes some dead code!