### PR TITLE
Improve performance in __CF_IsBridgedObject/__CF_IsCFObject

### DIFF
--- a/Frameworks/CoreFoundation/Base.subproj/CFInternal.h
+++ b/Frameworks/CoreFoundation/Base.subproj/CFInternal.h
@@ -712,7 +712,7 @@ CF_INLINE bool __CF_IsBridgedObject(CFTypeRef obj) {
     // However, this would not grant access to anything that could not be accessed by more conventional means
     // (ie: overriding an existing CF/Foundation class)
     // and as such would not constitute an escalation of privilege.
-    return [object conformsToProtocol:__CFRuntimeGetBridgeProtocol()];
+    return class_conformsToProtocol((Class)(object->_cfisa), __CFRuntimeGetBridgeProtocol());
 }
 
 

--- a/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
@@ -272,6 +272,10 @@ CFTypeID _CFRuntimeRegisterClass(const CFRuntimeClass * const cls) {
 void _CFRuntimeBridgeTypeToClass(CFTypeID cf_typeID, const void *cls_ref) {
     __CFLock(&__CFBigRuntimeFunnel);
     __CFRuntimeObjCClassTable[cf_typeID] = (uintptr_t)cls_ref;
+
+    // WINOBJC: Label the class with the 'bridged object' protocol, so that it can be quickly distinguished from non-bridged objects
+    class_addProtocol((Class)cls_ref, __CFRuntimeGetBridgeProtocol());
+    
     __CFUnlock(&__CFBigRuntimeFunnel);
 }
 

--- a/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/Frameworks/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1141,6 +1141,10 @@ void __CFInitialize(void) {
         for (CFIndex idx = 1; idx < __CFRuntimeClassTableSize; ++idx) {
             __CFRuntimeObjCClassTable[idx] = (uintptr_t)&_OBJC_CLASS__NSCFType;
         }
+
+        // WINOBJC: Label NSCFType with the 'bridged object' protocol
+        class_addProtocol(_OBJC_CLASS__NSCFType, __CFRuntimeGetBridgeProtocol());
+
 #endif
         
 #if DEPLOYMENT_RUNTIME_SWIFT


### PR DESCRIPTION
 - __CF_IsCFObject() calls __CF_IsBridgedObject()
 - Previously, __CF_IsBridgedObject() would do an O(n^2) comparison against the entire runtime class table.
   (O(n) traversal of table * O(n) check of inheritance tree)
 - These two functions are used in CF memory management functions, such as CFRetain/Release,
   and due to their prevalence, took up substantial portions of CPU time.
 - Changed bridged classes to adopt an empty 'bridged object' protocol when they are bridged/added to the class table.
   This protocol can be quickly checked against, and obviates the need to traverse the table.
 - Removed some redundant _cfisa checks in _CF_IsCFObject

Fixes #1490