### PR TITLE
Add support for blending operations to CGContext

### DIFF
--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -27,6 +27,12 @@
 
 #import "CoreGraphicsInternal.h"
 
+enum _CGContextBlendType {
+    _kCGContextBlendD2DBlend = 0x0100,
+    _kCGContextBlendD2DCompose = 0x0200,
+    _kCGContextBlendOperator = 0x0400,
+};
+
 // Context Internal
 COREGRAPHICS_EXPORT CGContextRef _CGContextCreateWithD2DRenderTarget(ID2D1RenderTarget* renderTarget);
 COREGRAPHICS_EXPORT void _CGContextSetShadowProjectionTransform(CGContextRef context, CGAffineTransform transform);

--- a/Frameworks/include/CGContextInternal.h
+++ b/Frameworks/include/CGContextInternal.h
@@ -30,7 +30,8 @@
 enum _CGContextBlendType {
     _kCGContextBlendD2DBlend = 0x0100,
     _kCGContextBlendD2DCompose = 0x0200,
-    _kCGContextBlendOperator = 0x0400,
+    _kCGContextBlendD2DComposeWithEffect = 0x0400,
+    _kCGContextBlendOperator = 0x0800,
 };
 
 // Context Internal

--- a/include/CoreGraphics/CGContext.h
+++ b/include/CoreGraphics/CGContext.h
@@ -55,57 +55,57 @@ typedef CF_ENUM(CFIndex, CGInterpolationQuality) {
 };
 
 typedef CF_ENUM(CFIndex, CGBlendMode) {
-    // These magic constants may seem unusual, but they break down as follows:
-    // 0xAA 0xBB
-    // ^    ^
-    // +----|---- Direct2D Blend Type (Composition, Blend Effect, Special Operator)
-    //      +---- Mapped value from Direct2D:
+    // Each of these constants has a Facility and a Facility Value, documented below.
+    // 0xAABB
+    //   ^  ^
+    //   +--|---- Composition Facility (Primitive Composition, Direct2D Blend Effect, Special Operator)
+    //      +---- Composition facility value (usually mapped directly from Direct2D):
     //            Blends: https://msdn.microsoft.com/en-us/library/windows/desktop/dn934217(v=vs.85).aspx
     //            Composition: https://msdn.microsoft.com/en-us/library/windows/desktop/hh446995(v=vs.85).aspx
 
     // D2D Blend Effect Modes
     kCGBlendModeMultiply = 0x0100,
-    kCGBlendModeScreen,
-    kCGBlendModeDarken,
-    kCGBlendModeLighten,
+    kCGBlendModeScreen = 0x0101,
+    kCGBlendModeDarken = 0x0102,
+    kCGBlendModeLighten = 0x0103,
 
     kCGBlendModeColorBurn = 0x0105,
     kCGBlendModeColorDodge = 0x0109,
 
     kCGBlendModeOverlay = 0x010B,
-    kCGBlendModeSoftLight,
-    kCGBlendModeHardLight,
+    kCGBlendModeSoftLight = 0x010C,
+    kCGBlendModeHardLight = 0x010D,
 
-    kCGBlendModeDifference = 0x0118,
-    kCGBlendModeExclusion,
+    kCGBlendModeDifference = 0x0112,
+    kCGBlendModeExclusion = 0x0113,
 
-    kCGBlendModeHue,
-    kCGBlendModeSaturation,
-    kCGBlendModeColor,
-    kCGBlendModeLuminosity,
+    kCGBlendModeHue = 0x0114,
+    kCGBlendModeSaturation = 0x0115,
+    kCGBlendModeColor = 0x0116,
+    kCGBlendModeLuminosity = 0x0117,
 
     // D2D Composite Draw Modes
     kCGBlendModeSourceOver = 0x0200,
-    kCGBlendModeDestinationOver,
+    kCGBlendModeDestinationOver = 0x0201,
 
-    kCGBlendModeSourceIn,
-    kCGBlendModeDestinationIn,
+    kCGBlendModeSourceIn = 0x0402,
+    kCGBlendModeDestinationIn = 0x0403,
 
-    kCGBlendModeSourceOut,
-    kCGBlendModeDestinationOut,
+    kCGBlendModeSourceOut = 0x0404,
+    kCGBlendModeDestinationOut = 0x0205,
 
-    kCGBlendModeSourceAtop,
-    kCGBlendModeDestinationAtop,
+    kCGBlendModeSourceAtop = 0x0206,
+    kCGBlendModeDestinationAtop = 0x0407,
 
-    kCGBlendModeXOR,
-    kCGBlendModePlusLighter,
+    kCGBlendModeXOR = 0x0208,
+    kCGBlendModePlusLighter = 0x0209,
 
-    kCGBlendModeCopy = 0x020B, // D2D Composite mode 11 = *bounded* source copy.
+    kCGBlendModeCopy = 0x040A,
 
     kCGBlendModePlusDarker = kCGBlendModePlusLighter, // [Unsupported right now, maps to kCGBlendModePlusLighter with a warning.]
 
     // Special mode (clears the affected region)
-    kCGBlendModeClear = 0x0400,
+    kCGBlendModeClear = 0x0800,
 
     kCGBlendModeNormal = kCGBlendModeSourceOver,
 };

--- a/include/CoreGraphics/CGContext.h
+++ b/include/CoreGraphics/CGContext.h
@@ -55,34 +55,59 @@ typedef CF_ENUM(CFIndex, CGInterpolationQuality) {
 };
 
 typedef CF_ENUM(CFIndex, CGBlendMode) {
-    kCGBlendModeNormal,
-    kCGBlendModeMultiply,
+    // These magic constants may seem unusual, but they break down as follows:
+    // 0xAA 0xBB
+    // ^    ^
+    // +----|---- Direct2D Blend Type (Composition, Blend Effect, Special Operator)
+    //      +---- Mapped value from Direct2D:
+    //            Blends: https://msdn.microsoft.com/en-us/library/windows/desktop/dn934217(v=vs.85).aspx
+    //            Composition: https://msdn.microsoft.com/en-us/library/windows/desktop/hh446995(v=vs.85).aspx
+
+    // D2D Blend Effect Modes
+    kCGBlendModeMultiply = 0x0100,
     kCGBlendModeScreen,
-    kCGBlendModeOverlay,
     kCGBlendModeDarken,
     kCGBlendModeLighten,
-    kCGBlendModeColorDodge,
-    kCGBlendModeColorBurn,
+
+    kCGBlendModeColorBurn = 0x0105,
+    kCGBlendModeColorDodge = 0x0109,
+
+    kCGBlendModeOverlay = 0x010B,
     kCGBlendModeSoftLight,
     kCGBlendModeHardLight,
-    kCGBlendModeDifference,
+
+    kCGBlendModeDifference = 0x0118,
     kCGBlendModeExclusion,
+
     kCGBlendModeHue,
     kCGBlendModeSaturation,
     kCGBlendModeColor,
     kCGBlendModeLuminosity,
-    kCGBlendModeClear,
-    kCGBlendModeCopy,
-    kCGBlendModeSourceIn,
-    kCGBlendModeSourceOut,
-    kCGBlendModeSourceAtop,
+
+    // D2D Composite Draw Modes
+    kCGBlendModeSourceOver = 0x0200,
     kCGBlendModeDestinationOver,
+
+    kCGBlendModeSourceIn,
     kCGBlendModeDestinationIn,
+
+    kCGBlendModeSourceOut,
     kCGBlendModeDestinationOut,
+
+    kCGBlendModeSourceAtop,
     kCGBlendModeDestinationAtop,
+
     kCGBlendModeXOR,
-    kCGBlendModePlusDarker,
-    kCGBlendModePlusLighter
+    kCGBlendModePlusLighter,
+
+    kCGBlendModeCopy,
+
+    kCGBlendModePlusDarker = kCGBlendModePlusLighter, // [Unsupported right now, maps to kCGBlendModePlusLighter with a warning.]
+
+    // Special mode (clears the affected region)
+    kCGBlendModeClear = 0x0400,
+
+    kCGBlendModeNormal = kCGBlendModeSourceOver,
 };
 
 // clang-format off

--- a/include/CoreGraphics/CGContext.h
+++ b/include/CoreGraphics/CGContext.h
@@ -100,7 +100,7 @@ typedef CF_ENUM(CFIndex, CGBlendMode) {
     kCGBlendModeXOR,
     kCGBlendModePlusLighter,
 
-    kCGBlendModeCopy,
+    kCGBlendModeCopy = 0x020B, // D2D Composite mode 11 = *bounded* source copy.
 
     kCGBlendModePlusDarker = kCGBlendModePlusLighter, // [Unsupported right now, maps to kCGBlendModePlusLighter with a warning.]
 

--- a/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
@@ -58,7 +58,7 @@ class CGContextBlendMode : public WhiteBackgroundTest<>, public ::testing::WithP
     }
 };
 
-DRAW_TEST_P(CGContextBlendMode, OverlappedEllipses) {
+DRAW_TEST_P(CGContextBlendMode, OverlappedRects) {
     CGContextRef context = GetDrawingContext();
     CGRect bounds = GetDrawingBounds();
     CGBlendMode blendMode = ::testing::get<1>(GetParam()).blendMode;
@@ -70,12 +70,12 @@ DRAW_TEST_P(CGContextBlendMode, OverlappedEllipses) {
     CGPoint secondEllipseCenter{ firstEllipseCenter.x + (bounds.size.width / 3.f), firstEllipseCenter.y };
 
     CGContextSetRGBFillColor(context, .25, .71, .95, alpha);
-    CGContextFillEllipseInRect(context, _CGRectCenteredOnPoint({ bounds.size.height, bounds.size.height }, firstEllipseCenter));
+    CGContextFillRect(context, _CGRectCenteredOnPoint({ bounds.size.height, bounds.size.height }, firstEllipseCenter));
 
     CGContextSetBlendMode(context, blendMode);
 
     CGContextSetRGBFillColor(context, .95, .25, .66, alpha);
-    CGContextFillEllipseInRect(context, _CGRectCenteredOnPoint({ bounds.size.height, bounds.size.height }, secondEllipseCenter));
+    CGContextFillRect(context, _CGRectCenteredOnPoint({ bounds.size.height, bounds.size.height }, secondEllipseCenter));
 }
 
 INSTANTIATE_TEST_CASE_P(DISABLED_CompositionModes,

--- a/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
@@ -21,7 +21,7 @@ struct CGNamedBlendMode {
     CGBlendMode blendMode;
 };
 
-CGNamedBlendMode porterDuffBlendModes[] =
+CGNamedBlendMode pdfBlendModes[] =
     { { "kCGBlendModeMultiply", kCGBlendModeMultiply },     { "kCGBlendModeScreen", kCGBlendModeScreen },
       { "kCGBlendModeDarken", kCGBlendModeDarken },         { "kCGBlendModeLighten", kCGBlendModeLighten },
       { "kCGBlendModeColorBurn", kCGBlendModeColorBurn },   { "kCGBlendModeColorDodge", kCGBlendModeColorDodge },
@@ -32,6 +32,20 @@ CGNamedBlendMode porterDuffBlendModes[] =
       { "kCGBlendModeLuminosity", kCGBlendModeLuminosity } };
 
 CGNamedBlendMode blendOperators[] = { { "kCGBlendModeClear", kCGBlendModeClear } };
+
+CGNamedBlendMode compositionModesWithoutPlusDarker[] = {
+    { "kCGBlendModeNormal", kCGBlendModeNormal },
+    { "kCGBlendModeDestinationOver", kCGBlendModeDestinationOver },
+    { "kCGBlendModeSourceIn", kCGBlendModeSourceIn },
+    { "kCGBlendModeDestinationIn", kCGBlendModeDestinationIn },
+    { "kCGBlendModeSourceOut", kCGBlendModeSourceOut },
+    { "kCGBlendModeDestinationOut", kCGBlendModeDestinationOut },
+    { "kCGBlendModeSourceAtop", kCGBlendModeSourceAtop },
+    { "kCGBlendModeDestinationAtop", kCGBlendModeDestinationAtop },
+    { "kCGBlendModeXOR", kCGBlendModeXOR },
+    { "kCGBlendModePlusLighter", kCGBlendModePlusLighter },
+    { "kCGBlendModeCopy", kCGBlendModeCopy },
+};
 
 CGNamedBlendMode compositionModes[] = {
     { "kCGBlendModeNormal", kCGBlendModeNormal },
@@ -123,14 +137,20 @@ DRAW_TEST_P(CGContextBlendMode, OverlappedRects) {
     }
 }
 
-INSTANTIATE_TEST_CASE_P(CompositionModes,
-                        CGContextBlendMode,
-                        ::testing::Combine(::testing::Values(false, true), ::testing::ValuesIn(compositionModes)));
+// Disabled: layered = false; not supported. plus darker; not supported.
+DISABLED_INSTANTIATE_TEST_CASE_P(CompositionModes,
+                                 CGContextBlendMode,
+                                 ::testing::Combine(::testing::Values(true), ::testing::ValuesIn(compositionModesWithoutPlusDarker)),
+                                 ::testing::Combine(::testing::Values(false), ::testing::ValuesIn(compositionModes)));
 
-INSTANTIATE_TEST_CASE_P(PorterDuffModes,
+INSTANTIATE_TEST_CASE_P(AdobePDFBlendModes,
                         CGContextBlendMode,
-                        ::testing::Combine(::testing::Values(false, true), ::testing::ValuesIn(porterDuffBlendModes)));
+                        ::testing::Combine(::testing::Values(false, true), ::testing::ValuesIn(pdfBlendModes)));
 
+#if 0
+// Disabled: there is no supported configuration of this test, so we cannot fulfill the requirement
+// that DISABLED_INSTANTIATE_TEST_CASE_P have a set of "enabled" values.
 INSTANTIATE_TEST_CASE_P(OperatorBlendModes,
                         CGContextBlendMode,
                         ::testing::Combine(::testing::Values(false, true), ::testing::ValuesIn(blendOperators)));
+#endif

--- a/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextBlendModeTests.cpp
@@ -15,6 +15,8 @@
 //******************************************************************************
 
 #include "DrawingTest.h"
+#include "DrawingTestConfig.h"
+#include "ImageHelpers.h"
 
 struct CGNamedBlendMode {
     const char* name;
@@ -62,31 +64,21 @@ CGNamedBlendMode compositionModes[] = {
     { "kCGBlendModePlusDarker", kCGBlendModePlusDarker },
 };
 
-class CGContextBlendMode : public WhiteBackgroundTest<>, public ::testing::WithParamInterface<::testing::tuple<bool, CGNamedBlendMode>> {
-    CFStringRef CreateOutputFilename() {
-        const char* blendModeName = ::testing::get<1>(GetParam()).name;
-        bool useTransparencyLayer = ::testing::get<0>(GetParam());
-        return CFStringCreateWithFormat(nullptr, nullptr, CFSTR("TestImage.CGContext.Blending_%s%s.png"), useTransparencyLayer ? "Layered_" : "", blendModeName);
-    }
-};
-
-DRAW_TEST_P(CGContextBlendMode, OverlappedRects) {
-    CGContextRef context = GetDrawingContext();
-    CGRect bounds = GetDrawingBounds();
-    CGBlendMode blendMode = ::testing::get<1>(GetParam()).blendMode;
-    bool useTransparencyLayer = ::testing::get<0>(GetParam());
-
-    bounds = CGRectInset(bounds, 8.f, 8.f);
-
+static void __drawLeftStack(CGContextRef context, CGRect bounds, int variant = 0) {
     CGFloat unitHeight = bounds.size.height / 4.f;
 
-    CGContextSetLineWidth(context, 6.0f);
+    CGRect cursor = _CGRectCenteredOnPoint({ 2.f * bounds.size.width / 3.f, unitHeight },
+                                           { bounds.origin.x + (bounds.size.width / 3.f), bounds.origin.y + (unitHeight / 2.f) });
 
-    // Draw two rects and two lines, at both alphas.
-    CGRect cursor = _CGRectCenteredOnPoint({2.f * bounds.size.width / 3.f, unitHeight}, {bounds.origin.x +(bounds.size.width / 3.f), bounds.origin.y + (unitHeight / 2.f)});
-
+    CGContextSaveGState(context);
     CGContextSetRGBFillColor(context, .25, .71, .95, 1.0);
-    CGContextSetRGBStrokeColor(context, .25, .71, .95, 1.0);
+    if (variant == 0) {
+        // variant 0 = blue lines, blue boxes; variant 1 = dark red lines, blue boxes.
+        // This lets us test "lighten" more effectively.
+        CGContextSetRGBStrokeColor(context, .25, .71, .95, 1.0);
+    } else {
+        CGContextSetRGBStrokeColor(context, .45, 0, 0, 1.0);
+    }
 
     CGContextFillRect(context, cursor);
     cursor.origin.y += unitHeight;
@@ -96,22 +88,27 @@ DRAW_TEST_P(CGContextBlendMode, OverlappedRects) {
     cursor.origin.y += unitHeight;
 
     CGContextSetRGBFillColor(context, .25, .71, .95, 0.5);
-    CGContextSetRGBStrokeColor(context, .25, .71, .95, 0.5);
+    if (variant == 0) {
+        CGContextSetRGBStrokeColor(context, .25, .71, .95, 0.5);
+    } else {
+        CGContextSetRGBStrokeColor(context, .45, 0, 0, 0.5);
+    }
 
     CGContextFillRect(context, cursor);
     cursor.origin.y += unitHeight;
     CGContextMoveToPoint(context, CGRectGetMinX(cursor), CGRectGetMinY(cursor));
     CGContextAddLineToPoint(context, CGRectGetMaxX(cursor), CGRectGetMaxY(cursor));
     CGContextStrokePath(context);
-    cursor.origin.y += unitHeight;
+    CGContextRestoreGState(context);
+}
 
-    CGContextSetBlendMode(context, blendMode);
+static void __drawRightStackPink(CGContextRef context, CGRect bounds) {
+    CGFloat unitHeight = bounds.size.height / 4.f;
 
-    if (useTransparencyLayer) {
-        CGContextBeginTransparencyLayer(context, nullptr);
-    }
+    CGRect cursor = _CGRectCenteredOnPoint({ 2.f * bounds.size.width / 3.f, unitHeight },
+                                    { bounds.origin.x + (2.f * bounds.size.width / 3.f), bounds.origin.y + (unitHeight / 2.f) });
 
-    cursor = _CGRectCenteredOnPoint({2.f * bounds.size.width / 3.f, unitHeight}, {bounds.origin.x +(2.f * bounds.size.width / 3.f), bounds.origin.y + (unitHeight / 2.f)});
+    CGContextSaveGState(context);
     CGContextSetRGBFillColor(context, .95, .25, .66, 1.0);
     CGContextSetRGBStrokeColor(context, .95, .25, .66, 1.0);
 
@@ -130,7 +127,41 @@ DRAW_TEST_P(CGContextBlendMode, OverlappedRects) {
     CGContextMoveToPoint(context, CGRectGetMinX(cursor), CGRectGetMaxY(cursor));
     CGContextAddLineToPoint(context, CGRectGetMaxX(cursor), CGRectGetMinY(cursor));
     CGContextStrokePath(context);
-    cursor.origin.y += unitHeight;
+
+    CGContextRestoreGState(context);
+}
+
+class CGContextBlendMode : public WhiteBackgroundTest<>, public ::testing::WithParamInterface<::testing::tuple<bool, CGNamedBlendMode>> {
+    CFStringRef CreateOutputFilename() {
+        const char* blendModeName = ::testing::get<1>(GetParam()).name;
+        bool useTransparencyLayer = ::testing::get<0>(GetParam());
+        return CFStringCreateWithFormat(nullptr,
+                                        nullptr,
+                                        CFSTR("TestImage.CGContext.Blending_%s%s.png"),
+                                        useTransparencyLayer ? "Layered_" : "",
+                                        blendModeName);
+    }
+};
+
+DRAW_TEST_P(CGContextBlendMode, OverlappedRects) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    CGBlendMode blendMode = ::testing::get<1>(GetParam()).blendMode;
+    bool useTransparencyLayer = ::testing::get<0>(GetParam());
+
+    bounds = CGRectInset(bounds, 8.f, 8.f);
+
+    CGContextSetLineWidth(context, 6.0f);
+
+    __drawLeftStack(context, bounds);
+
+    CGContextSetBlendMode(context, blendMode);
+
+    if (useTransparencyLayer) {
+        CGContextBeginTransparencyLayer(context, nullptr);
+    }
+
+    __drawRightStackPink(context, bounds);
 
     if (useTransparencyLayer) {
         CGContextEndTransparencyLayer(context);
@@ -154,3 +185,65 @@ INSTANTIATE_TEST_CASE_P(OperatorBlendModes,
                         CGContextBlendMode,
                         ::testing::Combine(::testing::Values(false, true), ::testing::ValuesIn(blendOperators)));
 #endif
+
+class CGContextBlendModeImage : public WhiteBackgroundTest<>, public ::testing::WithParamInterface<CGNamedBlendMode> {
+    CFStringRef CreateOutputFilename() {
+        const char* blendModeName = GetParam().name;
+        // This works around the fact that TAEF cannot give us test case names.
+        // We have to divine them from the test full name. :(
+        auto testFullName = GetTestFullName();
+        bool source = (testFullName.find("ImageAsSource", 0) != std::string::npos);
+        return CFStringCreateWithFormat(nullptr, nullptr, CFSTR("TestImage.CGContext.Blending_Image%s_%s.png"), source ? "Source" : "Destination", blendModeName);
+    }
+
+public:
+    static woc::StrongCF<CGImageRef> s_testImage;
+    static void SetUpTestCase() {
+        auto drawingConfig = DrawingTestConfig::Get();
+        auto testFilename = woc::MakeStrongCF<CFStringRef>(_CFStringCreateWithStdString(drawingConfig->GetResourcePath("winobjc.png")));
+        s_testImage.attach(_CGImageCreateFromPNGFile(testFilename));
+    }
+
+    static void TearDownTestCase() {
+        s_testImage.attach(nullptr);
+    }
+};
+woc::StrongCF<CGImageRef> CGContextBlendModeImage::s_testImage;
+
+DRAW_TEST_P(CGContextBlendModeImage, ImageAsSource) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    CGBlendMode blendMode = GetParam().blendMode;
+
+    bounds = CGRectInset(bounds, 8.f, 8.f);
+
+    CGContextSetLineWidth(context, 6.0f);
+
+    __drawLeftStack(context, bounds, 1);
+
+    CGContextSetBlendMode(context, blendMode);
+
+    CGContextDrawImage(context, GetDrawingBounds(), s_testImage);
+}
+
+DRAW_TEST_P(CGContextBlendModeImage, ImageAsDestination) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+    CGBlendMode blendMode = GetParam().blendMode;
+
+    bounds = CGRectInset(bounds, 8.f, 8.f);
+
+    CGContextSetLineWidth(context, 6.0f);
+
+    CGContextDrawImage(context, GetDrawingBounds(), s_testImage);
+
+    CGContextSetBlendMode(context, blendMode);
+
+    CGContextBeginTransparencyLayer(context, nullptr);
+    __drawRightStackPink(context, bounds);
+    CGContextEndTransparencyLayer(context);
+}
+
+INSTANTIATE_TEST_CASE_P(CompositionModes, CGContextBlendModeImage, ::testing::ValuesIn(compositionModesWithoutPlusDarker));
+
+INSTANTIATE_TEST_CASE_P(AdobePDFBlendModes, CGContextBlendModeImage, ::testing::ValuesIn(pdfBlendModes));

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeColor.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeColor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b97f932aaf39cf8324975d28ccfd43de761a538e71ef5b780fa8c385f7c0e65
+size 11747

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeColorBurn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3214cfab80b8ffd782ab5594e13df3d538f3cbedf2264cd3cf88512366168d27
+size 11780

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeColorDodge.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce821dc29dbe82a5eb0fde0b4094f0a9d55534163fe7fa2ba2a76bc04493856b
+size 11268

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeCopy.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeCopy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef48017120de62c9867fd1fb8a0962e567fad41fdc892da196f93cffa1acab5f
+size 4376

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDarken.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDarken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45f28034e72dc585f1cba876c7d80a750c1fdab3026aa8aff06c3396d46e2500
+size 13787

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationAtop.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationAtop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:060135074b97590d4825ac0228bb1a6c483123ea495b62afee7ec224cf7c661a
+size 7677

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationIn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:060135074b97590d4825ac0228bb1a6c483123ea495b62afee7ec224cf7c661a
+size 7677

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationOut.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:185ab1e9cbd5fbe728aefeb80617a3c650f5251520ab1a4ee79575ab558bfdb1
+size 13291

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationOver.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDestinationOver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:511389b0cd81cb61c0976e3ac07a6462cc6c8d7c14814d9760e1f42fc2cd0b77
+size 9629

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDifference.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeDifference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaf4ffc23756abf7cafd702db3294b55e857dab9e7ffbd3d9843288cbb1ad00a
+size 13981

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeExclusion.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeExclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99d49354bfecc041ec59d1289fea2f8e72b948e5696c515158e4e72404ffcb16
+size 13955

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeHardLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeHardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fcb12c7ae6aad29ec8e87d1537de9ffaec2055a9157000d6bbd903c6bdb07ec
+size 13597

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeHue.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeHue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84a101ebddbb254d0dc1d2378dfe033fef1fcc2f63f42662adfaaa6014d3769a
+size 11651

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeLighten.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeLighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02bd4f8d665a72f838d5ecb637f002776c0899b7be4f180a8b6d94b03281f3cc
+size 11357

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeLuminosity.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeLuminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a78cd411c97031953ba965f7810d22828de2fbe89ca2c0134a2b983823e7d64b
+size 13116

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeMultiply.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeMultiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:951e9c42bb879857b65875914a0cbb0025b2b08ba89a3e506a9b40c0422dd2d5
+size 14103

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeNormal.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeNormal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9639df2224cfe1617e0084ac2cb3ba9f411eed6ce417ba76e11e863b9dd315b9
+size 13235

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeOverlay.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeOverlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf87ba8ebc2309ad9c3a88d645678b49c75eb0569b1161b24b21173fffffbd67
+size 11711

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModePlusLighter.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModePlusLighter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13231d3ec5bc4efac4156e5fa96e6ae5a0d9b42b8f4c121a624078974538fd7d
+size 10634

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSaturation.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSaturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:302a6b60190ce37c50fce9c82e604f752623ac888bb5a6e7f13ff92bcfa481c5
+size 11499

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeScreen.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a13b2e969f0b41ddf0e02b6dfb983b3aad47abd1779059fd2ef8cf27facbada
+size 11492

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSoftLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5189e6b71d2d22c73a3f72d2f3c6be076990dd36ebe8bd451498ee82889ef23
+size 11593

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSourceAtop.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSourceAtop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58fd6578768789db3be52b740f83ca25eab343b848bbeda1dc216af31939b46d
+size 13253

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSourceIn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSourceIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef48017120de62c9867fd1fb8a0962e567fad41fdc892da196f93cffa1acab5f
+size 4376

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSourceOut.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeSourceOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a83c32787379a42f1842fb90e9e6aba6ee0414e780c3fd13b05b384990eb9c17
+size 638

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeXOR.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageDestination_kCGBlendModeXOR.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:185ab1e9cbd5fbe728aefeb80617a3c650f5251520ab1a4ee79575ab558bfdb1
+size 13291

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeColor.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeColor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65194bd2593eea33acecbc2c6df33bf67eeef213081e8d965dd4a51e858852c4
+size 7378

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeColorBurn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac5c8c078ae21ca65da11b6be142029b4a135efe84f2d493327be7d2bb8a20e8
+size 7651

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeColorDodge.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9956d5cf275746ebe0ac9ddf19b2d1de0878291c494075a50149e1cc2bb76e6
+size 6245

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeCopy.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeCopy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c19bf826f31fbb4a740fcfb7938beda1b9d4c6ea3d5a6415a10289200bf25ae
+size 8854

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDarken.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDarken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dc91692619d669a79d50f992629cf537024407c1f1fa24ca01ea4b7d90b8630
+size 14313

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationAtop.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationAtop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed80e2bfe6b52fdaa890ef28b8c860de8ac6cdd498b8b784e77cfd22eb8121a5
+size 11000

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationIn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed80e2bfe6b52fdaa890ef28b8c860de8ac6cdd498b8b784e77cfd22eb8121a5
+size 11000

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationOut.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b951fdc9dcb6ef7d0d322802f76935153b720673362de6e6f81e19f8e0ebad65
+size 14030

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationOver.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDestinationOver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b30ef76c7e8493e6657195664021c1388933892f4606bf2f4b6bc1c231e7f8a
+size 3730

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDifference.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeDifference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29afff0b9ff3c27677a60988a664c1dfcc044b47a00eb415170b962e2d969108
+size 11231

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeExclusion.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeExclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:109ae0f449317f962beff9d7e8d46ff99dd67ff71d0ede403fd9db3619d3733e
+size 11392

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeHardLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeHardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2cca17996979f1ab973dac1a38bb7bc9d037c996d0d9bdae9443d6257f03370
+size 13221

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeHue.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeHue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c8267966146433014cd2fd35631b348a061db46740070467fc9ae43eab0e14f
+size 7267

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeLighten.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeLighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25a1209acfa44c0164ed25173a886522fb887af8b67ef3ad083f28c3d33cc569
+size 4524

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeLuminosity.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeLuminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2366ba16d03ab796748196ba0a3663da0253d577b003b2965161823c4bbd8db9
+size 12498

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeMultiply.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeMultiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab85300011da6c1ff9a87505386a0882d88f1c786596a99f5328ffb1d8f37d96
+size 14232

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeNormal.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeNormal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db67800aba3496d979e70bb6e5df834076eb1a32b45cbbdb120b3a15428c896a
+size 14201

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeOverlay.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeOverlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcbe215174b34edd0f6d94574318eaea7d2355d5b546ec2b1ef0f087da8e82f1
+size 6927

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModePlusLighter.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModePlusLighter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b1ed08d9f7b299e08e4daa6ad95ba638e667d9062eb467a23db8f60387ccad7
+size 5830

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSaturation.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSaturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b31b18c092541b7b758adaf9b936df062a1aac33bc721fb1a9743f4122f8cb82
+size 5986

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeScreen.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:609ed21e751821d49165d1559c26ddbfa541c0422220079ce5b0bfbfbc8a8e99
+size 6319

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSoftLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a965ac0739f2f0e9715506a15bd7ef7c0bc7de2c614eaf22964147946223ab2c
+size 6928

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSourceAtop.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSourceAtop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db67800aba3496d979e70bb6e5df834076eb1a32b45cbbdb120b3a15428c896a
+size 14201

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSourceIn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSourceIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c19bf826f31fbb4a740fcfb7938beda1b9d4c6ea3d5a6415a10289200bf25ae
+size 8854

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSourceOut.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeSourceOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a83c32787379a42f1842fb90e9e6aba6ee0414e780c3fd13b05b384990eb9c17
+size 638

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeXOR.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_ImageSource_kCGBlendModeXOR.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b951fdc9dcb6ef7d0d322802f76935153b720673362de6e6f81e19f8e0ebad65
+size 14030

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeColor.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeColor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c70445e433c37333651e751076e7fcfe454a7eb91e0a09e311cc8f7627cb176
+size 4267

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeColorBurn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2c5f3e87bf34fc856d10e7835fee3c86126fa2bbb0da6cfa4a52b0b6037190f
+size 4305

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeColorDodge.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6f42f9b311e3ebf97ed6d1174f6c169626ebcc7649cbce035a2aed29c4cc4c2
+size 4098

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeCopy.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeCopy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef48017120de62c9867fd1fb8a0962e567fad41fdc892da196f93cffa1acab5f
+size 4376

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDarken.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDarken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0722d0fcf09613bdd51fea1a99e38836c02571bfbe5eed3edf65e7215853c4b6
+size 6445

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationAtop.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationAtop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7bea96bf7ce165a4e605164e534b42281a9cbe9640f3911eccbb929d9c21959
+size 4460

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationIn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7bea96bf7ce165a4e605164e534b42281a9cbe9640f3911eccbb929d9c21959
+size 4460

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationOut.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d187e11b99ecaeaad95d72b0ed6a31b81928d656b777f1d022902b6d28876f02
+size 6477

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationOver.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDestinationOver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c595265ec827bc827a093992acf4383141984b00885da65eafe5180d429e943e
+size 3677

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDifference.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeDifference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4173f0b4c6156658487ef822d482e517b20abd36334522707a9e45ea6aa70136
+size 6612

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeExclusion.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeExclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ee40cef654ff6144571d3aefe57d0f2c63525d17ad30f2e91f269ab3d16c8fb
+size 6631

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeHardLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeHardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcd9f354225c7ccd46160a03fadf82c57a599616b83478890f9fbc21c7bb46b7
+size 5843

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeHue.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeHue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c70445e433c37333651e751076e7fcfe454a7eb91e0a09e311cc8f7627cb176
+size 4267

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeLighten.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeLighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f80b434ebef8ac1a5f4cc3766c347682b9f1f0a9eb63fc50290d88d553e292c4
+size 4086

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeLuminosity.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeLuminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:306a686407111ebc8d9ed9042f12f35b81e50242d5d43691f1d673756b19368e
+size 6180

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeMultiply.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeMultiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:665ad7aadf242c203e34cbc662e1891ec4779f2535a36ba2cc330f964ae7134f
+size 6536

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeNormal.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeNormal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1b5551bf79f6653bf6e0e283917779844eb1578d3c5eeb98b28818745a74772
+size 6396

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeOverlay.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeOverlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ea920bf3b5d1a82ec68471c431b88da6e885de5454116ef1e40df96b438818
+size 4267

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModePlusLighter.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModePlusLighter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c466023a3772978d877ab52cf1b7efa04790a0d239f4b6c069ef1e3556ba3055
+size 4019

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSaturation.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSaturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d540b8597655c1596b3bf2265b4501df70e9d052ea77d9633080586fcd3211ce
+size 4023

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeScreen.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5feddbf52a1b2f9325e32ef8f18e3b639a2de027c031c7a82d7489621d2acda
+size 4205

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSoftLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24ab7399edf0c617f583aeceaa48dae2cbff5993b333f13df1ddb0838175cb06
+size 4205

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSourceAtop.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSourceAtop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43e8076e0e28f2dd80286f5e0eb0dbac5d3a324e32d2133232667f40e4042a72
+size 6393

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSourceIn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSourceIn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef48017120de62c9867fd1fb8a0962e567fad41fdc892da196f93cffa1acab5f
+size 4376

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSourceOut.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeSourceOut.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a83c32787379a42f1842fb90e9e6aba6ee0414e780c3fd13b05b384990eb9c17
+size 638

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeXOR.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_Layered_kCGBlendModeXOR.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d187e11b99ecaeaad95d72b0ed6a31b81928d656b777f1d022902b6d28876f02
+size 6477

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeColor.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeColor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0029ccb03b38330b78a68d61b13834d750a72b7b42186c29b4c6ea3eae60d19
+size 4271

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeColorBurn.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df027c04a97dc1d6ad0ba63f55f05f1280153c5cddf2a68c8a2d4d19371b2415
+size 4299

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeColorDodge.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ddb809779574c5529dc8add5e2de74dda5142a2a49b38cd83c44b716b730f9
+size 4096

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeDarken.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeDarken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cf53f5b151a65cd00ef52a3860a06ea355ba294c142572426ebd3432bcb6596
+size 6449

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeDifference.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeDifference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5372bcf7e70a74935937ac6e233740957a5a598c66214f2a3332ead2c65b7afb
+size 6723

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeExclusion.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeExclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f858f922cffbaedcf39e8055ab03e27d515f94a1becabf4b2b86498c359c71f3
+size 6767

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeHardLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeHardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffee18bf381ff19ef4405e1555f26deddf230dd311bf4cfae0d6a89482a15a3e
+size 5927

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeHue.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeHue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:590a6d258769cfe6efc2c175f73acefff0dc3318acd0a20dba500d41e91d2cde
+size 4271

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeLighten.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeLighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52f32de1450df67c90a032508bfbed0e4aa1fab4191c615d919e480f189d9d96
+size 4083

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeLuminosity.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeLuminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:872fd75e9cd51ea6fb95d79e44266390ab0ca1026f200d0f84637ac781f292a3
+size 6186

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeMultiply.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeMultiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c60caeec77b8e6b80cacb43cd1bcb69f87f4ced68576a81448713e53dd49eb53
+size 6677

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeOverlay.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeOverlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b6f1be8152df27be5d22659ad37401ae8e26491afd0924479e41ba1f35fdb0
+size 4265

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeSaturation.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeSaturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dec21a44f2ed06f7486cd0829711cd234f39f108dfc44b79e374da7de2ac6cc5
+size 4025

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeScreen.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e44dc744fe6ef63528f863dc17bbe81841048ea7fb39250854056f6c591983e
+size 4203

--- a/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeSoftLight.png
+++ b/tests/unittests/CoreGraphics.drawing/data/reference/TestImage.CGContext.Blending_kCGBlendModeSoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b56e9538ddffbae46d54933606a97db815f9d7327900511e9c20574a523666c
+size 4222

--- a/tests/unittests/CoreGraphics.drawing/data/winobjc.png
+++ b/tests/unittests/CoreGraphics.drawing/data/winobjc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b2314b8b4392a4532fb5b4918dec265d48752c989b6e4a6a8722eb9d191fa4
+size 8008


### PR DESCRIPTION
This pull request adds support for blending to CGContext. There are a number of caveats.

* `kCGBlendModeClear` is not supported.
* The *Source In*, *Destination In*, *Source Out*, *Destination Atop*, and *Source Copy* blend modes cannot be used properly without transparency layers. Their use per-primitive will result in unusual artifacts.
* `kCGBlendModePlusDarker` is not supported (and was not supported in the original Cairo implementation).

Some blend modes (the ones without Source/Destination) in the name require a full buffer read-back and compose operation. This is unavoidable. 😦

This change unfortunately _does_ include a rewrite of the CGD2D rendering stack. Instead of adding yet another nesting level of command lists and layers, I switched it to a scaffold/commit stack. Depending on various conditions, operations will be queued up, started in order, and committed in reverse order. A great many of those operations involve creating command lists and layers and blending them or otherwise composing them.

There is a not-insignificant performance penalty in certain cases:


```
|                                    before             after   delta
| CoreText__CTLineDrawComplete       742.51            716.11   -3.5546% faster |
| CoreText__CTLineDrawGroup         292,909           307,828    5.0934% slower |
| CoreText__CTLineDrawSingle         233.43            280.05   19.9746% slower |

times in μs.
```

While 19% seems like a lot, it's only 47μs/operation; an application running at 60fps requires its rendering operations complete in ~16000μs. It's not _significant_, but it is a cost taken per operation.

I believe there is opportunity for improvement; specifically, I had to compromise on allocations to achieve the desired effects of polymorphism in the new render operation stack.

Please examine this very closely.

Fixes #1389.