### PR TITLE
Fix#1973: rt_dynamic_cast should only be visible in objc++

### DIFF
--- a/deps/prebuilt/Universal Windows/ARM/RTObjCInterop.dll
+++ b/deps/prebuilt/Universal Windows/ARM/RTObjCInterop.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b09fd867175caf5a3699ab43a18882a7d92300822046d63003ee8f27a1c1fa26
+oid sha256:1b7672e933ae532716f2fea92451f18b9d796fa5a20bbb7fef45529aa22a05cd
 size 131584

--- a/deps/prebuilt/Universal Windows/ARM/RTObjCInterop.lib
+++ b/deps/prebuilt/Universal Windows/ARM/RTObjCInterop.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd4df2afae65b4f77dc0a29febb8c5e80ccfce64c0cad25284eb8ce4ab866884
+oid sha256:79161df3228fa51e4e0ca3a2fd5df08b809e9667c79eb1f2c2580578c45d9312
 size 15124

--- a/deps/prebuilt/Universal Windows/ARM/RTObjCInterop.pdb
+++ b/deps/prebuilt/Universal Windows/ARM/RTObjCInterop.pdb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc51da4a5fb1c404349ec8a9d67e3083052d02bf38fd411da77b70a840d579ff
-size 1355776
+oid sha256:16743cd2dd83aac61e7377cc42f5b586ba2bce179222e5f7b0263fc8954db6c7
+size 1339392

--- a/deps/prebuilt/Universal Windows/x86/RTObjCInterop.dll
+++ b/deps/prebuilt/Universal Windows/x86/RTObjCInterop.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:faf20c6828627667ac8f4084c2ece246d39eb49f2713ac0ff7e6d786d0932224
+oid sha256:a793fa9f4e1c54c4b3668c435dca2d0e36195bd8ed3f7007150222380c06f097
 size 129024

--- a/deps/prebuilt/Universal Windows/x86/RTObjCInterop.lib
+++ b/deps/prebuilt/Universal Windows/x86/RTObjCInterop.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bbd3b438bb9d8e37d2b764227c6d7e470e0f08ded1cc43c6140cf0dac73948df
+oid sha256:5a784ac79afe76bfc91fa5a909c4cbe1b2cb0610e847f287e66388f1e2bd53ee
 size 15390

--- a/deps/prebuilt/Universal Windows/x86/RTObjCInterop.pdb
+++ b/deps/prebuilt/Universal Windows/x86/RTObjCInterop.pdb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b5cd4b3292f3c7b175d853dbec899c43c92a1bf650bbc6d9f64f16548e73ac8
+oid sha256:d7bfc551aca1f356e55a7e0dea24397f05b1760064b33b5a8c749de0a23f5682
 size 1339392

--- a/include/Platform/Universal Windows/UWP/InteropBase.h
+++ b/include/Platform/Universal Windows/UWP/InteropBase.h
@@ -51,11 +51,11 @@ WINRT_EXPORT
 
 @end
 
-// Does a safe cast of rtObject into a derived projected class type. Throws if it is an invalid cast.
+// Does a safe cast of rtObject into a derived projected class type. Returns nil if cast fails.
+#ifdef __cplusplus
 WINRT_EXPORT_FN
 id rt_dynamic_cast(Class classType, RTObject* rtObject);
 
-#ifdef __cplusplus
 template <typename ClassType>
 ClassType* rt_dynamic_cast(RTObject* rtObject) {
     return rt_dynamic_cast([ClassType class], rtObject);


### PR DESCRIPTION
rt_dynamic_cast uses COM objects and thus cannot be used from ObjC and therefore, should only visible to ObjC++.