### PR TITLE
Using temp fix for CGContextGetClipBoundingBox to obtain ID2D1DeviceC…

### DIFF
--- a/Frameworks/CoreGraphics/CGContext.mm
+++ b/Frameworks/CoreGraphics/CGContext.mm
@@ -1371,7 +1371,7 @@ CGRect CGContextGetClipBoundingBox(CGContextRef context) {
 
     auto& state = context->CurrentGState();
     if (!state.clippingGeometry) {
-        D2D1_SIZE_F targetSize = context->DeviceContext()->GetSize();
+        D2D1_SIZE_F targetSize = context->GetContextSize();
         return CGContextConvertRectToUserSpace(context, CGRect{ CGPointZero, { targetSize.width, targetSize.height } });
     }
 

--- a/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
+++ b/tests/UnitTests/CoreGraphics.drawing/CGContextDrawingTests.cpp
@@ -261,3 +261,14 @@ DRAW_TEST_F(CGContext, NullColorStroke, WhiteBackgroundTest<>) {
     borderRect = CGRectInset(bounds, 60, 100);
     CGContextStrokeRect(context, borderRect);
 }
+
+DRAW_TEST_F(CGContext, ClipBoundingBox, WhiteBackgroundTest<>) {
+    CGContextRef context = GetDrawingContext();
+    CGRect bounds = GetDrawingBounds();
+
+    CGContextAddArc(context, 150, 150, 50, 0, 1.7 * M_PI, 1);
+    CGContextClip(context);
+
+    CGContextSetRGBFillColor(context, 0.0, 1.0, 0.0, 1.0);
+    CGContextFillRect(context, CGContextGetClipBoundingBox(context));
+}

--- a/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ClipBoundingBox.png
+++ b/tests/UnitTests/CoreGraphics.drawing/data/reference/TestImage.CGContext.ClipBoundingBox.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a62d6627e5666f32e526f62569a1af9957e5f17eed024eb38152cda2560af742
+size 1650


### PR DESCRIPTION
…ontext::GetSize() and adding tests. fixes #2344