### PR TITLE
Fix build issues with bundle project templates

### DIFF
--- a/tools/WinObjC.Packaging/WinObjC.Packageable.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packageable.targets
@@ -29,7 +29,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);$(ComputeLinkInputsTargets);FindPublicHeaders</GetPackageContentsDependsOn>
+    <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);$(ComputeLinkInputsTargets)</GetPackageContentsDependsOn>
+    <GetPackageContentsDependsOn Condition="'$(ConfigurationType)' == 'StaticLibrary'">$(GetPackageContentsDependsOn);FindPublicHeaders</GetPackageContentsDependsOn>
   </PropertyGroup>
 
   <!-- Add MSBuild outputs into the package -->

--- a/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Bundle/Bundle.vcxproj
+++ b/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Bundle/Bundle.vcxproj
@@ -5,6 +5,8 @@
     <ProjectName>$projectname$</ProjectName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <WindowsAppContainer>false</WindowsAppContainer>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>

--- a/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Bundle/packageable.project.json
+++ b/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Bundle/packageable.project.json
@@ -3,10 +3,14 @@
     "WinObjC.Packaging": "*"
   },
   "frameworks": {
-    ".NETFramework,Version=v4.0": {}
+    "uap10.0": {
+      "imports": "native"
+    }
   },
   "runtimes": {
-    "win": {},
-    "win-x86": {}
+    "win10-arm": {},
+    "win10-x86": {},
+    "win10-arm-aot": {},
+    "win10-x86-aot": {}
   }
 }

--- a/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Bundle/project.json
+++ b/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Bundle/project.json
@@ -2,7 +2,9 @@
   "dependencies": {
   },
   "frameworks": {
-    ".NETFramework,Version=v4.0": {}
+    "uap10.0": {
+      "imports": "native"
+    }
   },
   "runtimes": {
     "win10-arm": {},


### PR DESCRIPTION
fixes #2044
Bonus: removes bundle project's need for the WinObjC.Language package