### PR TITLE
UIViewController modal appearance event fixes and addition of UIModalPresentationFormSheet overlay

### DIFF
--- a/Frameworks/UIKit/UIPopoverPresentationController.mm
+++ b/Frameworks/UIKit/UIPopoverPresentationController.mm
@@ -23,12 +23,6 @@
 #import "UIPopoverPresentationControllerInternal.h"
 #import "UIPopoverControllerInternal.h"
 
-@interface UIPopoverPresentationController ()
-
-- (void)_handleDismiss;
-
-@end
-
 @interface _UIPopoverControllerDelegateInternal : NSObject <UIPopoverControllerDelegate>
 
 @property (nonatomic, assign) UIPopoverPresentationController* controller;
@@ -66,8 +60,6 @@
     if ([_delegate respondsToSelector:@selector(popoverPresentationControllerDidDismissPopover:)]) {
         [_delegate popoverPresentationControllerDidDismissPopover:_controller];
     }
-
-    [_controller _handleDismiss];
 }
 
 @end
@@ -79,7 +71,6 @@
     StrongId<UIBarButtonItem*> _barButtonItem;
     StrongId<UIView*> _sourceView;
     CGRect _sourceRect;
-    StrongId<dispatch_block_t> _dismissCompletion;
 }
 
 /**
@@ -97,9 +88,8 @@
     return self;
 }
 
-- (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion dismissCompletion:(dispatch_block_t)dismissCompletion {
+- (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion {
     _popoverControllerInternal->_presentCompletion.attach([presentCompletion copy]);
-    _dismissCompletion.attach([dismissCompletion copy]);
 
     if ([[_delegateInternal delegate] respondsToSelector:@selector(prepareForPopoverPresentation:)]) {
         [[_delegateInternal delegate] prepareForPopoverPresentation:self];
@@ -119,16 +109,6 @@
 
 - (void)_dismissAnimated:(BOOL)animated completion:(dispatch_block_t)dismissCompletion {
     [_popoverControllerInternal _dismissPopoverAnimated:animated completion:dismissCompletion];
-}
-
-- (void)_handleDismiss {
-    // Stay alive while we invoke _dismissCompletion (UIViewController tears
-    // down its strong ref to us in this completion; we must avoid our
-    // deallocation while this block we own is executing).
-    StrongId<UIPopoverPresentationController> strongSelf = self;
-
-    _dismissCompletion();
-    _dismissCompletion = nil;
 }
 
 /**

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -1356,9 +1356,10 @@ static void adjustSubviews(UIView* self, CGSize parentSize, CGSize delta) {
     if (controller != nil && window != nil) {
         UIViewController* rootController = [[[[UIApplication sharedApplication] windows] objectAtIndex:0] rootViewController];
         UIViewController* parentController = [UIViewController controllerForView:superview];
-        if (![controller _managesViewEvents] && (rootController == controller || [controller parentViewController] != nil ||
-            [controller isKindOfClass:[UINavigationController class]] || [parentController isKindOfClass:[UINavigationController class]] ||
-            g_alwaysSendViewEvents)) {
+        if (![controller _managesViewEvents] &&
+            (rootController == controller || [controller parentViewController] != nil ||
+             [controller isKindOfClass:[UINavigationController class]] || [parentController isKindOfClass:[UINavigationController class]] ||
+             g_alwaysSendViewEvents)) {
             if (stackLevel == 0) {
                 // viewWillAppear: must be sent when a view controller's view is added directly to a view hierarchy.
                 [controller _notifyViewWillAppear:FALSE];
@@ -1379,8 +1380,8 @@ static void adjustSubviews(UIView* self, CGSize parentSize, CGSize delta) {
 
         UIViewController* parentController = [UIViewController controllerForView:superview];
         if (![controller _managesViewEvents] && (rootController == controller || [controller parentViewController] != nil ||
-            [controller isKindOfClass:[UINavigationController class]] || [parentController isKindOfClass:[UINavigationController class]] ||
-            g_alwaysSendViewEvents))
+                                                 [controller isKindOfClass:[UINavigationController class]] ||
+                                                 [parentController isKindOfClass:[UINavigationController class]] || g_alwaysSendViewEvents))
             [controller _notifyViewDidDisappear:FALSE];
     }
 

--- a/Frameworks/UIKit/UIView.mm
+++ b/Frameworks/UIKit/UIView.mm
@@ -1317,13 +1317,13 @@ static void adjustSubviews(UIView* self, CGSize parentSize, CGSize delta) {
         }
 
         UIViewController* parentController = [UIViewController controllerForView:superview];
-        if (![controller _managesViewEvents] && (rootController == controller || g_alwaysSendViewEvents))
+        if (!controller.isBeingPresented && (rootController == controller || g_alwaysSendViewEvents))
             [controller _notifyViewWillAppear:g_presentingAnimated]; /*** should we do this? ****/
     }
     if (controller != nil && window == nil) {
         UIViewController* rootController = [[[[UIApplication sharedApplication] windows] objectAtIndex:0] rootViewController];
         UIViewController* parentController = [UIViewController controllerForView:superview];
-        if (![controller _managesViewEvents] && (rootController == controller || g_alwaysSendViewEvents))
+        if (!controller.isBeingDismissed && (rootController == controller || g_alwaysSendViewEvents))
             [controller _notifyViewWillDisappear:g_presentingAnimated]; /*** should we do this? ****/
     }
 
@@ -1356,10 +1356,9 @@ static void adjustSubviews(UIView* self, CGSize parentSize, CGSize delta) {
     if (controller != nil && window != nil) {
         UIViewController* rootController = [[[[UIApplication sharedApplication] windows] objectAtIndex:0] rootViewController];
         UIViewController* parentController = [UIViewController controllerForView:superview];
-        if (![controller _managesViewEvents] &&
-            (rootController == controller || [controller parentViewController] != nil ||
-             [controller isKindOfClass:[UINavigationController class]] || [parentController isKindOfClass:[UINavigationController class]] ||
-             g_alwaysSendViewEvents)) {
+        if (!controller.isBeingPresented && (rootController == controller || [controller parentViewController] != nil ||
+                                             [controller isKindOfClass:[UINavigationController class]] ||
+                                             [parentController isKindOfClass:[UINavigationController class]] || g_alwaysSendViewEvents)) {
             if (stackLevel == 0) {
                 // viewWillAppear: must be sent when a view controller's view is added directly to a view hierarchy.
                 [controller _notifyViewWillAppear:FALSE];
@@ -1379,9 +1378,9 @@ static void adjustSubviews(UIView* self, CGSize parentSize, CGSize delta) {
         }
 
         UIViewController* parentController = [UIViewController controllerForView:superview];
-        if (![controller _managesViewEvents] && (rootController == controller || [controller parentViewController] != nil ||
-                                                 [controller isKindOfClass:[UINavigationController class]] ||
-                                                 [parentController isKindOfClass:[UINavigationController class]] || g_alwaysSendViewEvents))
+        if (!controller.isBeingDismissed && (rootController == controller || [controller parentViewController] != nil ||
+                                             [controller isKindOfClass:[UINavigationController class]] ||
+                                             [parentController isKindOfClass:[UINavigationController class]] || g_alwaysSendViewEvents))
             [controller _notifyViewDidDisappear:FALSE];
     }
 

--- a/Frameworks/UIKit/UIViewController.mm
+++ b/Frameworks/UIKit/UIViewController.mm
@@ -1114,14 +1114,6 @@ NSMutableDictionary* _pageMappings;
     [self setToolbarItems:newItems animated:FALSE];
 }
 
-- (BOOL)_managesViewEvents {
-    return priv->_managesViewEvents;
-}
-
-- (void)_setManagesViewEvents:(BOOL)managesViewEvents {
-    priv->_managesViewEvents = managesViewEvents;
-}
-
 - (void)_setBeingPresented:(BOOL)beingPresented {
     _beingPresented = beingPresented;
 }
@@ -1271,14 +1263,8 @@ NSMutableDictionary* _pageMappings;
     [presented->priv->_modalOverlayView removeFromSuperview];
     presented->priv->_modalOverlayView = nil;
 
-    // Prevent default view appearance handling in UIView occuring when we
-    // remove the presented controller's view from its window.
-    presented->priv->_managesViewEvents = YES;
-
     UIView* presentedView = [presented view];
     [presentedView removeFromSuperview];
-
-    presented->priv->_managesViewEvents = NO;
 
     UIView* view = [self view];
     [[view superview] bringSubviewToFront:view];
@@ -1477,16 +1463,8 @@ NSMutableDictionary* _pageMappings;
         [parentWindow addSubview:priv->_modalOverlayView];
     }
 
-    // Avoid default view appearance mechanisms in UIView.mm (which e.g. handle view
-    // appearence events for views with an owning controller manually added to a window).
-    // Note that mechanism in UIView.mm currently overeagerly calls viewDidAppear when adding
-    // a controller owned view to a window.
-    self->priv->_managesViewEvents = YES;
-
     UIView* view = [self view];
     [parentWindow addSubview:view];
-
-    self->priv->_managesViewEvents = NO;
 
     if (animated) {
         CGPoint origPos = [view center];
@@ -2128,8 +2106,10 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
  @Status Caveat
  @Notes  WinObjC-only extension providing access
          to UIModalPresentationFormSheet overlay.
+         Not exposed in header (clients must access
+         via performSelector).
 */
-- (UIView*)modalOverlayView {
+- (UIView*)_modalOverlayView {
     return priv->_modalOverlayView;
 }
 

--- a/Frameworks/UIKit/UIViewController.mm
+++ b/Frameworks/UIKit/UIViewController.mm
@@ -1188,7 +1188,9 @@ NSMutableDictionary* _pageMappings;
 
     [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
 
+    // Ensure viewDidLoad precedes attachment of presentedViewController.
     [controller view];
+
     priv->_presentedViewController = controller;
     controller->priv->_parentViewController = self;
     controller->priv->_presentingViewController = self;
@@ -1201,7 +1203,7 @@ NSMutableDictionary* _pageMappings;
         // popover is dismissed, without animation, in the presentViewController completion block itself.
         UIPopoverPresentationController* popover = [controller->priv->_popoverPresentationController retain];
 
-        dispatch_block_t popoverPresent = ^{
+        dispatch_block_t presentCompletion = ^{
             [controller _setBeingPresented:NO];
 
             [[UIApplication sharedApplication] endIgnoringInteractionEvents];
@@ -1217,7 +1219,7 @@ NSMutableDictionary* _pageMappings;
             // Dispatch the presentation asynchronously so users have the opportunity to configure the
             // popoverPresentationController after presentViewController but before the actual popover is presented.
             [controller _setBeingPresented:YES];
-            [controller->priv->_popoverPresentationController _presentAnimated:animated presentCompletion:popoverPresent];
+            [controller->priv->_popoverPresentationController _presentAnimated:animated presentCompletion:presentCompletion];
         });
     } else {
         [controller _setBeingPresented:YES];
@@ -2103,11 +2105,8 @@ static UIInterfaceOrientation findOrientation(UIViewController* self) {
 }
 
 /**
- @Status Caveat
- @Notes  WinObjC-only extension providing access
-         to UIModalPresentationFormSheet overlay.
-         Not exposed in header (clients must access
-         via performSelector).
+ WinObjC-only extension providing access to UIModalPresentationFormSheet overlay.
+ It is not exposed in header; clients must access via performSelector.
 */
 - (UIView*)_modalOverlayView {
     return priv->_modalOverlayView;

--- a/Frameworks/UIKit/WYPopoverController.mm
+++ b/Frameworks/UIKit/WYPopoverController.mm
@@ -1931,7 +1931,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
         }
     }
 
-    [viewController _setManagesViewEvents:YES];
+    [viewController _setBeingPresented:YES];
     
     CGSize contentViewSize = self.popoverContentSize;
 
@@ -1984,7 +1984,7 @@ static WYPopoverTheme *defaultTheme_ = nil;
             
             strongSelf->backgroundView.appearing = NO;
 
-            [strongSelf->viewController _setManagesViewEvents:NO];
+            [strongSelf->viewController _setBeingPresented:NO];
         }
         
         if (completion)
@@ -2628,8 +2628,6 @@ static WYPopoverTheme *defaultTheme_ = nil;
 
     [viewController _setBeingDismissed:YES];
 
-    [viewController _setManagesViewEvents:YES];
-    
     void (^adjustTintAutomatic)() = ^() {
 #ifdef WY_BASE_SDK_7_ENABLED
         if ([inView.window respondsToSelector:@selector(setTintAdjustmentMode:)]) {
@@ -2665,7 +2663,6 @@ static WYPopoverTheme *defaultTheme_ = nil;
                 [strongSelf->viewController viewDidDisappear:aAnimated];
             }
 
-            [strongSelf->viewController _setManagesViewEvents:NO];
             [strongSelf->viewController _setBeingDismissed:NO];
         }
         

--- a/Frameworks/include/UIPopoverPresentationControllerInternal.h
+++ b/Frameworks/include/UIPopoverPresentationControllerInternal.h
@@ -18,7 +18,7 @@
 
 @interface UIPopoverPresentationController ()
 
-- (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion dismissCompletion:(dispatch_block_t)dismissCompletion;
+- (void)_presentAnimated:(BOOL)animated presentCompletion:(dispatch_block_t)presentCompletion;
 - (void)_dismissAnimated:(BOOL)animated completion:(dispatch_block_t)dismissCompletion;
 
 @end

--- a/Frameworks/include/UIViewControllerInternal.h
+++ b/Frameworks/include/UIViewControllerInternal.h
@@ -57,7 +57,6 @@ struct UIViewControllerPriv {
     StrongId<UIStoryboard> _storyboard;
     BOOL hasLoaded, isLoading;
     BOOL _isEditing;
-    BOOL _managesViewEvents;
     UIInterfaceOrientation _curOrientation;
     BOOL _didSetRotation;
     BOOL _resizeToScreen;
@@ -101,8 +100,6 @@ struct UIViewControllerPriv {
 - (void)_notifyViewWillDisappear:(BOOL)isAnimated;
 - (void)_notifyViewDidDisappear:(BOOL)isAnimated;
 
-- (BOOL)_managesViewEvents;
-- (void)_setManagesViewEvents:(BOOL)managesViewEvents;
 - (void)_setBeingPresented:(BOOL)beingPresented;
 - (void)_setBeingDismissed:(BOOL)beingDismissed;
 - (void)_unlinkPresentedController;

--- a/Frameworks/include/UIViewControllerInternal.h
+++ b/Frameworks/include/UIViewControllerInternal.h
@@ -67,6 +67,7 @@ struct UIViewControllerPriv {
     UIModalPresentationStyle _presentationStyle;
     BOOL _hidesBottomBar;
     UIModalTransitionStyle _modalTransitionStyle;
+    StrongId<UIView> _modalOverlayView;
     BOOL _isRootView;
     CGSize _contentSizeForViewInPopover;
     unsigned _edgesForExtendedLayout;

--- a/Frameworks/include/UIViewControllerInternal.h
+++ b/Frameworks/include/UIViewControllerInternal.h
@@ -57,6 +57,7 @@ struct UIViewControllerPriv {
     StrongId<UIStoryboard> _storyboard;
     BOOL hasLoaded, isLoading;
     BOOL _isEditing;
+    BOOL _managesViewEvents;
     UIInterfaceOrientation _curOrientation;
     BOOL _didSetRotation;
     BOOL _resizeToScreen;
@@ -67,9 +68,6 @@ struct UIViewControllerPriv {
     BOOL _hidesBottomBar;
     UIModalTransitionStyle _modalTransitionStyle;
     BOOL _isRootView;
-    idretainp<void (^)(void)> _dismissCompletionBlock;
-    idretainp<void (^)(void)> _presentCompletionBlock;
-    idretaintype(UIViewController) _dismissController;
     CGSize _contentSizeForViewInPopover;
     unsigned _edgesForExtendedLayout;
     BOOL _modalInPopover;
@@ -101,6 +99,12 @@ struct UIViewControllerPriv {
 - (void)_notifyViewDidAppear:(BOOL)isAnimated;
 - (void)_notifyViewWillDisappear:(BOOL)isAnimated;
 - (void)_notifyViewDidDisappear:(BOOL)isAnimated;
+
+- (BOOL)_managesViewEvents;
+- (void)_setManagesViewEvents:(BOOL)managesViewEvents;
+- (void)_setBeingPresented:(BOOL)beingPresented;
+- (void)_setBeingDismissed:(BOOL)beingDismissed;
+- (void)_unlinkPresentedController;
 
 - (void)_setResizeToScreen:(BOOL)resize;
 - (void)_doResizeToScreen;

--- a/build/UIKit/lib/UIKitLib.vcxproj
+++ b/build/UIKit/lib/UIKitLib.vcxproj
@@ -256,10 +256,10 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPercentDrivenInteractiveTransition.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPopoverBackgroundView.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPopoverController.mm" />
-    <ClangCompile Include="..\..\..\Frameworks\UIKit\WYPopoverController.m">
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\WYPopoverController.mm">
       <ObjectiveCARC>true</ObjectiveCARC>
     </ClangCompile>
-    <ClangCompile Include="..\..\..\Frameworks\UIKit\WYStoryboardPopoverSegue.m">
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\WYStoryboardPopoverSegue.m">
       <ObjectiveCARC>true</ObjectiveCARC>
     </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPress.mm" />

--- a/include/UIKit/UIViewController.h
+++ b/include/UIKit/UIViewController.h
@@ -117,6 +117,7 @@ UIKIT_EXPORT_CLASS
 @property (readonly, nonatomic, strong) NSExtensionContext* extensionContext STUB_PROPERTY;
 @property (readonly, nonatomic, strong) UISearchDisplayController* searchDisplayController;
 @property (readonly, nonatomic, strong) UIView* viewIfLoaded STUB_PROPERTY;
+@property (readonly, nonatomic, strong) UIView* modalOverlayView; // WinObjC extension
 
 @property (copy) UIBezierPath* accessibilityPath;
 @property (nonatomic) CGRect accessibilityFrame;

--- a/include/UIKit/UIViewController.h
+++ b/include/UIKit/UIViewController.h
@@ -138,8 +138,8 @@ UIKIT_EXPORT_CLASS
 - (BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers STUB_METHOD;
 - (BOOL)canPerformUnwindSegueAction:(SEL)action fromViewController:(UIViewController*)fromViewController withSender:(id)sender STUB_METHOD;
 - (BOOL)disablesAutomaticKeyboardDismissal STUB_METHOD;
-- (BOOL)isBeingDismissed STUB_METHOD;
-- (BOOL)isBeingPresented STUB_METHOD;
+@property (nonatomic, readonly, getter=isBeingPresented) BOOL beingPresented;
+@property (nonatomic, readonly, getter=isBeingDismissed) BOOL beingDismissed;
 - (BOOL)isMovingFromParentViewController STUB_METHOD;
 - (BOOL)isMovingToParentViewController STUB_METHOD;
 - (BOOL)isViewLoaded;

--- a/include/UIKit/UIViewController.h
+++ b/include/UIKit/UIViewController.h
@@ -117,7 +117,6 @@ UIKIT_EXPORT_CLASS
 @property (readonly, nonatomic, strong) NSExtensionContext* extensionContext STUB_PROPERTY;
 @property (readonly, nonatomic, strong) UISearchDisplayController* searchDisplayController;
 @property (readonly, nonatomic, strong) UIView* viewIfLoaded STUB_PROPERTY;
-@property (readonly, nonatomic, strong) UIView* modalOverlayView; // WinObjC extension
 
 @property (copy) UIBezierPath* accessibilityPath;
 @property (nonatomic) CGRect accessibilityFrame;

--- a/include/UIKit/UIViewController.h
+++ b/include/UIKit/UIViewController.h
@@ -174,7 +174,7 @@ UIKIT_EXPORT_CLASS
 - (id<UIViewControllerPreviewing>)registerForPreviewingWithDelegate:(id<UIViewControllerPreviewingDelegate>)delegate
                                                          sourceView:(UIView*)sourceView STUB_METHOD;
 - (id<UIViewControllerTransitionCoordinator>)transitionCoordinator STUB_METHOD;
--(instancetype)initWithNibName:(NSString*)nibName bundle:(NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNibName:(NSString*)nibName bundle:(NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
 - (void)addChildViewController:(UIViewController*)childController;
 - (void)addKeyCommand:(UIKeyCommand*)keyCommand STUB_METHOD;
 - (void)applicationFinishedRestoringState STUB_METHOD;

--- a/samples/WOCCatalog/WOCCatalog/ControlsViewController.m
+++ b/samples/WOCCatalog/WOCCatalog/ControlsViewController.m
@@ -181,6 +181,14 @@ static const int MULTIPLEPRESENTDISMISS_ROW = 5;
                            animated:YES
                          completion:^{
                              assert(!([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad && self.view.hidden));
+#ifdef WINOBJC
+                             UITapGestureRecognizer* tapOutsideModal =
+                                 [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissModal)];
+                             // Use WinObjC 'private' extension for dismiss on tap outside modal.
+                             // See http://stackoverflow.com/questions/9102497/dismiss-modal-view-form-sheet-controller-on-outside-tap
+                             // for private API approach acheiving this on the ref-platform.
+                             [[viewController performSelector:@selector(_modalOverlayView)] addGestureRecognizer:tapOutsideModal];
+#endif
                          }];
     } else if (indexPath.row == MULTIPLEPRESENTDISMISS_ROW) {
         UIViewController* viewController = [[PopoverViewController alloc] initWithImage:[UIImage imageNamed:@"photo1.jpg"]];
@@ -213,6 +221,10 @@ static const int MULTIPLEPRESENTDISMISS_ROW = 5;
 
 - (void)toggleResizeModal {
     self.resizeModal = !self.resizeModal;
+}
+
+- (void)dismissModal {
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)setUIActivityIndicatorView {


### PR DESCRIPTION
Fixes #2113 and #2114. In addition, fixes to bring the invocation order of the view[Did/Will][Appear/Disappear] events in line with the ref platform have had to take #2115 into account (commit 20a4224 from March 19 has a better approach for working around #2115 than the initial commits to this pull).

Notes:

I went with the block based animation to avoid need for a CATransaction (form sheet overlay and the modal view itself have separate layers).

I've also been using a modified version of the testcase in #2194 to validate the order of the [will/did]MoveTo[Superview/Window] events. WinObjC differs from the ref platform (which for example, seems to move the view of a controller completely covered by a modal to an offscreen dummy window first and then removes it from that dummy window entirely, while WinObjC just leaves them in the view hierarchy). However, these changes do a better job of the ordering of the window/superview events vs the view controller appearance events (for example the window/superview events should be finished by the time of viewDidAppear); though, this is not something validated by the testcase in #2194.