### PR TITLE
Add GitVersionTask and NuGet.Build.Packaging as WinObjC.Packaging deps

### DIFF
--- a/tools/WinObjC.Packaging/ImportedByThisProj.props
+++ b/tools/WinObjC.Packaging/ImportedByThisProj.props
@@ -20,4 +20,15 @@
     <PackageTags>WinObjC.Packaging</PackageTags>
     <IsDevelopmentDependency>true</IsDevelopmentDependency>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageFile Include="GitVersionTask">
+      <Kind>Dependency</Kind>
+      <Version>4.0.0-beta0011</Version>
+    </PackageFile>
+    <PackageFile Include="NuGet.Build.Packaging">
+      <Kind>Dependency</Kind>
+      <Version>0.1.186</Version>
+    </PackageFile>
+  </ItemGroup>
 </Project>

--- a/tools/WinObjC.Packaging/ImportedByThisProj.targets
+++ b/tools/WinObjC.Packaging/ImportedByThisProj.targets
@@ -46,13 +46,4 @@
       </PackageFile>
     </ItemGroup>
   </Target>
-
-  <!-- Undo what Nuget.Build.Packaging did to unset itself as a project dependency in the output package nuspec -->
-  <Target Name="ModifyPackageInheritance" DependsOnTargets="ReadLegacyDependencies" BeforeTargets="GetPackageContents" >
-    <ItemGroup>
-      <PackageReference Condition="'%(PackageReference.Identity)' == 'NuGet.Build.Packaging'">
-        <PrivateAssets></PrivateAssets>
-      </PackageReference>
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
The WinObjC.Packaging package was relying on InferLegacyPackageReferences being set to true. Recent changes in winobjc.nuproj.common.props now have that set as false. Decided to instead include the package dependency without relying on the project.json.

Note 1: We may want to consider updating the versions of these two included packages, GitVersionTask and NuGet.Build.Packaging. They are currently set to a version that is known to work for WinObjC.Packaging.

Note 2: Once tools.sln is switched to PackageReference instead of project.json we can do fancy things here to use the same versions of GitVersionTask and NuGet.Build.Packaging that the WinObjC.Packaging project is using.