### PR TITLE
Reintroduce unique_cf's move ctor/assignment.

### DIFF
--- a/include/xplat/Starboard/SmartTypes.h
+++ b/include/xplat/Starboard/SmartTypes.h
@@ -528,6 +528,9 @@ public:
     unique_cf(T val): AutoCF<T, CFLifetimeRetain>(std::move(val)) {
     }
 
+    unique_cf(unique_cf<T>&& other): AutoCF<T, CFLifetimeRetain>(std::move(other)) {
+    }
+
     void reset(T val = nullptr) {
         AutoCF<T, CFLifetimeRetain>::attach(val);
     }
@@ -538,7 +541,11 @@ public:
 
     unique_cf<T>& operator=(T val) = delete;
     unique_cf<T>& operator=(const unique_cf<T>& other) = delete;
-    unique_cf<T>& operator=(unique_cf<T>&& other) = delete;
+
+    unique_cf<T>& operator=(unique_cf<T>&& other) {
+        this->AutoCF<T>::operator=(std::move(other));
+        return *this;
+    }
 };
 
 template <typename T = CFTypeRef>

--- a/tests/UnitTests/Starboard/AutoCFTests.cpp
+++ b/tests/UnitTests/Starboard/AutoCFTests.cpp
@@ -157,3 +157,31 @@ TEST(AutoCF, LegacyUniqueCF) {
     // Only one retain, even though the default ctor is being used.
     ASSERT_EQ(1, CFGetRetainCount(testObject));
 }
+
+TEST(AutoCF, LegacyUniqueCFMove) {
+    woc::unique_cf<CFTestClassRef> testObject{ CFTestClassCreate(nullptr) };
+
+    // Only one retain, even though the default ctor is being used.
+    ASSERT_EQ(1, CFGetRetainCount(testObject));
+
+    woc::unique_cf<CFTestClassRef> testMovedObject{ std::move(testObject) };
+
+    // Still only one retain.
+    ASSERT_EQ(1, CFGetRetainCount(testMovedObject));
+}
+
+TEST(AutoCF, LegacyUniqueCFMoveAssignment) {
+    woc::unique_cf<CFTestClassRef> testMovedObject{};
+
+    {
+        woc::unique_cf<CFTestClassRef> testObject{ CFTestClassCreate(nullptr) };
+
+        // Only one retain, even though the default ctor is being used.
+        ASSERT_EQ(1, CFGetRetainCount(testObject));
+
+        testMovedObject = std::move(testObject);
+    }
+
+    // Still only one retain.
+    ASSERT_EQ(1, CFGetRetainCount(testMovedObject));
+}


### PR DESCRIPTION
Fixes #1925.