### PR TITLE
Fixing override-projectjson to handle project.json with a depth > 2.

### DIFF
--- a/common/Override-ProjectJson.ps1
+++ b/common/Override-ProjectJson.ps1
@@ -46,7 +46,7 @@ foreach($ProjectJsonFile in $ProjectJsons)
     }  
 
     if ($needsUpdate -eq $true) {
-        $FileAsJson | ConvertTo-Json | set-content $ProjectJsonFile  
+        $FileAsJson | ConvertTo-Json -Depth 100 | set-content $ProjectJsonFile
     }
 }  
   


### PR DESCRIPTION
By default converto-json only handles json data with a depth of 2.  After that it starts "toString()'ing" things.
https://msdn.microsoft.com/en-us/powershell/reference/5.1/microsoft.powershell.utility/convertto-json

I changed the max depth to 100,  this is the max supported value.