### PR TITLE
Allow a 0b stride bitmap context to calculate its own stride.

### DIFF
--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -192,6 +192,7 @@ COREGRAPHICS_EXPORT void* _CGImageGetRawBytes(CGImageRef image);
 // Obtain the associated DisplayTexture
 __declspec(dllexport) std::shared_ptr<IDisplayTexture> _CGImageGetDisplayTexture(CGImageRef image);
 
+size_t _CGImageImputeBitsPerPixelFromFormat(CGColorSpaceRef colorSpace, size_t bitsPerComponent, CGBitmapInfo bitmapInfo);
 HRESULT _CGImageGetWICPixelFormatFromImageProperties(unsigned int bitsPerComponent,
                                                      unsigned int bitsPerPixel,
                                                      CGColorSpaceRef colorSpace,


### PR DESCRIPTION
This adds a few more failure cases for bad bitmap contexts,
and changes format imputation in the CG<->WIC mapper.

Fixes #1997, #1998.