### PR TITLE
Enable vertical pixel-snapping when drawing glyph runs

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -44,6 +44,7 @@
 #include <COMIncludes_end.h>
 
 #import <atomic>
+#import <cmath>
 #import <list>
 #import <vector>
 #import <stack>
@@ -1924,6 +1925,9 @@ HRESULT __CGContext::DrawGlyphRun(const DWRITE_GLYPH_RUN* glyphRun, bool transfo
     // Undo assumed inversion about Y axis
     CGAffineTransform textTransform = CGAffineTransformScale(textMatrix, 1.0, -1.0);
     CGAffineTransform deviceTransform = CGContextGetUserSpaceToDeviceSpaceTransform(this);
+
+    // Snap the vertical baseline to the nearest pixel to avoid blurring on devices with vertical antialiasing
+    textTransform.ty = std::round(textTransform.ty);
 
     CGAffineTransform finalTextTransform = CGAffineTransformConcat(textTransform, deviceTransform);
     if ((fabs(finalTextTransform.a * glyphRun->fontEmSize) <= c_glyphThreshold &&

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.LineHeightMultiple.0.75.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.LineHeightMultiple.0.75.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d9ffec486a6b9c69f270e2d33a671b8f92df096b196f94ca036751aacebc9ac
-size 28377
+oid sha256:fb1ba677d6f3a87ddbe5be6da7ac6b936a40e4fe19062e0c3ed4f018fc62ef02
+size 25864

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.LineHeightMultiple.1.25.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.LineHeightMultiple.1.25.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:172054a7adaf485406b3196257f8e20b33346e61e17ba2677221f0739b5f0770
-size 29800
+oid sha256:9e6fbf71371a92e20d3d3b6c353d48ba9d986bf4fa4e5ab0765e1d5acf11a598
+size 26881


### PR DESCRIPTION
 - Devices with vertical antialiasing would render text as blurry if rendered on a fractional vertical coordinate.
   - CGContext functions that draw glyphs do not necessarily use coordinates from our custom text renderer,
     which already has pixel snapping enabled.
   - As such, manually round the y-translation in CGContext::DrawGlyphRun()
 - Updated reference images for two drawing tests dealing with line height.

 Fixes #1594