### PR TITLE
Remove automatic versioning from WinObjC.Packaging package

### DIFF
--- a/tools/WinObjC.Packaging/ImportedByThisProj.props
+++ b/tools/WinObjC.Packaging/ImportedByThisProj.props
@@ -22,10 +22,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageFile Include="GitVersionTask">
-      <Kind>Dependency</Kind>
-      <Version>4.0.0-beta0011</Version>
-    </PackageFile>
     <PackageFile Include="NuGet.Build.Packaging">
       <Kind>Dependency</Kind>
       <Version>0.1.186</Version>

--- a/tools/WinObjC.Packaging/WinObjC.Packager.props
+++ b/tools/WinObjC.Packaging/WinObjC.Packager.props
@@ -17,22 +17,4 @@
     <!-- WinObjC.Packaging specific properties -->
     <PresetPackageContents Condition="'$(PresetPackageContents)' == ''">true</PresetPackageContents>
   </PropertyGroup>
-
-  <!-- Create package version based on GitInfo (if available) and a timestamp -->
-  <PropertyGroup>
-    <GetPackageVersionDependsOn>SetPackageVersion;$(GetPackageVersionDependsOn);</GetPackageVersionDependsOn>
-  </PropertyGroup>
-  <Target Name="SetPackageVersion" Returns="$(PackageVersion)" DependsOnTargets="$(GitVersionDependsOn)" Condition="'$(PackageVersion)' == ''">
-    <Warning Condition="'$(GitVersion_BranchName)' == ''"
-      Text="Cannot determine git branch - default package version will be applied. Please make sure GitVersionTask is listed as a nuget dependency for this project and that git.exe is part of the PATH environment variable." />
-
-    <PropertyGroup>
-      <PackageTimestamp Condition="'$(PackageTimestamp)' == ''">$([System.DateTime]::Now.ToString(yyyyMMddHHmmss))</PackageTimestamp>
-
-      <PackageVersion Condition="'$(PackageVersion)' == '' And '$(GitVersion_BranchName)' == ''">0.0.1-$(PackageTimestamp).pr</PackageVersion>
-      <PackageVersion Condition="'$(PackageVersion)' == '' And '$(GitVersion_BranchName)' == 'master'">$(GitVersion_Major).$(GitVersion_Minor).0-$(PackageTimestamp)</PackageVersion>
-      <PackageVersion Condition="'$(PackageVersion)' == '' And '$(GitVersion_BranchName)' == 'develop'">$(GitVersion_Major).$(GitVersion_Minor).$([MSBuild]::Add('$(GitVersion_Patch)', '1'))-$(PackageTimestamp).dev</PackageVersion>
-      <PackageVersion Condition="'$(PackageVersion)' == ''">$(GitVersion_Major).$(GitVersion_Minor).$([MSBuild]::Add('$(GitVersion_Patch)', '1'))-$(PackageTimestamp).pr</PackageVersion>
-    </PropertyGroup>
-  </Target>
 </Project>

--- a/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Package/Package.Creation.props
+++ b/tools/WinObjC.Tools/vsimporter-templates/WinStore10-Package/Package.Creation.props
@@ -6,6 +6,7 @@
     <PackageId>$safeprojectname$</PackageId> 
     <Authors>$username$</Authors>
     <Description>$projectname$</Description>
+    <PackageVersion>1.0.0</PackageVersion>
     <!-- Optional -->
     <Title>$projectname$</Title>
     <Owners>$username$</Owners>
@@ -15,6 +16,5 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <Copyright>Copyright © $username$</Copyright>
     <PackageTags>$safeprojectname$</PackageTags>
-    <PackageVersion><!-- Override Package Version Here --></PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The current versioning fails to do anything correctly. It was not properly tested (by me) when it switched from using GitInfo to GitVersionTask. Versioning can be added back in later, but this is not a required function of WinObjC.Packaging and needs more thought on how it should be integrated.