### PR TITLE
Fix drawing tests for the new TAEF world and fix OS X tests.

### DIFF
--- a/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
@@ -232,7 +232,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     
-    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\EntryPoint.cpp" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\TAEFEntryPoint.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\CGTextDrawing.cpp" />

--- a/tests/Tests.Shared/test-api.h
+++ b/tests/Tests.Shared/test-api.h
@@ -566,7 +566,7 @@ __declspec(noinline) inline std::string _ExchangeAlternateTestName(
 
 // clang-format on
 
-__if_not_exists(GetCurrentTestDirectory) {
+IF_NOT_EXISTS_BEGIN(GetCurrentTestDirectory)
     static std::string GetCurrentTestDirectory() {
         WEX::Common::String testDeploymentPath;
         WEX::TestExecution::RuntimeParameters::TryGetValue(L"TestDeploymentDir", testDeploymentPath);
@@ -575,9 +575,9 @@ __if_not_exists(GetCurrentTestDirectory) {
         static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
         return converter.to_bytes(toReturn);
     }
-}
+IF_NOT_EXISTS_END
 
-__if_not_exists(GetTestFullName) {
+IF_NOT_EXISTS_BEGIN(GetTestFullName)
     static std::string GetTestFullName() {
         std::string alternateTestName = _ExchangeAlternateTestName(std::string(), false);
         if (!alternateTestName.empty()) {
@@ -594,7 +594,7 @@ __if_not_exists(GetTestFullName) {
         toReturn.replace(toReturn.find("_"), 1, ".");
         return toReturn;
     }
-}
+IF_NOT_EXISTS_END
 
 #ifndef LOG_TEST_PROPERTY
 #define LOG_TEST_PROPERTY(key, value)                                            \

--- a/tests/UnitTests/CoreGraphics.drawing/Makefile
+++ b/tests/UnitTests/CoreGraphics.drawing/Makefile
@@ -4,7 +4,7 @@
 
 # CoreGraphics.Drawing.UnitTests.exe
 UT_NAME = CoreGraphics.Drawing
-UT_FILES := $(wildcard *.cpp)
+UT_FILES := $(filter-out TAEF%,$(wildcard *.cpp))
 UT_RESOURCES := data
 UT_FRAMEWORKS = CoreGraphics ImageIO CoreText
 

--- a/tests/frameworks/gtest/include/gtest/gtest-param-test.h
+++ b/tests/frameworks/gtest/include/gtest/gtest-param-test.h
@@ -1377,9 +1377,9 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 
 
 
-# define TEST_P(test_case_name, test_name) \
+# define GTEST_TEST_P_(test_case_name, test_name, test_fixture_name) \
   class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) \
-      : public test_case_name { \
+      : public test_fixture_name { \
    public: \
     GTEST_TEST_CLASS_NAME_(test_case_name, test_name)() {} \
     virtual void TestBody(); \
@@ -1405,6 +1405,8 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
                              test_name)::gtest_registering_dummy_ = \
       GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::AddToRegistry(); \
   void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::TestBody()
+
+# define TEST_P(test_case_name, test_name) GTEST_TEST_P_(test_case_name, test_name, test_case_name)
 
 // The optional last argument to INSTANTIATE_TEST_CASE_P allows the user
 // to specify a function or functor that generates custom test name suffixes

--- a/tests/frameworks/include/TestFramework.h
+++ b/tests/frameworks/include/TestFramework.h
@@ -20,8 +20,19 @@
 #include <Foundation/Foundation.h>
 #endif
 
+#ifndef IF_NOT_EXISTS_BEGIN
+#ifdef _MSC_VER
+#define IF_NOT_EXISTS_BEGIN(name) __if_not_exists(name) {
+#define IF_NOT_EXISTS_END }
+#else
+#define IF_NOT_EXISTS_BEGIN(name)
+#define IF_NOT_EXISTS_END
+#endif
+#endif
+
 #if TARGET_OS_MAC
 #include "gtest-api.h"
+#include <mach-o/dyld.h>
 #else
 #include "test-api.h"
 #endif
@@ -229,22 +240,22 @@ protected:
 #define boolean Boolean
 #endif
 
-__if_not_exists(GetCurrentTestDirectory) {
+IF_NOT_EXISTS_BEGIN(GetCurrentTestDirectory)
     static std::string GetCurrentTestDirectory() {
         std::string tempBuffer;
-        uint32_t maxPath = _MAX_PATH;
+        uint32_t maxPath = PATH_MAX;
         tempBuffer.resize(maxPath);
         _NSGetExecutablePath(&tempBuffer[0], &maxPath);
         return tempBuffer.substr(0, tempBuffer.find_last_of('/')).c_str();
     }
-}
+IF_NOT_EXISTS_END
 
-__if_not_exists(GetTestFullName) {
+IF_NOT_EXISTS_BEGIN(GetTestFullName)
     static std::string GetTestFullName() {
         return std::string(::testing::UnitTest::GetInstance()->current_test_info()->test_case_name()) + "." +
                ::testing::UnitTest::GetInstance()->current_test_info()->name();
     }
-}
+IF_NOT_EXISTS_END
 
 #ifndef LOG_TEST_PROPERTY
 #define LOG_TEST_PROPERTY(key, value) RecordProperty(key, value)

--- a/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
@@ -58,7 +58,7 @@ class CGContextBlendMode : public WhiteBackgroundTest<>, public ::testing::WithP
     }
 };
 
-TEST_P(CGContextBlendMode, OverlappedEllipses) {
+DRAW_TEST_P(CGContextBlendMode, OverlappedEllipses) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGBlendMode blendMode = ::testing::get<1>(GetParam()).blendMode;

--- a/tests/unittests/CoreGraphics.drawing/CGContextDrawing_ImageMaskTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextDrawing_ImageMaskTests.cpp
@@ -181,7 +181,7 @@ std::vector<std::tuple<ClippingShape, CGSize, std::function<void(CGContextRef, C
     { ClippingShapeRectangle, CGSize{ 256, 128 }, __GradientMaskGenerator },
 };
 
-TEST_P(CGContextClipping, StraightMask) {
+DRAW_TEST_P(CGContextClipping, StraightMask) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     ClippingShape shape = ::testing::get<0>(GetParam());
@@ -193,7 +193,7 @@ TEST_P(CGContextClipping, StraightMask) {
     _FillContext();
 }
 
-TEST_P(CGContextClipping, TransformedMask) {
+DRAW_TEST_P(CGContextClipping, TransformedMask) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     ClippingShape shape = ::testing::get<0>(GetParam());
@@ -207,7 +207,7 @@ TEST_P(CGContextClipping, TransformedMask) {
     _FillContext();
 }
 
-TEST_P(CGContextClipping, StackedMaskSameType) {
+DRAW_TEST_P(CGContextClipping, StackedMaskSameType) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     ClippingShape shape = ::testing::get<0>(GetParam());
@@ -222,7 +222,7 @@ TEST_P(CGContextClipping, StackedMaskSameType) {
     _FillContext();
 }
 
-TEST_P(CGContextClipping, StackedMaskOtherType) {
+DRAW_TEST_P(CGContextClipping, StackedMaskOtherType) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     ClippingShape shape = ::testing::get<0>(GetParam());
@@ -238,7 +238,7 @@ TEST_P(CGContextClipping, StackedMaskOtherType) {
     _FillContext();
 }
 
-TEST_P(CGContextClipping, MaskedAndClipped) {
+DRAW_TEST_P(CGContextClipping, MaskedAndClipped) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     ClippingShape shape = ::testing::get<0>(GetParam());

--- a/tests/unittests/CoreGraphics.drawing/TAEFEntryPoint.cpp
+++ b/tests/unittests/CoreGraphics.drawing/TAEFEntryPoint.cpp
@@ -1,0 +1,156 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <windows.h>
+#include <TestFramework.h>
+#include <memory>
+#include <roapi.h>
+#include <WexTestClass.h>
+#include <wrl\client.h>
+#include <wrl\wrappers\corewrappers.h>
+#include <windows.storage.h>
+
+#include <CoreFoundation/CoreFoundation.h>
+
+#include "DrawingTestConfig.h"
+
+using namespace ABI::Windows::Storage;
+using namespace Microsoft::WRL;
+using namespace Windows::Foundation;
+
+Wrappers::HString GetAppDataPath() {
+    Wrappers::HString toReturn;
+    ComPtr<IStorageFolder> folder;
+    ComPtr<IApplicationDataStatics> applicationDataStatics;
+    ComPtr<IApplicationData> applicationData;
+    ComPtr<IStorageItem> storageItem;
+
+    if (FAILED(Windows::Foundation::GetActivationFactory(Wrappers::HStringReference(RuntimeClass_Windows_Storage_ApplicationData).Get(),
+                                                         &applicationDataStatics))) {
+        return toReturn;
+    }
+
+    if (FAILED(applicationDataStatics->get_Current(&applicationData))) {
+        return toReturn;
+    }
+
+    if (FAILED(applicationData->get_LocalFolder(&folder))) {
+        return toReturn;
+    }
+
+    if (FAILED(folder.As<IStorageItem>(&storageItem))) {
+        return toReturn;
+    }
+
+    if (FAILED(storageItem->get_Path(toReturn.GetAddressOf()))) {
+        return toReturn;
+    }
+
+    return toReturn;
+}
+
+static std::string __ModuleDirectory() {
+    static std::string modulePath = GetCurrentTestDirectory();
+    return modulePath;
+}
+
+static std::string __OutputDirectory() {
+    static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    Wrappers::HString appDataDirectory = GetAppDataPath();
+    return converter.to_bytes(WindowsGetStringRawBuffer(appDataDirectory.Get(), nullptr));
+}
+
+class TAEFDrawingTestConfigImpl : public DrawingTestConfigImpl {
+private:
+    DrawingTestMode _mode;
+    std::string _outputPath;
+    std::string _comparisonPath;
+
+public:
+    TAEFDrawingTestConfigImpl()
+        : _mode(DrawingTestMode::Compare), _outputPath(__OutputDirectory()), _comparisonPath(GetCurrentTestDirectory() + "/data/reference") {
+        static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+
+        WEX::Common::String outputPath;
+        WEX::TestExecution::RuntimeParameters::TryGetValue(L"out", outputPath);
+        if (!outputPath.IsEmpty()) {
+            _outputPath = converter.to_bytes(std::wstring(outputPath));
+        }
+
+        WEX::Common::String comparisonPath;
+        WEX::TestExecution::RuntimeParameters::TryGetValue(L"compare", comparisonPath);
+        if (!comparisonPath.IsEmpty()) {
+            _comparisonPath = converter.to_bytes(std::wstring(comparisonPath));
+        }
+
+        WEX::Common::String generateMode;
+        WEX::TestExecution::RuntimeParameters::TryGetValue(L"generate", generateMode);
+        if (generateMode.CompareNoCase(L"true") || generateMode.CompareNoCase(L"yes")) {
+            _mode = DrawingTestMode::Generate;
+        }
+    }
+
+    virtual DrawingTestMode GetMode() override {
+        return _mode;
+    }
+
+    virtual std::string GetOutputPath() override {
+        return _outputPath;
+    }
+
+    virtual std::string GetComparisonPath() override {
+        return _comparisonPath;
+    }
+
+    virtual std::string GetResourcePath(const std::string& resource) override {
+        // Using / as a path separator is valid on both Windows and OS X.
+        return __ModuleDirectory() + "/data/" + resource;
+    }
+};
+
+std::shared_ptr<DrawingTestConfigImpl> _configImpl;
+/* static */ DrawingTestConfigImpl* DrawingTestConfig::Get() {
+    return _configImpl.get();
+}
+
+BEGIN_MODULE()
+MODULE_PROPERTY(L"RunAs", L"UAP")
+END_MODULE()
+
+MODULE_SETUP(ModuleSetup) {
+    if (FAILED(RoInitialize(RO_INIT_MULTITHREADED))) {
+        return FALSE;
+    }
+
+    Wrappers::HString path = GetAppDataPath();
+    if (path.IsValid()) {
+        unsigned int rawLength;
+        _wchdir(WindowsGetStringRawBuffer(path.Get(), &rawLength));
+    }
+
+    int argc = 1;
+    char* argv[] = { "UnitTests" };
+    testing::InitGoogleTest(&argc, argv);
+
+    _configImpl = std::move(std::make_shared<TAEFDrawingTestConfigImpl>());
+
+    return TRUE;
+}
+
+MODULE_CLEANUP(ModuleCleanup) {
+    RoUninitialize();
+    return true;
+}

--- a/tests/unittests/EntryPoint.cpp
+++ b/tests/unittests/EntryPoint.cpp
@@ -14,10 +14,10 @@
 //
 //******************************************************************************
 
-#include "pch.h"
 #include <gtest-api.h>
 
 #ifdef WIN32
+#include "pch.h"
 #include <roapi.h>
 #include <WexTestClass.h>
 #include <wrl\client.h>


### PR DESCRIPTION
Additionally, this pull request fixes:
* The combined TAEF/CLI entrypoint in drawing tests.
* The file output medium for drawing tests; it'll use WEX's file logger now!

Fixes #1941, #1940.