### PR TITLE
Colorspace support for CGColor and improvements to the class.

### DIFF
--- a/Frameworks/CoreGraphics/CGColor.mm
+++ b/Frameworks/CoreGraphics/CGColor.mm
@@ -164,10 +164,10 @@ const CGFloat* CGColorGetComponents(CGColorRef color) {
 
 /**
  @Status Caveat
- @Notes Not all colors have 4 components, but all of the ones we currently support do!
+ @Notes Limited support for colorspace
 */
 size_t CGColorGetNumberOfComponents(CGColorRef color) {
-    return 4;
+    return CGColorSpaceGetNumberOfComponents(CGColorGetColorSpace(color)) + 1;
 }
 
 /**

--- a/Frameworks/UIKit/UIColor.mm
+++ b/Frameworks/UIKit/UIColor.mm
@@ -226,6 +226,8 @@ rgb hsv2rgb(hsv in) {
     UIImage* _image;
     id _pattern;
     __CGColorQuad _components;
+    // Note: This should be part of the CGColor struct
+    woc::StrongCF<CGColorSpaceRef> _colorSpace;
 }
 
 /**
@@ -613,6 +615,14 @@ _pattern = (id) _CGPatternCreateFromImage(pImg);
 
 - (const __CGColorQuad*)_getColors {
     return &_components;
+}
+
+- (CGColorSpaceRef)colorSpace {
+    return _colorSpace;
+}
+
+- (void)setColorSpace:(CGColorSpaceRef)colorSpace {
+    _colorSpace = colorSpace;
 }
 
 /**

--- a/Frameworks/include/UIColorInternal.h
+++ b/Frameworks/include/UIColorInternal.h
@@ -37,7 +37,7 @@ inline void _ClearColorQuad(__CGColorQuad& color) {
 }
 + (UIColor*)_colorWithCGPattern:(CGPatternRef)pattern;
 + (UIColor*)_windowsTableViewCellSelectionBackgroundColor;
-
 - (const __CGColorQuad*)_getColors;
 - (BrushType)_type;
+@property (nonatomic, assign) CGColorSpaceRef colorSpace;
 @end

--- a/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="..\..\..\CoreImage\dll\CoreImage.vcxproj">
       <Project>{3EFCDFF3-6013-448F-8611-534D0F819D6B}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\UIKit\dll\UIKit.vcxproj">
+      <Project>{43D2CFE5-0711-4E61-8F5C-F8D3B65D3A49}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DA6C01EA-A22E-4807-BACE-63C5C6ABAE77}</ProjectGuid>

--- a/tests/unittests/CoreGraphics/CGColorTests.mm
+++ b/tests/unittests/CoreGraphics/CGColorTests.mm
@@ -17,6 +17,11 @@
 #import <TestFramework.h>
 #import <CoreGraphics/CoreGraphics.h>
 
+// TODO #2243: Remove the UIKit dependency
+#if WINOBJC
+#include <UIKit/UIColor.h>
+#endif
+
 #define EXPECT_EQ_COMPONENTS(a, b) \
     EXPECT_EQ((a)[0], (b)[0]);     \
     EXPECT_EQ((a)[1], (b)[1]);     \
@@ -24,6 +29,9 @@
     EXPECT_EQ((a)[3], (b)[3])
 
 TEST(CGColor, CGColorGetComponents) {
+#if WINOBJC
+    [UIColor class];
+#endif
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -49,6 +57,10 @@ TEST(CGColor, CGColorGetComponents) {
 }
 
 TEST(CGColor, CGColorEquals) {
+#if WINOBJC
+    [UIColor class];
+#endif
+
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -80,6 +92,9 @@ TEST(CGColor, CGColorEquals) {
 }
 
 TEST(CGColor, GetColorSpace) {
+#if WINOBJC
+    [UIColor class];
+#endif
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -101,6 +116,9 @@ TEST(CGColor, GetColorSpace) {
 }
 
 TEST(CGColor, GetConstantColor) {
+#if WINOBJC
+    [UIColor class];
+#endif
     auto grayColorSpace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceGray());
 
     CFStringRef colors[] = { kCGColorWhite, kCGColorBlack, kCGColorClear };

--- a/tests/unittests/CoreGraphics/CGColorTests.mm
+++ b/tests/unittests/CoreGraphics/CGColorTests.mm
@@ -23,12 +23,18 @@
     EXPECT_EQ((a)[2], (b)[2]);     \
     EXPECT_EQ((a)[3], (b)[3])
 
-DISABLED_TEST(CGColor, CGColorGetComponents) {
+TEST(CGColor, CGColorGetComponents) {
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
     CGColorRef clr = CGColorCreate(clrRgb, colors);
     CGColorRef copy = CGColorCreateCopyWithAlpha(clr, 0.5); // transparent red
+
+    EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(copy)));
+    EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr)));
+
+    EXPECT_EQ(4, CGColorGetNumberOfComponents(clr));
+    EXPECT_EQ(4, CGColorGetNumberOfComponents(copy));
 
     const CGFloat* components = CGColorGetComponents(copy);
     CGFloat expected[] = { 1, 0, 0, 0.5 };
@@ -42,7 +48,38 @@ DISABLED_TEST(CGColor, CGColorGetComponents) {
     CGColorSpaceRelease(clrRgb);
 }
 
-DISABLED_TEST(CGColor, CGColorEquals) {
+TEST(CGColor, CGColorEquals) {
+    CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
+
+    CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
+    CGColorRef clr1 = CGColorCreate(clrRgb, colors);
+    CGColorRef clr2 = CGColorCreateCopy(clr1);
+    CGColorRef clr3 = CGColorCreateCopyWithAlpha(clr1, 0.9);
+    CGColorRef clr4 = CGColorCreate(clrRgb, colors);
+
+    EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr1)));
+    EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr2)));
+    EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr3)));
+    EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr4)));
+
+    EXPECT_EQ(4, CGColorGetNumberOfComponents(clr1));
+    EXPECT_EQ(4, CGColorGetNumberOfComponents(clr2));
+    EXPECT_EQ(4, CGColorGetNumberOfComponents(clr3));
+    EXPECT_EQ(4, CGColorGetNumberOfComponents(clr4));
+
+    EXPECT_TRUE(CGColorEqualToColor(clr1, clr1));
+    EXPECT_TRUE(CGColorEqualToColor(clr1, clr2));
+    EXPECT_TRUE(CGColorEqualToColor(clr1, clr4));
+    EXPECT_FALSE(CGColorEqualToColor(clr1, clr3));
+
+    CGColorRelease(clr1);
+    CGColorRelease(clr2);
+    CGColorRelease(clr3);
+    CGColorRelease(clr4);
+    CGColorSpaceRelease(clrRgb);
+}
+
+TEST(CGColor, GetColorSpace) {
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -61,4 +98,16 @@ DISABLED_TEST(CGColor, CGColorEquals) {
     CGColorRelease(clr3);
     CGColorRelease(clr4);
     CGColorSpaceRelease(clrRgb);
+}
+
+TEST(CGColor, GetConstantColor) {
+    auto grayColorSpace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceGray());
+
+    CFStringRef colors[] = { kCGColorWhite, kCGColorBlack, kCGColorClear };
+
+    for (int i = 0; i < std::extent<decltype(colors)>::value; ++i) {
+        CGColorRef col = CGColorGetConstantColor(colors[i]);
+        EXPECT_EQ(CGColorSpaceGetModel(grayColorSpace), CGColorSpaceGetModel(CGColorGetColorSpace(col)));
+        EXPECT_EQ(2, CGColorGetNumberOfComponents(col));
+    }
 }


### PR DESCRIPTION
The CGColor is still a UIColor class [re-implementation is planned], but we have improved the functionality.

fixes #2041