### PR TITLE
Adding support for borders to UILabel and UIButton (via CALayer and t…

### DIFF
--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -288,7 +288,6 @@ CAPrivateInfo::~CAPrivateInfo() {
     _undefinedKeys = nil;
     _actions = nil;
     CGColorRelease(_backgroundColor);
-    CGColorRelease(_borderColor);
     _name = nil;
     if (_animations) {
         [_animations release];
@@ -1582,64 +1581,55 @@ static void doRecursiveAction(CALayer* layer, NSString* actionName) {
     return priv->_backgroundColor;
 }
 
-- (void)_setContentColor:(CGColorRef)newColor {
-    UNIMPLEMENTED();
-}
-
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (void)setBorderColor:(CGColorRef)color {
-    UNIMPLEMENTED();
-    if (color != nil) {
-        priv->borderColor = *[static_cast<UIColor*>(color) _getColors];
-    } else {
-        _ClearColorQuad(priv->borderColor);
-    }
-
-    CGColorRef old = priv->_borderColor;
-    priv->_borderColor = CGColorRetain(color);
-    CGColorRelease(old);
+    // Set the border color via CATransaction
+    [CATransaction _setPropertyForLayer:self name:@"borderColor" value:(NSObject*)color];
+    [self setNeedsDisplay];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (CGColorRef)borderColor {
-    UNIMPLEMENTED();
-    return priv->_borderColor;
+    // Grab the current border color directly off of the layer proxy
+    return [(UIColor*)priv->_layerProxy->GetPropertyValue("borderColor") CGColor];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (void)setBorderWidth:(float)width {
-    UNIMPLEMENTED();
-    priv->borderWidth = width;
+    // Set the border width via CATransaction
+    [CATransaction _setPropertyForLayer:self name:@"borderWidth" value:[NSNumber numberWithFloat:width]];
+    [self setNeedsDisplay];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (float)borderWidth {
-    UNIMPLEMENTED();
-    return priv->borderWidth;
+    // Grab the current border width directly off of the layer proxy
+    return [(NSNumber*)priv->_layerProxy->GetPropertyValue("borderWidth") floatValue];
 }
 
 /**
- @Status Stub
+ @Status NotInPlan
+ @Notes Rounded corners with clipped children are not currently achievable in Xaml.
 */
 - (void)setCornerRadius:(float)radius {
-    UNIMPLEMENTED();
-    priv->cornerRadius = radius;
+    UNIMPLEMENTED_WITH_MSG("Rounded corners with clipped children are not achievable in Xaml.");
 }
 
 /**
- @Status Stub
+ @Status NotInPlan
+ @Notes Rounded corners with clipped children are not currently achievable in Xaml.
 */
 - (float)cornerRadius {
-    UNIMPLEMENTED();
-    return priv->cornerRadius;
+    UNIMPLEMENTED_WITH_MSG("Rounded corners with clipped children are not achievable in Xaml.");
+    return StubReturn();
 }
 
 /**
@@ -2518,7 +2508,7 @@ bool _floatAlmostEqual(float a, float b) {
     return ret;
 }
 
-- (NSObject*)presentationValueForKey:(NSString*)key {
+- (NSObject*)_presentationValueForKey:(NSString*)key {
     return reinterpret_cast<NSObject*>(priv->_layerProxy->GetPropertyValue([key UTF8String]));
 }
 

--- a/Frameworks/UIKit.Xaml/Button.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Button.xaml.cpp
@@ -66,6 +66,16 @@ Canvas^ Button::SublayerCanvas::get() {
     return _contentCanvas;
 }
 
+// Accessor for the LayerProperty that manages the BorderBrush of this button
+Private::CoreAnimation::LayerProperty^ Button::GetBorderBrushProperty() {
+    return ref new Private::CoreAnimation::LayerProperty(_border, _border->BorderBrushProperty);
+}
+
+// Accessor for the LayerProperty that manages the BorderThickness of this button
+Private::CoreAnimation::LayerProperty^ Button::GetBorderThicknessProperty() {
+    return ref new Private::CoreAnimation::LayerProperty(_border, _border->BorderThicknessProperty);
+}
+
 void Button::OnPointerPressed(PointerRoutedEventArgs^ e) {
     // Call the pointer hook if it exists
     if (_pointerPressedHook) {

--- a/Frameworks/UIKit.Xaml/Button.xaml.h
+++ b/Frameworks/UIKit.Xaml/Button.xaml.h
@@ -52,6 +52,12 @@ public:
         Windows::UI::Xaml::Controls::Canvas^ get();
     }
 
+    // Accessor for the LayerProperty that manages the BorderBrush of this button
+    virtual Private::CoreAnimation::LayerProperty^ GetBorderBrushProperty();
+
+    // Accessor for the LayerProperty that manages the BorderThickness of this button
+    virtual Private::CoreAnimation::LayerProperty^ GetBorderThicknessProperty();
+
 internal:
     void HookPointerEvents(
         const Microsoft::WRL::ComPtr<ABI::Windows::UI::Xaml::Input::IPointerEventHandler>& pointerPressedHook,

--- a/Frameworks/UIKit.Xaml/Label.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Label.xaml.cpp
@@ -53,10 +53,43 @@ Canvas^ Label::SublayerCanvas::get() {
     if (!_sublayerCanvas) {
         _sublayerCanvas = ref new Canvas();
         _sublayerCanvas->Name = "Sublayers";
-        Children->Append(_sublayerCanvas);
+
+        // If we have a border make sure the sublayer canvas is inserted before it
+        if (_border) {
+            unsigned int insertIndex = 0;
+            Children->IndexOf(_border, &insertIndex);
+            Children->InsertAt(insertIndex, _sublayerCanvas);
+        } else {
+            // Just add the sublayer canvas to the end because we don't yet have a border on this element
+            Children->Append(_sublayerCanvas);
+        }
     }
 
     return _sublayerCanvas;
+}
+
+Border^ Label::_GetBorder() {
+    if (!_border) {
+        // We always want the border added to the end of the Children collection
+        _border = ref new Border();
+        Children->Append(_border);
+    }
+
+    return _border;
+}
+
+// Accessor for the LayerProperty that manages the BorderBrush of this label
+Private::CoreAnimation::LayerProperty^ Label::GetBorderBrushProperty() {
+    // Make sure we have a border element, and return it along with its associated border property
+    Border^ border = _GetBorder();
+    return ref new Private::CoreAnimation::LayerProperty(border, border->BorderBrushProperty);
+}
+
+// Accessor for the LayerProperty that manages the BorderThickness of this label
+Private::CoreAnimation::LayerProperty^ Label::GetBorderThicknessProperty() {
+    // Make sure we have a border element, and return it along with its associated border property
+    Border^ border = _GetBorder();
+    return ref new Private::CoreAnimation::LayerProperty(border, border->BorderThicknessProperty);
 }
 
 Windows::Foundation::Size Label::ArrangeOverride(Windows::Foundation::Size finalSize) {

--- a/Frameworks/UIKit.Xaml/Label.xaml.h
+++ b/Frameworks/UIKit.Xaml/Label.xaml.h
@@ -44,15 +44,24 @@ public:
         Windows::UI::Xaml::Controls::Canvas^ get();
     }
 
+    // Accessor for the LayerProperty that manages the BorderBrush of this label
+    virtual Private::CoreAnimation::LayerProperty^ GetBorderBrushProperty();
+
+    // Accessor for the LayerProperty that manages the BorderThickness of this label
+    virtual Private::CoreAnimation::LayerProperty^ GetBorderThicknessProperty();
+
 internal:
     property Windows::UI::Xaml::Controls::TextBlock^ TextBlock {
         Windows::UI::Xaml::Controls::TextBlock^ get();
     }
 
 private:
+    Windows::UI::Xaml::Controls::Border^ _GetBorder();
+
     // Layer elements; created on demand
     Windows::UI::Xaml::Controls::Image^ _content;
     Windows::UI::Xaml::Controls::Canvas^ _sublayerCanvas;
+    Windows::UI::Xaml::Controls::Border^ _border;
 };
 
 } /* Xaml*/

--- a/Frameworks/UIKit.Xaml/Layer.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/Layer.xaml.cpp
@@ -35,6 +35,19 @@ DependencyProperty^ Layer::s_layerContentProperty = nullptr;
 DependencyProperty^ Layer::s_sublayerCanvasProperty = nullptr;
 bool Layer::s_dependencyPropertiesRegistered = false;
 
+LayerProperty::LayerProperty(DependencyObject^ target, DependencyProperty^ property) : _target(target), _property(property) {
+}
+
+void LayerProperty::SetValue(Platform::Object^ value) {
+    // Set the specified value on our underlying target/property pair
+    _target->SetValue(_property, value);
+}
+
+Platform::Object^ LayerProperty::GetValue() {
+    // Retrieve the current value from our underlying target/property pair
+    return _target->GetValue(_property);
+}
+
 Layer::Layer() {
     InitializeComponent();
 
@@ -70,6 +83,18 @@ bool Layer::HasLayerContent::get() {
 Canvas^ Layer::SublayerCanvas::get() {
     // We *are* the sublayer canvas
     return this;
+}
+
+// Accessor for the LayerProperty that manages the BorderBrush of this layer
+LayerProperty^ Layer::GetBorderBrushProperty() {
+    // We don't support borders on basic layers yet, because Canvas doesn't support one intrinsically
+    return nullptr;
+}
+
+// Accessor for the LayerProperty that manages the BorderThickness of this layer
+LayerProperty^ Layer::GetBorderThicknessProperty() {
+    // We don't support borders on basic layers yet, because Canvas doesn't support one intrinsically
+    return nullptr;
 }
 
 DependencyProperty^ Layer::LayerContentProperty::get() {

--- a/Frameworks/UIKit.Xaml/Layer.xaml.h
+++ b/Frameworks/UIKit.Xaml/Layer.xaml.h
@@ -24,6 +24,21 @@ namespace Xaml {
 namespace Private {
 namespace CoreAnimation {
 
+// Pairs a DependencyProperty and its associated DependencyObject for setting/getting values on objects within an ILayer instance.
+// For example, can wrap an internal FrameworkElement and its associated BorderBrushProperty.
+[Windows::Foundation::Metadata::WebHostHidden]
+public ref class LayerProperty sealed {
+public:
+    LayerProperty(Windows::UI::Xaml::DependencyObject^ target, Windows::UI::Xaml::DependencyProperty^ property);
+
+    void SetValue(Platform::Object^ value);
+    Platform::Object^ GetValue();
+
+private:
+    Windows::UI::Xaml::DependencyObject^ _target;
+    Windows::UI::Xaml::DependencyProperty^ _property;
+};
+
 [Windows::Foundation::Metadata::WebHostHidden]
 public interface class ILayer {
 public:
@@ -41,6 +56,12 @@ public:
     property Windows::UI::Xaml::Controls::Canvas^ SublayerCanvas {
         Windows::UI::Xaml::Controls::Canvas^ get();
     }
+
+    // Accessor for the LayerProperty that manages the BorderBrush of this layer
+    LayerProperty^ GetBorderBrushProperty();
+
+    // Accessor for the LayerProperty that manages the BorderThickness of this layer
+    LayerProperty^ GetBorderThicknessProperty();
 };
 
 [Windows::Foundation::Metadata::WebHostHidden]
@@ -62,6 +83,12 @@ public:
     virtual property Windows::UI::Xaml::Controls::Canvas^ SublayerCanvas {
         Windows::UI::Xaml::Controls::Canvas^ get();
     }
+
+    // Accessor for the LayerProperty that manages the BorderBrush of this layer
+    virtual LayerProperty^ GetBorderBrushProperty();
+
+    // Accessor for the LayerProperty that manages the BorderThickness of this layer
+    virtual LayerProperty^ GetBorderThicknessProperty();
 
     // Allows arbitrary framework elements to opt-into hosting layer content
     static property Windows::UI::Xaml::DependencyProperty^ LayerContentProperty {

--- a/Frameworks/UIKit/StarboardXaml/LayerProxy.h
+++ b/Frameworks/UIKit/StarboardXaml/LayerProxy.h
@@ -20,6 +20,13 @@
 #include <memory>
 #include <set>
 
+struct LayerColor {
+    float r = 0.0;
+    float g = 0.0;
+    float b = 0.0;
+    float a = 0.0;
+};
+
 // A LayerProxy is CALayer's proxy to its backing Xaml FrameworkElement.
 // LayerProxy is used to update the Xaml FrameworkElement's visual state (positioning, animations, etc.) based upon CALayer API calls,
 // and it's also responsible for the CALayer's sublayer management (*if* that backing Xaml FrameworkElement supports sublayers).
@@ -34,9 +41,7 @@ public:
     Microsoft::WRL::ComPtr<IInspectable> GetSublayerXamlElement() override;
     void* GetPropertyValue(const char* propertyName) override;
     void SetShouldRasterize(bool shouldRasterize) override;
-
-    // TODO: Can we remove this altogether at some point?
-    void SetTopMost() override;
+    void SetTopMost() override; // TODO: Can we remove this altogether at some point?
 
     // General property management
     void SetTexture(const std::shared_ptr<IDisplayTexture>& texture, float width, float height, float scale);
@@ -56,7 +61,11 @@ private:
     void _SetPropertyInt(const char* name, int value);
     void _SetHidden(bool hidden);
     void _SetMasksToBounds(bool masksToBounds);
-    void _SetBackgroundColor(float r, float g, float b, float a);
+    void _SetBackgroundColor(const LayerColor& color);
+    void _SetBorderColor(const LayerColor& color);
+    LayerColor _GetBorderColor();
+    void _SetBorderWidth(float width);
+    float _GetBorderWidth();
     void _SetContents(const Microsoft::WRL::ComPtr<IInspectable>& bitmap, float width, float height, float scale);
     void _SetContentsCenter(float x, float y, float width, float height);
 

--- a/Frameworks/UIKit/UITableViewCell.mm
+++ b/Frameworks/UIKit/UITableViewCell.mm
@@ -856,9 +856,9 @@ static void setInternalAccessoryColor(UITableViewCell* self) {
             }
         }
 
-        CGColorRef color =
-            static_cast<CGColorRef>([UIColor colorWithRed:contentColor.r green:contentColor.g blue:contentColor.b alpha:contentColor.a]);
-        [[self->_internalAccessoryView layer] _setContentColor:color];
+        // TODO: This used to call into a private/unimplemented CALayer function
+        // Not sure what we should be doing here.
+        UNIMPLEMENTED();
     }
 }
 

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -2908,7 +2908,7 @@ static void adjustSubviews(UIView* self, CGSize parentSize, CGSize delta) {
             CABasicAnimation* ret = [CABasicAnimation animationWithKeyPath:key];
 
             if (_animationProperties[stackLevel]._beginsFromCurrentState && ![key isEqualToString:@"opacity"]) {
-                [ret setFromValue:[actionLayer presentationValueForKey:key]];
+                [ret setFromValue:[actionLayer _presentationValueForKey:key]];
             } else {
                 [ret setFromValue:[actionLayer valueForKey:key]];
             }

--- a/Frameworks/include/CALayerInternal.h
+++ b/Frameworks/include/CALayerInternal.h
@@ -41,8 +41,7 @@ public:
     BOOL isOpaque;
 
     CATransform3D transform;
-    __CGColorQuad backgroundColor, borderColor;
-    float borderWidth, cornerRadius;
+    __CGColorQuad backgroundColor;
     float opacity;
 };
 
@@ -59,7 +58,7 @@ public:
     BOOL needsUpdate;
     idretain _name;
     NSMutableDictionary* _animations;
-    CGColorRef _backgroundColor, _borderColor;
+    CGColorRef _backgroundColor;
     BOOL needsDisplayOnBoundsChange;
 
     BOOL _shouldRasterize;
@@ -91,12 +90,11 @@ public:
 - (instancetype)_initWithXamlElement:(WXFrameworkElement*)xamlElement;
 @property (nonatomic, readonly, strong) WXFrameworkElement* _xamlElement;
 
-- (NSObject*)presentationValueForKey:(NSString*)key;
+- (NSObject*)_presentationValueForKey:(NSString*)key;
 
 - (int)_pixelWidth;
 - (int)_pixelHeight;
 
-- (void)_setContentColor:(CGColorRef)newColor;
 - (void)_setOrigin:(CGPoint)origin;
 - (void)_setShouldLayout;
 - (void)setContentsOrientation:(UIImageOrientation)orientation;

--- a/include/QuartzCore/CALayer.h
+++ b/include/QuartzCore/CALayer.h
@@ -95,8 +95,8 @@ CA_EXPORT_CLASS
 @property (retain) CALayer* mask STUB_PROPERTY;
 @property (getter=isDoubleSided) BOOL doubleSided STUB_PROPERTY;
 @property CGFloat cornerRadius STUB_PROPERTY;
-@property CGFloat borderWidth STUB_PROPERTY;
-@property CGColorRef borderColor STUB_PROPERTY;
+@property CGFloat borderWidth;
+@property CGColorRef borderColor;
 @property CGColorRef backgroundColor;
 @property float shadowOpacity STUB_PROPERTY;
 @property CGFloat shadowRadius STUB_PROPERTY;

--- a/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UIButtonViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UIButtonViewController.m
@@ -78,12 +78,15 @@
 
     if (indexPath.row == 0) {
         UILabel* label = [[UILabel alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop, _labelWidth, _labelHeight)];
-        label.text = @"UIButton, no backgroundColor";
+        label.text = @"UIButton, no backgroundColor with green border";
 
         UIButton* button =
             [[UIButton alloc] initWithFrame:CGRectMake(_marginLeft, _marginTop + _labelHeight, _defaultWidth, _defaultHeight)];
         [button setTitle:@"Button" forState:UIControlStateNormal];
         [button setTitleColor:[UIColor blackColor] forState:UIControlStateNormal];
+
+        button.layer.borderColor = [[UIColor greenColor] CGColor];
+        button.layer.borderWidth = 1.0;
 
         [cell addSubview:label];
         [cell addSubview:button];


### PR DESCRIPTION
…he CoreAnimation/UIKit composition layer).  Note that we still don't have border support on basic CALayers, because we haven't needed to add them yet, but the plumbing is in now place to add them when needed.

Fixes #1884.