### PR TITLE
Annotate CoreText and CoreFoundation apis that are not in plan

### DIFF
--- a/Frameworks/CoreFoundation/String.subproj/CFString.c
+++ b/Frameworks/CoreFoundation/String.subproj/CFString.c
@@ -6720,21 +6720,19 @@ void CFShowStr(CFStringRef str) {
 #undef HANGUL_NCOUNT
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes String hypenation is non-trivial and not used widely.  For regular text layout, Coretext provides hypenation through Dwrite.
 */
 CF_EXPORT CFIndex CFStringGetHyphenationLocationBeforeIndex(CFStringRef string, CFIndex location, CFRange limitRange, CFOptionFlags options, CFLocaleRef locale, UTF32Char *character) {
-    // TODO: 7495205: Needs implementation
     UNIMPLEMENTED();
     return StubReturn();
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes String hypenation is non-trivial and not used widely.  For regular text layout, Coretext provides hypenation through Dwrite.
 */
 CF_EXPORT Boolean CFStringIsHyphenationAvailableForLocale(CFLocaleRef locale) {
-    // TODO: 7495205: Needs implementation
     UNIMPLEMENTED();
     return StubReturn();
 }

--- a/Frameworks/CoreFoundation/String.subproj/CFString.c
+++ b/Frameworks/CoreFoundation/String.subproj/CFString.c
@@ -6721,7 +6721,7 @@ void CFShowStr(CFStringRef str) {
 
 /**
  @Status NotInPlan
- @Notes String hypenation is non-trivial and not used widely.  For regular text layout, Coretext provides hypenation through Dwrite.
+ @Notes String hyphenation is non-trivial and not used widely.  For regular text layout, Coretext provides hypenation through Dwrite.
 */
 CF_EXPORT CFIndex CFStringGetHyphenationLocationBeforeIndex(CFStringRef string, CFIndex location, CFRange limitRange, CFOptionFlags options, CFLocaleRef locale, UTF32Char *character) {
     UNIMPLEMENTED();
@@ -6730,7 +6730,7 @@ CF_EXPORT CFIndex CFStringGetHyphenationLocationBeforeIndex(CFStringRef string, 
 
 /**
  @Status NotInPlan
- @Notes String hypenation is non-trivial and not used widely.  For regular text layout, Coretext provides hypenation through Dwrite.
+ @Notes String hyphenation is non-trivial and not used widely.  For regular text layout, Coretext provides hypenation through Dwrite.
 */
 CF_EXPORT Boolean CFStringIsHyphenationAvailableForLocale(CFLocaleRef locale) {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -274,8 +274,8 @@ CTFontRef CTFontCreateWithFontDescriptorAndOptions(CTFontDescriptorRef descripto
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes docs not clear for uiType, not much usage
 */
 CTFontRef CTFontCreateUIFontForLanguage(CTFontUIFontType uiType, CGFloat size, CFStringRef language) {
     UNIMPLEMENTED();
@@ -371,8 +371,8 @@ CTFontRef CTFontCreateCopyWithFamily(CTFontRef font, CGFloat size, const CGAffin
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes would require implementation over dwrite
 */
 CTFontRef CTFontCreateForString(CTFontRef currentFont, CFStringRef string, CFRange range) {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTFontCollection.mm
+++ b/Frameworks/CoreText/CTFontCollection.mm
@@ -20,8 +20,8 @@
 const CFStringRef kCTFontCollectionRemoveDuplicatesOption = static_cast<CFStringRef>(@"kCTFontCollectionRemoveDuplicatesOption");
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes font collection support can be added as needed.
 */
 CTFontCollectionRef CTFontCollectionCreateFromAvailableFonts(CFDictionaryRef options) {
     UNIMPLEMENTED();
@@ -29,8 +29,8 @@ CTFontCollectionRef CTFontCollectionCreateFromAvailableFonts(CFDictionaryRef opt
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes font collection support can be added as needed.
 */
 CTFontCollectionRef CTFontCollectionCreateWithFontDescriptors(CFArrayRef queryDescriptors, CFDictionaryRef options) {
     UNIMPLEMENTED();
@@ -38,8 +38,8 @@ CTFontCollectionRef CTFontCollectionCreateWithFontDescriptors(CFArrayRef queryDe
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes font collection support can be added as needed.
 */
 CTFontCollectionRef CTFontCollectionCreateCopyWithFontDescriptors(CTFontCollectionRef original,
                                                                   CFArrayRef queryDescriptors,
@@ -49,8 +49,8 @@ CTFontCollectionRef CTFontCollectionCreateCopyWithFontDescriptors(CTFontCollecti
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes font collection support can be added as needed.
 */
 CFArrayRef CTFontCollectionCreateMatchingFontDescriptors(CTFontCollectionRef collection) {
     UNIMPLEMENTED();
@@ -58,8 +58,8 @@ CFArrayRef CTFontCollectionCreateMatchingFontDescriptors(CTFontCollectionRef col
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes font collection support can be added as needed.
 */
 CFArrayRef CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback(CTFontCollectionRef collection,
                                                                            CTFontCollectionSortDescriptorsCallback sortCallback,
@@ -69,8 +69,8 @@ CFArrayRef CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback(CTFon
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes not applicable (no type)
 */
 CFTypeID CTFontCollectionGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTFontDescriptor.mm
+++ b/Frameworks/CoreText/CTFontDescriptor.mm
@@ -266,6 +266,18 @@ CFTypeRef CTFontDescriptorCopyLocalizedAttribute(CTFontDescriptorRef descriptor,
 }
 
 /**
+ @Status NotInPlan
+ @Notes  Not documented
+*/
+
+bool CTFontDescriptorMatchFontDescriptorsWithProgressHandler(CFArrayRef descriptors,
+                                                             CFSetRef mandatoryAttributes,
+                                                             CTFontDescriptorProgressHandler progressBlock) {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
  @Status Interoperable
  @Notes
 */

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -208,9 +208,10 @@ static NSMutableAttributedString* _getTruncatedStringFromSourceLine(CTLineRef so
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes This would be hard to get right for justfication factors (0, 1).
 */
+
 CTLineRef CTLineCreateJustifiedLine(CTLineRef line, CGFloat justificationFactor, double justificationWidth) {
     UNIMPLEMENTED();
     return StubReturn();
@@ -265,7 +266,7 @@ CFRange CTLineGetStringRange(CTLineRef line) {
 }
 
 /**
- @Status Stub
+ @Status Caveat
  @Notes Returns 0.0
 */
 double CTLineGetPenOffsetForFlush(CTLineRef line, CGFloat flushFactor, double flushWidth) {
@@ -389,8 +390,18 @@ CGFloat CTLineGetOffsetForStringIndex(CTLineRef lineRef, CFIndex charIndex, CGFl
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes This API is mostly un-documented and appears to be very low usage.
+*/
+
+CGRect CTLineGetBoundsWithOptions(CTLineRef line, CTLineBoundsOptions options) {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status NotInPlan
+ @Notes this would require us to move to using briged type implementation, seems of little value at this point
 */
 CFTypeID CTLineGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -401,7 +401,7 @@ CGRect CTLineGetBoundsWithOptions(CTLineRef line, CTLineBoundsOptions options) {
 
 /**
  @Status NotInPlan
- @Notes this would require us to move to using briged type implementation, seems of little value at this point
+ @Notes this would require us to move to using bridged type implementation, seems of little value at this point
 */
 CFTypeID CTLineGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -304,7 +304,7 @@ CGAffineTransform CTRunGetTextMatrix(CTRunRef run) {
 
 /**
  @Status NotInPlan
- @Notes this would require us to move to using briged type implementation, seems of little value at this point
+ @Notes this would require us to move to using bridged type implementation, seems of little value at this point
 */
 CFTypeID CTRunGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -303,8 +303,8 @@ CGAffineTransform CTRunGetTextMatrix(CTRunRef run) {
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes this would require us to move to using briged type implementation, seems of little value at this point
 */
 CFTypeID CTRunGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTRunDelegate.mm
+++ b/Frameworks/CoreText/CTRunDelegate.mm
@@ -37,7 +37,7 @@ void* CTRunDelegateGetRefCon(CTRunDelegateRef runDelegate) {
 
 /**
  @Status NotInPlan
- @Notes this would require us to move to using briged type implementation, seems of little value at this point
+ @Notes this would require us to move to using bridged type implementation, seems of little value at this point
 */
 CFTypeID CTRunDelegateGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTRunDelegate.mm
+++ b/Frameworks/CoreText/CTRunDelegate.mm
@@ -18,8 +18,8 @@
 #import <StubReturn.h>
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes run delegates cannot be supported easily with dwrite
 */
 CTRunDelegateRef CTRunDelegateCreate(const CTRunDelegateCallbacks* callbacks, void* refCon) {
     UNIMPLEMENTED();
@@ -27,8 +27,8 @@ CTRunDelegateRef CTRunDelegateCreate(const CTRunDelegateCallbacks* callbacks, vo
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes run delegates cannot be supported easliy with dwrite
 */
 void* CTRunDelegateGetRefCon(CTRunDelegateRef runDelegate) {
     UNIMPLEMENTED();
@@ -36,8 +36,8 @@ void* CTRunDelegateGetRefCon(CTRunDelegateRef runDelegate) {
 }
 
 /**
- @Status Stub
- @Notes
+ @Status NotInPlan
+ @Notes this would require us to move to using briged type implementation, seems of little value at this point
 */
 CFTypeID CTRunDelegateGetTypeID() {
     UNIMPLEMENTED();

--- a/Frameworks/CoreText/CTTypesetter.mm
+++ b/Frameworks/CoreText/CTTypesetter.mm
@@ -129,7 +129,7 @@ CFIndex CTTypesetterSuggestClusterBreakWithOffset(CTTypesetterRef typesetter, CF
 }
 
 /**
- @Status Stub
+ @Status NotInPlan
  @Notes
 */
 CFTypeID CTTypesetterGetTypeID() {

--- a/Frameworks/CoreText/CTUtilities.mm
+++ b/Frameworks/CoreText/CTUtilities.mm
@@ -18,10 +18,9 @@
 #import <StubReturn.h>
 
 /**
- @Status Stub
- @Notes
+ @Status Caveat
+ @Notes returns kCTVersionNumber10_5 but we don't support all apis at that level
 */
 uint32_t CTGetCoreTextVersion() {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return kCTVersionNumber10_5;
 }

--- a/build/CoreText/dll/CoreText.def
+++ b/build/CoreText/dll/CoreText.def
@@ -186,6 +186,7 @@ LIBRARY CoreText
         CTFontDescriptorCopyAttributes
         CTFontDescriptorCopyAttribute
         CTFontDescriptorCopyLocalizedAttribute
+        CTFontDescriptorMatchFontDescriptorsWithProgressHandler
         CTFontDescriptorGetTypeID
 
         ; CTFrame Reference.mm
@@ -230,6 +231,7 @@ LIBRARY CoreText
         CTLineGetStringRange
         CTLineGetPenOffsetForFlush
         CTLineGetImageBounds
+        CTLineGetBoundsWithOptions
         CTLineGetTypographicBounds
         CTLineGetTrailingWhitespaceWidth
         CTLineGetStringIndexForPosition

--- a/include/CoreText/CTFont.h
+++ b/include/CoreText/CTFont.h
@@ -193,7 +193,7 @@ CORETEXT_EXPORT CTFontRef CTFontCreateWithFontDescriptorAndOptions(CTFontDescrip
                                                                    CGFloat size,
                                                                    const CGAffineTransform* matrix,
                                                                    CTFontOptions options);
-CORETEXT_EXPORT CTFontRef CTFontCreateUIFontForLanguage(CTFontUIFontType uiType, CGFloat size, CFStringRef language) STUB_METHOD;
+CORETEXT_EXPORT CTFontRef CTFontCreateUIFontForLanguage(CTFontUIFontType uiType, CGFloat size, CFStringRef language) NOTINPLAN_METHOD;
 CORETEXT_EXPORT CTFontRef CTFontCreateCopyWithAttributes(CTFontRef font,
                                                          CGFloat size,
                                                          const CGAffineTransform* matrix,
@@ -201,7 +201,7 @@ CORETEXT_EXPORT CTFontRef CTFontCreateCopyWithAttributes(CTFontRef font,
 CORETEXT_EXPORT CTFontRef CTFontCreateCopyWithSymbolicTraits(
     CTFontRef font, CGFloat size, const CGAffineTransform* matrix, CTFontSymbolicTraits symTraitValue, CTFontSymbolicTraits symTraitMask);
 CORETEXT_EXPORT CTFontRef CTFontCreateCopyWithFamily(CTFontRef font, CGFloat size, const CGAffineTransform* matrix, CFStringRef family);
-CORETEXT_EXPORT CTFontRef CTFontCreateForString(CTFontRef currentFont, CFStringRef string, CFRange range) STUB_METHOD;
+CORETEXT_EXPORT CTFontRef CTFontCreateForString(CTFontRef currentFont, CFStringRef string, CFRange range) NOTINPLAN_METHOD;
 CORETEXT_EXPORT CTFontDescriptorRef CTFontCopyFontDescriptor(CTFontRef font);
 CORETEXT_EXPORT CFTypeRef CTFontCopyAttribute(CTFontRef font, CFStringRef attribute);
 CORETEXT_EXPORT CGFloat CTFontGetSize(CTFontRef font);

--- a/include/CoreText/CTFontCollection.h
+++ b/include/CoreText/CTFontCollection.h
@@ -30,13 +30,13 @@ enum { kCTFontCollectionCopyDefaultOptions = 0, kCTFontCollectionCopyUnique = (1
 
 CORETEXT_EXPORT const CFStringRef kCTFontCollectionRemoveDuplicatesOption;
 
-CORETEXT_EXPORT CTFontCollectionRef CTFontCollectionCreateFromAvailableFonts(CFDictionaryRef options) STUB_METHOD;
+CORETEXT_EXPORT CTFontCollectionRef CTFontCollectionCreateFromAvailableFonts(CFDictionaryRef options) NOTINPLAN_METHOD;
 CORETEXT_EXPORT CTFontCollectionRef CTFontCollectionCreateWithFontDescriptors(CFArrayRef queryDescriptors,
-                                                                              CFDictionaryRef options) STUB_METHOD;
+                                                                              CFDictionaryRef options) NOTINPLAN_METHOD;
 CORETEXT_EXPORT CTFontCollectionRef CTFontCollectionCreateCopyWithFontDescriptors(CTFontCollectionRef original,
                                                                                   CFArrayRef queryDescriptors,
-                                                                                  CFDictionaryRef options) STUB_METHOD;
-CORETEXT_EXPORT CFArrayRef CTFontCollectionCreateMatchingFontDescriptors(CTFontCollectionRef collection) STUB_METHOD;
+                                                                                  CFDictionaryRef options) NOTINPLAN_METHOD;
+CORETEXT_EXPORT CFArrayRef CTFontCollectionCreateMatchingFontDescriptors(CTFontCollectionRef collection) NOTINPLAN_METHOD;
 CORETEXT_EXPORT CFArrayRef CTFontCollectionCreateMatchingFontDescriptorsSortedWithCallback(
-    CTFontCollectionRef collection, CTFontCollectionSortDescriptorsCallback sortCallback, void* refCon) STUB_METHOD;
-CORETEXT_EXPORT CFTypeID CTFontCollectionGetTypeID() STUB_METHOD;
+    CTFontCollectionRef collection, CTFontCollectionSortDescriptorsCallback sortCallback, void* refCon) NOTINPLAN_METHOD;
+CORETEXT_EXPORT CFTypeID CTFontCollectionGetTypeID() NOTINPLAN_METHOD;

--- a/include/CoreText/CTFontDescriptor.h
+++ b/include/CoreText/CTFontDescriptor.h
@@ -26,12 +26,13 @@
 #import <CoreGraphics/CGBase.h>
 
 typedef const struct __CTFontDescriptor* CTFontDescriptorRef;
+
 typedef uint32_t CTFontOrientation;
 typedef uint32_t CTFontFormat;
 typedef uint32_t CTFontPriority;
 typedef uint32_t CTFontSymbolicTraits;
 typedef uint32_t CTFontStylisticClass;
-
+typedef uint32_t CTFontDescriptorMatchingState;
 enum { kCTFontDefaultOrientation = 0, kCTFontHorizontalOrientation = 1, kCTFontVerticalOrientation = 2 };
 enum {
     kCTFontFormatUnrecognized = 0,
@@ -86,6 +87,19 @@ enum {
     kCTFontScriptsClass = (10 << kCTFontClassMaskShift),
     kCTFontSymbolicClass = (12 << kCTFontClassMaskShift)
 };
+enum {
+    kCTFontDescriptorMatchingDidBegin,
+    kCTFontDescriptorMatchingDidFailWithError,
+    kCTFontDescriptorMatchingDidFinish,
+    kCTFontDescriptorMatchingDidFinishDownloading,
+    kCTFontDescriptorMatchingDidMatch,
+    kCTFontDescriptorMatchingDownloading,
+    kCTFontDescriptorMatchingStalled,
+    kCTFontDescriptorMatchingWillBeginDownloading,
+    kCTFontDescriptorMatchingWillBeginQuerying
+};
+
+typedef bool (^CTFontDescriptorProgressHandler)(CTFontDescriptorMatchingState state, CFDictionaryRef progressParameter);
 
 CORETEXT_EXPORT const CFStringRef kCTFontURLAttribute;
 CORETEXT_EXPORT const CFStringRef kCTFontNameAttribute;
@@ -132,4 +146,6 @@ CORETEXT_EXPORT CFTypeRef CTFontDescriptorCopyAttribute(CTFontDescriptorRef desc
 CORETEXT_EXPORT CFTypeRef CTFontDescriptorCopyLocalizedAttribute(CTFontDescriptorRef descriptor,
                                                                  CFStringRef attribute,
                                                                  CFStringRef _Nullable* language);
+CORETEXT_EXPORT bool CTFontDescriptorMatchFontDescriptorsWithProgressHandler(
+    CFArrayRef descriptors, CFSetRef mandatoryAttributes, CTFontDescriptorProgressHandler progressBlock) NOTINPLAN_METHOD;
 CORETEXT_EXPORT CFTypeID CTFontDescriptorGetTypeID();

--- a/include/CoreText/CTLine.h
+++ b/include/CoreText/CTLine.h
@@ -24,23 +24,36 @@
 #import <CoreGraphics/CGGeometry.h>
 
 typedef const struct __CTLine* CTLineRef;
+
 typedef uint32_t CTLineTruncationType;
 enum { kCTLineTruncationStart = 0, kCTLineTruncationEnd = 1, kCTLineTruncationMiddle = 2 };
+typedef uint32_t CTLineBoundsOptions;
+enum {
+    kCTLineBoundsExcludeTypographicLeading = 0 << 1,
+    kCTLineBoundsExcludeTypographicShifts = 1 << 1,
+    kCTLineBoundsUseHangingPunctuation = 1 << 2,
+    kCTLineBoundsUseGlyphPathBounds = 1 << 3,
+    kCTLineBoundsUseOpticalBounds = 1 << 4,
+    kCTLineBoundsIncludeLanguageExtents = 1 << 5
+};
 
 CORETEXT_EXPORT CTLineRef CTLineCreateWithAttributedString(CFAttributedStringRef attrString);
 CORETEXT_EXPORT CTLineRef CTLineCreateTruncatedLine(CTLineRef line,
                                                     double width,
                                                     CTLineTruncationType truncationType,
                                                     CTLineRef truncationToken);
-CORETEXT_EXPORT CTLineRef CTLineCreateJustifiedLine(CTLineRef line, CGFloat justificationFactor, double justificationWidth) STUB_METHOD;
+CORETEXT_EXPORT CTLineRef CTLineCreateJustifiedLine(CTLineRef line,
+                                                    CGFloat justificationFactor,
+                                                    double justificationWidth) NOTINPLAN_METHOD;
 CORETEXT_EXPORT void CTLineDraw(CTLineRef line, CGContextRef context);
 CORETEXT_EXPORT CFIndex CTLineGetGlyphCount(CTLineRef line);
 CORETEXT_EXPORT CFArrayRef CTLineGetGlyphRuns(CTLineRef line);
 CORETEXT_EXPORT CFRange CTLineGetStringRange(CTLineRef line);
-CORETEXT_EXPORT double CTLineGetPenOffsetForFlush(CTLineRef line, CGFloat flushFactor, double flushWidth) STUB_METHOD;
+CORETEXT_EXPORT double CTLineGetPenOffsetForFlush(CTLineRef line, CGFloat flushFactor, double flushWidth);
 CORETEXT_EXPORT CGRect CTLineGetImageBounds(CTLineRef line, CGContextRef context) STUB_METHOD;
+CORETEXT_EXPORT CGRect CTLineGetBoundsWithOptions(CTLineRef line, CTLineBoundsOptions options) NOTINPLAN_METHOD;
 CORETEXT_EXPORT double CTLineGetTypographicBounds(CTLineRef line, CGFloat* ascent, CGFloat* descent, CGFloat* leading);
 CORETEXT_EXPORT double CTLineGetTrailingWhitespaceWidth(CTLineRef line) STUB_METHOD;
 CORETEXT_EXPORT CFIndex CTLineGetStringIndexForPosition(CTLineRef line, CGPoint position);
 CORETEXT_EXPORT CGFloat CTLineGetOffsetForStringIndex(CTLineRef line, CFIndex charIndex, CGFloat* secondaryOffset);
-CORETEXT_EXPORT CFTypeID CTLineGetTypeID() STUB_METHOD;
+CORETEXT_EXPORT CFTypeID CTLineGetTypeID() NOTINPLAN_METHOD;

--- a/include/CoreText/CTRun.h
+++ b/include/CoreText/CTRun.h
@@ -49,4 +49,4 @@ CORETEXT_EXPORT double CTRunGetTypographicBounds(CTRunRef run, CFRange range, CG
 CORETEXT_EXPORT CGRect CTRunGetImageBounds(CTRunRef run, CGContextRef context, CFRange range) STUB_METHOD;
 CORETEXT_EXPORT void CTRunDraw(CTRunRef run, CGContextRef context, CFRange range);
 CORETEXT_EXPORT CGAffineTransform CTRunGetTextMatrix(CTRunRef run) STUB_METHOD;
-CORETEXT_EXPORT CFTypeID CTRunGetTypeID() STUB_METHOD;
+CORETEXT_EXPORT CFTypeID CTRunGetTypeID() NOTINPLAN_METHOD;

--- a/include/CoreText/CTRunDelegate.h
+++ b/include/CoreText/CTRunDelegate.h
@@ -37,6 +37,6 @@ enum {
     kCTRunDelegateCurrentVersion = kCTRunDelegateVersion1,
 };
 
-CORETEXT_EXPORT CTRunDelegateRef CTRunDelegateCreate(const CTRunDelegateCallbacks* callbacks, void* refCon) STUB_METHOD;
-CORETEXT_EXPORT void* CTRunDelegateGetRefCon(CTRunDelegateRef runDelegate) STUB_METHOD;
-CORETEXT_EXPORT CFTypeID CTRunDelegateGetTypeID() STUB_METHOD;
+CORETEXT_EXPORT CTRunDelegateRef CTRunDelegateCreate(const CTRunDelegateCallbacks* callbacks, void* refCon) NOTINPLAN_METHOD;
+CORETEXT_EXPORT void* CTRunDelegateGetRefCon(CTRunDelegateRef runDelegate) NOTINPLAN_METHOD;
+CORETEXT_EXPORT CFTypeID CTRunDelegateGetTypeID() NOTINPLAN_METHOD;

--- a/include/CoreText/CTTypesetter.h
+++ b/include/CoreText/CTTypesetter.h
@@ -39,4 +39,4 @@ CORETEXT_EXPORT CFIndex CTTypesetterSuggestClusterBreakWithOffset(CTTypesetterRe
                                                                   CFIndex startIndex,
                                                                   double width,
                                                                   double offset) STUB_METHOD;
-CORETEXT_EXPORT CFTypeID CTTypesetterGetTypeID() STUB_METHOD;
+CORETEXT_EXPORT CFTypeID CTTypesetterGetTypeID() NOTINPLAN_METHOD;

--- a/include/CoreText/CTUtilities.h
+++ b/include/CoreText/CTUtilities.h
@@ -19,7 +19,7 @@
 
 #include <stdint.h>
 
-CORETEXT_EXPORT uint32_t CTGetCoreTextVersion() STUB_METHOD;
+CORETEXT_EXPORT uint32_t CTGetCoreTextVersion();
 
 #define kCTVersionNumber10_5 0x00020000
 #define kCTVersionNumber10_5_2 0x00020001

--- a/include/StubIncludes.h
+++ b/include/StubIncludes.h
@@ -40,16 +40,22 @@
 
 #if defined(NO_STUB_METHODS)
 #define STUB_METHOD __attribute__((unavailable("method not yet implemented")))
+#define NOTINPLAN_METHOD __attribute__((unavailable("method not in current implementation roadmap")))
 #elif defined(WARN_STUB_METHODS)
 #define STUB_METHOD __attribute__((deprecated("method not yet implemented")))
+#define NOTINPLAN_METHOD __attribute__((deprecated("method not in current implementation roadmap")))
 #else
 #define STUB_METHOD
+#define NOTINPLAN_METHOD
 #endif
 
 #if defined(NO_STUB_PROPERTIES)
 #define STUB_PROPERTY __attribute__((unavailable("property not yet implemented")))
+#define NOTINPLAN_PROPERTY __attribute__((unavailable("property not in current implementation roadmap")))
 #elif defined(WARN_STUB_PROPERTIES)
 #define STUB_PROPERTY __attribute__((deprecated("property not yet implemented")))
+#define NOTINPLAN_PROPERTY __attribute__((deprecated("property not in current implementation roadmap")))
 #else
 #define STUB_PROPERTY
+#define NOTINPLAN_PROPERTY
 #endif


### PR DESCRIPTION
This is just internal book keeping for APIs that we don't plan to implement in near future.  Subject to change of course.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/1988)
<!-- Reviewable:end -->
