### PR TITLE
Set package path with intended target file name

### DIFF
--- a/tools/AssetCatalogBuilder/AssetCatalogBuilder.csproj
+++ b/tools/AssetCatalogBuilder/AssetCatalogBuilder.csproj
@@ -100,7 +100,7 @@
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents">
     <ItemGroup>
       <PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-        <PackagePath>build\bin\%(Filename)%(Extension)</PackagePath>
+        <PackagePath>build\bin\%(TargetPath)</PackagePath>
       </PackageFile>
       <PackageFile Include="$(TargetDir)CommandLine.dll">
         <PackagePath>build\bin\CommandLine.dll</PackagePath>

--- a/tools/ClangCompileTask/ClangCompile.csproj
+++ b/tools/ClangCompileTask/ClangCompile.csproj
@@ -71,7 +71,7 @@
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents">
     <ItemGroup>
       <PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-        <PackagePath>build\msvc\%(Filename)%(Extension)</PackagePath>
+        <PackagePath>build\msvc\%(TargetPath)</PackagePath>
       </PackageFile>
     </ItemGroup>
   </Target>

--- a/tools/PropSchemaGen/PropSchemaGen.csproj
+++ b/tools/PropSchemaGen/PropSchemaGen.csproj
@@ -75,7 +75,7 @@
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents">
     <ItemGroup>
       <PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-        <PackagePath>build\msvc\%(Filename)%(Extension)</PackagePath>
+        <PackagePath>build\msvc\%(TargetPath)</PackagePath>
       </PackageFile>
     </ItemGroup>
   </Target>

--- a/tools/xib2xaml/xamltools/xamltools.csproj
+++ b/tools/xib2xaml/xamltools/xamltools.csproj
@@ -98,7 +98,7 @@
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents">
     <ItemGroup>
       <PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-        <PackagePath>build\bin\%(Filename)%(Extension)</PackagePath>
+        <PackagePath>build\bin\%(TargetPath)</PackagePath>
       </PackageFile>
     </ItemGroup>
   </Target>

--- a/tools/xib2xaml/xib2xaml/xib2xaml.csproj
+++ b/tools/xib2xaml/xib2xaml/xib2xaml.csproj
@@ -150,7 +150,7 @@
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents">
     <ItemGroup>
       <PackageFile Include="@(BuiltProjectOutputGroupOutput -> '%(FinalOutputPath)')">
-        <PackagePath>build\bin\%(Filename)%(Extension)</PackagePath>
+        <PackagePath>build\bin\%(TargetPath)</PackagePath>
       </PackageFile>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
fixes #2331

EXECUTABLE_NAME.exe.config files were being put in the package as ambiguous app.config files. This created problems since NuGetizer would be able to put App.config and app.config in the same file path.

Before:
```
WinObjC.Language\build\
├── bin\
|     └── acbuilder.exe
|     └── App.config (pulled in for acbuilder.exe)
|     └── xib2xaml.exe
|     └── app.config (pulled in for xib2xaml.exe)
└── msvc\
      └── PropSchemaGen.exe
      └── App.config (pulled in for PropSchemaGen.exe)
```

Now:
```
WinObjC.Language\build\
├── bin\
|     └── acbuilder.exe
|     └── acbuilder.exe.config
|     └── xib2xaml.exe
|     └── xib2xaml.exe.config
└── msvc\
      └── PropSchemaGen.exe
      └── PropSchemaGen.exe.config
```