### PR TITLE
Improve perf in KVO and NSString

### DIFF
--- a/Frameworks/CoreFoundation/String.subproj/CFString.c
+++ b/Frameworks/CoreFoundation/String.subproj/CFString.c
@@ -1017,7 +1017,6 @@ static Boolean __CFStringEqual(CFTypeRef cf1, CFTypeRef cf2) {
     return true;
 }
 
-
 /* String hashing: Should give the same results whatever the encoding; so we hash UniChars.
 If the length is less than or equal to 96, then the hash function is simply the 
 following (n is the nth UniChar character, starting from 0):
@@ -2146,7 +2145,7 @@ const char * CFStringGetCStringPtr(CFStringRef str, CFStringEncoding encoding) {
     
     // CF_SWIFT_FUNCDISPATCHV(__kCFStringTypeID, const char *, (CFSwiftRef)str, NSString._fastCStringContents);
     // WINOBJC: pass along encoding instead of hardcoded bool.
-    CF_OBJC_FUNCDISPATCHV(__kCFStringTypeID, const char *, (NSString *)str, _fastCStringContents:CFStringConvertEncodingToNSStringEncoding(encoding));
+    CF_OBJC_FUNCDISPATCHV(__kCFStringTypeID, const char *, (NSString *)str, _fastCStringContents:encoding);
 
     __CFAssertIsString(str);
 

--- a/Frameworks/CoreText/DWriteWrapper_CTFont.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CTFont.mm
@@ -43,9 +43,7 @@ static const struct {
  * Helper function that efficiently compares two CFStringRef and returns true if they are equal (case insensitive)
  */
 static inline bool __CFStringEqual(CFStringRef left, CFStringRef right) {
-    CFIndex leftLength = CFStringGetLength(left);
-    return leftLength == CFStringGetLength(right) &&
-           CFStringFindWithOptions(left, right, { 0, leftLength }, kCFCompareCaseInsensitive, nullptr);
+    return CFStringCompare(left, right, kCFCompareCaseInsensitive) == kCFCompareEqualTo;
 }
 
 /**

--- a/Frameworks/Foundation/NSConstantString.mm
+++ b/Frameworks/Foundation/NSConstantString.mm
@@ -45,6 +45,23 @@
 }
 #pragma pop
 
+// Override [NSString hash] and [NSString isEqualToString:] for faster perf
+- (NSUInteger)hash {
+    return CFStringHashCString(reinterpret_cast<uint8_t*>(c_string), len);
+}
+
+- (BOOL)isEqualToString:(NSString*)str {
+    if (self == str) {
+        return YES;
+    }
+
+    if ([str isKindOfClass:[NSConstantString class]]) {
+        return __CFStringMakeConstantString(c_string) == __CFStringMakeConstantString(static_cast<NSConstantString*>(str)->c_string);
+    }
+
+    return [super isEqualToString:str];
+}
+
 - INNER_BRIDGE_CALL(static_cast<NSString*>(__CFStringMakeConstantString(c_string)), NSUInteger, length);
 - INNER_BRIDGE_CALL(static_cast<NSString*>(__CFStringMakeConstantString(c_string)), unichar, characterAtIndex:(NSUInteger)index);
 - INNER_BRIDGE_CALL(static_cast<NSString*>(__CFStringMakeConstantString(c_string)), void,

--- a/Frameworks/Foundation/NSKVOSupport.mm
+++ b/Frameworks/Foundation/NSKVOSupport.mm
@@ -234,7 +234,7 @@ static NSSet* _keyPathsForValuesAffectingValueForKey(Class self, NSString* key) 
             // fast path using c string manipulation, will cover most cases, as most keyPaths are short
             char selectorName[sc_bufferSize] = "keyPathsForValuesAffecting"; // 26 chars
             selectorName[sc_prefixLength] = toupper(rawKey[0]);
-            strcat_s(&selectorName[sc_prefixLength + 1], sc_bufferSize - sc_prefixLength - 1, &rawKey[1]);
+            strcpy_s(&selectorName[sc_prefixLength + 1], sc_bufferSize - sc_prefixLength - 1, &rawKey[1]);
             sel = sel_registerName(selectorName);
 
         } else {

--- a/build/Tests/Benchmark/Framework.Benchmark.vcxproj
+++ b/build/Tests/Benchmark/Framework.Benchmark.vcxproj
@@ -221,7 +221,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\BenchmarkSampleTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\KVOBenchmarkTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\NSOperationQueueBenchmarkTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\StringBenchmarkTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\TextBenchmarkTests.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tests/Benchmark/KVOBenchmarkTests.mm
+++ b/tests/Benchmark/KVOBenchmarkTests.mm
@@ -1,0 +1,147 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <Starboard/SmartTypes.h>
+#import "Benchmark.h"
+#import <CppUtils.h>
+#import <atomic>
+
+// Minimal object that supports KVO notifications for a property
+@interface TestKVOObject : NSObject
+@property NSInteger intProperty;
+@end
+
+@implementation TestKVOObject
+@end
+
+// Minimal object for observing to TestKVOObject
+static std::atomic<size_t> s_observedCount;
+@interface TestKVOObserver : NSObject
+@end
+
+@implementation TestKVOObserver
+- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context {
+    ++s_observedCount;
+}
+@end
+
+class AddObservers : public ::benchmark::BenchmarkCaseBase {
+    StrongId<TestKVOObject> _testKVOObject;
+    StrongId<NSMutableArray> _testObservers;
+
+public:
+    void PreRun() {
+        _testKVOObject.attach([TestKVOObject new]);
+        _testObservers.attach([NSMutableArray new]);
+        @autoreleasepool {
+            for (size_t i = 0; i < 1000; ++i) {
+                [_testObservers addObject:[[NSObject new] autorelease]];
+            }
+        }
+    }
+
+    inline void Run() {
+        for (NSObject* obj in _testObservers.get()) {
+            [_testKVOObject addObserver:obj forKeyPath:@"intProperty" options:0 context:nullptr];
+        }
+    }
+
+    void PostRun() {
+        for (NSObject* obj in _testObservers.get()) {
+            [_testKVOObject removeObserver:obj forKeyPath:@"intProperty" context:nullptr];
+        }
+    }
+
+    size_t GetRunCount() const {
+        return 30;
+    }
+};
+
+BENCHMARK_F(KVO, AddObservers)
+
+class RemoveObservers : public ::benchmark::BenchmarkCaseBase {
+    StrongId<TestKVOObject> _testKVOObject;
+    StrongId<NSMutableArray> _testObservers;
+
+public:
+    void PreRun() {
+        _testKVOObject.attach([TestKVOObject new]);
+        _testObservers.attach([NSMutableArray new]);
+        @autoreleasepool {
+            for (size_t i = 0; i < 1000; ++i) {
+                [_testObservers addObject:[[NSObject new] autorelease]];
+            }
+        }
+
+        for (NSObject* obj in _testObservers.get()) {
+            [_testKVOObject addObserver:obj forKeyPath:@"intProperty" options:0 context:nullptr];
+        }
+    }
+
+    inline void Run() {
+        for (NSObject* obj in _testObservers.get()) {
+            [_testKVOObject removeObserver:obj forKeyPath:@"intProperty" context:nullptr];
+        }
+    }
+
+    size_t GetRunCount() const {
+        return 30;
+    }
+};
+
+BENCHMARK_F(KVO, RemoveObservers)
+
+class ObserveChange : public ::benchmark::BenchmarkCaseBase {
+    StrongId<TestKVOObject> _testKVOObject;
+    StrongId<NSMutableArray<TestKVOObserver*>> _testObservers;
+
+public:
+    void PreRun() {
+        _testKVOObject.attach([TestKVOObject new]);
+        _testObservers = [NSMutableArray<TestKVOObserver*> arrayWithCapacity:1000];
+
+        @autoreleasepool {
+            for (size_t i = 0; i < 1000; ++i) {
+                TestKVOObserver* observer = [[TestKVOObserver new] autorelease];
+                [_testKVOObject addObserver:observer forKeyPath:@"intProperty" options:0 context:nullptr];
+                [_testObservers addObject:observer];
+            }
+        }
+    }
+
+    inline void Run() {
+        for (size_t i = 0; i < 100; ++i) {
+            [_testKVOObject setIntProperty:([_testKVOObject intProperty] + 1)];
+
+            // wait for kvo notifications to propagate
+            while (s_observedCount < 1000) {
+            }
+            s_observedCount = 0;
+        }
+    }
+
+    void PostRun() {
+        for (TestKVOObserver* observer in _testObservers.get()) {
+            [_testKVOObject removeObserver:observer forKeyPath:@"intProperty" context:nullptr];
+        }
+    }
+
+    size_t GetRunCount() const {
+        return 20;
+    }
+};
+
+BENCHMARK_F(KVO, ObserveChange)

--- a/tests/Benchmark/NSOperationQueueBenchmarkTests.mm
+++ b/tests/Benchmark/NSOperationQueueBenchmarkTests.mm
@@ -25,6 +25,7 @@ BENCHMARK(NSOperationQueue, CreateAndAutorelease, 10) {
         }
     }
 }
+
 class AddOperation : public ::benchmark::BenchmarkCaseBase {
     StrongId<NSOperationQueue> m_queue;
 

--- a/tests/Benchmark/StringBenchmarkTests.mm
+++ b/tests/Benchmark/StringBenchmarkTests.mm
@@ -1,0 +1,52 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <Starboard/SmartTypes.h>
+#import "Benchmark.h"
+
+BENCHMARK(String, StringLiteral_Hash, 1000) {
+    for (size_t i = 0; i < 10000; ++i) {
+        [@"test string" hash];
+    }
+}
+
+BENCHMARK(String, StringLiteral_IsEqual_Equal, 2000) {
+    for (size_t i = 0; i < 10000; ++i) {
+        [@"test string" isEqual:@"test string"];
+    }
+}
+
+BENCHMARK(String, StringLiteral_IsEqual_NotEqual, 1000) {
+    for (size_t i = 0; i < 1000; ++i) {
+        [@"test string" isEqual:@"test STRING"];
+    }
+}
+
+BENCHMARK(String, StringNonLiteral_IsEqual_Equal, 1000) {
+    NSMutableString* a = [NSMutableString stringWithString:@"test string"];
+    NSMutableString* b = [NSMutableString stringWithString:@"test string"];
+    for (size_t i = 0; i < 10000; ++i) {
+        [a isEqual:b];
+    }
+}
+
+BENCHMARK(String, StringNonLiteral_IsEqual_NotEqual, 1000) {
+    NSMutableString* a = [NSMutableString stringWithString:@"test string"];
+    NSMutableString* b = [NSMutableString stringWithString:@"test STRING"];
+    for (size_t i = 0; i < 1000; ++i) {
+        [a isEqual:b];
+    }
+}


### PR DESCRIPTION
- Fixed a bug in CFStringGetCStringPtr where it called _fastCStringContents with an NSString encoding,
  but _fastCStringContents expected a CFString encoding. As a result, CFStringGetCStringPtr now actually returns something for most strings.
    - Similarly, [NSString UTF8String] on a literal now returns a fast pointer rather than an autorelease buffer.
- Changed [NSString isEqualToString:], [NSConstantString hash], and [NSConstantString isEqualToString:] to rely on faster functions
    - Made a similar change to speed up a local helper (sorry @aballway i misled you)
- Changed _NSKVCSplitKeypath, [Class keyPathsForValuesAffectingKey:] to use C-string parsing
    - added a private helper for keyPathsForValuesAffectingKey: to not construct the empty set, for internal usage
- Changed NSKVOKeypathObserver to store an observer as assign instead of as weak.
  This makes us theoretically less safe if an observer deallocs without removing itself as an observer.
  However, the observed object already threw once it reached its dealloc and still had observers,
  and the above case is considered incorrect anyway,
  so it only allowed us to fail quietly in the case where the observed object has a much longer lifetime, which is of questionable value.
  Opting in favor of assign here, as it provided a substantial (-~40%) decrease in time it takes to addObserver:
- Changed _dispatchWillChange to just take an NSMutableDictionary instead of doing an unnecessary mutableCopy
- Minor change to setObservationInfo: to be atomic on the associated object table rather than the object itself
- Added more benchmark tests for KVO, String scenarios

Fixes #2040