### PR TITLE
[tests] Add a script that will generate CoreGraphics.Drawing images.

### DIFF
--- a/tests/Generate-TestImages.ps1
+++ b/tests/Generate-TestImages.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Generates CoreGraphics Drawing Test Images for the Islandwood Project
+
+.PARAMETER TestDirectory
+    The path to test binaries
+
+.PARAMETER Config
+    Test configuration to use for the test. Valid values are Debug or Release
+
+.PARAMETER TestFilter
+    Test filter to use for the test. Supports wildcard characters
+
+.PARAMETER Output
+    Directory into which to place the generated images.
+
+.EXAMPLE
+    Generate-TestImages.ps1
+
+#>
+param(
+    [string]$TestDirectory,
+
+    [string][ValidateSet("Debug", "Release")]
+    $Config = "Debug",
+
+    [string]$TestFilter,
+
+    [string]$Output = ".\images"
+)
+
+mkdir $Output -EA SilentlyContinue | Out-Null
+
+# Since TE runs the tests in a UAP host process, it can't normally write files
+# outside its container. Adding ALL APPLICATION PACKAGES to the ACLs on the output
+# directory gives it that right.
+& icacls $Output /grant "ALL APPLICATION PACKAGES:(OI)(CI)(F)" /t /q | Out-Null
+
+& "$PSScriptRoot\Run-Tests.ps1" -TestDirectory:$TestDirectory -Config:$Config -TestFilter:$TestFilter -ModuleFilter:"CoreGraphics.Drawing.UnitTests.dll" -Parameters:@{
+    "Generate" = "True"
+    "Out" = "$(Resolve-Path $Output)"
+}
+
+exit $LASTEXITCODE

--- a/tests/Run-Tests.ps1
+++ b/tests/Run-Tests.ps1
@@ -26,6 +26,9 @@
 .PARAMETER NoCopy
     Switch to disable copying test to the device
 
+.PARAMETER Parameters
+    Parameters to pass to the library or libraries under test.
+
 .PARAMETER RedirectTAEFErrors
     Redirect TAEF errors/failures to stderr.  This is used to integrate with VSTS powershell task.
 
@@ -61,7 +64,9 @@ param(
 
     [switch]$RedirectTAEFErrors,
 
-    [string]$WTTLogPath
+    [string]$WTTLogPath,
+
+    [System.Collections.HashTable]$Parameters = $null
 )
 $script:exitCode = 0
 
@@ -236,6 +241,13 @@ if ($WTLOutputFile)
 if($TestFilter)
 {
     $argList += " /name:$TestFilter"
+}
+
+If($Parameters)
+{
+    ForEach ($p in $Parameters.GetEnumerator()) {
+        $argList += " /p:$($p.Name)=$($p.Value)"
+    }
 }
 
 ExecTest($argList)


### PR DESCRIPTION
This pull request adds a script called `tests\Generate-TestImages.ps1`.

## NAME
    tests\Generate-TestImages.ps1

## SYNOPSIS
    Generates CoreGraphics Drawing Test Images for the Islandwood Project


## SYNTAX

```
    tests\Generate-TestImages.ps1 [[-TestDirectory] <String>]
    [[-Config] <String>] [[-TestFilter] <String>] [[-Output] <String>
    [<CommonParameters>]
```


## PARAMETERS

```
    -TestDirectory <String>
        The path to test binaries

    -Config <String>
        Test configuration to use for the test. Valid values are Debug or Release

        Default value                Debug

    -TestFilter <String>
        Test filter to use for the test. Supports wildcard characters

    -Output <String>
        Directory into which to place the generated images.

        Default value                .\images
```