### PR TITLE
Properly support RTL text drawing in CoreText

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -2089,7 +2089,7 @@ HRESULT __CGContext::DrawGlyphRuns(GlyphRunData* glyphRuns, size_t runsCount, bo
             // First glyph's origin is at the given relative position for the glyph run
             CGPoint runningPosition{ glyphRuns[i].relativePosition.x, std::round(glyphRuns[i].relativePosition.y) };
             for (size_t j = 0; j < run->glyphCount; ++j) {
-                if (run->bidiLevel & 1) {
+                if (_GlyphRunIsRTL(*run)) {
                     // Translate position of glyph by advance
                     // Need to translate each glyph by its own advance because it's RTL
                     runningPosition.x -= run->glyphAdvances[j];
@@ -2103,13 +2103,13 @@ HRESULT __CGContext::DrawGlyphRuns(GlyphRunData* glyphRuns, size_t runsCount, bo
                 positions[j] = DWRITE_GLYPH_OFFSET{ transformedPosition.x + run->glyphOffsets[j].advanceOffset,
                                                     std::round(transformedPosition.y + run->glyphOffsets[j].ascenderOffset) };
 
-                if ((run->bidiLevel & 1) == 0) {
+                if (!_GlyphRunIsRTL(*run)) {
                     // Translate position of next glyph by current glyph's advance
                     runningPosition.x += run->glyphAdvances[j];
                 }
             }
 
-            // Even if text is RTL set bidiLevel to 0 to draw in correct orientation for proper transformation by glyph
+            // Already compensated for RTL glyph positions, so set bidiLevel to 0
             auto transformedGlyphRun = std::make_shared<DWRITE_GLYPH_RUN>(DWRITE_GLYPH_RUN{ run->fontFace,
                                                                                             run->fontEmSize,
                                                                                             run->glyphCount,
@@ -2137,7 +2137,7 @@ HRESULT __CGContext::DrawGlyphRuns(GlyphRunData* glyphRuns, size_t runsCount, bo
                                                                        runData.run->glyphOffsets,
                                                                        runData.run->glyphCount,
                                                                        runData.run->isSideways,
-                                                                       ((runData.run->bidiLevel & 1) == 1),
+                                                                       _GlyphRunIsRTL(*(runData.run)),
                                                                        sink.Get()));
         }
         RETURN_IF_FAILED(sink->Close());

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -95,9 +95,9 @@ CTFrameRef CTFramesetterCreateFrame(CTFramesetterRef framesetterRef, CFRange ran
         (lineBreakMode == kCTLineBreakByClipping || lineBreakMode == kCTLineBreakByTruncatingHead ||
          lineBreakMode == kCTLineBreakByTruncatingTail || lineBreakMode == kCTLineBreakByTruncatingMiddle)) {
         for (size_t i = 0; i < ret->_lineOrigins.size(); ++i) {
-            if (CTLineGetTypographicBounds(static_cast<CTLineRef>([ret->_lines objectAtIndex:i]), nullptr, nullptr, nullptr) >
-                frameRect.size.width) {
-                ret->_lineOrigins[i].x = frameRect.origin.x;
+            _CTLine* line = [ret->_lines objectAtIndex:i];
+            if (line->_width > frameRect.size.width) {
+                ret->_lineOrigins[i].x -= line->_relativeXOffset;
             }
         }
     }

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -345,7 +345,7 @@ CFIndex CTLineGetStringIndexForPosition(CTLineRef lineRef, CGPoint position) {
         curPos += run->_relativeXOffset;
         CGFloat runPos = curPos;
         for (int i = 0; i < run->_dwriteGlyphRun.glyphCount; i++) {
-            if (run->_dwriteGlyphRun.bidiLevel & 1) {
+            if (_GlyphRunIsRTL(run->_dwriteGlyphRun)) {
                 if (runPos <= position.x) {
                     return run->_stringIndices[i];
                 }
@@ -379,7 +379,7 @@ CGFloat CTLineGetOffsetForStringIndex(CTLineRef lineRef, CFIndex charIndex, CGFl
                                 run->_stringIndices.begin() - 1;
 
                     if (index >= 0) {
-                        if (run->_dwriteGlyphRun.bidiLevel & 1) {
+                        if (_GlyphRunIsRTL(run->_dwriteGlyphRun)) {
                             ret += std::accumulate(run->_dwriteGlyphRun.glyphAdvances,
                                                    run->_dwriteGlyphRun.glyphAdvances + index,
                                                    run->_relativeXOffset,

--- a/Frameworks/CoreText/CTRun.mm
+++ b/Frameworks/CoreText/CTRun.mm
@@ -107,7 +107,7 @@ CTRunStatus CTRunGetStatus(CTRunRef runRef) {
     if (runRef) {
         _CTRun* run = static_cast<_CTRun*>(runRef);
 
-        if (run->_dwriteGlyphRun.bidiLevel & 1) {
+        if (_GlyphRunIsRTL(run->_dwriteGlyphRun)) {
             ret |= kCTRunStatusRightToLeft;
             if (!std::is_sorted(run->_stringIndices.cbegin(), run->_stringIndices.cend(), std::greater<UINT16>())) {
                 ret |= kCTRunStatusNonMonotonic;

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -113,25 +113,29 @@ bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Outptr_ DWRITE_GLYP
 static inline HRESULT __DWriteTextFormatApplyParagraphStyle(const ComPtr<IDWriteTextFormat>& textFormat, CTParagraphStyleRef settings) {
     CTTextAlignment alignment = kCTNaturalTextAlignment;
     if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierAlignment, sizeof(CTTextAlignment), &alignment)) {
-        RETURN_IF_FAILED(textFormat->SetTextAlignment(__CTAlignmentToDWrite(alignment)));
+        if (alignment != kCTNaturalTextAlignment) {
+            RETURN_IF_FAILED(textFormat->SetTextAlignment(__CTAlignmentToDWrite(alignment)));
+        }
     }
 
     CTWritingDirection direction;
     if (CTParagraphStyleGetValueForSpecifier(settings, kCTParagraphStyleSpecifierBaseWritingDirection, sizeof(direction), &direction)) {
-        DWRITE_READING_DIRECTION dwriteDirection = DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
-        if (direction == kCTWritingDirectionRightToLeft) {
-            dwriteDirection = DWRITE_READING_DIRECTION_RIGHT_TO_LEFT;
+        if (direction != kCTWritingDirectionNatural) {
+            DWRITE_READING_DIRECTION dwriteDirection = DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
+            if (direction == kCTWritingDirectionRightToLeft) {
+                dwriteDirection = DWRITE_READING_DIRECTION_RIGHT_TO_LEFT;
 
-            // DWrite alignment is based upon reading direction whereas CoreText alignment is constant
-            // so we have to flip the writing direction
-            if (alignment == kCTRightTextAlignment || alignment == kCTNaturalTextAlignment) {
-                RETURN_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING));
-            } else if (alignment == kCTLeftTextAlignment) {
-                RETURN_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING));
+                // DWrite alignment is based upon reading direction whereas CoreText alignment is constant
+                // so we have to flip the writing direction
+                if (alignment == kCTRightTextAlignment || alignment == kCTNaturalTextAlignment) {
+                    RETURN_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING));
+                } else if (alignment == kCTLeftTextAlignment) {
+                    RETURN_IF_FAILED(textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_TRAILING));
+                }
             }
-        }
 
-        RETURN_IF_FAILED(textFormat->SetReadingDirection(dwriteDirection));
+            RETURN_IF_FAILED(textFormat->SetReadingDirection(dwriteDirection));
+        }
     }
 
     CTLineBreakMode lineBreakMode;
@@ -371,7 +375,7 @@ public:
     };
 
     HRESULT STDMETHODCALLTYPE GetCurrentTransform(_In_opt_ void* clientDrawingContext, _Out_ DWRITE_MATRIX* transform) throw() {
-        *transform = {1, 0, 0, 1, 0, 0};
+        *transform = { 1, 0, 0, 1, 0, 0 };
         return S_OK;
     };
 
@@ -505,7 +509,10 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
             line->_strRange.length = stringRange;
             line->_glyphCount = glyphCount;
             line->_relativeXOffset = static_cast<_CTRun*>(line->_runs[0])->_relativeXOffset;
-            line->_relativeYOffset = static_cast<_CTRun*>(line->_runs[0])->_relativeYOffset;
+            if (static_cast<_CTRun*>([line->_runs objectAtIndex:0])->_dwriteGlyphRun.bidiLevel & 1) {
+                // First run is RTL so line's offset is position isn't the same
+                line->_relativeXOffset -= line->_width;
+            }
 
             CGPoint lineOrigin = CGPointZero;
             if (static_cast<_CTRun*>([line->_runs objectAtIndex:0])->_dwriteGlyphRun.glyphCount != 0) {

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -20,6 +20,7 @@
 
 #import "DWriteWrapper_CoreText.h"
 #import "CoreTextInternal.h"
+#import "CGContextInternal.h"
 
 #import <LoggingNative.h>
 #import <StringHelpers.h>
@@ -505,19 +506,19 @@ static _CTFrame* _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CG
         if ([runs count] > 0) {
             prevYPosForDraw = yPos;
             line->_runs = runs;
-            line->_strRange.location = static_cast<_CTRun*>(line->_runs[0])->_range.location;
+            _CTRun* firstRun = static_cast<_CTRun*>(runs[0]);
+            line->_strRange.location = firstRun->_range.location;
             line->_strRange.length = stringRange;
             line->_glyphCount = glyphCount;
-            line->_relativeXOffset = static_cast<_CTRun*>(line->_runs[0])->_relativeXOffset;
-            if (static_cast<_CTRun*>([line->_runs objectAtIndex:0])->_dwriteGlyphRun.bidiLevel & 1) {
+            line->_relativeXOffset = firstRun->_relativeXOffset;
+            if (_GlyphRunIsRTL(firstRun->_dwriteGlyphRun)) {
                 // First run is RTL so line's offset is position isn't the same
                 line->_relativeXOffset -= line->_width;
             }
 
             CGPoint lineOrigin = CGPointZero;
-            if (static_cast<_CTRun*>([line->_runs objectAtIndex:0])->_dwriteGlyphRun.glyphCount != 0) {
-                lineOrigin = { static_cast<_CTRun*>(line->_runs[0])->_glyphOrigins[0].x,
-                               static_cast<_CTRun*>(line->_runs[0])->_glyphOrigins[0].y };
+            if (firstRun->_dwriteGlyphRun.glyphCount != 0) {
+                lineOrigin = { firstRun->_glyphOrigins[0].x, firstRun->_glyphOrigins[0].y };
             }
 
             [frame->_lines addObject:line];

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -60,6 +60,10 @@ struct GlyphRunData {
 
 COREGRAPHICS_EXPORT void _CGContextDrawGlyphRuns(CGContextRef ctx, GlyphRunData* glyphRuns, size_t runCount);
 
+inline bool _GlyphRunIsRTL(const DWRITE_GLYPH_RUN& run) {
+    return (run.bidiLevel & 1);
+}
+
 COREGRAPHICS_EXPORT const CFStringRef _kCGCharacterShapeAttributeName;
 COREGRAPHICS_EXPORT const CFStringRef _kCGFontAttributeName;
 COREGRAPHICS_EXPORT const CFStringRef _kCGKernAttributeName;

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -82,3 +82,4 @@ inline uint32_t _CTToDWriteFontTableTag(uint32_t tag) {
     // CT has the opposite byte order of DWrite, so we need 'BASE' -> 'ESAB'
     return ((tag & 0xff) << 24) | ((tag & 0xff00) << 8) | ((tag & 0xff0000) >> 8) | ((tag & 0xff000000) >> 24);
 }
+

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -78,7 +78,6 @@ inline void _SafeRelease(T** p) {
 @public
     CFRange _strRange;
     CGFloat _relativeXOffset;
-    CGFloat _relativeYOffset;
     CGFloat _width;
     NSUInteger _glyphCount;
     StrongId<NSMutableArray<_CTRun*>> _runs;

--- a/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.RTLText.Rotated.-30.png
+++ b/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.RTLText.Rotated.-30.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33605168852baac5901a0d5a87be9958824610611c8f92ec514dc2fb3e42b3ee
+size 38946

--- a/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.RTLText.Rotated.0.png
+++ b/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.RTLText.Rotated.0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ccc65e752bc8751076f8ccada926a5c962f35f8cdb200b7d7b7761c0a60b05b
+size 31729

--- a/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.RTLText.Rotated.45.png
+++ b/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.RTLText.Rotated.45.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a719adbfa19d5723121706e46e19ab31b125a262bfc8da8a34d92ec1fa0cbbc8
+size 36133

--- a/tests/unittests/CoreText/CTLineTests.mm
+++ b/tests/unittests/CoreText/CTLineTests.mm
@@ -1,4 +1,4 @@
-//******************************************************************************
+﻿//******************************************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 //
@@ -33,58 +33,88 @@ NSMutableAttributedString* getAttributedString(NSString* str) {
 
 TEST(CTLine, CTLineGetStringIndexForPosition) {
     CFAttributedStringRef string = (__bridge CFAttributedStringRef)getAttributedString(@"hello");
-    CTLineRef line = CTLineCreateWithAttributedString(string);
+    auto line = woc::MakeAutoCF<CTLineRef>(CTLineCreateWithAttributedString(string));
 
     // testing with position < 0
     CGPoint position = { -1, 0 };
     CFIndex index = CTLineGetStringIndexForPosition(line, position);
-    EXPECT_EQ_MSG(index, 0, "Failed: Wrong Index for given position");
+    EXPECT_EQ(index, 0);
 
     // testing with position > length of line.
     position = { 873214, 0 };
     index = CTLineGetStringIndexForPosition(line, position);
-    EXPECT_EQ_MSG(index, CFAttributedStringGetLength(string), "Failed: Wrong Index for given position");
+    EXPECT_EQ(index, CFAttributedStringGetLength(string));
 
     position = { 23, 0 };
     index = CTLineGetStringIndexForPosition(line, position);
-    EXPECT_EQ_MSG(index, 1, "Failed: Wrong Index for given position");
+    EXPECT_EQ(index, 1);
 
     position = { 44, 0 };
     index = CTLineGetStringIndexForPosition(line, position);
-    EXPECT_EQ_MSG(index, 2, "Failed: Wrong Index for given position");
+    EXPECT_EQ(index, 2);
+
+    string = (__bridge CFAttributedStringRef)getAttributedString(@"وهذا هو نص عينة للتحقق من الصحة");
+    line = woc::MakeAutoCF<CTLineRef>(CTLineCreateWithAttributedString(string));
+
+    // testing with position < 0
+    position = { -1, 0 };
+    index = CTLineGetStringIndexForPosition(line, position);
+    EXPECT_EQ(index, CFAttributedStringGetLength(string));
+
+    // testing with position > length of line.
+    position = { 873214, 0 };
+    index = CTLineGetStringIndexForPosition(line, position);
+    EXPECT_EQ(index, 0);
+
+    position = { 50, 0 };
+    index = CTLineGetStringIndexForPosition(line, position);
+    EXPECT_EQ(index, 29);
+
+    position = { 100, 0 };
+    index = CTLineGetStringIndexForPosition(line, position);
+    EXPECT_EQ(index, 27);
 }
 
 TEST(CTLine, CTLineGetOffsetForStringIndex) {
     const double errorDelta = 1;
     CFAttributedStringRef string = (__bridge CFAttributedStringRef)getAttributedString(@"hello");
-    CTLineRef line = CTLineCreateWithAttributedString(string);
+    auto line = woc::MakeAutoCF<CTLineRef>(CTLineCreateWithAttributedString(string));
 
     CGFloat secOffset;
     // testing with index < 0
     CGFloat offset = CTLineGetOffsetForStringIndex(line, -1, &secOffset);
-    EXPECT_EQ_MSG(offset, 0, "Failed: Wrong offset for given index");
+    EXPECT_EQ(offset, 0);
 
     // testing with index = 0
     offset = CTLineGetOffsetForStringIndex(line, 0, &secOffset);
-    EXPECT_EQ_MSG(offset, 0, "Failed: Wrong offset for given index");
+    EXPECT_EQ(offset, 0);
 
     // testing with index > last index.
     offset = CTLineGetOffsetForStringIndex(line, 928347, &secOffset);
-    EXPECT_GT_MSG(offset, 58, "Failed: Wrong offset for given index");
+    EXPECT_GT(offset, 58);
 
     offset = CTLineGetOffsetForStringIndex(line, 2, &secOffset);
-    EXPECT_NEAR_MSG(43.55, offset, errorDelta, "Failed: Wrong offset for given index");
+    EXPECT_NEAR(43.55, offset, errorDelta);
 
     offset = CTLineGetOffsetForStringIndex(line, 4, &secOffset);
-    EXPECT_NEAR_MSG(62.93, offset, errorDelta, "Failed: Wrong offset for given index");
+    EXPECT_NEAR(62.93, offset, errorDelta);
 
     // passing secondaryOffset reference as NULL
-    offset = CTLineGetOffsetForStringIndex(line, 4, NULL);
-    EXPECT_NEAR_MSG(62.93, offset, errorDelta, "Failed: Wrong offset for given index");
+    offset = CTLineGetOffsetForStringIndex(line, 4, nullptr);
+    EXPECT_NEAR(62.93, offset, errorDelta);
 
     // comparing secondaryOffset and offset.
     offset = CTLineGetOffsetForStringIndex(line, 4, &secOffset);
-    EXPECT_EQ_MSG(offset, secOffset, "Failed: Wrong offset for given index");
+    EXPECT_EQ(offset, secOffset);
+
+    string = (__bridge CFAttributedStringRef)getAttributedString(@"وهذا هو نص عينة للتحقق من الصحة.");
+    line = woc::MakeAutoCF<CTLineRef>(CTLineCreateWithAttributedString(string));
+
+    offset = CTLineGetOffsetForStringIndex(line, 5, nullptr);
+    EXPECT_NEAR(509.04, offset, errorDelta);
+
+    offset = CTLineGetOffsetForStringIndex(line, 14, nullptr);
+    EXPECT_NEAR(323.45, offset, errorDelta);
 }
 
 TEST(CTLine, CTLineCreateWithAttributedString) {


### PR DESCRIPTION
Now properly draws RTL text with support for text matrix manipulation.
Change CTLineGetOffsetForStringIndex and CTFramesetterCreateFrame to remove assumption of LTR text.

Fixes #1932