### PR TITLE
Update Benchmarks for TAEF

### DIFF
--- a/tests/Benchmark/BenchmarkPublisher.h
+++ b/tests/Benchmark/BenchmarkPublisher.h
@@ -24,7 +24,7 @@ using Microseconds = double;
 
 class BenchmarkPublisher {
 public:
-    virtual void RegisterCaseResults(const std::string& caseName, const std::vector<Microseconds>& results) = 0;
+    virtual void RegisterCaseResults(const std::string& caseName, std::vector<Microseconds>& results) = 0;
     virtual void PublishResults() = 0;
 };
 

--- a/tests/Benchmark/EntryPoint.cpp
+++ b/tests/Benchmark/EntryPoint.cpp
@@ -19,7 +19,6 @@
 #include <fstream>
 #include <algorithm>
 
-#ifdef WIN32
 #include <roapi.h>
 #include <wrl/client.h>
 #include <wrl/wrappers/corewrappers.h>
@@ -60,12 +59,11 @@ Wrappers::HString GetAppDataPath() {
     return toReturn;
 }
 
-#endif
-
 using namespace benchmark;
 struct __Result {
     std::string testName;
     Microseconds totalRuntime;
+    Microseconds minRuntime;
     Microseconds meanRuntime;
     Microseconds stdDeviation;
     size_t runCount;
@@ -77,17 +75,19 @@ public:
     virtual void RegisterCaseResults(const std::string& caseName, const std::vector<Microseconds>& results) {
         // Algorithm for calculating sample mean and variance with minimal rounding errors
         Microseconds netRuntime = 0.0;
+        Microseconds minRuntime = FLT_MAX;
         Microseconds mean = 0.0;
         Microseconds q = 0.0;
         size_t runCount = results.size();
         for (size_t i = 0; i < runCount; ++i) {
             Microseconds previousMean = mean;
+            minRuntime = min(minRuntime, results[i]);
             netRuntime += results[i];
             mean += (results[i] - mean) / (i + 1);
             q += (results[i] - previousMean) * (results[i] - mean);
         }
         Microseconds sampleStandardDeviation = std::sqrt(q / (runCount - 1));
-        m_results.emplace_back(__Result{ caseName, netRuntime, mean, sampleStandardDeviation, runCount });
+        m_results.emplace_back(__Result{ caseName, netRuntime, minRuntime, mean, sampleStandardDeviation, runCount });
     }
 
 protected:
@@ -95,10 +95,10 @@ protected:
 };
 
 class CSVBenchmarkPublisher : public PublisherBase {
-    std::string m_outPath;
+    std::wstring m_outPath;
 
 public:
-    CSVBenchmarkPublisher(std::string&& outPath) : m_outPath(outPath) {
+    CSVBenchmarkPublisher(std::wstring&& outPath) : m_outPath(outPath) {
     }
 
     virtual void PublishResults() {
@@ -107,79 +107,41 @@ public:
                 << ","
                 << "Total Runtime"
                 << ","
+                << "Min Runtime"
+                << ","
                 << "Mean Runtime"
                 << ","
                 << "Standard Deviation"
                 << ","
-                << "Run Count"
-                << "\n";
+                << "Run Count" << std::endl;
         for (auto res : m_results) {
-            outFile << res.testName << "," << res.totalRuntime << "," << res.meanRuntime << "," << res.stdDeviation << "," << res.runCount
-                    << "\n";
+            outFile << res.testName << "," << res.totalRuntime << "," << res.minRuntime << "," << res.meanRuntime << "," << res.stdDeviation
+                    << "," << res.runCount << std::endl;
         }
 
         outFile.flush();
         outFile.close();
-        m_results.clear();
-    }
-};
 
-class LogBenchmarkPublisher : public PublisherBase {
-    size_t m_maxNameWidth = 0;
-
-public:
-    virtual void RegisterCaseResults(const std::string& testName, const std::vector<Microseconds>& results) {
-        m_maxNameWidth = max(m_maxNameWidth, testName.size());
-        PublisherBase::RegisterCaseResults(testName, results);
-    }
-
-    virtual void PublishResults() {
-        // Align output horizontally
-        std::string spaces(m_maxNameWidth - 5, ' ');
-        std::cout << "Case Name" << spaces << "|"
-                  << "Total Runtime"
-                  << "\t\t|"
-                  << "Mean Runtime"
-                  << "\t\t|"
-                  << "Standard Deviation"
-                  << "\t|"
-                  << "Run Count"
-                  << "\n";
-        for (auto res : m_results) {
-            std::string spaces(m_maxNameWidth - res.testName.size() + 4, ' ');
-            std::cout << std::fixed << res.testName << spaces << "|" << res.totalRuntime << "\t\t|" << res.meanRuntime << "\t\t|"
-                      << res.stdDeviation << "\t\t|" << res.runCount << "\n";
-        }
-
-        std::cout << std::endl;
+        // Actually saves the file since this is running as TAEF
+        WEX::Logging::Log::File(m_outPath.c_str());
         m_results.clear();
     }
 };
 
 static std::shared_ptr<BenchmarkPublisher> s_publisher;
 void BenchmarkPublisherFactory::CreatePublisher(int argc, char** argv) {
-// Currently only support CSV format
-#ifdef WIN32
+    // Currently only support CSV format
     static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 
     WEX::Common::String outputPath;
-    WEX::TestExecution::RuntimeParameters::TryGetValue(L"out", outputPath);
+    WEX::TestExecution::RuntimeParameters::TryGetValue(L"output", outputPath);
     if (!outputPath.IsEmpty()) {
-        s_publisher.reset(new CSVBenchmarkPublisher(converter.to_bytes(std::wstring(outputPath))));
+        s_publisher.reset(new CSVBenchmarkPublisher(std::wstring(outputPath)));
     }
-
-#else
-    for (int i = 1; i < argc && argv[i]; ++i) {
-        char* arg = argv[i];
-        if (strncmp(arg, "--out=", 6) == 0) {
-            s_publisher.reset(new CSVBenchmarkPublisher(std::move(std::string(arg + 6))));
-        }
-    }
-#endif
 
     if (!s_publisher) {
-        LOG_INFO("No arguments given to benchmark. Defaulting to logging results");
-        s_publisher.reset(new LogBenchmarkPublisher());
+        WEX::Logging::Log::Comment(L"Using default output filename");
+        s_publisher.reset(new CSVBenchmarkPublisher(std::wstring(L"benchmark_results.csv")));
     }
 }
 
@@ -187,17 +149,11 @@ std::shared_ptr<BenchmarkPublisher> BenchmarkPublisherFactory::GetPublisher() {
     return s_publisher;
 }
 
-#ifdef WIN32
 BEGIN_MODULE()
 MODULE_PROPERTY(L"RunAs", L"UAP")
 END_MODULE()
 
 MODULE_SETUP(ModuleSetup) {
-#else
-int main(int argc, char** argv) {
-#endif
-
-#ifdef WIN32
     if (FAILED(RoInitialize(RO_INIT_MULTITHREADED))) {
         return FALSE;
     }
@@ -210,23 +166,14 @@ int main(int argc, char** argv) {
 
     int argc = 1;
     char* argv[] = { "UnitTests" };
-#endif
 
     BenchmarkPublisherFactory::CreatePublisher(argc, argv);
     testing::InitGoogleTest(&argc, argv);
-#ifdef WIN32
     return TRUE;
-#else
-    auto result = RUN_ALL_TESTS();
-    BenchmarkPublisherFactory::GetPublisher()->PublishResults();
-    return result;
-#endif
 }
 
-#ifdef WIN32
 MODULE_CLEANUP(ModuleCleanup) {
     BenchmarkPublisherFactory::GetPublisher()->PublishResults();
     RoUninitialize();
     return true;
 }
-#endif


### PR DESCRIPTION
Use WEX file logging to save output csv data from benchmarking cases.
Changes default from logging to a default csv file.
Adds minimum runtime to recorded statistics.

Fixes #1939
