### PR TITLE
[Foundation Dependency Removal] Should use use CoreFoundation vs Foundation: Strings should be created via CFSTR vs NS

### DIFF
--- a/Frameworks/CoreGraphics/CGColorSpace.mm
+++ b/Frameworks/CoreGraphics/CGColorSpace.mm
@@ -27,18 +27,18 @@
 
 static const wchar_t* TAG = L"CGColorSpace";
 
-const CFStringRef kCGColorSpaceGenericGray = static_cast<CFStringRef>(@"kCGColorSpaceGenericGray");
-const CFStringRef kCGColorSpaceGenericRGB = static_cast<CFStringRef>(@"kCGColorSpaceGenericRGB");
-const CFStringRef kCGColorSpaceGenericCMYK = static_cast<CFStringRef>(@"kCGColorSpaceGenericCMYK");
-const CFStringRef kCGColorSpaceGenericRGBLinear = static_cast<CFStringRef>(@"kCGColorSpaceGenericRGBLinear");
-const CFStringRef kCGColorSpaceAdobeRGB1998 = static_cast<CFStringRef>(@"kCGColorSpaceAdobeRGB1998");
-const CFStringRef kCGColorSpaceSRGB = static_cast<CFStringRef>(@"kCGColorSpaceSRGB");
-const CFStringRef kCGColorSpaceGenericGrayGamma2_2 = static_cast<CFStringRef>(@"kCGColorSpaceGenericGrayGamma2_2");
-const CFStringRef kCGColorSpaceGenericXYZ = static_cast<CFStringRef>(@"kCGColorSpaceGenericXYZ");
-const CFStringRef kCGColorSpaceACESCGLinear = static_cast<CFStringRef>(@"kCGColorSpaceACESCGLinear");
-const CFStringRef kCGColorSpaceITUR_709 = static_cast<CFStringRef>(@"kCGColorSpaceITUR_709");
-const CFStringRef kCGColorSpaceITUR_2020 = static_cast<CFStringRef>(@"kCGColorSpaceITUR_2020");
-const CFStringRef kCGColorSpaceROMMRGB = static_cast<CFStringRef>(@"kCGColorSpaceROMMRGB");
+const CFStringRef kCGColorSpaceGenericGray = CFSTR("kCGColorSpaceGenericGray");
+const CFStringRef kCGColorSpaceGenericRGB = CFSTR("kCGColorSpaceGenericRGB");
+const CFStringRef kCGColorSpaceGenericCMYK = CFSTR("kCGColorSpaceGenericCMYK");
+const CFStringRef kCGColorSpaceGenericRGBLinear = CFSTR("kCGColorSpaceGenericRGBLinear");
+const CFStringRef kCGColorSpaceAdobeRGB1998 = CFSTR("kCGColorSpaceAdobeRGB1998");
+const CFStringRef kCGColorSpaceSRGB = CFSTR("kCGColorSpaceSRGB");
+const CFStringRef kCGColorSpaceGenericGrayGamma2_2 = CFSTR("kCGColorSpaceGenericGrayGamma2_2");
+const CFStringRef kCGColorSpaceGenericXYZ = CFSTR("kCGColorSpaceGenericXYZ");
+const CFStringRef kCGColorSpaceACESCGLinear = CFSTR("kCGColorSpaceACESCGLinear");
+const CFStringRef kCGColorSpaceITUR_709 = CFSTR("kCGColorSpaceITUR_709");
+const CFStringRef kCGColorSpaceITUR_2020 = CFSTR("kCGColorSpaceITUR_2020");
+const CFStringRef kCGColorSpaceROMMRGB = CFSTR("kCGColorSpaceROMMRGB");
 
 struct __CGColorSpace : CoreFoundation::CppBase<__CGColorSpace> {
     __CGColorSpace(CGColorSpaceModel model, CGColorSpaceRef baseSpace = nullptr, size_t lastIndex = 0)

--- a/Frameworks/CoreGraphics/CGFont.mm
+++ b/Frameworks/CoreGraphics/CGFont.mm
@@ -30,10 +30,10 @@
 
 #import <vector>
 
-const CFStringRef kCGFontVariationAxisName = static_cast<CFStringRef>(@"kCGFontVariationAxisName");
-const CFStringRef kCGFontVariationAxisMinValue = static_cast<CFStringRef>(@"kCGFontVariationAxisMinValue");
-const CFStringRef kCGFontVariationAxisMaxValue = static_cast<CFStringRef>(@"kCGFontVariationAxisMaxValue");
-const CFStringRef kCGFontVariationAxisDefaultValue = static_cast<CFStringRef>(@"kCGFontVariationAxisDefaultValue");
+const CFStringRef kCGFontVariationAxisName = CFSTR("kCGFontVariationAxisName");
+const CFStringRef kCGFontVariationAxisMinValue = CFSTR("kCGFontVariationAxisMinValue");
+const CFStringRef kCGFontVariationAxisMaxValue = CFSTR("kCGFontVariationAxisMaxValue");
+const CFStringRef kCGFontVariationAxisDefaultValue = CFSTR("kCGFontVariationAxisDefaultValue");
 
 using namespace Microsoft::WRL;
 

--- a/Frameworks/CoreGraphics/CGPDFContext.mm
+++ b/Frameworks/CoreGraphics/CGPDFContext.mm
@@ -17,21 +17,21 @@
 #import <StubReturn.h>
 #import <CoreGraphics/CGPDFContext.h>
 
-const CFStringRef kCGPDFContextAuthor = static_cast<CFStringRef>(@"kCGPDFContextAuthor");
-const CFStringRef kCGPDFContextCreator = static_cast<CFStringRef>(@"kCGPDFContextCreator");
-const CFStringRef kCGPDFContextTitle = static_cast<CFStringRef>(@"kCGPDFContextTitle");
-const CFStringRef kCGPDFContextOwnerPassword = static_cast<CFStringRef>(@"kCGPDFContextOwnerPassword");
-const CFStringRef kCGPDFContextUserPassword = static_cast<CFStringRef>(@"kCGPDFContextUserPassword");
-const CFStringRef kCGPDFContextAllowsPrinting = static_cast<CFStringRef>(@"kCGPDFContextAllowsPrinting");
-const CFStringRef kCGPDFContextAllowsCopying = static_cast<CFStringRef>(@"kCGPDFContextAllowsCopying");
-const CFStringRef kCGPDFContextSubject = static_cast<CFStringRef>(@"kCGPDFContextSubject");
-const CFStringRef kCGPDFContextKeywords = static_cast<CFStringRef>(@"kCGPDFContextKeywords");
-const CFStringRef kCGPDFContextEncryptionKeyLength = static_cast<CFStringRef>(@"kCGPDFContextEncryptionKeyLength");
-const CFStringRef kCGPDFContextMediaBox = static_cast<CFStringRef>(@"kCGPDFContextMediaBox");
-const CFStringRef kCGPDFContextCropBox = static_cast<CFStringRef>(@"kCGPDFContextCropBox");
-const CFStringRef kCGPDFContextBleedBox = static_cast<CFStringRef>(@"kCGPDFContextBleedBox");
-const CFStringRef kCGPDFContextTrimBox = static_cast<CFStringRef>(@"kCGPDFContextTrimBox");
-const CFStringRef kCGPDFContextArtBox = static_cast<CFStringRef>(@"kCGPDFContextArtBox");
+const CFStringRef kCGPDFContextAuthor = CFSTR("kCGPDFContextAuthor");
+const CFStringRef kCGPDFContextCreator = CFSTR("kCGPDFContextCreator");
+const CFStringRef kCGPDFContextTitle = CFSTR("kCGPDFContextTitle");
+const CFStringRef kCGPDFContextOwnerPassword = CFSTR("kCGPDFContextOwnerPassword");
+const CFStringRef kCGPDFContextUserPassword = CFSTR("kCGPDFContextUserPassword");
+const CFStringRef kCGPDFContextAllowsPrinting = CFSTR("kCGPDFContextAllowsPrinting");
+const CFStringRef kCGPDFContextAllowsCopying = CFSTR("kCGPDFContextAllowsCopying");
+const CFStringRef kCGPDFContextSubject = CFSTR("kCGPDFContextSubject");
+const CFStringRef kCGPDFContextKeywords = CFSTR("kCGPDFContextKeywords");
+const CFStringRef kCGPDFContextEncryptionKeyLength = CFSTR("kCGPDFContextEncryptionKeyLength");
+const CFStringRef kCGPDFContextMediaBox = CFSTR("kCGPDFContextMediaBox");
+const CFStringRef kCGPDFContextCropBox = CFSTR("kCGPDFContextCropBox");
+const CFStringRef kCGPDFContextBleedBox = CFSTR("kCGPDFContextBleedBox");
+const CFStringRef kCGPDFContextTrimBox = CFSTR("kCGPDFContextTrimBox");
+const CFStringRef kCGPDFContextArtBox = CFSTR("kCGPDFContextArtBox");
 
 /**
  @Status Stub


### PR DESCRIPTION
#2352 