### PR TITLE
Implementation of CGContextFlush. #2046

### DIFF
--- a/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
@@ -237,6 +237,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\CGContextDrawing_FillModeTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\CGContextDrawing_AntiAliasTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawing_ClearRectTests.cpp" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGContextDrawing_FlushTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\CGPathDrawingTests.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.Drawing\DrawingTest.cpp" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\CoreGraphics.drawing\ImageComparison.cpp" />

--- a/include/CoreGraphics/CGContext.h
+++ b/include/CoreGraphics/CGContext.h
@@ -124,7 +124,7 @@ typedef CF_OPTIONS(CFIndex, CGTextDrawingMode) {
 };
 // clang-format on
 
-COREGRAPHICS_EXPORT void CGContextFlush(CGContextRef c) STUB_METHOD;
+COREGRAPHICS_EXPORT void CGContextFlush(CGContextRef c);
 COREGRAPHICS_EXPORT CFTypeID CGContextGetTypeID();
 COREGRAPHICS_EXPORT void CGContextRelease(CGContextRef c);
 COREGRAPHICS_EXPORT CGContextRef CGContextRetain(CGContextRef c);

--- a/tests/UnitTests/CoreGraphics.drawing/CGContextDrawing_FlushTests.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/CGContextDrawing_FlushTests.cpp
@@ -1,0 +1,132 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include "DrawingTest.h"
+
+#if WINOBJC
+#include "CGContextInternal.h"
+
+DRAW_TEST_F(CGContextFlush, FillFlush, WhiteBackgroundTest<>) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    _CGContextPushBeginDraw(context);
+
+    CGContextSetRGBFillColor(context, 1, 0, 0, 1);
+    CGContextFillRect(context, bounds);
+
+    // Flush the red fill rect
+    CGContextFlush(context);
+
+    CGContextSetRGBFillColor(context, 0, 0, 1, 1);
+    CGContextFillRect(context, CGRectMake(0, 0, 300, 300));
+
+    // We should still have red & blue rectangle should not show up.
+    unsigned char* dataPtr = static_cast<unsigned char*>(CGBitmapContextGetData(context));
+    ASSERT_NE(dataPtr, nullptr);
+
+    // Validate only the red fill rect is executed.
+    EXPECT_EQ(dataPtr[0], 0x00);
+    EXPECT_EQ(dataPtr[1], 0x00);
+    EXPECT_EQ(dataPtr[2], 0xff);
+    EXPECT_EQ(dataPtr[3], 0xff);
+
+    CGContextFlush(context);
+
+    // We should now see the blue fill rect
+    EXPECT_EQ(dataPtr[0], 0xff);
+    EXPECT_EQ(dataPtr[1], 0x00);
+    EXPECT_EQ(dataPtr[2], 0x00);
+    EXPECT_EQ(dataPtr[3], 0xff);
+
+    // Add some extra drawings
+    CGContextClearRect(context, CGRectMake(100, 100, 200, 300));
+
+    CGPoint center = _CGRectGetCenter(bounds);
+
+    CGMutablePathRef concentricCirclesPath = CGPathCreateMutable();
+
+    CGPathAddEllipseInRect(concentricCirclesPath, nullptr, _CGRectCenteredOnPoint({ 50, 50 }, center));
+    CGPathAddEllipseInRect(concentricCirclesPath, nullptr, _CGRectCenteredOnPoint({ 100, 100 }, center));
+    CGPathAddEllipseInRect(concentricCirclesPath, nullptr, _CGRectCenteredOnPoint({ 150, 150 }, center));
+    CGPathAddEllipseInRect(concentricCirclesPath, nullptr, _CGRectCenteredOnPoint({ 200, 200 }, center));
+
+    CGContextSetRGBFillColor(context, 1.0, 0.0, 0.0, 0.5);
+    CGContextSetRGBStrokeColor(context, 1.0, 0.0, 0.0, 1.0);
+
+    CGContextAddPath(context, concentricCirclesPath);
+    CGContextDrawPath(context, kCGPathFillStroke);
+
+    CGPathRelease(concentricCirclesPath);
+
+    _CGContextPopEndDraw(context);
+}
+
+DRAW_TEST_F(CGContextFlush, FillFlushMultipleDrawingCounters, WhiteBackgroundTest<>) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    static int sDrawCount = 5;
+
+    for (int i = 0; i < sDrawCount; ++i) {
+        _CGContextPushBeginDraw(context);
+    }
+
+    CGContextSetRGBFillColor(context, 1, 0, 0, 1);
+    CGContextFillRect(context, bounds);
+
+    for (int i = 0; i < sDrawCount; ++i) {
+        // Multiple flushes should work.
+        CGContextFlush(context);
+    }
+
+    // Add some extra drawings
+    CGContextClearRect(context, bounds);
+
+    // We should still have red & clear should not of been executed.
+    unsigned char* dataPtr = static_cast<unsigned char*>(CGBitmapContextGetData(context));
+    ASSERT_NE(dataPtr, nullptr);
+
+    // Validate only the red fill rect is executed.
+    EXPECT_EQ(dataPtr[0], 0x00);
+    EXPECT_EQ(dataPtr[1], 0x00);
+    EXPECT_EQ(dataPtr[2], 0xff);
+    EXPECT_EQ(dataPtr[3], 0xff);
+
+    for (int i = 0; i < 3; ++i) {
+        // Multiple flushes should work.
+        CGContextFlush(context);
+    }
+
+    // validate clear
+    EXPECT_EQ(dataPtr[0], 0x00);
+    EXPECT_EQ(dataPtr[1], 0x00);
+    EXPECT_EQ(dataPtr[2], 0x00);
+    EXPECT_EQ(dataPtr[3], 0x00);
+
+    CGContextSetRGBStrokeColor(context, 0, 1, 0, 1);
+    CGContextStrokeRect(context, CGRectMake(100, 100, 200, 300));
+
+    // Still should be clear.
+    EXPECT_EQ(dataPtr[0], 0x00);
+    EXPECT_EQ(dataPtr[1], 0x00);
+    EXPECT_EQ(dataPtr[2], 0x00);
+    EXPECT_EQ(dataPtr[3], 0x00);
+
+    for (int i = 0; i < sDrawCount; ++i) {
+        _CGContextPopEndDraw(context);
+    }
+}
+
+#endif

--- a/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.CGContextFlush.FillFlush.png
+++ b/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.CGContextFlush.FillFlush.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0927d76ce1a0b86a5ecab7e4ec54c89e4138d79dec173e8e64374d667991ab7
+size 11071

--- a/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.CGContextFlush.FillFlushMultipleDrawingCounters.png
+++ b/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.CGContextFlush.FillFlushMultipleDrawingCounters.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1930f2134f68787c31acdd8699faf6935f9e41aa17b1a32690089371d043e6d9
+size 1029

--- a/tests/unittests/CoreGraphics.drawing/CGContextDrawing_FillModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextDrawing_FillModeTests.cpp
@@ -22,7 +22,7 @@ class CGContextFillMode : public WhiteBackgroundTest<>, public ::testing::WithPa
     CFStringRef CreateOutputFilename() {
         CGPathDrawingMode fillMode = GetParam();
 
-        char* fillModeName;
+        const char* fillModeName;
         switch (fillMode) {
             case kCGPathFill:
                 fillModeName = "Fill";


### PR DESCRIPTION
The implementation is based on D2D:EndDraw vs D2D:Flush.

This is mainly due to the fact that D2D goes through D3D, the flush would flush the D2D batch command and will not flush D3D batch for
WicBitmapRenderTargert. Also there is an issue of a potential shadow copy used by D2D, and flush does not copy over the shadow copy into the original buffer.
EndDraw supports both of the issues addressed above.