### PR TITLE
Fix some rendering issues that were causing #2095.

### DIFF
--- a/Frameworks/QuartzCore/CALayer.mm
+++ b/Frameworks/QuartzCore/CALayer.mm
@@ -427,14 +427,20 @@ CGContextRef CreateLayerContentsBitmapContext32(int width, int height, float sca
             [priv->delegate drawLayer:self inContext:ctx];
         }
     } else {
-        CGRect rect;
+        // If the layer has cached contents, blit them directly.
 
-        rect.origin.x = 0;
-        rect.origin.y = priv->bounds.size.height * priv->contentsScale;
-        rect.size.width = priv->bounds.size.width * priv->contentsScale;
-        rect.size.height = -priv->bounds.size.height * priv->contentsScale;
+        // Since the layer was rendered in Quartz referential (ULO) AND the current context
+        // is assumed to be Quartz referential (ULO), BUT the layer's cached contents
+        // were captured in a CGImage (CGImage referential, LLO), we have to flip
+        // the context again before we render it.
 
-        _CGContextDrawImageRect(ctx, priv->contents, rect, destRect);
+        // |1  0 0| is the transformation matrix for flipping a rect anchored at 0,0 about its Y midpoint.
+        // |0 -1 0|
+        // |0  h 1|
+        CGContextSaveGState(ctx);
+        CGContextConcatCTM(ctx, CGAffineTransformMake(1, 0, 0, -1, 0, destRect.size.height));
+        CGContextDrawImage(ctx, destRect, priv->contents);
+        CGContextRestoreGState(ctx);
     }
 
     //  Draw sublayers

--- a/Frameworks/UIKit/UIImage.mm
+++ b/Frameworks/UIKit/UIImage.mm
@@ -491,8 +491,8 @@ static inline CGImageRef getImage(UIImage* uiImage) {
 
     CGRect pos;
     pos.origin = point;
-    pos.size.width = (img_height / _scale);
-    pos.size.height = (img_width / _scale);
+    pos.size.height = (img_height / _scale);
+    pos.size.width = (img_width / _scale);
 
     // |1  0 0| is the transformation matrix for flipping a rect about its Y midpoint m. (m = (y + h/2))
     // |0 -1 0|


### PR DESCRIPTION
* `-[CALayer renderInContext:]` has the ability to render a cached version of itself; it was doing so upside-down because it was using a Cairo implementation detail.
* `-[UIImage drawAtPoint:]` squashed every image it rendered because it switched width & height.

The bug in UIImage dates back to the Cairo implementation as well; the invalid size was passed to a function that ignored it. When our refactor made use of that parameter, things rapidly went south.
We did not catch the second regression because all the images we drew with it were square.