### PR TITLE
Fixing lab tests.  Also combinining tests into 1 common test.

### DIFF
--- a/tests/Run-FunctionalTests.ps1
+++ b/tests/Run-FunctionalTests.ps1
@@ -2,9 +2,6 @@
 .SYNOPSIS
     Runs Functional Tests for Islandwood project.
 
-.PARAMETER TAEFDirectory
-    The path to TAEF binaries
-
 .PARAMETER TestDirectory
     The path to test binaries
 
@@ -17,6 +14,9 @@
 .PARAMETER Device
     IP or MAC address of the device to run tests on
 
+.PARAMETER ModuleFilter
+    Regex of Test Modules to look for
+
 .PARAMETER TestFilter
     Test filter to use for the test. Supports wildcard characters
 
@@ -26,12 +26,6 @@
 .PARAMETER NoCopy
     Switch to disable copying test to the device
 
-.PARAMETER TestWorkingDirectory
-    Path to the working test directory from where the tests will be run
-
-.PARAMETER PackageRootPath
-    Path to build share where the TAEF package can be found
-
 .PARAMETER RedirectTAEFErrors
     Redirect TAEF errors/failures to stderr.  This is used to integrate with VSTS powershell task.
 
@@ -39,14 +33,12 @@
     Path to find WTTLog dll
 
 .EXAMPLE
-    Run-FunctionalTests.ps1 -TAEFDirectory D:\TAEF
-    Run-FunctionalTests.ps1 -TAEFDirectory \data\test\bin -Platform ARM
+    Desktop: Run-FunctionalTests.ps1
+    Phone:  Run-FunctionalTests.ps1 -Platform ARM
 
 #>
 param(
-    [string]$TAEFDirectory = "",
-
-    [string]$TestDirectory = "",
+    [string]$TestDirectory,
 
     [string][ValidateSet("Win32", "ARM")]
     $Platform = "Win32",
@@ -56,236 +48,32 @@ param(
 
     [string]$Device = "127.0.0.1",
 
-    [string]$TestFilter = $null,
+    [string]$ModuleFilter,
+    
+    [string]$TestFilter,
 
-    [string]$WTLOutputDirectory = $null,
+    [string]$WTLOutputDirectory,
 
     [switch]$NoCopy,
 
-    [string]$TestWorkingDirectory = "",
-
-    [string]$PackageRootPath = $null,
-
     [switch]$RedirectTAEFErrors,
 
-    [string]$WTTLogPath = $null
+    [string]$WTTLogPath
 )
 
-$script:exitCode = 0
+$args = @()
+$args += ("-TestType", "FunctionalTest")
+if ($TestDirectory) { $args += ("-TestDirectory", $TestDirectory) }
+if ($Platform) { $args += ("-Platform", $Platform) }
+if ($Config) { $args += ("-Config", $Config) }
+if ($Device) { $args += ("-Device", $Device) }
+if ($ModuleFilter) { $args += ("-ModuleFilter", $ModuleFilter) }
+if ($TestFilter) { $args += ("-TestFilter", $TestFilter) }
+if ($WTLOutputDirectory) { $args += ("-WTLOutputDirectory", $WTLOutputDirectory) }
+if ($NoCopy) { $args += ("-NoCopy") }
+if ($RedirectTAEFErrors) { $args += ("-RedirectTAEFErrors") }
+if ($WTTLogPath) { $args += ("-WTTLogPath", $WTTLogPath) }
 
-if ($NoCopy)
-{
-    if ($TestWorkingDirectory -eq "")
-    {
-         throw "Please specify -TestWorkingDirectory argument with -NoCopy option."
-    }
-}
-
-if ($TestWorkingDirectory -ne "")
-{
-    if (!$NoCopy)
-    {
-         throw "Please specify -NoCopy option when using -TestWorkingDirectory argument."
-    }
-}
-
-$TargetingDevice = ($Platform -eq "ARM")
-
-function EnsureDeviceConnection
-{
-    if ($DeviceAddress -eq $null)
-    {
-        if ((Get-Command Open-Device -ErrorAction SilentlyContinue) -eq $null)
-        {
-            Write-Host "Can't connect to device. Try installing TShell."
-            throw "DeviceConnectError"
-        }
-
-        # If the caller has already connected to the device, use the existing connection.
-        # Otherwise, try connecting to device now.
-        Open-Device $Device
-    }
-}
-
-function DeployTests
-{
-    if ($TargetingDevice)
-    {
-        # Make sure TAEF package is installed on the device
-        Try
-        {
-            # Checking for installed packages is not trivial. For now keep it simple.
-            dird \data\test\bin\TE.TestMode.UAP.dll | Out-Null
-        }
-        Catch
-        {
-            $TAEFPackageName = "Microsoft.Windows.Test.Taef"
-
-            Write-Host -ForegroundColor Cyan "Installing $TAEFPackageName package - this may take about a minute"
-            if ($PackageRootPath -eq [string]$null)
-            {
-                deployd -Packages $TAEFPackageName -OnDevice
-            }
-            else
-            {
-                deployd -Packages $TAEFPackageName -PackageRootPath $PackageRootPath
-            }
-        }
-
-        if (!$NoCopy)
-        {
-
-            # Copy the tests to the device
-            Write-Host -ForegroundColor Cyan "Copying tests to the device - this may take about a minute"
-
-            Try
-            {
-                mdd $TestDstDirectory
-            }
-            Catch
-            {
-                # putd fails if the directory doesn't already exist.
-                # mdd fails if the directory does already exist.
-                # This is awkward.
-            }
-
-            putd -recurse $TestSrcDirectory\* $TestDstDirectory
-        }
-    }
-    else
-    {
-        # Otherwise run tests in place
-    }
-}
-
-function ExecTest($argList)
-{
-    Write-Host -ForegroundColor Cyan "Starting test execution..."
-
-    if ($TAEFDirectory -eq "")
-    {
-        $taefPath = Join-Path $TestSrcDirectory te.exe
-    }
-    else
-    {
-        $taefPath = Join-Path $TAEFDirectory te.exe
-    }
-
-    $testPath = Join-Path $TestDstDirectory $DefaultTestBinary
-
-    if ($TargetingDevice)
-    {
-        cmdd $taefPath $testPath $argList
-
-        if ($WTLOutputDirectory -ne [string]$null)
-        {
-            # Fetch the output from the device
-            getd $outputRemoteName $outputLocalName
-            deld $outputRemoteName
-        }
-    }
-    else
-    {
-        $arguments = "$testPath" + "$argList"
-        if ($RedirectTAEFErrors) {
-            $output = Invoke-Expression "$taefPath $arguments"
-            $script:exitCode = $LASTEXITCODE
-            foreach ($o in $output) {
-                            
-                if ($o.StartsWith("Error:") -or $o.Contains("[Failed]")) {
-
-                    #TAEF does not report exceptions/crashes/failures during test cleanup as test failures.
-                    #However, it will log a message like: "Error: TAEF: [HRESULT 0x8000FFFF] ...."
-                    #We want to detect and mark these as test failures.
-                    $script:exitCode = 1
-
-                    #Note: Adding ##[error]: is just to make the errors show up as red in VSTS output
-                    #Unfortunately, writing the output to stderr (write-error) creates a lot of noise in powershell.
-                    #And attempting to use Console.WriteError or $host.ui.WriteErrorLine results in lines be displayed out of order.
-                    write-host "##[error]: $o" -foregroundcolor red
-
-                } else {
-                    write-host $o
-                }
-            }
-        } else {
-            Invoke-Expression "$taefPath $arguments"
-            $script:exitCode = $LASTEXITCODE
-        }
-    }
-}
-
-if (!$NoCopy)
-{
-    if ($TestDirectory -eq "")
-    {
-        $MyPath = (get-item $MyInvocation.MyCommand.Path).Directory.FullName;
-        $TestSrcDirectory = Join-Path $MyPath "..\build\$Platform\$Config\Tests"
-    }
-    else
-    {
-        $TestSrcDirectory = $TestDirectory
-    }
-
-    if ($TargetingDevice)
-    {
-        $TestDstDirectory = "\data\test\bin\islandwood\FunctionalTests"
-    }
-    else
-    {
-        $TestDstDirectory = $TestSrcDirectory
-    }
-}
-else
-{
-    $TestDstDirectory = $TestWorkingDirectory
-}
-
-if ($TargetingDevice)
-{
-    EnsureDeviceConnection
-}
-
-$DefaultTestBinary = "FunctionalTests.dll"
-
-DeployTests
-
-if (($WTLOutputDirectory -ne [string]$null) -and ((Test-Path -Path $WTLOutputDirectory -PathType Container) -eq 0))
-{
-    New-Item -ItemType Directory -Path $WTLOutputDirectory
-}
-
-$outputLocalName = $null;
-$outputRemoteName = $null;
-$argList = "";
-
-$outputFileName = "FunctionalTestsResult.wtl"
-
-# Decide where the WTL output files will live
-if ($WTLOutputDirectory -ne [string]$null)
-{
-    $WTTLogFullPath = Join-Path $WTTLogPath wttlog.dll 
-    Copy-Item $WTTLogFullPath -Destination $TestSrcDirectory -Force
-
-    if ($TargetingDevice)
-    {
-        $outputLocalName = Join-Path -Path $WTLOutputDirectory -ChildPath $outputFileName
-        $outputRemoteName = Join-Path -Path $TestDstDirectory -ChildPath $outputFileName
-        $argList += " /logFile:$outputRemoteName /enableWttLogging"
-    }
-    else
-    {
-        $outputLocalName = Join-Path -Path $WTLOutputDirectory -ChildPath $outputFileName
-        $argList += " /logFile:$outputLocalName /enableWttLogging"
-    }
-}
-
-
-if($TestFilter -ne [string]$null)
-{
-    $argList += " /name:$TestFilter"
-}
-
-ExecTest($argList)
-
-exit $script:exitCode
+$cmd = "$PSScriptRoot\Run-Tests.ps1"
+Invoke-Expression "$cmd $args"
+exit $LASTEXITCODE

--- a/tests/Run-FunctionalTests.ps1
+++ b/tests/Run-FunctionalTests.ps1
@@ -48,11 +48,11 @@ param(
 
     [string]$Device = "127.0.0.1",
 
-    [string]$ModuleFilter,
+    [string]$ModuleFilter = "FunctionalTests.dll",
     
     [string]$TestFilter,
 
-    [string]$WTLOutputDirectory,
+    [string]$WTLOutputFile,
 
     [switch]$NoCopy,
 
@@ -62,14 +62,13 @@ param(
 )
 
 $args = @()
-$args += ("-TestType", "FunctionalTest")
 if ($TestDirectory) { $args += ("-TestDirectory", $TestDirectory) }
 if ($Platform) { $args += ("-Platform", $Platform) }
 if ($Config) { $args += ("-Config", $Config) }
 if ($Device) { $args += ("-Device", $Device) }
 if ($ModuleFilter) { $args += ("-ModuleFilter", $ModuleFilter) }
 if ($TestFilter) { $args += ("-TestFilter", $TestFilter) }
-if ($WTLOutputDirectory) { $args += ("-WTLOutputDirectory", $WTLOutputDirectory) }
+if ($WTLOutputFile) { $args += ("-WTLOutputFile", $WTLOutputFile) }
 if ($NoCopy) { $args += ("-NoCopy") }
 if ($RedirectTAEFErrors) { $args += ("-RedirectTAEFErrors") }
 if ($WTTLogPath) { $args += ("-WTTLogPath", $WTTLogPath) }

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -1,0 +1,269 @@
+<#
+.SYNOPSIS
+    Runs Functional Tests for Islandwood project.
+
+.PARAMETER TestDirectory
+    The path to test binaries
+
+.PARAMETER Platform
+    platform to run tests on. Valid values are Win32 or ARM
+
+.PARAMETER Config
+    Test configuration to use for the test. Valid values are Debug or Release
+
+.PARAMETER Device
+    IP or MAC address of the device to run tests on
+
+.PARAMETER ModuleFilter
+    Regex of Test Modules to look for
+
+.PARAMETER TestFilter
+    Test filter to use for the test. Supports wildcard characters
+
+.PARAMETER WTLOutputDirectory
+    Path to test output. If not set, no result file will be saved.
+
+.PARAMETER NoCopy
+    Switch to disable copying test to the device
+
+.PARAMETER RedirectTAEFErrors
+    Redirect TAEF errors/failures to stderr.  This is used to integrate with VSTS powershell task.
+
+.PARAMETER WTTLogPath
+    Path to find WTTLog dll
+
+.EXAMPLE
+    Desktop: Run-Tests.ps1 -TestType FunctionalTest
+             Run-Tests.ps1 -TestType UnitTest
+    Phone:  Run-Tests.ps1 -TestType FunctionalTest -Platform ARM
+            Run-Tests.ps1 -TestType UnitTest -Platform ARM
+
+#>
+param(
+    [Parameter(Mandatory=$true)]
+    [string][ValidateSet("FunctionalTest", "UnitTest")]
+    $TestType,
+
+    [string]$TestDirectory,
+
+    [string][ValidateSet("Win32", "ARM")]
+    $Platform = "Win32",
+
+    [string][ValidateSet("Debug", "Release")]
+    $Config = "Debug",
+
+    [string]$Device = "127.0.0.1",
+
+    [string]$ModuleFilter,
+    
+    [string]$TestFilter,
+
+    [string]$WTLOutputDirectory,
+
+    [switch]$NoCopy,
+
+    [switch]$RedirectTAEFErrors,
+
+    [string]$WTTLogPath
+)
+$script:exitCode = 0
+
+$TargetingDevice = ($Platform -eq "ARM")
+
+$outputFileName;
+if ($TestType -eq "FunctionalTest")
+{
+    $outputFileName = "FunctionalTestsResult.wtl"
+    if (!$ModuleFilter) 
+    {
+        $ModuleFilter = "FunctionalTests.dll"
+    }
+}
+else
+{
+    $outputFileName = "UnitTestsResult.wtl"
+    if (!$ModuleFilter) 
+    {
+        $ModuleFilter = "*.UnitTests.dll"
+    }
+}
+
+function EnsureDeviceConnection
+{
+    if ($DeviceAddress -eq $null)
+    {
+        if ((Get-Command Open-Device -ErrorAction SilentlyContinue) -eq $null)
+        {
+            Write-Host "Can't connect to device. Try installing TShell."
+            throw "DeviceConnectError"
+        }
+
+        # If the caller has already connected to the device, use the existing connection.
+        # Otherwise, try connecting to device now.
+        Open-Device $Device
+    }
+}
+
+function DeployTests
+{
+    if (!$NoCopy)
+    {
+        if ($TargetingDevice)
+        {
+            # Copy the tests to the device
+            Write-Host -ForegroundColor Cyan "Copying tests to the device - this may take about a minute"
+
+
+            $toCopy = Get-ChildItem $TestSrcDirectory -exclude *.exp,*.ilk,*.lib,*.pdb
+            foreach($f in $toCopy)
+            {
+                $dst = Join-Path $TestDstDirectory $f.name
+                if($f -is [System.IO.DirectoryInfo])
+                {                    
+                    Write-Host -ForegroundColor Cyan  "Copying $f\* $dst\"
+                    putd -recurse $f\* $dst\
+                }
+                else
+                {
+                    Write-Host -ForegroundColor Cyan "Copying $f $dst"
+                    putd $f $dst
+                }
+            }
+
+            #Copy wttlog if output is requested.
+            if ($WTLOutputDirectory)
+            {
+                $WTTLogFullPath = Join-Path $WTTLogPath wttlog.dll 
+                putd $WTTLogFullPath $TestDstDirectory
+            }
+            
+        }
+        else
+        {
+            # For Desktop, we can run tests in place
+            
+            #Copy wttlog if output is requested.
+            if ($WTLOutputDirectory)
+            {
+                $WTTLogFullPath = Join-Path $WTTLogPath wttlog.dll 
+                Copy-Item $WTTLogFullPath -Destination $TestDstDirectory -Force           
+            }
+
+        }
+    }
+}
+
+function ExecTest($argList)
+{
+    Write-Host -ForegroundColor Cyan "Starting test execution..."
+
+    $taefPath = Join-Path $TestDstDirectory te.exe 
+    $testPath = Join-Path $TestDstDirectory $ModuleFilter
+
+    if ($TargetingDevice)
+    {
+        Write-Host -ForegroundColor Cyan  "cmdd $taefPath $testPath $argList"
+        cmdd $taefPath $testPath $argList
+
+        if ($WTLOutputDirectory)
+        {
+            # Fetch the output from the device
+            getd $outputRemoteName $outputLocalName
+            deld $outputRemoteName
+        }
+    }
+    else
+    {
+        $arguments = "$testPath" + "$argList"
+        if ($RedirectTAEFErrors) {            
+            $output = Invoke-Expression "$taefPath $arguments"
+            $script:exitCode = $LASTEXITCODE
+            foreach ($o in $output) {
+                            
+                if ($o.StartsWith("Error:") -or $o.Contains("[Failed]")) {
+
+                    #TAEF does not report exceptions/crashes/failures during test cleanup as test failures.
+                    #However, it will log a message like: "Error: TAEF: [HRESULT 0x8000FFFF] ...."
+                    #We want to detect and mark these as test failures.
+                    $script:exitCode = 1
+
+                    #Note: Adding ##[error]: is just to make the errors show up as red in VSTS output
+                    #Unfortunately, writing the output to stderr (write-error) creates a lot of noise in powershell.
+                    #And attempting to use Console.WriteError or $host.ui.WriteErrorLine results in lines be displayed out of order.
+                    write-host "##[error]: $o" -foregroundcolor red
+
+                } else {
+                    write-host $o
+                }
+            }
+        } else {
+            Invoke-Expression "$taefPath $arguments"
+            $script:exitCode = $LASTEXITCODE
+        }
+    }
+}
+
+#Set the location of the test binaries
+if ($TestDirectory -eq "")
+{
+    $MyPath = (get-item $MyInvocation.MyCommand.Path).Directory.FullName;
+    $TestSrcDirectory = Join-Path $MyPath "..\build\$Platform\$Config\Tests"
+}
+else
+{
+    $TestSrcDirectory = $TestDirectory
+}
+
+if ($TargetingDevice)
+{
+    $TestDstDirectory = "c:\data\test\bin\islandwood\Tests"
+}
+else
+{
+    #On Desktop we run in place
+    $TestDstDirectory = $TestSrcDirectory
+}
+
+if ($TargetingDevice)
+{
+    EnsureDeviceConnection
+}
+
+$DefaultTestBinary = "FunctionalTests.dll"
+
+DeployTests
+
+if (($WTLOutputDirectory) -and ((Test-Path -Path $WTLOutputDirectory -PathType Container) -eq 0))
+{
+    New-Item -ItemType Directory -Path $WTLOutputDirectory
+}
+
+$outputLocalName
+$outputRemoteName
+$argList = "";
+
+# Decide where the WTL output files will live
+if ($WTLOutputDirectory)
+{
+    if ($TargetingDevice)
+    {
+        $outputLocalName = Join-Path -Path $WTLOutputDirectory -ChildPath $outputFileName
+        $outputRemoteName = Join-Path -Path $TestDstDirectory -ChildPath $outputFileName
+        $argList += " /logFile:$outputRemoteName /enableWttLogging"
+    }
+    else
+    {
+        $outputLocalName = Join-Path -Path $WTLOutputDirectory -ChildPath $outputFileName
+        $argList += " /logFile:$outputLocalName /enableWttLogging"
+    }
+}
+
+
+if($TestFilter)
+{
+    $argList += " /name:$TestFilter"
+}
+
+ExecTest($argList)
+
+exit $script:exitCode

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -33,10 +33,10 @@
     Path to find WTTLog dll
 
 .EXAMPLE
-    Desktop: Run-Tests.ps1 -TestType FunctionalTest
-             Run-Tests.ps1 -TestType UnitTest
-    Phone:  Run-Tests.ps1 -TestType FunctionalTest -Platform ARM
-            Run-Tests.ps1 -TestType UnitTest -Platform ARM
+    Desktop: Run-Tests.ps1 -ModuleFilter *unittests.dll
+             Run-Tests.ps1 -ModuleFilter functionaltests.dll
+    Phone:  Run-Tests.ps1 -ModuleFilter *unittests.dll -platform ARM
+            Run-Tests.ps1 -ModuleFilter functionaltests.dll -platform ARM
 
 #>
 param(

--- a/tests/Run-UnitTests.ps1
+++ b/tests/Run-UnitTests.ps1
@@ -2,9 +2,6 @@
 .SYNOPSIS
     Runs Functional Tests for Islandwood project.
 
-.PARAMETER TAEFDirectory
-    The path to TAEF binaries
-
 .PARAMETER TestDirectory
     The path to test binaries
 
@@ -17,11 +14,11 @@
 .PARAMETER Device
     IP or MAC address of the device to run tests on
 
-.PARAMETER TestFilter
-    Test filter to use for the test. Supports wildcard characters
-
 .PARAMETER ModuleFilter
     Regex of Test Modules to look for
+
+.PARAMETER TestFilter
+    Test filter to use for the test. Supports wildcard characters
 
 .PARAMETER WTLOutputDirectory
     Path to test output. If not set, no result file will be saved.
@@ -29,28 +26,19 @@
 .PARAMETER NoCopy
     Switch to disable copying test to the device
 
-.PARAMETER TestWorkingDirectory
-    Path to the working test directory from where the tests will be run
-
-.PARAMETER PackageRootPath
-    Path to build share where the TAEF package can be found
-
 .PARAMETER RedirectTAEFErrors
     Redirect TAEF errors/failures to stderr.  This is used to integrate with VSTS powershell task.
 
 .PARAMETER WTTLogPath
     Path to find WTTLog dll
 
-
 .EXAMPLE
-    Run-UnitTests.ps1 -TAEFDirectory D:\TAEF
-    Run-UnitTests.ps1 -TAEFDirectory \data\test\bin -Platform ARM
+    Run-UnitTests.ps1 
+    Run-UnitTests.ps1 -Platform ARM
 
 #>
 param(
-    [string]$TAEFDirectory = "",
-
-    [string]$TestDirectory = "",
+    [string]$TestDirectory,
 
     [string][ValidateSet("Win32", "ARM")]
     $Platform = "Win32",
@@ -60,234 +48,32 @@ param(
 
     [string]$Device = "127.0.0.1",
 
-    [string]$TestFilter = $null,
+    [string]$ModuleFilter,
 
-    [string]$ModuleFilter = "*.UnitTests.dll",
+    [string]$TestFilter,
 
-    [string]$WTLOutputDirectory = $null,
+    [string]$WTLOutputDirectory,
 
     [switch]$NoCopy,
 
-    [string]$TestWorkingDirectory = "",
-
-    [string]$PackageRootPath = $null,
-
     [switch]$RedirectTAEFErrors,
 
-    [string]$WTTLogPath = $null
+    [string]$WTTLogPath
 )
 
-if ($NoCopy)
-{
-    if ($TestWorkingDirectory -eq "")
-    {
-         throw "Please specify -TestWorkingDirectory argument with -NoCopy option."
-    }
-}
+$args = @()
+$args += ("-TestType", "UnitTest")
+if ($TestDirectory) { $args += ("-TestDirectory", $TestDirectory) }
+if ($Platform) { $args += ("-Platform", $Platform) }
+if ($Config) { $args += ("-Config", $Config) }
+if ($Device) { $args += ("-Device", $Device) }
+if ($ModuleFilter) { $args += ("-ModuleFilter", $ModuleFilter) }
+if ($TestFilter) { $args += ("-TestFilter", $TestFilter) }
+if ($WTLOutputDirectory) { $args += ("-WTLOutputDirectory", $WTLOutputDirectory) }
+if ($NoCopy) { $args += ("-NoCopy") }
+if ($RedirectTAEFErrors) { $args += ("-RedirectTAEFErrors") }
+if ($WTTLogPath) { $args += ("-WTTLogPath", $WTTLogPath) }
 
-if ($TestWorkingDirectory -ne "")
-{
-    if (!$NoCopy)
-    {
-         throw "Please specify -NoCopy option when using -TestWorkingDirectory argument."
-    }
-}
-
-$TargetingDevice = ($Platform -eq "ARM")
-
-function EnsureDeviceConnection
-{
-    if ($DeviceAddress -eq $null)
-    {
-        if ((Get-Command Open-Device -ErrorAction SilentlyContinue) -eq $null)
-        {
-            Write-Host "Can't connect to device. Try installing TShell."
-            throw "DeviceConnectError"
-        }
-
-        # If the caller has already connected to the device, use the existing connection.
-        # Otherwise, try connecting to device now.
-        Open-Device $Device
-    }
-}
-
-function DeployTests
-{
-    if ($TargetingDevice)
-    {
-        # Make sure TAEF package is installed on the device
-        Try
-        {
-            # Checking for installed packages is not trivial. For now keep it simple.
-            dird \data\test\bin\TE.TestMode.UAP.dll | Out-Null
-        }
-        Catch
-        {
-            $TAEFPackageName = "Microsoft.Windows.Test.Taef"
-
-            Write-Host -ForegroundColor Cyan "Installing $TAEFPackageName package - this may take about a minute"
-            if ($PackageRootPath -eq [string]$null)
-            {
-                deployd -Packages $TAEFPackageName -OnDevice
-            }
-            else
-            {
-                deployd -Packages $TAEFPackageName -PackageRootPath $PackageRootPath
-            }
-        }
-
-        if (!$NoCopy)
-        {
-
-            # Copy the tests to the device
-            Write-Host -ForegroundColor Cyan "Copying tests to the device - this may take about a minute"
-
-            Try
-            {
-                mdd $TestDstDirectory
-            }
-            Catch
-            {
-                # putd fails if the directory doesn't already exist.
-                # mdd fails if the directory does already exist.
-                # This is awkward.
-            }
-
-            putd -recurse $TestSrcDirectory\* $TestDstDirectory
-        }
-    }
-    else
-    {
-        # Otherwise run tests in place
-    }
-}
-
-function ExecTest($argList)
-{
-    Write-Host -ForegroundColor Cyan "Starting test execution..."
-
-    if ($TAEFDirectory -eq "")
-    {
-        $taefPath = Join-Path $TestSrcDirectory te.exe
-    }
-    else
-    {
-        $taefPath = Join-Path $TAEFDirectory te.exe
-    }
-
-    $testPath = Join-Path $TestDstDirectory $ModuleFilter
-
-    if ($TargetingDevice)
-    {
-        cmdd $taefPath $testPath $argList
-
-        if ($WTLOutputDirectory -ne [string]$null)
-        {
-            # Fetch the output from the device
-            getd $outputRemoteName $outputLocalName
-            deld $outputRemoteName
-        }
-    }
-    else
-    {
-        $arguments = "$testPath" + "$argList"
-        if ($RedirectTAEFErrors) {
-            $output = Invoke-Expression "$taefPath $arguments"
-            $script:exitCode = $LASTEXITCODE
-            foreach ($o in $output) {
-                            
-                if ($o.StartsWith("Error:") -or $o.Contains("[Failed]")) {
-
-                    #TAEF does not report exceptions/crashes/failures during test cleanup as test failures.
-                    #However, it will log a message like: "Error: TAEF: [HRESULT 0x8000FFFF] ...."
-                    #We want to detect and mark these as test failures.
-                    $script:exitCode = 1
-
-                    #Note: Adding ##[error]: is just to make the errors show up as red in VSTS output
-                    #Unfortunately, writing the output to stderr (write-error) creates a lot of noise in powershell.
-                    #And attempting to use Console.WriteError or $host.ui.WriteErrorLine results in lines be displayed out of order.
-                    write-host "##[error]: $o" -foregroundcolor red
-
-                } else {
-                    write-host $o
-                }
-            }
-        } else {
-            Invoke-Expression "$taefPath $arguments"
-            $script:exitCode = $LASTEXITCODE
-        }
-    }
-}
-
-if (!$NoCopy)
-{
-    if ($TestDirectory -eq "")
-    {
-        $MyPath = (get-item $MyInvocation.MyCommand.Path).Directory.FullName;
-        $TestSrcDirectory = Join-Path $MyPath "..\build\$Platform\$Config\Tests"
-    }
-    else
-    {
-        $TestSrcDirectory = $TestDirectory
-    }
-
-    if ($TargetingDevice)
-    {
-        $TestDstDirectory = "\data\test\bin\islandwood\UnitTests"
-    }
-    else
-    {
-        $TestDstDirectory = $TestSrcDirectory
-    }
-}
-else
-{
-    $TestDstDirectory = $TestWorkingDirectory
-}
-
-if ($TargetingDevice)
-{
-    EnsureDeviceConnection
-}
-
-DeployTests
-
-if (($WTLOutputDirectory -ne [string]$null) -and ((Test-Path -Path $WTLOutputDirectory -PathType Container) -eq 0))
-{
-    New-Item -ItemType Directory -Path $WTLOutputDirectory
-}
-
-$outputLocalName = $null;
-$outputRemoteName = $null;
-$argList = "";
-
-$outputFileName = "UnitTestsResult.wtl"
-
-# Decide where the WTL output files will live
-if ($WTLOutputDirectory -ne [string]$null)
-{
-    $WTTLogFullPath = Join-Path $WTTLogPath wttlog.dll 
-    Copy-Item $WTTLogFullPath -Destination $TestSrcDirectory -Force
-
-    if ($TargetingDevice)
-    {
-        $outputLocalName = Join-Path -Path $WTLOutputDirectory -ChildPath $outputFileName
-        $outputRemoteName = Join-Path -Path $TestDstDirectory -ChildPath $outputFileName
-        $argList += " /logFile:$outputRemoteName /enableWttLogging"
-    }
-    else
-    {
-        $outputLocalName = Join-Path -Path $WTLOutputDirectory -ChildPath $outputFileName
-        $argList += " /logFile:$outputLocalName /enableWttLogging"
-    }
-}
-
-
-if($TestFilter -ne [string]$null)
-{
-    $argList += " /name:$TestFilter"
-}
-
-ExecTest $argList
-
-exit $script:exitCode
+$cmd = "$PSScriptRoot\Run-Tests.ps1"
+Invoke-Expression "$cmd $args"
+exit $LASTEXITCODE

--- a/tests/Run-UnitTests.ps1
+++ b/tests/Run-UnitTests.ps1
@@ -48,11 +48,11 @@ param(
 
     [string]$Device = "127.0.0.1",
 
-    [string]$ModuleFilter,
+    [string]$ModuleFilter = "*.UnitTests.dll",
 
     [string]$TestFilter,
 
-    [string]$WTLOutputDirectory,
+    [string]$WTLOutputFile,
 
     [switch]$NoCopy,
 
@@ -62,14 +62,13 @@ param(
 )
 
 $args = @()
-$args += ("-TestType", "UnitTest")
 if ($TestDirectory) { $args += ("-TestDirectory", $TestDirectory) }
 if ($Platform) { $args += ("-Platform", $Platform) }
 if ($Config) { $args += ("-Config", $Config) }
 if ($Device) { $args += ("-Device", $Device) }
 if ($ModuleFilter) { $args += ("-ModuleFilter", $ModuleFilter) }
 if ($TestFilter) { $args += ("-TestFilter", $TestFilter) }
-if ($WTLOutputDirectory) { $args += ("-WTLOutputDirectory", $WTLOutputDirectory) }
+if ($WTLOutputFile) { $args += ("-WTLOutputFile", $WTLOutputFile) }
 if ($NoCopy) { $args += ("-NoCopy") }
 if ($RedirectTAEFErrors) { $args += ("-RedirectTAEFErrors") }
 if ($WTTLogPath) { $args += ("-WTTLogPath", $WTTLogPath) }


### PR DESCRIPTION
Fixing tests for phone in lab.
Combining run-unittest and run-fuctionaltest into run-tests.   Run-unittest and run-functionaltest just call run-test with the appropriate parameters set.
Some cleanup:
 1.we don't need to check powershell string for [string]$null.).
 2.we don't need to deploy taef anymore since taef binaries are in the tests directory.

Validation: 
Phone: run ut's and ft's in phone lab and locally.  
Desktop: run ut's and ft's locally (and build agent via pull request)