### PR TITLE
Switch our D2D factory to be multithreaded.

### DIFF
--- a/Frameworks/CoreGraphics/D2DWrapper.mm
+++ b/Frameworks/CoreGraphics/D2DWrapper.mm
@@ -19,32 +19,18 @@
 
 using namespace Microsoft::WRL;
 
-namespace {
-template <typename T>
-struct HRComPtr {
-    HRESULT hr;
-    ComPtr<T> ptr;
-};
-}
-
 HRESULT _CGGetD2DFactory(ID2D1Factory** factory) {
-    static auto sFactory = []() -> HRComPtr<ID2D1Factory> {
-        ComPtr<ID2D1Factory> factory;
-        HRESULT hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, factory.ReleaseAndGetAddressOf());
-        return { hr, std::move(factory) };
-    }();
-    sFactory.ptr.CopyTo(factory);
-    return sFactory.hr;
+    static ComPtr<ID2D1Factory> sFactory;
+    static HRESULT sHr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory), &sFactory);
+    sFactory.CopyTo(factory);
+    RETURN_HR(sHr);
 }
 
 HRESULT _CGGetWICFactory(IWICImagingFactory** factory) {
-    static auto sFactory = []() -> HRComPtr<IWICImagingFactory> {
-        ComPtr<IWICImagingFactory> factory;
-        HRESULT hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&factory));
-        return { hr, std::move(factory) };
-    }();
-    sFactory.ptr.CopyTo(factory);
-    return sFactory.hr;
+    static ComPtr<IWICImagingFactory> sWicFactory;
+    static HRESULT sHr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&sWicFactory));
+    sWicFactory.CopyTo(factory);
+    RETURN_HR(sHr);
 }
 
 // TODO GH#1375: Remove this when CGPath's fill mode has been worked out.

--- a/Frameworks/CoreGraphics/D2DWrapper.mm
+++ b/Frameworks/CoreGraphics/D2DWrapper.mm
@@ -21,6 +21,16 @@ using namespace Microsoft::WRL;
 
 namespace {
 template <typename T>
+// HRComPtr is a ComPtr bundled with an HRESULT. Since the below factory functions
+// have two effective return values, both of which are statically computed on first
+// request, we need to use this to ensure defined behaviour.
+//
+// Contrast HRComPtr with this approach:
+// static ComPtr<IUnknown> x;
+// static HRESULT y = CoCreateInstance(... &x ...);
+//
+// It cannot safely be said that ComPtr::ComPtr() has been called before CoCreateInstance,
+// especially when multiple threads contend for the lock on x.
 struct HRComPtr {
     HRESULT hr;
     ComPtr<T> ptr;

--- a/Frameworks/CoreGraphics/D2DWrapper.mm
+++ b/Frameworks/CoreGraphics/D2DWrapper.mm
@@ -21,7 +21,7 @@ using namespace Microsoft::WRL;
 
 HRESULT _CGGetD2DFactory(ID2D1Factory** factory) {
     static ComPtr<ID2D1Factory> sFactory;
-    static HRESULT sHr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory), &sFactory);
+    static HRESULT sHr = D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, __uuidof(ID2D1Factory), &sFactory);
     sFactory.CopyTo(factory);
     RETURN_HR(sHr);
 }

--- a/Frameworks/CoreGraphics/D2DWrapper.mm
+++ b/Frameworks/CoreGraphics/D2DWrapper.mm
@@ -21,16 +21,6 @@ using namespace Microsoft::WRL;
 
 namespace {
 template <typename T>
-// HRComPtr is a ComPtr bundled with an HRESULT. Since the below factory functions
-// have two effective return values, both of which are statically computed on first
-// request, we need to use this to ensure defined behaviour.
-//
-// Contrast HRComPtr with this approach:
-// static ComPtr<IUnknown> x;
-// static HRESULT y = CoCreateInstance(... &x ...);
-//
-// It cannot safely be said that ComPtr::ComPtr() has been called before CoCreateInstance,
-// especially when multiple threads contend for the lock on x.
 struct HRComPtr {
     HRESULT hr;
     ComPtr<T> ptr;

--- a/Frameworks/CoreGraphics/D2DWrapper.mm
+++ b/Frameworks/CoreGraphics/D2DWrapper.mm
@@ -19,18 +19,32 @@
 
 using namespace Microsoft::WRL;
 
+namespace {
+template <typename T>
+struct HRComPtr {
+    HRESULT hr;
+    ComPtr<T> ptr;
+};
+}
+
 HRESULT _CGGetD2DFactory(ID2D1Factory** factory) {
-    static ComPtr<ID2D1Factory> sFactory;
-    static HRESULT sHr = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory), &sFactory);
-    sFactory.CopyTo(factory);
-    RETURN_HR(sHr);
+    static auto sFactory = []() -> HRComPtr<ID2D1Factory> {
+        ComPtr<ID2D1Factory> factory;
+        HRESULT hr = D2D1CreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, factory.ReleaseAndGetAddressOf());
+        return { hr, std::move(factory) };
+    }();
+    sFactory.ptr.CopyTo(factory);
+    return sFactory.hr;
 }
 
 HRESULT _CGGetWICFactory(IWICImagingFactory** factory) {
-    static ComPtr<IWICImagingFactory> sWicFactory;
-    static HRESULT sHr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&sWicFactory));
-    sWicFactory.CopyTo(factory);
-    RETURN_HR(sHr);
+    static auto sFactory = []() -> HRComPtr<IWICImagingFactory> {
+        ComPtr<IWICImagingFactory> factory;
+        HRESULT hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&factory));
+        return { hr, std::move(factory) };
+    }();
+    sFactory.ptr.CopyTo(factory);
+    return sFactory.hr;
 }
 
 // TODO GH#1375: Remove this when CGPath's fill mode has been worked out.


### PR DESCRIPTION
This commit also switches our static initialization around to be less
likely to trigger the static init order fiasco.

Fixes #1895.