### PR TITLE
Change Packaging's header include path to a non-clang path

### DIFF
--- a/tools/WinObjC.Packaging/Package.Default.props
+++ b/tools/WinObjC.Packaging/Package.Default.props
@@ -28,6 +28,14 @@
     <!-- Add each .lib to the linker -->
     <Link Include="@(_ImportLibsFromPackage->'%(FullPath)')"/>
   </ItemGroup>
+
+  <ItemDefinitionGroup>
+    <!-- Add header search path -->
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\include\;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
   <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary'">
     <!-- Add references for clang -->
     <ReferenceCopyLocalPaths Include="@(_DllsFromPackage)"/>
@@ -50,11 +58,4 @@
       <DestinationSubDirectory>%(RecursiveDir)</DestinationSubDirectory>
     </ReferenceCopyLocalPaths>
   </ItemGroup>
-
-  <!-- Add dependency paths needed by projects that consume this package -->
-  <ItemDefinitionGroup>
-    <ClangCompile>
-      <InternalSystemIncludePaths>$(MSBuildThisFileDirectory)\include\;%(InternalSystemIncludePaths);</InternalSystemIncludePaths>
-    </ClangCompile>
-  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Fixes #2277

WinObjC.Packaging's default header include paths now modify "AdditionalIncludeDirectories"

This path should not rely on a ClangCompile path since WinObjC.Packaging (and any package created with it) does not depend on WinObjC.Language.