### PR TITLE
Make UTs build on reference platform

### DIFF
--- a/Frameworks/Foundation/_NSInvocation.arm.mm
+++ b/Frameworks/Foundation/_NSInvocation.arm.mm
@@ -15,6 +15,7 @@
 //******************************************************************************
 
 #import "NSInvocationInternal.h"
+#import <IwMalloc.h>
 
 #import <Starboard/SmartTypes.h>
 #import <objc/runtime.h>
@@ -396,7 +397,7 @@ bool _NSInvocationCallFrame::getRequiresStructReturn() const {
 void _NSInvocationCallFrame::copyInExistingFrame(void* frame) {
     // On x86, we can copy the frame as-is; for ARM we have to only copy the allocated portions.
     uint8_t* base = _buffer;
-    for(auto& extent: _allocationExtents) {
+    for (auto& extent : _allocationExtents) {
         memcpy(base + extent.offset, (uint8_t*)frame + extent.offset, extent.length);
     }
 }

--- a/Frameworks/Foundation/_NSInvocation.x86.mm
+++ b/Frameworks/Foundation/_NSInvocation.x86.mm
@@ -15,6 +15,7 @@
 //******************************************************************************
 
 #import "NSInvocationInternal.h"
+#import <IwMalloc.h>
 
 #import <objc/runtime.h>
 #import <objc/encoding.h>

--- a/include/xplat/Starboard/SmartTypes.h
+++ b/include/xplat/Starboard/SmartTypes.h
@@ -19,7 +19,6 @@
 #include "Starboard/TypeTraits.h"
 
 #if defined(__OBJC__)
-#include "IwMalloc.h"
 #include <Foundation/Foundation.h>
 #include <CoreFoundation/CFBase.h>
 #endif

--- a/tests/unittests/EntryPoint.cpp
+++ b/tests/unittests/EntryPoint.cpp
@@ -67,13 +67,14 @@ MODULE_PROPERTY(L"RunAs", L"UAP")
 END_MODULE()
 
 MODULE_SETUP(ModuleSetup) {
-#else
-int main(int argc, char** argv) {
-#endif
     // Initialize GTest framework.
     int _argc = 1;
     char* _argv[] = { "UnitTests" };
     testing::InitGoogleTest(&_argc, _argv);
+#else
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+#endif
 
 #ifdef WIN32
     if (FAILED(RoInitialize(RO_INIT_MULTITHREADED))) {

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -348,6 +348,8 @@ TEST(NSData, Copying_NSMutableData) {
     ASSERT_OBJCNE(copiedData, mutableData);
 }
 
+#ifdef WINOBJC
+
 TEST(NSData, Copying_CustomBufferWithOwnership) {
     woc::unique_iw<char> backingBuffer(IwStrDup("hello world"));
     NSData* originalOwningData = [NSData dataWithBytesNoCopy:backingBuffer.release() length:11 freeWhenDone:YES];
@@ -368,6 +370,8 @@ TEST(NSData, Copying_CustomBufferWithoutOwnership) {
     *(backingBuffer.get() + 5) = '!';
     ASSERT_OBJCNE(copiedData, originalNonOwningData);
 }
+
+#endif
 
 TEST(NSData, MutableInstanceArchivesAsMutable) {
     NSMutableData* input = [NSMutableData dataWithBytes:"hello" length:5];

--- a/tests/unittests/Foundation/NSDataTests.mm
+++ b/tests/unittests/Foundation/NSDataTests.mm
@@ -348,10 +348,8 @@ TEST(NSData, Copying_NSMutableData) {
     ASSERT_OBJCNE(copiedData, mutableData);
 }
 
-#ifdef WINOBJC
-
 TEST(NSData, Copying_CustomBufferWithOwnership) {
-    woc::unique_iw<char> backingBuffer(IwStrDup("hello world"));
+    std::unique_ptr<char[]> backingBuffer(new char[11]{ 'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd' });
     NSData* originalOwningData = [NSData dataWithBytesNoCopy:backingBuffer.release() length:11 freeWhenDone:YES];
     NSData* copiedData = [[originalOwningData copy] autorelease];
 
@@ -360,7 +358,7 @@ TEST(NSData, Copying_CustomBufferWithOwnership) {
 }
 
 TEST(NSData, Copying_CustomBufferWithoutOwnership) {
-    woc::unique_iw<char> backingBuffer(IwStrDup("hello world"));
+    std::unique_ptr<char[]> backingBuffer(new char[11]{ 'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd' });
     NSData* originalNonOwningData = [NSData dataWithBytesNoCopy:backingBuffer.get() length:11 freeWhenDone:NO];
     NSData* copiedData = [[originalNonOwningData copy] autorelease];
 
@@ -370,8 +368,6 @@ TEST(NSData, Copying_CustomBufferWithoutOwnership) {
     *(backingBuffer.get() + 5) = '!';
     ASSERT_OBJCNE(copiedData, originalNonOwningData);
 }
-
-#endif
 
 TEST(NSData, MutableInstanceArchivesAsMutable) {
     NSMutableData* input = [NSMutableData dataWithBytes:"hello" length:5];

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSBundle.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSBundle.mm
@@ -25,7 +25,6 @@
 #import <Foundation/Foundation.h>
 #import <Starboard/SmartTypes.h>
 #import <TestFramework.h>
-#import <LoggingNative.h>
 
 TEST(NSBundle, Paths) {
     auto bundle = [NSBundle mainBundle];
@@ -116,18 +115,14 @@ protected:
 
         NSError* error = nil;
         [[NSFileManager defaultManager] createDirectoryAtPath:tempDir withIntermediateDirectories:false attributes:nil error:&error];
-        if (error) {
-            TraceError(L"TestNSBundle", L"%hs", [[error description] UTF8String]);
-            return;
-        }
+        // WINOBJC: Change to ASSERT macro to remove LoggingNative reference
+        ASSERT_EQ(nil, error);
 
         // Make a flat bundle in the playground
         auto bundlePath = [tempDir stringByAppendingString:_bundleName];
         [[NSFileManager defaultManager] createDirectoryAtPath:bundlePath withIntermediateDirectories:false attributes:nil error:&error];
-        if (error) {
-            TraceError(L"TestNSBundle", L"%hs", [[error description] UTF8String]);
-            return;
-        }
+        // WINOBJC: Change to ASSERT macro to remove LoggingNative reference
+        ASSERT_EQ(nil, error);
 
         // Put some resources in the bundle
         for (NSString* n in _bundleResourceNames) {
@@ -138,10 +133,9 @@ protected:
         // Add a resource into a subdirectory
         auto subDirPath = [[bundlePath stringByAppendingString:@"/"] stringByAppendingString:_subDirectory];
         [[NSFileManager defaultManager] createDirectoryAtPath:subDirPath withIntermediateDirectories:false attributes:nil error:&error];
-        if (error) {
-            TraceError(L"TestNSBundle", L"%hs", [[error description] UTF8String]);
-            return;
-        }
+        // WINOBJC: Change to ASSERT macro to remove LoggingNative reference
+        ASSERT_EQ(nil, error);
+
         [[NSFileManager defaultManager] createFileAtPath:[@[ subDirPath, @"/", _main, @".", _type ] componentsJoinedByString:@""]
                                                 contents:nil
                                               attributes:nil];

--- a/tests/unittests/UT.common.mk
+++ b/tests/unittests/UT.common.mk
@@ -28,12 +28,12 @@ OSX_VERSION_MIN := 10.10
 _UT_OBJECTS := $(addsuffix .o,$(addprefix $(_UT_OBJ_DIR)/,$(subst $(_UT_PROJECT_DIR)/,,$(UT_FILES))))
 
 # Common shims for all tests.
-_UT_OBJECTS += $(_UT_OBJ_DIR)/windows.o $(_UT_OBJ_DIR)/IwMalloc.o $(_UT_OBJ_DIR)/LoggingNative.o
+_UT_OBJECTS += $(_UT_OBJ_DIR)/windows.o
 ifeq ($(strip $(filter EntryPoint.cpp,$(UT_FILES))),)
 _UT_OBJECTS += $(_UT_OBJ_DIR)/EntryPoint.o
 endif
 
-_INC := $(_UT_BASE_DIR)/../frameworks/include $(_UT_BASE_DIR)/../frameworks/gtest $(_UT_BASE_DIR)/../frameworks/gtest/include 
+_INC := $(_UT_BASE_DIR)/../frameworks/include $(_UT_BASE_DIR)/../frameworks/gtest $(_UT_BASE_DIR)/../frameworks/gtest/include
 _INC += $(_UT_BASE_DIR)/../frameworks/OSXShims/include $(_UT_BASE_DIR)/../../include/xplat
 
 _ALL_CXXFLAGS := -std=c++14
@@ -58,23 +58,15 @@ _ALL_LDFLAGS += $(UT_LDFLAGS)
 # LDFLAGS from the commandline (to make certain build scenarios easier.)
 _ALL_LDFLAGS += $(LDFLAGS)
 
-ECHO_CC = @(echo "[ CC ] $^"; 
+ECHO_CC = @(echo "[ CC ] $^";
 ECHO_LD = @(echo "[ LD ] $@";
 ECHO_RES = @(echo "[ RES ] $^";
 ECHO_RESDIR = @(echo "[ DIR ] $^";
 ECHO_END = )
 
-$(_UT_OBJ_DIR)/IwMalloc.o : $(_UT_BASE_DIR)/../../Frameworks/WinObjCRT/MemoryManagement.cpp
-	@mkdir -p $(dir $@)
-	$(ECHO_CC)$(CLANG) -c -o $@ $(_ALL_CFLAGS) $(_ALL_CXXFLAGS) $<$(ECHO_END)
-
 $(_UT_OBJ_DIR)/windows.o : $(_UT_BASE_DIR)/../frameworks/OSXShims/src/windows.cpp
 	@mkdir -p $(dir $@)
 	$(ECHO_CC)$(CLANG) -c -o $@ $(_ALL_CFLAGS) $(_ALL_CXXFLAGS) $<$(ECHO_END)
-
-$(_UT_OBJ_DIR)/LoggingNative.o : $(_UT_BASE_DIR)/../frameworks/OSXShims/src/LoggingNative.mm
-	@mkdir -p $(dir $@)
-	$(ECHO_CC)$(CLANG) -c -o $@ $(_ALL_CFLAGS) $(_ALL_CXXFLAGS) -x objective-c++ $<$(ECHO_END)
 
 $(_UT_OBJ_DIR)/EntryPoint.o : $(_UT_BASE_DIR)/EntryPoint.cpp
 	@mkdir -p $(dir $@)


### PR DESCRIPTION
With files required for Foundation.UnitTests being moved the unit tests no longer build on the reference platform.  This resolves the issue by removing the dependency on the moved files as they should not be used by unit tests on the reference platform.

Fixes #2252