### PR TITLE
Fix #2313: UITableView items no longer stretch to the size of their parent on window resize 

### DIFF
--- a/Frameworks/UIKit.Xaml/ScrollView.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/ScrollView.xaml.cpp
@@ -65,6 +65,17 @@ ScrollViewer^ ScrollView::InnerScrollViewer::get() {
     return scrollViewer;
 }
 
+Windows::Foundation::Size ScrollView::ArrangeOverride(Windows::Foundation::Size finalSize) {
+    if (this->SublayerCanvas->Width < Width) {
+        // if the canvas's width is smaller than that of scrollview
+        // need adjust canvas's width to be same of the scrollview
+        // in order to have proper resizing behavior
+        this->SublayerCanvas->Width = finalSize.Width;
+    }
+    
+    return __super::ArrangeOverride(finalSize);
+}
+
 } /* Xaml*/
 } /* UIKit*/
 

--- a/Frameworks/UIKit.Xaml/ScrollView.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/ScrollView.xaml.cpp
@@ -66,11 +66,11 @@ ScrollViewer^ ScrollView::InnerScrollViewer::get() {
 }
 
 Windows::Foundation::Size ScrollView::ArrangeOverride(Windows::Foundation::Size finalSize) {
-    if (this->SublayerCanvas->Width < Width) {
+    if (SublayerCanvas->Width < finalSize.Width) {
         // if the canvas's width is smaller than that of scrollview
         // need adjust canvas's width to be same of the scrollview
         // in order to have proper resizing behavior
-        this->SublayerCanvas->Width = finalSize.Width;
+        SublayerCanvas->Width = finalSize.Width;
     }
     
     return __super::ArrangeOverride(finalSize);

--- a/Frameworks/UIKit.Xaml/ScrollView.xaml.h
+++ b/Frameworks/UIKit.Xaml/ScrollView.xaml.h
@@ -31,6 +31,8 @@ public ref class ScrollView sealed : public Private::CoreAnimation::ILayer
 public:
     ScrollView();
 
+    Windows::Foundation::Size ArrangeOverride(Windows::Foundation::Size finalSize) override;
+
     // Accessor for our Layer content; we create one on demand
     virtual property Windows::UI::Xaml::Controls::Image^ LayerContent {
         Windows::UI::Xaml::Controls::Image^ get();


### PR DESCRIPTION
when canvas width is smaller than scrollview, we need adjust canvas's width to be width of scrollview.