### PR TITLE
Fix performance issue with NSData base64EncodedStringWithOptions

### DIFF
--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -124,7 +124,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
                 memcpy(dest, source, (rawLength % lineLength)*sizeof(wchar_t));
             }
 
-            return [NSString stringWithCharacters:reinterpret_cast<unichar*>(result.get()) length:newLength];
+            return [NSString stringWithCharacters:reinterpret_cast<UniChar*>(result.get()) length:newLength];
         }
     } 
 

--- a/Frameworks/Foundation/NSData.mm
+++ b/Frameworks/Foundation/NSData.mm
@@ -121,7 +121,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSData, NSDataPrototype, CFDataGetTypeID);
             
             if (rawLength % lineLength != 0) {
                 // finally add the remaining characters
-                memcpy(dest, source, (rawLength % lineLength)*sizeof(wchar_t));
+                memcpy(dest, source, (rawLength % lineLength) * sizeof(wchar_t));
             }
 
             return [NSString stringWithCharacters:reinterpret_cast<UniChar*>(result.get()) length:newLength];

--- a/build/Tests/Benchmark/Framework.Benchmark.vcxproj
+++ b/build/Tests/Benchmark/Framework.Benchmark.vcxproj
@@ -223,6 +223,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\BenchmarkSampleTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\NSOperationQueueBenchmarkTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\TextBenchmarkTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\Benchmark\NSDataBenchmarkTests.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(StarboardBasePath)\common\winobjc.packagereference.override.targets" Condition="Exists('$(StarboardBasePath)\common\winobjc.packagereference.override.targets')"/>

--- a/tests/Benchmark/NSDataBenchmarkTests.mm
+++ b/tests/Benchmark/NSDataBenchmarkTests.mm
@@ -1,0 +1,42 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <Starboard/SmartTypes.h>
+#import "Benchmark.h"
+#import <CppUtils.h>
+
+class EncodeStringWithOptions : public ::benchmark::BenchmarkCaseBase {
+    StrongId<NSMutableData> m_data;
+
+public:
+    void PreRun() {
+        m_data = [NSMutableData dataWithLength:3*1024*1024];
+    }
+
+    inline void Run() {
+        NSString* str = [m_data base64EncodedStringWithOptions : NSDataBase64Encoding64CharacterLineLength];
+    }
+
+    void PostRun() {
+    }
+
+    size_t GetRunCount() const {
+        return 10;
+    }
+};
+
+BENCHMARK_F(NSData, EncodeStringWithOptions);
+

--- a/tests/Benchmark/NSDataBenchmarkTests.mm
+++ b/tests/Benchmark/NSDataBenchmarkTests.mm
@@ -22,8 +22,8 @@ class EncodeStringWithOptions : public ::benchmark::BenchmarkCaseBase {
     StrongId<NSMutableData> m_data;
 
 public:
-    void PreRun() {
-        m_data = [NSMutableData dataWithLength:3*1024*1024];
+    EncodeStringWithOptions() 
+        : m_data ([NSMutableData dataWithLength : 3 * 1024 * 1024]){
     }
 
     inline void Run() {


### PR DESCRIPTION
Our perf was terrible because we were inserting new lines into a mutable string and making a copy of it.  Fixing by processing everything in a raw buffer and creating the resulting string.  

Perf on release build for a 3MB buffer:

Before: 21s (21,347,000.00Ms)
After: 28ms (28,929.70 Ms)

Fixes #1996

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2325)
<!-- Reviewable:end -->
