### PR TITLE
Implement CGPathGetBoundingBox + CGPathGetPathBoundingBox

### DIFF
--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -757,7 +757,7 @@ void CGPathCloseSubpath(CGMutablePathRef path) {
 }
 
 namespace {
-static void __updateRectWithControlPoint(CGRect* rect, CGPoint point) {
+void __updateRectWithControlPoint(CGRect* rect, CGPoint point) {
     if (point.x < rect->origin.x) {
         rect->size.width += rect->origin.x - point.x;
         rect->origin.x = point.x;
@@ -772,8 +772,8 @@ static void __updateRectWithControlPoint(CGRect* rect, CGPoint point) {
     }
 }
 
-static void __CGPathApplyGetBoundingBoxWithControlPoints(void* rectangle, const CGPathElement* element) {
-    CGRect* rect = (CGRect*)rectangle;
+void __CGPathApplyGetBoundingBoxWithControlPoints(void* rectangle, const CGPathElement* element) {
+    CGRect* rect = static_cast<CGRect*>(rectangle);
     switch (element->type) {
         case kCGPathElementAddQuadCurveToPoint:
             __updateRectWithControlPoint(rect, element->points[0]);
@@ -797,8 +797,6 @@ CGRect CGPathGetBoundingBox(CGPathRef path) {
     if (path == NULL) {
         return CGRectNull;
     }
-
-    D2D1_RECT_F bounds;
 
     if (FAILED(path->ClosePath())) {
         return CGRectNull;
@@ -932,12 +930,11 @@ CGRect CGPathGetPathBoundingBox(CGPathRef path) {
         return CGRectNull;
     }
 
-    D2D1_RECT_F bounds;
-
     if (FAILED(path->ClosePath())) {
         return CGRectNull;
     }
 
+    D2D1_RECT_F bounds;
     if (FAILED(path->GetPathGeometry()->GetBounds(D2D1::IdentityMatrix(), &bounds))) {
         return CGRectNull;
     }

--- a/Frameworks/CoreGraphics/CGPath.mm
+++ b/Frameworks/CoreGraphics/CGPath.mm
@@ -803,12 +803,12 @@ CGRect CGPathGetBoundingBox(CGPathRef path) {
     if (FAILED(path->ClosePath())) {
         return CGRectNull;
     }
-    CGRect returnRect = CGPathGetPathBoundingBox(path);
-    if (returnRect == CGRectNull) {
+    CGRect boundingBoxWithControlPoints = CGPathGetPathBoundingBox(path);
+    if (boundingBoxWithControlPoints == CGRectNull) {
         return CGRectNull;
     }
-    CGPathApply(path, &returnRect, __CGPathApplyGetBoundingBoxWithControlPoints);
-    return returnRect;
+    CGPathApply(path, &boundingBoxWithControlPoints, __CGPathApplyGetBoundingBoxWithControlPoints);
+    return boundingBoxWithControlPoints;
 }
 
 /**

--- a/include/CoreGraphics/CGPath.h
+++ b/include/CoreGraphics/CGPath.h
@@ -120,7 +120,7 @@ COREGRAPHICS_EXPORT bool CGPathEqualToPath(CGPathRef path1, CGPathRef path2);
 
 COREGRAPHICS_EXPORT CGRect CGPathGetBoundingBox(CGPathRef path);
 
-COREGRAPHICS_EXPORT CGRect CGPathGetPathBoundingBox(CGPathRef path) STUB_METHOD;
+COREGRAPHICS_EXPORT CGRect CGPathGetPathBoundingBox(CGPathRef path);
 COREGRAPHICS_EXPORT CGPoint CGPathGetCurrentPoint(CGPathRef path);
 COREGRAPHICS_EXPORT CFTypeID CGPathGetTypeID();
 

--- a/tests/testapps/CGCatalog/CGCatalog/CGPathApplyCurveViewController.m
+++ b/tests/testapps/CGCatalog/CGCatalog/CGPathApplyCurveViewController.m
@@ -71,6 +71,14 @@
 
         CGPathApply(thepath, currentContext, CGPathApplyCallback);
 
+        CGContextAddRect(currentContext, CGPathGetPathBoundingBox(thepath));
+        CGContextSetRGBStrokeColor(currentContext, 1, 0, 0, 1);
+        CGContextStrokePath(currentContext);
+
+        CGContextAddRect(currentContext, CGPathGetBoundingBox(thepath));
+        CGContextSetRGBStrokeColor(currentContext, 0, 0, 1, 1);
+        CGContextStrokePath(currentContext);
+
         CGPathRelease(thepath);
     }];
 

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -579,6 +579,48 @@ DRAW_TEST_F(CGPath, FillArcsSimple, UIKitMimicTest<>) {
     CGPathRelease(thepath);
 }
 
+DRAW_TEST_F(CGPath, BoundingBoxes, UIKitMimicTest<>) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    CGFloat width = bounds.size.width;
+    CGFloat height = bounds.size.height;
+    CGFloat xstart = bounds.origin.x;
+    CGFloat ystart = bounds.origin.y;
+
+    CGMutablePathRef thepath = CGPathCreateMutable();
+
+    CGAffineTransform transformation = CGAffineTransformIdentity;
+    transformation = CGAffineTransformScale(transformation, .8, .8);
+    transformation = CGAffineTransformTranslate(transformation, .1 * width, .1 * height);
+
+    CGPathMoveToPoint(thepath, &transformation, xstart + .75 * width, ystart + .5 * height);
+    CGPathAddArc(thepath, &transformation, xstart + .5 * width, ystart + .5 * height, .5 * height, 0, M_PI / 2, true);
+    CGPathAddArc(thepath, &transformation, xstart + .5 * width, ystart + .5 * height, .5 * height, M_PI / 2, 0, true);
+    CGPathMoveToPoint(thepath, &transformation, xstart + .25 * width, ystart + .5 * height);
+    CGPathAddArc(thepath, &transformation, xstart + .375 * width, ystart + .5 * height, .25 * height, M_PI, 0, false);
+    CGPathMoveToPoint(thepath, &transformation, xstart + .5 * width, ystart + .5 * height);
+    CGPathAddArc(thepath, &transformation, xstart + .625 * width, ystart + .5 * height, .25 * height, M_PI, 0, true);
+    CGPathMoveToPoint(thepath, &transformation, xstart + .4375 * width, ystart + .5 * height);
+    CGPathAddArc(thepath, &transformation, xstart + .375 * width, ystart + .5 * height, .125 * height, 0, M_PI / 2, true);
+    CGPathAddArc(thepath, &transformation, xstart + .375 * width, ystart + .5 * height, .125 * height, M_PI / 2, 0, true);
+    CGPathMoveToPoint(thepath, &transformation, xstart + .6875 * width, ystart + .5 * height);
+    CGPathAddArc(thepath, &transformation, xstart + .625 * width, ystart + .5 * height, .125 * height, 0, M_PI / 2, true);
+    CGPathAddArc(thepath, &transformation, xstart + .625 * width, ystart + .5 * height, .125 * height, M_PI / 2, 0, true);
+
+    // Draw the control points as those affect the bounding box.
+    CGPathApply(thepath, context, CGPathControlPointCallback);
+
+    // Don't draw the path itself, we only care about the bounding boxes for these paths.
+    CGContextAddRect(context, CGPathGetPathBoundingBox(thepath));
+    CGContextSetRGBStrokeColor(context, 1, 0, 0, 1);
+    CGContextStrokePath(context);
+
+    CGContextAddRect(context, CGPathGetBoundingBox(thepath));
+    CGContextSetRGBStrokeColor(context, 0, 0, 1, 1);
+    CGContextStrokePath(context);
+
+    CGPathRelease(thepath);
+}
 DRAW_TEST_F(CGPath, FillArcsComplex, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -621,7 +621,27 @@ DRAW_TEST_F(CGPath, BoundingBoxes, UIKitMimicTest<>) {
 
     CGPathRelease(thepath);
 }
-DRAW_TEST_F(CGPath, FillArcsComplex, UIKitMimicTest<>) {
+
+DRAW_TEST_F(CGPath, AddRects, UIKitMimicTest<>) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    CGFloat width = bounds.size.width;
+    CGFloat height = bounds.size.height;
+    CGFloat xstart = bounds.origin.x;
+    CGFloat ystart = bounds.origin.y;
+
+    CGRect rects[] = { CGRectMake(xstart + width * .1, ystart + height * .1, width * .3, height * .3),
+                       CGRectMake(xstart + width * .6, ystart + height * .1, width * .3, height * .3),
+                       CGRectMake(xstart + width * .1, ystart + height * .6, width * .3, height * .3),
+                       CGRectMake(xstart + width * .6, ystart + height * .6, width * .3, height * .3) };
+
+    CGMutablePathRef thepath = CGPathCreateMutable();
+    CGPathMoveToPoint(thepath, NULL, xstart + width * .1, ystart + height * .1);
+    CGPathAddRects(thepath, NULL, rects, 4);
+    CGContextAddPath(context, thepath);
+    CGContextStrokePath(context);
+    CGPathRelease(thepath);
+}DRAW_TEST_F(CGPath, FillArcsComplex, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGFloat width = bounds.size.width;

--- a/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
+++ b/tests/unittests/CoreGraphics.Drawing/CGPathDrawingTests.cpp
@@ -641,7 +641,9 @@ DRAW_TEST_F(CGPath, AddRects, UIKitMimicTest<>) {
     CGContextAddPath(context, thepath);
     CGContextStrokePath(context);
     CGPathRelease(thepath);
-}DRAW_TEST_F(CGPath, FillArcsComplex, UIKitMimicTest<>) {
+}
+
+DRAW_TEST_F(CGPath, FillArcsComplex, UIKitMimicTest<>) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGFloat width = bounds.size.width;

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddRects.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.AddRects.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95a733424ed46eaf55cf759433cd7ee3f06e9db996247ee310fc38d3e78a0dad
+size 3637

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.BoundingBoxes.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.BoundingBoxes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f74df490eb7d4a872f3071b12b3c773dab1d81a2e515f2c99d001a0b1051b0a7
+size 9768

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.BoundingBoxes.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.BoundingBoxes.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:519180065acf5a9b7dbbf72a4480fda9b347f000f9c31edb7326a3f5b9eb19ff
-size 9594

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.BoundingBoxes.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGPath.BoundingBoxes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:519180065acf5a9b7dbbf72a4480fda9b347f000f9c31edb7326a3f5b9eb19ff
+size 9594

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -982,3 +982,51 @@ TEST(CGPath, CGPathAddArcToPoint) {
     EXPECT_EQ(boundingBox.size, CGSizeMake(50, 50));
     CGPathRelease(thepath);
 }
+
+static void inline CGRectCompareWithSlack(CGRect lhs, CGRect rhs) {
+    EXPECT_NEAR(lhs.origin.x, rhs.origin.x, .001);
+    EXPECT_NEAR(lhs.origin.y, rhs.origin.y, .001);
+    EXPECT_NEAR(lhs.size.width, rhs.size.width, .001);
+    EXPECT_NEAR(lhs.size.height, rhs.size.height, .001);
+}
+
+TEST(CGPath, GetBoundingBoxes) {
+    CGFloat width = 256;
+    CGFloat height = 128;
+
+    CGMutablePathRef thepath = CGPathCreateMutable();
+
+    CGAffineTransform transformation = CGAffineTransformIdentity;
+    transformation = CGAffineTransformScale(transformation, .8, .8);
+    transformation = CGAffineTransformTranslate(transformation, .1 * width, .1 * height);
+
+    CGPathMoveToPoint(thepath, &transformation, .75 * width, .5 * height);
+    CGPathAddArc(thepath, &transformation, .5 * width, .5 * height, .5 * height, 0, M_PI / 2, true);
+    CGPathAddArc(thepath, &transformation, .5 * width, .5 * height, .5 * height, M_PI / 2, 0, true);
+    CGPathMoveToPoint(thepath, &transformation, .25 * width, .5 * height);
+    CGPathAddArc(thepath, &transformation, .375 * width, .5 * height, .25 * height, M_PI, 0, false);
+    CGPathMoveToPoint(thepath, &transformation, .5 * width, .5 * height);
+    CGPathAddArc(thepath, &transformation, .625 * width, .5 * height, .25 * height, M_PI, 0, true);
+    CGPathMoveToPoint(thepath, &transformation, .4375 * width, .5 * height);
+    CGPathAddArc(thepath, &transformation, .375 * width, .5 * height, .125 * height, 0, M_PI / 2, true);
+    CGPathAddArc(thepath, &transformation, .375 * width, .5 * height, .125 * height, M_PI / 2, 0, true);
+    CGPathMoveToPoint(thepath, &transformation, .6875 * width, .5 * height);
+    CGPathAddArc(thepath, &transformation, .625 * width, .5 * height, .125 * height, 0, M_PI / 2, true);
+    CGPathAddArc(thepath, &transformation, .625 * width, .5 * height, .125 * height, M_PI / 2, 0, true);
+
+    CGRect boundingBox = CGPathGetBoundingBox(thepath);
+    CGRectCompareWithSlack(boundingBox, CGRectMake(67.6526, 6.21259, 106.43, 106.427));
+    // EXPECT_TRUE(abs(boundingBox.origin.x - 67.6526) < .001);
+    // EXPECT_TRUE(abs(boundingBox.origin.y - 6.21259) < .001);
+    // EXPECT_TRUE(abs(boundingBox.size.width - 106.43) < .001);
+    // EXPECT_TRUE(abs(boundingBox.size.height - 106.427) < .001);
+
+    boundingBox = CGPathGetPathBoundingBox(thepath);
+    CGRectCompareWithSlack(boundingBox, CGRectMake(71.6785, 10.2385, 102.401, 102.401));
+    // EXPECT_TRUE(abs(boundingBox.origin.x - 71.6785) < .001);
+    // EXPECT_TRUE(abs(boundingBox.origin.y - 10.2385) < .001);
+    // EXPECT_TRUE(abs(boundingBox.size.width - 102.401) < .001);
+    // EXPECT_TRUE(abs(boundingBox.size.height - 102.401) < .001);
+
+    CGPathRelease(thepath);
+}

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -983,11 +983,13 @@ TEST(CGPath, CGPathAddArcToPoint) {
     CGPathRelease(thepath);
 }
 
-static void inline CGRectCompareWithSlack(CGRect lhs, CGRect rhs) {
-    EXPECT_NEAR(lhs.origin.x, rhs.origin.x, .001);
-    EXPECT_NEAR(lhs.origin.y, rhs.origin.y, .001);
-    EXPECT_NEAR(lhs.size.width, rhs.size.width, .001);
-    EXPECT_NEAR(lhs.size.height, rhs.size.height, .001);
+#define compareRectsWithSlack(lhs, rhs)                      \
+    {                                                        \
+        EXPECT_NEAR(lhs.origin.x, rhs.origin.x, .001);       \
+        EXPECT_NEAR(lhs.origin.y, rhs.origin.y, .001);       \
+        EXPECT_NEAR(lhs.size.width, rhs.size.width, .001);   \
+        EXPECT_NEAR(lhs.size.height, rhs.size.height, .001); \
+    \
 }
 
 TEST(CGPath, GetBoundingBoxes) {
@@ -1015,18 +1017,10 @@ TEST(CGPath, GetBoundingBoxes) {
     CGPathAddArc(thepath, &transformation, .625 * width, .5 * height, .125 * height, M_PI / 2, 0, true);
 
     CGRect boundingBox = CGPathGetBoundingBox(thepath);
-    CGRectCompareWithSlack(boundingBox, CGRectMake(67.6526, 6.21259, 106.43, 106.427));
-    // EXPECT_TRUE(abs(boundingBox.origin.x - 67.6526) < .001);
-    // EXPECT_TRUE(abs(boundingBox.origin.y - 6.21259) < .001);
-    // EXPECT_TRUE(abs(boundingBox.size.width - 106.43) < .001);
-    // EXPECT_TRUE(abs(boundingBox.size.height - 106.427) < .001);
+    compareRectsWithSlack(boundingBox, CGRectMake(67.6526, 6.21259, 106.43, 106.427));
 
     boundingBox = CGPathGetPathBoundingBox(thepath);
-    CGRectCompareWithSlack(boundingBox, CGRectMake(71.6785, 10.2385, 102.401, 102.401));
-    // EXPECT_TRUE(abs(boundingBox.origin.x - 71.6785) < .001);
-    // EXPECT_TRUE(abs(boundingBox.origin.y - 10.2385) < .001);
-    // EXPECT_TRUE(abs(boundingBox.size.width - 102.401) < .001);
-    // EXPECT_TRUE(abs(boundingBox.size.height - 102.401) < .001);
+    compareRectsWithSlack(boundingBox, CGRectMake(71.6785, 10.2385, 102.401, 102.401));
 
     CGPathRelease(thepath);
 }

--- a/tests/unittests/CoreGraphics/CGPathTests.mm
+++ b/tests/unittests/CoreGraphics/CGPathTests.mm
@@ -983,7 +983,7 @@ TEST(CGPath, CGPathAddArcToPoint) {
     CGPathRelease(thepath);
 }
 
-#define compareRectsWithSlack(lhs, rhs)                      \
+#define COMPARE_RECTS_WITH_SLACK(lhs, rhs)                   \
     {                                                        \
         EXPECT_NEAR(lhs.origin.x, rhs.origin.x, .001);       \
         EXPECT_NEAR(lhs.origin.y, rhs.origin.y, .001);       \
@@ -1017,10 +1017,10 @@ TEST(CGPath, GetBoundingBoxes) {
     CGPathAddArc(thepath, &transformation, .625 * width, .5 * height, .125 * height, M_PI / 2, 0, true);
 
     CGRect boundingBox = CGPathGetBoundingBox(thepath);
-    compareRectsWithSlack(boundingBox, CGRectMake(67.6526, 6.21259, 106.43, 106.427));
+    COMPARE_RECTS_WITH_SLACK(boundingBox, CGRectMake(67.6526, 6.21259, 106.43, 106.427));
 
     boundingBox = CGPathGetPathBoundingBox(thepath);
-    compareRectsWithSlack(boundingBox, CGRectMake(71.6785, 10.2385, 102.401, 102.401));
+    COMPARE_RECTS_WITH_SLACK(boundingBox, CGRectMake(71.6785, 10.2385, 102.401, 102.401));
 
     CGPathRelease(thepath);
 }


### PR DESCRIPTION
Our implementation for CGPathGetBoundingBox was actually the implementation for CGPathGetPathBoundingBox. This has been corrected, and CGPathGetBoundingBox has been implemented properly to include control points. An additional test has been added and the Path Apply for Curves page of the CGCatalog test app has been updated to include these two APIs.

Fix #2145 

Also, as an addition, CGPathAddRects has been implemented and is no longer stubbed. A test has been added for it.