### PR TITLE
Fix bug in sizeWithFont

### DIFF
--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -259,9 +259,8 @@ static NSDictionary* _getDefaultUITextAttributes() {
         size.width = std::numeric_limits<CGFloat>::max();
     }
 
-    if (size.height == 0.0) {
-        size.height = std::numeric_limits<CGFloat>::max();
-    }
+    // Return the height that the text actually requires rather than the constrained size
+    size.height = std::numeric_limits<CGFloat>::max();
 
     return CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, self.length), nullptr, size, nullptr);
 }

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -244,6 +244,11 @@ static NSDictionary* _getDefaultUITextAttributes() {
 // Returns the bounding box size this string would occupy when drawn as specified
 // All sizeWith... functions in this file funnel to this
 - (CGSize)_sizeWithAttributes:(NSDictionary<NSString*, id>*)attributes constrainedToSize:(CGSize)size {
+    UIFont* font = attributes[NSFontAttributeName];
+    if (font == nil) {
+        return CGSizeZero;
+    }
+
     if ([attributes objectForKey:NSParagraphStyleAttributeName]) {
         NSMutableDictionary* copied = [NSMutableDictionary dictionaryWithDictionary:attributes];
         woc::unique_cf<CTParagraphStyleRef>
@@ -266,7 +271,6 @@ static NSDictionary* _getDefaultUITextAttributes() {
     CGSize ret = CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, self.length), nullptr, size, nullptr);
 
     // If the constrained height is less than a line height sizeWithFont will increase the returned size to fit at least one line
-    UIFont* font = attributes[NSFontAttributeName];
     CGFloat lineHeight = [font ascender] - [font descender];
     ret.height = std::max(ret.height, lineHeight);
 

--- a/Frameworks/UIKit/NSString+UIKitAdditions.mm
+++ b/Frameworks/UIKit/NSString+UIKitAdditions.mm
@@ -259,10 +259,18 @@ static NSDictionary* _getDefaultUITextAttributes() {
         size.width = std::numeric_limits<CGFloat>::max();
     }
 
-    // Return the height that the text actually requires rather than the constrained size
-    size.height = std::numeric_limits<CGFloat>::max();
+    if (size.height == 0.0) {
+        size.height = std::numeric_limits<CGFloat>::max();
+    }
 
-    return CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, self.length), nullptr, size, nullptr);
+    CGSize ret = CTFramesetterSuggestFrameSizeWithConstraints(framesetter.get(), CFRangeMake(0, self.length), nullptr, size, nullptr);
+
+    // If the constrained height is less than a line height sizeWithFont will increase the returned size to fit at least one line
+    UIFont* font = attributes[NSFontAttributeName];
+    CGFloat lineHeight = [font ascender] - [font descender];
+    ret.height = std::max(ret.height, lineHeight);
+
+    return ret;
 }
 
 // Private helper that converts a UILineBreakMode -> NSParagraphStyle

--- a/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
+++ b/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
@@ -16,6 +16,7 @@
 
 #import <TestFramework.h>
 #import <UIKit/UIKit.h>
+#import <CppUtils.h>
 
 static constexpr double c_errorDelta = .0001;
 TEST(NSString_UIKitAdditions, ShouldNotReturnSizeOfZeroWidth) {
@@ -34,4 +35,9 @@ TEST(NSString_UIKitAdditions, SizeWithFontShouldReturnLineHeightWhenConstrainedH
 
     size = [@"TEST\nTEST" sizeWithFont:font constrainedToSize:givenSize];
     EXPECT_NEAR(lineHeight, size.height, c_errorDelta);
+}
+
+TEST(NSString_UIKitAdditions, SizeWithNoFontShouldReturnCGSizeZero) {
+    CGSize arbitrarySize = { 100, 150 };
+    EXPECT_EQ(CGSizeZero, [@"TEST" sizeWithFont:nil constrainedToSize:arbitrarySize]);
 }

--- a/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
+++ b/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
@@ -23,3 +23,9 @@ TEST(NSString_UIKitAdditions, ShouldNotReturnSizeOfZeroWidth) {
     EXPECT_LT(0.0, size.width);
     EXPECT_LT(0.0, size.height);
 }
+
+TEST(NSString_UIKitAdditions, ShouldNotConstrainHeightWhenTextIsLarger) {
+    CGSize givenSize = { 0, 15 };
+    CGSize size = [@"TEST" sizeWithFont:[UIFont systemFontOfSize:144] constrainedToSize:givenSize];
+    EXPECT_GT(size.height, givenSize.height);
+}

--- a/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
+++ b/tests/unittests/UIKit/NSString+UIKitAdditionsTests.mm
@@ -17,6 +17,7 @@
 #import <TestFramework.h>
 #import <UIKit/UIKit.h>
 
+static constexpr double c_errorDelta = .0001;
 TEST(NSString_UIKitAdditions, ShouldNotReturnSizeOfZeroWidth) {
     CGSize size =
         [@"TEST" sizeWithFont:[UIFont systemFontOfSize:12.0f] constrainedToSize:CGSizeZero lineBreakMode:NSLineBreakByWordWrapping];
@@ -24,8 +25,13 @@ TEST(NSString_UIKitAdditions, ShouldNotReturnSizeOfZeroWidth) {
     EXPECT_LT(0.0, size.height);
 }
 
-TEST(NSString_UIKitAdditions, ShouldNotConstrainHeightWhenTextIsLarger) {
+TEST(NSString_UIKitAdditions, SizeWithFontShouldReturnLineHeightWhenConstrainedHeightIsTooSmall) {
     CGSize givenSize = { 0, 15 };
-    CGSize size = [@"TEST" sizeWithFont:[UIFont systemFontOfSize:144] constrainedToSize:givenSize];
-    EXPECT_GT(size.height, givenSize.height);
+    UIFont* font = [UIFont systemFontOfSize:144];
+    CGFloat lineHeight = [font ascender] - [font descender];
+    CGSize size = [@"TEST" sizeWithFont:font constrainedToSize:givenSize];
+    EXPECT_NEAR(lineHeight, size.height, c_errorDelta);
+
+    size = [@"TEST\nTEST" sizeWithFont:font constrainedToSize:givenSize];
+    EXPECT_NEAR(lineHeight, size.height, c_errorDelta);
 }


### PR DESCRIPTION
NSString+UIKitAdditions sizeWithFont:constrainedToSize: should return the height that the text requires rather than the height of the text that can actually fit in the region that CTFramesetterSuggestFrameSizeWithConstraints returns.