### PR TITLE
Make sample and test apps open in Visual Studio 2017

### DIFF
--- a/samples/CoreAnimationTest/CoreAnimationTest-WinStore10.sln
+++ b/samples/CoreAnimationTest/CoreAnimationTest-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CoreAnimationTest", "CoreAnimationTest", "{401D635E-20C9-42B3-BB8A-B7A399B62998}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CoreAnimationTest", "CoreAnimationTest.vsimporter\CoreAnimationTest-WinStore10\CoreAnimationTest.vcxproj", "{9F755F4B-5A21-4F6A-A690-5C9AA0ABE302}"

--- a/samples/GLKitComplex/GLKitComplex-WinStore10.sln
+++ b/samples/GLKitComplex/GLKitComplex-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GLKitComplex", "GLKitComplex", "{13B9CC41-DB2D-463E-9272-3B8BF93B9BB5}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GLKitComplex", "GLKitComplex.vsimporter\GLKitComplex-WinStore10\GLKitComplex.vcxproj", "{D8A0D1E3-4371-4E1D-B0CE-2C22DBEC62B2}"

--- a/samples/HelloGLKit/HelloGLKit-WinStore10.sln
+++ b/samples/HelloGLKit/HelloGLKit-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HelloGLKit", "HelloGLKit", "{E9BAE943-4C00-4B31-911D-5CC26A6C5B19}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloGLKit", "HelloGLKit.vsimporter\HelloGLKit-WinStore10\HelloGLKit.vcxproj", "{2CDC9FEF-FEAF-4AC9-95D1-10CBC49EC841}"

--- a/samples/HelloOpenGL/HelloOpenGL-WinStore10.sln
+++ b/samples/HelloOpenGL/HelloOpenGL-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HelloOpenGL", "HelloOpenGL", "{87D009FB-8229-44BF-976F-FF8C397D66EE}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloOpenGL", "HelloOpenGL.vsimporter\HelloOpenGL-WinStore10\HelloOpenGL.vcxproj", "{7F101DAF-1B12-40C2-B59E-E5E75ABAB35C}"

--- a/samples/HelloUI/HelloUI-WinStore10.sln
+++ b/samples/HelloUI/HelloUI-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HelloUI", "HelloUI", "{3F0EBABD-86FE-4A85-9A19-2D1C14313917}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloUI", "HelloUI.vsimporter\HelloUI-WinStore10\HelloUI.vcxproj", "{767B6E11-F911-4BE6-8325-6899AAE9D895}"

--- a/samples/KVOPerf/KVOPerf-WinStore10.sln
+++ b/samples/KVOPerf/KVOPerf-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "KVOPerf", "KVOPerf", "{13FFB877-5317-4581-BA9C-32E4201D44B2}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "KVOPerf", "KVOPerf.vsimporter\KVOPerf-WinStore10\KVOPerf.vcxproj", "{4EB34FDE-1B6C-4B1D-BEEF-33D300ABD49C}"

--- a/samples/WOCCatalog/WOCCatalog-WinStore10.sln
+++ b/samples/WOCCatalog/WOCCatalog-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WOCCatalog", "WOCCatalog", "{266E87EB-4E76-467A-87A4-BBF67295EE56}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WOCCatalog", "WOCCatalog.vsimporter\WOCCatalog-WinStore10\WOCCatalog.vcxproj", "{EE8C811A-2FA4-44D2-AEB9-916856EB592B}"

--- a/samples/WinRTSample/WinRTSample-WinStore10.sln
+++ b/samples/WinRTSample/WinRTSample-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WinRTSample", "WinRTSample", "{56BDB4C8-67A6-419C-A329-AB9F682186EE}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WinRTSample-Headers", "WinRTSample.vsimporter\WinRTSample-Headers-WinStore10\WinRTSample-Headers.vcxitems", "{05A8DC7F-9E04-45F9-8350-88A1D844B409}"

--- a/samples/XAMLCatalog/XAMLCatalog-WinStore10.sln
+++ b/samples/XAMLCatalog/XAMLCatalog-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "XAMLCatalog", "XAMLCatalog", "{4B7DEF89-C183-4BDC-8A15-4D23F5A06273}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XAMLCatalog", "XAMLCatalog.vsimporter\XAMLCatalog-WinStore10\XAMLCatalog.vcxproj", "{5FDCF19E-7E9E-4B7A-8E10-09661FD81E1C}"

--- a/samples/XAMLTest/XamlTest-WinStore10.sln
+++ b/samples/XAMLTest/XamlTest-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "XamlTest", "XamlTest", "{DD680EF4-9807-4EDF-B6B4-38F4B9126A91}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XamlTest", "XamlTest.vsimporter\XamlTest-WinStore10\XamlTest.vcxproj", "{40CF9F60-0C81-4A82-9E9F-D1E3E2DCD0CD}"

--- a/tests/testapps/AddressBookSample/AddressBookSample-WinStore10.sln
+++ b/tests/testapps/AddressBookSample/AddressBookSample-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AddressBookSample", "AddressBookSample", "{805A697A-C1C4-460B-A1F4-62329CB293CB}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AddressBookSample", "AddressBookSample.vsimporter\AddressBookSample-WinStore10\AddressBookSample.vcxproj", "{CC1A6702-00CC-4F9A-81DB-A8E80B532B9F}"

--- a/tests/testapps/CGCatalog/CGCatalog-WinStore10.sln
+++ b/tests/testapps/CGCatalog/CGCatalog-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CGCatalog", "CGCatalog", "{AA2014D1-215B-42F8-A37C-D7BFECD47946}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CGCatalog", "CGCatalog.vsimporter\CGCatalog-WinStore10\CGCatalog.vcxproj", "{FC1847AC-5E37-496F-801F-32F8911A49A7}"

--- a/tests/testapps/CTCatalog/CTCatalog-WinStore10.sln
+++ b/tests/testapps/CTCatalog/CTCatalog-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CTCatalog", "CTCatalog", "{7D9B5308-D449-4857-BD88-9BE535D13FE9}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CTCatalog", "CTCatalog.vsimporter\CTCatalog-WinStore10\CTCatalog.vcxproj", "{5FB16118-BF5A-4E1E-A5FD-E2452505BAD6}"

--- a/tests/testapps/Foundation-Dev/Foundation-Dev-WinStore10.sln
+++ b/tests/testapps/Foundation-Dev/Foundation-Dev-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Foundation-Dev", "Foundation-Dev", "{86CD6CDD-A2BB-4EFA-B921-9311CA1CFA43}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Foundation-Dev", "Foundation-Dev.vsimporter\Foundation-Dev-WinStore10\Foundation-Dev.vcxproj", "{F59A1B1A-1930-4C97-B474-063A58F28A85}"

--- a/tests/testapps/MinApp/MinApp-WinStore10.sln
+++ b/tests/testapps/MinApp/MinApp-WinStore10.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MinApp", "MinApp", "{00A79C68-10A2-4983-9E8D-06EABA0D3A70}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MinApp", "MinApp.vsimporter\MinApp-WinStore10\MinApp.vcxproj", "{045517F8-1553-4741-9C9F-F2E6BE64199D}"

--- a/tests/testapps/MinAppCppCx/MinAppCppCx.sln
+++ b/tests/testapps/MinAppCppCx/MinAppCppCx.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MinAppCppCx", "MinAppCppCx\MinAppCppCx.vcxproj", "{9B700D2D-E91B-454B-BEC2-B38B5A19C4AC}"
 EndProject
 Global

--- a/tests/uiautomation/XAMLCatalogTest/XAMLCatalogTest.sln
+++ b/tests/uiautomation/XAMLCatalogTest/XAMLCatalogTest.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.4
+MinimumVisualStudioVersion = 15.0.0.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XAMLCatalogTest", "XAMLCatalogTest.csproj", "{D2D62728-48E1-46C3-BA5B-F5923B0326B8}"
 EndProject
 Global


### PR DESCRIPTION
fixes #2327

These apps require Visual Studio 2017 because they use PackageReference