### PR TITLE
Support custom fonts in Xaml through _compatibleFamilyName

### DIFF
--- a/Frameworks/CoreGraphics/CGDataProvider.mm
+++ b/Frameworks/CoreGraphics/CGDataProvider.mm
@@ -59,6 +59,11 @@ public:
         return memcmp(GetData(), rhs.GetData(), GetSize()) == 0;
     }
 
+    // Subclasses containing CFURL should override this
+    virtual CFURLRef GetURL() const {
+        return nullptr;
+    }
+
     CFHashCode Hash() const {
         std::call_once(m_hashFlag, &__CGDataProviderInternal::SetHash, this);
         return m_hashValue;
@@ -250,6 +255,10 @@ public:
         std::call_once(m_dataFlag, &__CFURLDataProvider::GenerateData, this);
         return CFDataGetLength(m_data.get());
     }
+
+    CFURLRef GetURL() const override {
+        return m_url.get();
+    }
 };
 #pragma endregion // __CGDataProviderInternal
 
@@ -293,6 +302,10 @@ struct __CGDataProvider : CoreFoundation::CppBase<__CGDataProvider> {
 
     size_t GetSize() const {
         return m_internal->GetSize();
+    }
+
+    CFURLRef GetURL() const {
+        return m_internal->GetURL();
     }
 
     bool operator==(const __CGDataProvider& other) const {
@@ -433,6 +446,10 @@ const void* _CGDataProviderGetData(CGDataProviderRef provider) {
 
 size_t _CGDataProviderGetSize(CGDataProviderRef provider) {
     return provider ? provider->GetSize() : 0;
+}
+
+CFURLRef _CGDataProviderGetURL(CGDataProviderRef provider) {
+    return provider ? provider->GetURL() : nullptr;
 }
 
 #pragma endregion // Internal CGDataProvider Functions

--- a/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.mm
+++ b/Frameworks/CoreGraphics/DWriteFontBinaryDataCollectionLoader.mm
@@ -174,8 +174,8 @@ HRESULT DWriteFontBinaryDataCollectionLoader::GetFontFileAt(decltype(m_fontDatas
         RETURN_IF_FAILED(MakeAndInitialize<DWriteFontBinaryDataLoader>(&loader, it->first.get()));
         RETURN_IF_FAILED(dwriteFactory->RegisterFontFileLoader(loader.Get()));
 
-        int unused;
-        RETURN_IF_FAILED(dwriteFactory->CreateCustomFontFileReference(&unused, sizeof(unused), loader.Get(), &it->second));
+        CGDataProviderRef reference = it->first.get();
+        RETURN_IF_FAILED(dwriteFactory->CreateCustomFontFileReference(&reference, sizeof(&reference), loader.Get(), &it->second));
     }
 
     return it->second.CopyTo(outFontFile);

--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -946,9 +946,9 @@ CFTypeID CTFontGetTypeID() {
 }
 
 // Private function for getting the XAML-compatible family name
-CFStringRef _CTFontGetCompatibleFamilyName(CTFontRef font) {
+CFStringRef _CTFontGetXamlCompatibleFamilyName(CTFontRef font) {
     auto fontName = woc::MakeAutoCF<CFStringRef>((CFStringRef)CTFontDescriptorCopyAttribute(font->_descriptor, kCTFontNameAttribute));
-    return _DWriteGetCompatibleFamilyName(fontName, font->_dwriteFontFace.Get());
+    return _DWriteGetXamlCompatibleFamilyName(fontName, font->_dwriteFontFace.Get());
 }
 
 // Private function for getting font weight for XAML

--- a/Frameworks/CoreText/CTFont.mm
+++ b/Frameworks/CoreText/CTFont.mm
@@ -945,6 +945,12 @@ CFTypeID CTFontGetTypeID() {
     return __kCTFontTypeID;
 }
 
+// Private function for getting the XAML-compatible family name
+CFStringRef _CTFontGetCompatibleFamilyName(CTFontRef font) {
+    auto fontName = woc::MakeAutoCF<CFStringRef>((CFStringRef)CTFontDescriptorCopyAttribute(font->_descriptor, kCTFontNameAttribute));
+    return _DWriteGetCompatibleFamilyName(fontName, font->_dwriteFontFace.Get());
+}
+
 // Private function for getting font weight for XAML
 DWRITE_FONT_WEIGHT _CTFontGetDWriteWeight(CTFontRef font) {
     ComPtr<IDWriteFontFace3> fontFace3;

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -183,7 +183,7 @@ HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescript
 
     // font name takes precedence
     if (fontName.get()) {
-        if (familyName.get() && !CFEqual(familyName.get(), _DWriteGetCompatibleFamilyName(fontName.get(), nullptr))) {
+        if (familyName.get() && !CFEqual(familyName.get(), _DWriteGetFontPropertiesFromName(fontName.get())->familyName.get())) {
             TraceError(TAG,
                        L"Mismatched font name (kCTFontNameAttribute) and family name (kCTFontFamilyNameAttribute) in "
                        L"_DWriteCreateFontFaceWithFontDescriptor");

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -183,7 +183,7 @@ HRESULT _DWriteCreateFontFaceWithFontDescriptor(CTFontDescriptorRef fontDescript
 
     // font name takes precedence
     if (fontName.get()) {
-        if (familyName.get() && !CFEqual(familyName.get(), _DWriteGetFamilyNameForFontName(fontName.get()))) {
+        if (familyName.get() && !CFEqual(familyName.get(), _DWriteGetCompatibleFamilyName(fontName.get(), nullptr))) {
             TraceError(TAG,
                        L"Mismatched font name (kCTFontNameAttribute) and family name (kCTFontFamilyNameAttribute) in "
                        L"_DWriteCreateFontFaceWithFontDescriptor");

--- a/Frameworks/UIKit/UIFont.mm
+++ b/Frameworks/UIKit/UIFont.mm
@@ -292,7 +292,7 @@ BASE_CLASS_REQUIRED_IMPLS(UIFont, UIFontPrototype, CTFontGetTypeID);
 // WinObjC-only extension for compatibility issues between DWrite and Xaml
 // Returns the family name of the font Xaml can use
 - (NSString*)_compatibleFamilyName {
-    return static_cast<NSString*>(_CTFontGetCompatibleFamilyName(static_cast<CTFontRef>(self)));
+    return static_cast<NSString*>(_CTFontGetXamlCompatibleFamilyName(static_cast<CTFontRef>(self)));
 }
 
 // WinObjC-only extension for compatibility issues between DWrite and Xaml

--- a/Frameworks/UIKit/UIFont.mm
+++ b/Frameworks/UIKit/UIFont.mm
@@ -292,7 +292,7 @@ BASE_CLASS_REQUIRED_IMPLS(UIFont, UIFontPrototype, CTFontGetTypeID);
 // WinObjC-only extension for compatibility issues between DWrite and Xaml
 // Returns the family name of the font Xaml can use
 - (NSString*)_compatibleFamilyName {
-    return static_cast<NSString*>(_DWriteGetFamilyNameForFontName(static_cast<CFStringRef>([self fontName])));
+    return static_cast<NSString*>(_CTFontGetCompatibleFamilyName(static_cast<CTFontRef>(self)));
 }
 
 // WinObjC-only extension for compatibility issues between DWrite and Xaml

--- a/Frameworks/include/CGDataProviderInternal.h
+++ b/Frameworks/include/CGDataProviderInternal.h
@@ -19,3 +19,4 @@
 #import <CoreGraphics/CGDataProvider.h>
 COREGRAPHICS_EXPORT const void* _CGDataProviderGetData(CGDataProviderRef provider);
 COREGRAPHICS_EXPORT size_t _CGDataProviderGetSize(CGDataProviderRef provider);
+COREGRAPHICS_EXPORT CFURLRef _CGDataProviderGetURL(CGDataProviderRef provider);

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -55,7 +55,7 @@ extern "C++" std::shared_ptr<const _DWriteFontProperties> _DWriteGetFontProperti
 
 COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontFamilyNames();
 COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName);
-COREGRAPHICS_EXPORT CFStringRef _DWriteGetFamilyNameForFontName(CFStringRef fontName);
+COREGRAPHICS_EXPORT CFStringRef _DWriteGetCompatibleFamilyName(CFStringRef fontName, IDWriteFontFace* fontFace);
 
 // Creation of DWrite font face/family objects
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily);

--- a/Frameworks/include/CoreGraphics/DWriteWrapper.h
+++ b/Frameworks/include/CoreGraphics/DWriteWrapper.h
@@ -55,7 +55,7 @@ extern "C++" std::shared_ptr<const _DWriteFontProperties> _DWriteGetFontProperti
 
 COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontFamilyNames();
 COREGRAPHICS_EXPORT CFArrayRef _DWriteCopyFontNamesForFamilyName(CFStringRef familyName);
-COREGRAPHICS_EXPORT CFStringRef _DWriteGetCompatibleFamilyName(CFStringRef fontName, IDWriteFontFace* fontFace);
+COREGRAPHICS_EXPORT CFStringRef _DWriteGetXamlCompatibleFamilyName(CFStringRef fontName, IDWriteFontFace* fontFace);
 
 // Creation of DWrite font face/family objects
 COREGRAPHICS_EXPORT HRESULT _DWriteCreateFontFamilyWithName(CFStringRef familyName, IDWriteFontFamily** outFontFamily);

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -99,4 +99,4 @@ CORETEXT_EXPORT CGSize _CTFrameGetSize(CTFrameRef frame);
 CORETEXT_EXPORT DWRITE_FONT_WEIGHT _CTFontGetDWriteWeight(CTFontRef font);
 CORETEXT_EXPORT DWRITE_FONT_STRETCH _CTFontGetDWriteStretch(CTFontRef font);
 CORETEXT_EXPORT DWRITE_FONT_STYLE _CTFontGetDWriteStyle(CTFontRef font);
-CORETEXT_EXPORT CFStringRef _CTFontGetCompatibleFamilyName(CTFontRef font);
+CORETEXT_EXPORT CFStringRef _CTFontGetXamlCompatibleFamilyName(CTFontRef font);

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -99,3 +99,4 @@ CORETEXT_EXPORT CGSize _CTFrameGetSize(CTFrameRef frame);
 CORETEXT_EXPORT DWRITE_FONT_WEIGHT _CTFontGetDWriteWeight(CTFontRef font);
 CORETEXT_EXPORT DWRITE_FONT_STRETCH _CTFontGetDWriteStretch(CTFontRef font);
 CORETEXT_EXPORT DWRITE_FONT_STYLE _CTFontGetDWriteStyle(CTFontRef font);
+CORETEXT_EXPORT CFStringRef _CTFontGetCompatibleFamilyName(CTFontRef font);

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -40,7 +40,7 @@ LIBRARY CoreGraphics
         _CFStringFromLocalizedString
         _DWriteCopyFontFamilyNames
         _DWriteCopyFontNamesForFamilyName
-        _DWriteGetFamilyNameForFontName
+        _DWriteGetCompatibleFamilyName
         _DWriteGetFontPropertiesFromName
         _DWriteCreateFontFamilyWithName
         _DWriteCreateFontWithName

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -40,7 +40,7 @@ LIBRARY CoreGraphics
         _CFStringFromLocalizedString
         _DWriteCopyFontFamilyNames
         _DWriteCopyFontNamesForFamilyName
-        _DWriteGetCompatibleFamilyName
+        _DWriteGetXamlCompatibleFamilyName
         _DWriteGetFontPropertiesFromName
         _DWriteCreateFontFamilyWithName
         _DWriteCreateFontWithName

--- a/build/CoreText/dll/CoreText.def
+++ b/build/CoreText/dll/CoreText.def
@@ -139,7 +139,7 @@ LIBRARY CoreText
         _CTFontGetDWriteWeight
         _CTFontGetDWriteStretch
         _CTFontGetDWriteStyle
-        _CTFontGetCompatibleFamilyName
+        _CTFontGetXamlCompatibleFamilyName
 
         ; CTFontCollection Reference.mm
         kCTFontCollectionRemoveDuplicatesOption DATA

--- a/build/CoreText/dll/CoreText.def
+++ b/build/CoreText/dll/CoreText.def
@@ -139,6 +139,7 @@ LIBRARY CoreText
         _CTFontGetDWriteWeight
         _CTFontGetDWriteStretch
         _CTFontGetDWriteStyle
+        _CTFontGetCompatibleFamilyName
 
         ; CTFontCollection Reference.mm
         kCTFontCollectionRemoveDuplicatesOption DATA

--- a/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj
+++ b/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj
@@ -96,6 +96,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <ShowProgress>NotSet</ShowProgress>
     </Link>
     <SBInfoPlistCopy>
       <ExcludedFromBuild>true</ExcludedFromBuild>
@@ -247,10 +248,8 @@
       <DeploymentContent>false</DeploymentContent>
     </Text>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
-
   <!-- Begin NuGet Section -->
   <PropertyGroup>
     <TargetFramework>uap10.0</TargetFramework>
@@ -262,7 +261,11 @@
     <PackageReference Include="WinObjC.Language" Version="*" />
     <PackageReference Include="WinObjC.Logging" Version="*" />
   </ItemGroup>
+  <ItemGroup>
+    <Font Include="..\..\XamlCatalog\Fonts\WinObjC-Bold.ttf" />
+    <Font Include="..\..\XamlCatalog\Fonts\WinObjC-Italic.ttf" />
+    <Font Include="..\..\XamlCatalog\Fonts\WinObjC.ttf" />
+  </ItemGroup>
   <!-- End NuGet Section -->
-  
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\common\winobjc.packagereference.override.targets" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\common\winobjc.packagereference.override.targets')"/>
+  <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\common\winobjc.packagereference.override.targets" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\common\winobjc.packagereference.override.targets')" />
 </Project>

--- a/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj.filters
+++ b/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Common">
@@ -173,5 +173,10 @@
     <Text Include="XAMLCatalog-Release-xcvars.txt">
       <Filter>Xcode Variable Files</Filter>
     </Text>
+  </ItemGroup>
+  <ItemGroup>
+    <Font Include="..\..\XAMLCatalog\Fonts\WinObjC.ttf" />
+    <Font Include="..\..\XAMLCatalog\Fonts\WinObjC-Bold.ttf" />
+    <Font Include="..\..\XAMLCatalog\Fonts\WinObjC-Italic.ttf" />
   </ItemGroup>
 </Project>

--- a/samples/XAMLCatalog/XAMLCatalog/CustomTextControlViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/CustomTextControlViewController.m
@@ -338,7 +338,7 @@
     float angle = 0;
     float scale = 1.0f;
 
-    UIFont* font = [UIFont boldSystemFontOfSize:14];
+    UIFont* font = [UIFont fontWithName:@"WinObjC" size:14];
     UIColor* color = [UIColor blackColor];
     UIColor* selectedColor = [UIColor blueColor];
     NSMutableDictionary* attrs =

--- a/samples/XAMLCatalog/XAMLCatalog/Fonts/WinObjC-Bold.ttf
+++ b/samples/XAMLCatalog/XAMLCatalog/Fonts/WinObjC-Bold.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166411edb4e0334fcf288cb45302d0e25f90e649d4f9f387f815c603f53f224a
+size 1452

--- a/samples/XAMLCatalog/XAMLCatalog/Fonts/WinObjC-Italic.ttf
+++ b/samples/XAMLCatalog/XAMLCatalog/Fonts/WinObjC-Italic.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11df5ebba52a883ca67085ad8559bf9a430934091209b85ae2ff91bb0fe63106
+size 1476

--- a/samples/XAMLCatalog/XAMLCatalog/Fonts/WinObjC.ttf
+++ b/samples/XAMLCatalog/XAMLCatalog/Fonts/WinObjC.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02f3175200cdb9fa79594fe7c5a560a8c6744e716877617189b5f4ccd0d8a86
+size 1452

--- a/samples/XAMLCatalog/XAMLCatalog/Info.plist
+++ b/samples/XAMLCatalog/XAMLCatalog/Info.plist
@@ -30,6 +30,12 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>WinObjC.ttf</string>
+		<string>WinObjC-Bold.ttf</string>
+		<string>WinObjC-Italic.ttf</string>
+	</array>
 	<key>UIStatusBarTintParameters</key>
 	<dict>
 		<key>UINavigationBar</key>

--- a/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj
+++ b/tests/testapps/CTCatalog/CTCatalog.vsimporter/CTCatalog-WinStore10/CTCatalog.vcxproj
@@ -255,7 +255,12 @@
     <PackageReference Include="WinObjC.Language" Version="*" />
     <PackageReference Include="WinObjC.Logging" Version="*" />
   </ItemGroup>
+  <ItemGroup>
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC-Bold.ttf" />
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC-Italic.ttf" />
+    <Font Include="..\..\CTCatalog\Fonts\WinObjC.ttf" />
+  </ItemGroup>
   <!-- End NuGet Section -->
-  
+
   <Import Project="$(MSBuildThisFileDirectory)\..\..\..\..\..\common\winobjc.packagereference.override.targets" Condition="Exists('$(MSBuildThisFileDirectory)\..\..\..\..\..\common\winobjc.packagereference.override.targets')"/>
 </Project>

--- a/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
+++ b/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
@@ -19,14 +19,14 @@
 #import <CoreGraphics/DWriteWrapper.h>
 
 TEST(DWriteWrapper, FontToFamilyName) {
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial"), nullptr));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Italic"), nullptr));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Bold"), nullptr));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Bold Italic"), nullptr));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Black"), nullptr));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman"), nullptr));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman Italic"), nullptr));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman Bold"), nullptr));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman Bold Italic"), nullptr));
-    EXPECT_OBJCEQ(nil, (id)_DWriteGetCompatibleFamilyName(CFSTR("NotAFont"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Arial"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Arial Italic"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Arial Bold"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Arial Bold Italic"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Arial Black"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Times New Roman"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Times New Roman Italic"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Times New Roman Bold"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("Times New Roman Bold Italic"), nullptr));
+    EXPECT_OBJCEQ(nil, (id)_DWriteGetXamlCompatibleFamilyName(CFSTR("NotAFont"), nullptr));
 }

--- a/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
+++ b/tests/unittests/CoreGraphics/DWriteWrapperTests.mm
@@ -19,14 +19,14 @@
 #import <CoreGraphics/DWriteWrapper.h>
 
 TEST(DWriteWrapper, FontToFamilyName) {
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Italic")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Bold")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Bold Italic")));
-    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetFamilyNameForFontName(CFSTR("Arial Black")));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman")));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman Italic")));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman Bold")));
-    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetFamilyNameForFontName(CFSTR("Times New Roman Bold Italic")));
-    EXPECT_OBJCEQ(nil, (id)_DWriteGetFamilyNameForFontName(CFSTR("NotAFont")));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Italic"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Bold"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Bold Italic"), nullptr));
+    EXPECT_OBJCEQ(@"Arial", (id)_DWriteGetCompatibleFamilyName(CFSTR("Arial Black"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman Italic"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman Bold"), nullptr));
+    EXPECT_OBJCEQ(@"Times New Roman", (id)_DWriteGetCompatibleFamilyName(CFSTR("Times New Roman Bold Italic"), nullptr));
+    EXPECT_OBJCEQ(nil, (id)_DWriteGetCompatibleFamilyName(CFSTR("NotAFont"), nullptr));
 }

--- a/tests/unittests/CoreText/CTFontTests.mm
+++ b/tests/unittests/CoreText/CTFontTests.mm
@@ -798,7 +798,7 @@ TEST(CTFont, GetCompatibleFamilyName) {
     EXPECT_NE(nil, familyName);
 
     // CompatibleFamilyName returns an absolute path, so can only check prefix and suffix
-    EXPECT_TRUE([static_cast<NSString*>(familyName) hasPrefix:@"ms-appx///"]);
+    EXPECT_TRUE([static_cast<NSString*>(familyName) hasPrefix:@"ms-appx:///"]);
     EXPECT_TRUE([static_cast<NSString*>(familyName) hasSuffix:@"/data/WinObjC.ttf#WinObjC"]);
 
     EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));

--- a/tests/unittests/CoreText/CTFontTests.mm
+++ b/tests/unittests/CoreText/CTFontTests.mm
@@ -794,7 +794,7 @@ TEST(CTFont, GetCompatibleFamilyName) {
     auto font = woc::MakeAutoCF<CTFontRef>(CTFontCreateWithName(fontName, 20, nullptr));
     EXPECT_NE(nullptr, font);
 
-    CFStringRef familyName = _CTFontGetCompatibleFamilyName(font);
+    CFStringRef familyName = _CTFontGetXamlCompatibleFamilyName(font);
     EXPECT_NE(nil, familyName);
 
     // CompatibleFamilyName returns an absolute path, so can only check prefix and suffix

--- a/tests/unittests/CoreText/CTFontTests.mm
+++ b/tests/unittests/CoreText/CTFontTests.mm
@@ -17,6 +17,7 @@
 #import <TestFramework.h>
 #import <Foundation/Foundation.h>
 #import <CoreText/CoreText.h>
+#import <CoreTextInternal.h>
 #import <Starboard/SmartTypes.h>
 #import <vector>
 
@@ -781,4 +782,25 @@ TEST(CTFont, CopyAvailableTables) {
     // Don't want to make test too precise so that it may fail should fonts change, but 'cmap' is a required font table
     // So it should be safe to always test that this value is available
     EXPECT_TRUE(CFArrayContainsValue(availableTables, { 0, count }, (const void*)kCTFontTableCmap));
+}
+
+TEST(CTFont, GetCompatibleFamilyName) {
+    CFStringRef fontName = CFSTR("WinObjC");
+    NSURL* testFileURL = __GetURLFromPathRelativeToModuleDirectory(@"/data/WinObjC.ttf");
+    CFErrorRef error = nullptr;
+    EXPECT_TRUE(CTFontManagerRegisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
+
+    auto font = woc::MakeAutoCF<CTFontRef>(CTFontCreateWithName(fontName, 20, nullptr));
+    EXPECT_NE(nullptr, font);
+
+    CFStringRef familyName = _CTFontGetCompatibleFamilyName(font);
+    EXPECT_NE(nil, familyName);
+
+    // CompatibleFamilyName returns an absolute path, so can only check prefix and suffix
+    EXPECT_TRUE([static_cast<NSString*>(familyName) hasPrefix:@"ms-appx///"]);
+    EXPECT_TRUE([static_cast<NSString*>(familyName) hasSuffix:@"/data/WinObjC.ttf#WinObjC"]);
+
+    EXPECT_TRUE(CTFontManagerUnregisterFontsForURL((__bridge CFURLRef)testFileURL, kCTFontManagerScopeSession, &error));
+    EXPECT_EQ(nullptr, error);
 }


### PR DESCRIPTION
Our implementation of supporting user-supplied fonts could not propagate to XAML because we cannot modify the system's font collection and instead have a separate font collection where we store user-supplied fonts.  XAML can't access this separate font collection, and instead has to pull the font from the file directly.  We already had a private method _compatibleFamilyName which returned the family name required for XAML as CTFontGetFamilyName would return different strings for some fonts, so this has been modified to return the string which XAML will use to get the specified font from its file.

This will be in format `@"ms-appx///[Absolute Path To File].ttf#FamilyName"`.  This however requires that the family name requested from the font be used for that specific font, as families can have multiple files.  For example, WinObjC-Bold.ttf has family name WinObjC as does WinObjC.ttf, but getting _compatibleFamilyName from a regular WinObjC font will not return the correct path to construct a Bold font, so **one should be careful to create the font UIFont with required attributes before trying to convert to XAML**.

We will get the path to the file by saving the CGDataConsumer which contains the CFURL it is registered with in the IDWriteFontFile we create.  Then, when we go to get the _compatibleFamilyName we retrieve the CGDataConsumer from which we retrieve the CFURL, pull out the path, and return the correct value.

This can be manually confirmed in XamlCatalog through the Custom Text Editor, which now uses our WinObjC font (the character 'A' is represented by a solid black circle).

Fixes #2273 

