### PR TITLE
Force all loaded textures to 32bpp in GLKit

### DIFF
--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -941,19 +941,8 @@ HRESULT _CGImageConvertToMaskCompatibleWICBitmap(CGImageRef image, IWICBitmap** 
 CGImageRef _CGImageCreateFromFileWithWICFormat(CFStringRef filename, WICPixelFormatGUID format) {
     RETURN_NULL_IF(!filename);
 
-    std::vector<char> buffer;
-    const char* fname = CFStringGetCStringPtr(filename, kCFStringEncodingUTF8);
-    if (fname == nullptr) {
-        CFIndex length = CFStringGetLength(filename) + 1;
-        buffer.reserve(length);
-        if (CFStringGetCString(filename, buffer.data(), length, kCFStringEncodingUTF8)) {
-            fname = buffer.data();
-        }
-    }
-
-    RETURN_NULL_IF(!fname);
-
-    woc::StrongCF<CGDataProviderRef> provider{ woc::MakeStrongCF(CGDataProviderCreateWithFilename(fname)) };
+    woc::StrongCF<CFURLRef> url{ woc::MakeStrongCF(CFURLCreateWithFileSystemPath(nullptr, filename, kCFURLWindowsPathStyle, NO)) };
+    woc::StrongCF<CGDataProviderRef> provider{ woc::MakeStrongCF(CGDataProviderCreateWithURL(url)) };
 
     woc::StrongCF<CGImageRef> image{ woc::MakeStrongCF(_CGImageCreateFromDataProvider(provider)) };
 

--- a/Frameworks/CoreGraphics/CGImage.mm
+++ b/Frameworks/CoreGraphics/CGImage.mm
@@ -934,4 +934,30 @@ HRESULT _CGImageConvertToMaskCompatibleWICBitmap(CGImageRef image, IWICBitmap** 
     return _CGImageGetWICImageSource(convertedImage.get(), pBitmap);
 }
 
+/**
+* Creates an image from file, if the image is not in the requested format, it is converted to
+* the requested format and returned.
+*/
+CGImageRef _CGImageCreateFromFileWithWICFormat(CFStringRef filename, WICPixelFormatGUID format) {
+    RETURN_NULL_IF(!filename);
+
+    std::vector<char> buffer;
+    const char* fname = CFStringGetCStringPtr(filename, kCFStringEncodingUTF8);
+    if (fname == nullptr) {
+        CFIndex length = CFStringGetLength(filename) + 1;
+        buffer.reserve(length);
+        if (CFStringGetCString(filename, buffer.data(), length, kCFStringEncodingUTF8)) {
+            fname = buffer.data();
+        }
+    }
+
+    RETURN_NULL_IF(!fname);
+
+    woc::StrongCF<CGDataProviderRef> provider{ woc::MakeStrongCF(CGDataProviderCreateWithFilename(fname)) };
+
+    woc::StrongCF<CGImageRef> image{ woc::MakeStrongCF(_CGImageCreateFromDataProvider(provider)) };
+
+    return _CGImageCreateCopyWithPixelFormat(image, format);
+}
+
 #pragma endregion WIC_HELPERS

--- a/Frameworks/include/CGImageInternal.h
+++ b/Frameworks/include/CGImageInternal.h
@@ -193,6 +193,8 @@ COREGRAPHICS_EXPORT void* _CGImageGetRawBytes(CGImageRef image);
 
 COREGRAPHICS_EXPORT CGImageRef _CGImageCreateFromDataProvider(CGDataProviderRef provider);
 
+COREGRAPHICS_EXPORT CGImageRef _CGImageCreateFromFileWithWICFormat(CFStringRef filename, WICPixelFormatGUID format);
+
 // Obtain the associated DisplayTexture
 __declspec(dllexport) std::shared_ptr<IDisplayTexture> _CGImageGetDisplayTexture(CGImageRef image);
 

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -387,6 +387,7 @@ LIBRARY CoreGraphics
         _CGImageCreateCopyWithPixelFormat
         _CGImageGetRawBytes
         _CGImageGetDisplayTexture
+        _CGImageCreateFromFileWithWICFormat
 
         ; private exports below
         _CGImageAddDestructionListener

--- a/build/GLKit/dll/GLKit.vcxproj
+++ b/build/GLKit/dll/GLKit.vcxproj
@@ -19,6 +19,9 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\CoreFoundation\dll\CoreFoundation.vcxproj">
+      <Project>{81F30AF6-EAC3-4DFA-929A-C25D69E8080B}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\CoreGraphics\dll\CoreGraphics.vcxproj">
       <Project>{26DA08DA-D0B9-4579-B168-E7F0A5F20E57}</Project>
     </ProjectReference>


### PR DESCRIPTION
 GLKit's implementation of GLKTexture only handled an image format of 32bpp properly (other formats e.g 8bpp indexed,etc) was not handled properly (the code was never exercised).

The root cause of this was that the earlier Cairo implementation treated every image as a 32bpp. Thus when we created an image with it's proper pixel format, GLKTexture code didn't know how to handle it and thus the errors were produced.

fixes #2150

The fix converts the images to 32bpp, since GLKTexture does not support any other format properly.
Eventually, GLKTexure needs to be re-written properly. 

Current Stage: 
![image](https://cloud.githubusercontent.com/assets/18413092/23593942/441abc44-01ca-11e7-92cb-911293279dab.png)

![image](https://cloud.githubusercontent.com/assets/18413092/23593944/501b3032-01ca-11e7-9887-dc566bac3c95.png)

![image](https://cloud.githubusercontent.com/assets/18413092/23593948/58edb45a-01ca-11e7-82bf-80eeb52c0276.png)

![image](https://cloud.githubusercontent.com/assets/18413092/23593950/5fa1e316-01ca-11e7-9c26-301ebd857abb.png)

![image](https://cloud.githubusercontent.com/assets/18413092/23593964/8e39b1e0-01ca-11e7-8a99-1718efe6aa1f.png)

![image](https://cloud.githubusercontent.com/assets/18413092/23593966/99d28400-01ca-11e7-81b0-5e813a47ed09.png)



