### PR TITLE
Disabling NSLogger tests as it requires debug logging package.  

### DIFF
--- a/tests/unittests/Foundation/WindowsOnly/NSLoggingTests.m
+++ b/tests/unittests/Foundation/WindowsOnly/NSLoggingTests.m
@@ -54,6 +54,10 @@ void validateWideEtl(const wchar_t* tag, const wchar_t* expectedBody, int expect
     ASSERT_STREQ(expectedBody, g_etlBufferTestHook.c_str());
 }
 
+/**
+#2303 - disabling NSLogger tests as they will fail in typical local dev scenario (debug build + release tools nuget)
+*/
+
 DISABLED_TEST(NSLogging, NSLoggingWideBasicTests) {
     g_isTestHookEnabled = true;
     auto reset = wil::ScopeExit([]() { g_isTestHookEnabled = false; });

--- a/tests/unittests/Foundation/WindowsOnly/NSLoggingTests.m
+++ b/tests/unittests/Foundation/WindowsOnly/NSLoggingTests.m
@@ -54,7 +54,7 @@ void validateWideEtl(const wchar_t* tag, const wchar_t* expectedBody, int expect
     ASSERT_STREQ(expectedBody, g_etlBufferTestHook.c_str());
 }
 
-TEST(NSLogging, NSLoggingWideBasicTests) {
+DISABLED_TEST(NSLogging, NSLoggingWideBasicTests) {
     g_isTestHookEnabled = true;
     auto reset = wil::ScopeExit([]() { g_isTestHookEnabled = false; });
 
@@ -88,7 +88,7 @@ TEST(NSLogging, NSLoggingWideBasicTests) {
     validateWideEtl(tag, format, WINEVENT_LEVEL_CRITICAL);
 }
 
-TEST(NSLogging, NSLoggingNSStringBasicTests) {
+DISABLED_TEST(NSLogging, NSLoggingNSStringBasicTests) {
     g_isTestHookEnabled = true;
     auto reset = wil::ScopeExit([]() { g_isTestHookEnabled = false; });
 
@@ -123,7 +123,7 @@ TEST(NSLogging, NSLoggingNSStringBasicTests) {
     validateWideEtl(tag, expectedBody, WINEVENT_LEVEL_CRITICAL);
 }
 
-TEST(NSLogging, NSLoggingWideFormatTests) {
+DISABLED_TEST(NSLogging, NSLoggingWideFormatTests) {
     g_isTestHookEnabled = true;
     auto reset = wil::ScopeExit([]() { g_isTestHookEnabled = false; });
 
@@ -143,7 +143,7 @@ TEST(NSLogging, NSLoggingWideFormatTests) {
     validateWideEtl(tag, expectedBody, WINEVENT_LEVEL_VERBOSE);
 }
 
-TEST(NSLogging, NSLoggingNSStringFormatTests) {
+DISABLED_TEST(NSLogging, NSLoggingNSStringFormatTests) {
     g_isTestHookEnabled = true;
     auto reset = wil::ScopeExit([]() { g_isTestHookEnabled = false; });
 
@@ -163,7 +163,7 @@ TEST(NSLogging, NSLoggingNSStringFormatTests) {
     validateWideEtl(tag, expectedBody, WINEVENT_LEVEL_VERBOSE);
 }
 
-TEST(NSLogging, NSLogTests) {
+DISABLED_TEST(NSLogging, NSLogTests) {
     g_isTestHookEnabled = true;
     g_isNSLogTestHookEnabled = true;
     auto reset = wil::ScopeExit([]() {


### PR DESCRIPTION
Under normal restore/build frameworks, the debug package will not be
available.  The test isn't really meaningful in foundation, as it is
testing the Logging pipeline.

Fixes #2285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2303)
<!-- Reviewable:end -->
