### PR TITLE
Fix #1999 'MoveMe' button in HelloUI moves erratically

### DIFF
--- a/Frameworks/UIKit/UIPanGestureRecognizer.mm
+++ b/Frameworks/UIKit/UIPanGestureRecognizer.mm
@@ -37,7 +37,6 @@
 static const wchar_t* TAG = L"UIPanGestureRecognizer";
 
 #define VELOCITY_THRESHOLD 50.0f
-NSArray* curPanList = nil;
 
 @implementation UIPanGestureRecognizer {
     CGPoint _translation;
@@ -409,10 +408,7 @@ static CGPoint pointFromView(const CGPoint& pt, UIView* viewAddr) {
     const CGPoint origin = { 0, 0 };
 
     CGPoint pos = pointFromView(translation, viewAddr) - pointFromView(origin, viewAddr);
-
-    for (UIGestureRecognizer* curgesture in curPanList) {
-        ((UIPanGestureRecognizer*)curgesture)->_priv->currentTranslation = pos;
-    }
+    _priv->currentTranslation = pos;
 }
 
 - (UIView*)_touchedView {


### PR DESCRIPTION
We removed the places which set curPanList in earlier change, which is used to support UIScollivew for gesture chaining but now that is not needed. 

but we keep curPanList around which didn't get set anymore. But it was still used in setTranslation in PanGesture. So when app resets the translation, we failed to do that because curPanList is nil. The fix is to remove enumerating the curPanList and set the translation to self, which is correct way of doing it.

