### PR TITLE
Make packaging proj generation disabled by default

### DIFF
--- a/tools/vsimporter/src/vsimporter.cpp
+++ b/tools/vsimporter/src/vsimporter.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
     int workspaceSet = 0;
     int interactiveFlag = 0;
     int genProjectionsFlag = 0;
-    int genPackagingFlag = 1;
+    int genPackagingFlag = 0;
     int allTargets = 0;
     int allSchemes = 0;
     int mode = GenerateMode;


### PR DESCRIPTION
#### Previous behavior:
-genpackaging automatically enabled when:
1. Any number of non-app projects are included in the vsimporter import
2. -genprojections is specified

#### New behavior:
-genpackaging disabled by default
Must set -genpackaging or -genpackaging=1 to generate packaging (nuproj) project for any vsimporter import
i.e. If you are creating middleware you should specify -genprojections AND -genpackaging. It is no longer automatic.

I'll update the wiki's vsimporter page to reflect this change.