### PR TITLE
Use block scope thread_local static for NSProgress progress stack

### DIFF
--- a/Frameworks/Foundation/NSProgress.mm
+++ b/Frameworks/Foundation/NSProgress.mm
@@ -48,11 +48,7 @@ struct CurrentProgress {
 
 // Returns the stack of NSProgress objects that have becomeCurrent on the current thread, initializing it if necessary
 static std::shared_ptr<std::stack<CurrentProgress>> & _getProgressStackForCurrentThread() {
-    thread_local static std::shared_ptr<std::stack<CurrentProgress>> tlsCurrentProgressStack;
-
-    if (!tlsCurrentProgressStack) {
-        tlsCurrentProgressStack = std::make_shared<std::stack<CurrentProgress>>();
-    }
+    thread_local static std::shared_ptr<std::stack<CurrentProgress>> tlsCurrentProgressStack = std::make_shared<std::stack<CurrentProgress>>();
 
     return tlsCurrentProgressStack;
 }

--- a/Frameworks/Foundation/NSProgress.mm
+++ b/Frameworks/Foundation/NSProgress.mm
@@ -47,9 +47,8 @@ struct CurrentProgress {
 };
 
 // Returns the stack of NSProgress objects that have becomeCurrent on the current thread, initializing it if necessary
-static std::shared_ptr<std::stack<CurrentProgress>> & _getProgressStackForCurrentThread() {
-    thread_local static std::shared_ptr<std::stack<CurrentProgress>> tlsCurrentProgressStack = std::make_shared<std::stack<CurrentProgress>>();
-
+static auto& _getProgressStackForCurrentThread() {
+    thread_local static auto tlsCurrentProgressStack = std::make_shared<std::stack<CurrentProgress>>();
     return tlsCurrentProgressStack;
 }
 

--- a/tests/unittests/Foundation/NSProgressTests.mm
+++ b/tests/unittests/Foundation/NSProgressTests.mm
@@ -583,3 +583,16 @@ TEST(NSProgress, KVOLocalizedDescription) {
         andExpectChangeCallbacks:nil];
     EXPECT_EQ(1, kvoListener.hits);
 }
+
+TEST(NSProgress, CurrentProgressLeak) {
+    NSProgress* progress = [NSProgress progressWithTotalUnitCount:100];
+
+    std::thread t([&progress]() {
+        [progress becomeCurrentWithPendingUnitCount:50];
+    });
+
+    t.join();
+
+    // Progress unfinished upon thread exit. Ensure we're not keeping progress alive:
+    EXPECT_EQ(1, [progress retainCount]);
+}


### PR DESCRIPTION
per comments in #1872. Works around issue with file_scope thread_local in current clang. Leak check unit test added.