### PR TITLE
Remove EbrCenterTextInRectVertically

### DIFF
--- a/Frameworks/UIKit/UITabBarButton.mm
+++ b/Frameworks/UIKit/UITabBarButton.mm
@@ -128,7 +128,7 @@
 
         CGRect textRect{};
 
-        // Horizontally center text
+        // Vertically center text
         textRect.origin.y = (rect.size.height - size.height) / 2.0;
         textRect.origin.x = rect.origin.x;
         textRect.size.width = rect.size.width;

--- a/Frameworks/UIKit/UITabBarButton.mm
+++ b/Frameworks/UIKit/UITabBarButton.mm
@@ -127,6 +127,8 @@
         size = [title sizeWithFont:font constrainedToSize:CGSizeMake(0.0f, 0.0f) lineBreakMode:UILineBreakModeClip];
 
         CGRect textRect{};
+
+        // Horizontally center text
         textRect.origin.y = (rect.size.height - size.height) / 2.0;
         textRect.origin.x = rect.origin.x;
         textRect.size.width = rect.size.width;

--- a/Frameworks/UIKit/UITabBarButton.mm
+++ b/Frameworks/UIKit/UITabBarButton.mm
@@ -126,15 +126,12 @@
         id font = [UIFont defaultFont];
         size = [title sizeWithFont:font constrainedToSize:CGSizeMake(0.0f, 0.0f) lineBreakMode:UILineBreakModeClip];
 
-        CGRect textRect;
-        textRect.origin.y = rect.size.height - size.height;
+        CGRect textRect{};
+        textRect.origin.y = (rect.size.height - size.height) / 2.0;
         textRect.origin.x = rect.origin.x;
         textRect.size.width = rect.size.width;
         textRect.size.height = size.height;
-        // TODO(DH)
-        // EbrCenterTextInRectVertically(&textRect, &size, font);
-
-        CGContextSetFillColorWithColor(context, (CGColorRef)[UIColor whiteColor]);
+        CGContextSetFillColorWithColor(context, CGColorGetConstantColor(kCGColorWhite));
         size = [title drawInRect:textRect withFont:font lineBreakMode:UILineBreakModeClip alignment:UITextAlignmentCenter];
     }
 }

--- a/Frameworks/UIKit/UITabBarButton.mm
+++ b/Frameworks/UIKit/UITabBarButton.mm
@@ -126,13 +126,8 @@
         id font = [UIFont defaultFont];
         size = [title sizeWithFont:font constrainedToSize:CGSizeMake(0.0f, 0.0f) lineBreakMode:UILineBreakModeClip];
 
-        CGRect textRect{};
-
         // Vertically center text
-        textRect.origin.y = (rect.size.height - size.height) / 2.0;
-        textRect.origin.x = rect.origin.x;
-        textRect.size.width = rect.size.width;
-        textRect.size.height = size.height;
+        CGRect textRect = CGRectMake((rect.size.height - size.height) / 2.0, rect.origin.x, rect.size.width, size.height);
         CGContextSetFillColorWithColor(context, CGColorGetConstantColor(kCGColorWhite));
         size = [title drawInRect:textRect withFont:font lineBreakMode:UILineBreakModeClip alignment:UITextAlignmentCenter];
     }

--- a/Frameworks/UIKit/UITextView.mm
+++ b/Frameworks/UIKit/UITextView.mm
@@ -757,15 +757,6 @@ static const float INPUTVIEW_DEFAULT_HEIGHT = 200.f;
     CGSize fontExtent = { 0, 0 };
 
     fontExtent = [[self _text] sizeWithFont:(id)_font forWidth:rect.size.width lineBreakMode:UILineBreakModeWordWrap];
-
-    CGRect centerRect;
-    centerRect.origin.x = 0;
-    centerRect.origin.y = 0;
-    centerRect.size = fontExtent;
-    // TODO(DH)
-    // EbrCenterTextInRectVertically(&centerRect, &fontExtent, _font);
-    rect.origin.y += centerRect.origin.y;
-
     ret.width = ourRect.size.width;
     ret.height = fontExtent.height + _marginSize * 2.0f;
 


### PR DESCRIPTION
Changes UITabBarButton to directly center text vertically in drawRect:
Removes dead code from UITextView-sizeThatFits:

Fixes #1812