### PR TITLE
Plug leak in NSURLProtocol_WinHTTP and NSURLSession

### DIFF
--- a/Frameworks/Foundation/NSURLSession.mm
+++ b/Frameworks/Foundation/NSURLSession.mm
@@ -33,20 +33,20 @@ const int64_t NSURLSessionTransferSizeUnknown = -1LL;
 
 #import <StubReturn.h>
 
-#define _THROW_IF_NULL_REQUEST(request)                                        \
-do {                                                                           \
-    if (request == nil) {                                                      \
-      @throw [NSException                                                      \
-          exceptionWithName:NSInvalidArgumentException                         \
-                     reason:[NSString                                          \
-                                stringWithFormat:@"*** %@ Cannot create data " \
-                                                 @"task without request or "   \
-                                                 @"resume data",               \
-                                                 NSStringFromSelector(_cmd)]   \
-                   userInfo:nil];                                              \
-    }                                                                          \
-}                                                                              \
-  while (false)
+#define _THROW_IF_NULL_REQUEST(request)                                                                    \
+    \
+do {                                                                                                       \
+        if (request == nil) {                                                                              \
+            @throw [NSException exceptionWithName:NSInvalidArgumentException                               \
+                                           reason:[NSString stringWithFormat:@"*** %@ Cannot create data " \
+                                                                             @"task without request or "   \
+                                                                             @"resume data",               \
+                                                                             NSStringFromSelector(_cmd)]   \
+                                         userInfo:nil];                                                    \
+        }                                                                                                  \
+    \
+}                                                                                                   \
+    while (false)
 
 NSString* const NSURLErrorBackgroundTaskCancelledReasonKey = @"NSURLErrorBackgroundTaskCancelledReasonKey";
 
@@ -330,7 +330,7 @@ static bool dispatchDelegateOptional(NSOperationQueue* queue, id object, SEL cmd
                                                                           configuration:_configuration
                                                                                 request:request];
     [self _registerDataTask:newTask withCompletionHandler:completionHandler];
-    return newTask;
+    return [newTask autorelease];
 }
 
 /**
@@ -370,7 +370,7 @@ static bool dispatchDelegateOptional(NSOperationQueue* queue, id object, SEL cmd
                                                                                   configuration:_configuration
                                                                                         request:request];
     [self _registerDownloadTask:newTask withCompletionHandler:completionHandler];
-    return newTask;
+    return [newTask autorelease];
 }
 
 /**
@@ -395,7 +395,7 @@ static bool dispatchDelegateOptional(NSOperationQueue* queue, id object, SEL cmd
                                                                                   configuration:_configuration
                                                                                      resumeData:resumeData];
     [self _registerDownloadTask:newTask withCompletionHandler:completionHandler];
-    return newTask;
+    return [newTask autorelease];
 }
 
 /**

--- a/Frameworks/Foundation/NSURLSession.mm
+++ b/Frameworks/Foundation/NSURLSession.mm
@@ -325,12 +325,12 @@ static bool dispatchDelegateOptional(NSOperationQueue* queue, id object, SEL cmd
         return nil;
     }
 
-    NSURLSessionDataTask* newTask = [[NSURLSessionDataTask alloc] _initWithTaskDelegate:self
-                                                                             identifier:[self _nextTaskIdentifier]
-                                                                          configuration:_configuration
-                                                                                request:request];
+    NSURLSessionDataTask* newTask = [[[NSURLSessionDataTask alloc] _initWithTaskDelegate:self
+                                                                              identifier:[self _nextTaskIdentifier]
+                                                                           configuration:_configuration
+                                                                                 request:request] autorelease];
     [self _registerDataTask:newTask withCompletionHandler:completionHandler];
-    return [newTask autorelease];
+    return newTask;
 }
 
 /**
@@ -365,12 +365,12 @@ static bool dispatchDelegateOptional(NSOperationQueue* queue, id object, SEL cmd
         return nil;
     }
 
-    NSURLSessionDownloadTask* newTask = [[NSURLSessionDownloadTask alloc] _initWithTaskDelegate:self
-                                                                                     identifier:[self _nextTaskIdentifier]
-                                                                                  configuration:_configuration
-                                                                                        request:request];
+    NSURLSessionDownloadTask* newTask = [[[NSURLSessionDownloadTask alloc] _initWithTaskDelegate:self
+                                                                                      identifier:[self _nextTaskIdentifier]
+                                                                                   configuration:_configuration
+                                                                                         request:request] autorelease];
     [self _registerDownloadTask:newTask withCompletionHandler:completionHandler];
-    return [newTask autorelease];
+    return newTask;
 }
 
 /**
@@ -390,12 +390,12 @@ static bool dispatchDelegateOptional(NSOperationQueue* queue, id object, SEL cmd
         return nil;
     }
 
-    NSURLSessionDownloadTask* newTask = [[NSURLSessionDownloadTask alloc] _initWithTaskDelegate:self
-                                                                                     identifier:[self _nextTaskIdentifier]
-                                                                                  configuration:_configuration
-                                                                                     resumeData:resumeData];
+    NSURLSessionDownloadTask* newTask = [[[NSURLSessionDownloadTask alloc] _initWithTaskDelegate:self
+                                                                                      identifier:[self _nextTaskIdentifier]
+                                                                                   configuration:_configuration
+                                                                                      resumeData:resumeData] autorelease];
     [self _registerDownloadTask:newTask withCompletionHandler:completionHandler];
-    return [newTask autorelease];
+    return newTask;
 }
 
 /**

--- a/Frameworks/include/CollectionHelpers.h
+++ b/Frameworks/include/CollectionHelpers.h
@@ -67,7 +67,7 @@ template <>
 HRESULT WRLToNSCollection<ABI::Windows::Foundation::Collections::IMap<HSTRING, HSTRING>>(
     ABI::Windows::Foundation::Collections::IMap<HSTRING, HSTRING>* map, NSDictionary* __autoreleasing* pDictionary) {
     using NSType = Private::CollectionType<ABI::Windows::Foundation::Collections::IMap<HSTRING, HSTRING>>::NSMutableEquivalentType;
-    NSType* collection = [[NSType alloc] init];
+    NSType* collection = [[[NSType alloc] init] autorelease];
     HRESULT hr = WRLHelpers::ForEach(
         map,
         [&collection](const Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IKeyValuePair<HSTRING, HSTRING>>& pair,
@@ -81,7 +81,7 @@ HRESULT WRLToNSCollection<ABI::Windows::Foundation::Collections::IMap<HSTRING, H
         });
     RETURN_IF_FAILED(hr);
 
-    *pDictionary = [collection autorelease];
+    *pDictionary = collection;
     return S_OK;
 }
 
@@ -91,7 +91,7 @@ template <>
 HRESULT WRLToNSCollection<ABI::Windows::Foundation::Collections::IPropertySet>(ABI::Windows::Foundation::Collections::IPropertySet* map,
                                                                                NSDictionary* __autoreleasing* pDictionary) {
     using NSType = Private::CollectionType<ABI::Windows::Foundation::Collections::IPropertySet>::NSMutableEquivalentType;
-    NSType* collection = [[NSType alloc] init];
+    NSType* collection = [[[NSType alloc] init] autorelease];
     RETURN_IF_FAILED(WRLHelpers::ForEach(
         map,
         [&collection](const Microsoft::WRL::ComPtr<ABI::Windows::Foundation::Collections::IKeyValuePair<HSTRING, IInspectable*>>& pair,
@@ -112,7 +112,7 @@ HRESULT WRLToNSCollection<ABI::Windows::Foundation::Collections::IPropertySet>(A
             return S_OK;
         }));
 
-    *pDictionary = [collection autorelease];
+    *pDictionary = collection;
     return S_OK;
 }
 

--- a/Frameworks/include/CollectionHelpers.h
+++ b/Frameworks/include/CollectionHelpers.h
@@ -81,7 +81,7 @@ HRESULT WRLToNSCollection<ABI::Windows::Foundation::Collections::IMap<HSTRING, H
         });
     RETURN_IF_FAILED(hr);
 
-    *pDictionary = collection;
+    *pDictionary = [collection autorelease];
     return S_OK;
 }
 


### PR DESCRIPTION
The significant changes are:

- Placing the contents of `-[asyncHttpOperation:completedWithStatus:]` in an `@autoreleasepool {}` because it is on a thread that may not have a pool set up
- Autoreleasing the results from `WRLToNSCollection` for NSDictionary and NSURLSession creation methods

Fixes #2232