### PR TITLE
Move pre-release label to end to avoid ordering issues with different…

### DIFF
--- a/common/winobjc.nuproj.common.props
+++ b/common/winobjc.nuproj.common.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageVersion_PreReleaseFormat>{PackageVersion_PreReleaseLabel}-{PackageVersion_Timestamp}</PackageVersion_PreReleaseFormat>
+    <PackageVersion_PreReleaseFormat>{PackageVersion_Timestamp}-{PackageVersion_PreReleaseLabel}</PackageVersion_PreReleaseFormat>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/WinObjC.Tools/WinObjC.Tools.nuproj
+++ b/tools/WinObjC.Tools/WinObjC.Tools.nuproj
@@ -29,7 +29,6 @@
   </PropertyGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>0a23b6b4-94bb-4b3a-ba73-a7cb5ef7d8f9</ProjectGuid>
-    <PackageVersion_PreReleaseFormat>{PackageVersion_PreReleaseLabel}-{PackageVersion_Timestamp}</PackageVersion_PreReleaseFormat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" />


### PR DESCRIPTION
… branches in the future.

Currently a pacakge like 1.0.0-pr-timestamp is preferred over 1.0.0-dev-timestamp.

This isn't necessarily a problem except if incorrect pacakges make it to public feeds.
By putting timestamp first, any newer packages will be preferred allowing us to correct easier.