### PR TITLE
Reimplement NSNotificationCenter (and NSNotification)

### DIFF
--- a/Frameworks/Foundation/NSNotification.mm
+++ b/Frameworks/Foundation/NSNotification.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -14,10 +14,28 @@
 //
 //******************************************************************************
 
-#import <StubReturn.h>
 #import <Foundation/NSNotification.h>
+#import <Foundation/NSCoder.h>
+#import <NSRaise.h>
+
+// NSNotification is a class cluster.
+@interface _NSConcreteNotification : NSNotification {
+    NSString* _name;
+    id _object;
+    NSDictionary* _userInfo;
+}
+@end
 
 @implementation NSNotification
+/**
+ @Status Interoperable
+*/
++ (id)allocWithZone:(NSZone*)zone {
+    if (self == [NSNotification class]) {
+        return [_NSConcreteNotification allocWithZone:zone];
+    }
+    return [super allocWithZone:zone];
+}
 
 /**
  @Status Interoperable
@@ -33,54 +51,98 @@
     return [[[self alloc] initWithName:name object:obj userInfo:info] autorelease];
 }
 
+- (Class)classForCoder {
+    return [NSNotification class];
+}
+
 /**
  @Status Interoperable
 */
+- (instancetype)init {
+    return NSInvalidAbstractInvocationReturn();
+}
+
+/**
+ @Status Interoperable
+*/
+- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {
+    return NSInvalidAbstractInvocationReturn();
+}
+
+/**
+ @Status Interoperable
+*/
+- (NSString*)name {
+    return NSInvalidAbstractInvocationReturn();
+}
+
+/**
+ @Status Interoperable
+*/
+- (id)object {
+    return NSInvalidAbstractInvocationReturn();
+}
+
+/**
+ @Status Interoperable
+*/
+- (NSDictionary*)userInfo {
+    return NSInvalidAbstractInvocationReturn();
+}
+
+static NSString* s_NSNotificationKeyName = @"NS.name";
+static NSString* s_NSNotificationKeyObject = @"NS.object";
+static NSString* s_NSNotificationKeyUserInfo = @"NS.userinfo";
+
+/**
+ @Status Interoperable
+*/
+- (instancetype)initWithCoder:(NSCoder*)decoder {
+    Class notificationClass = [self class];
+    [self release];
+
+    NSString* name = [decoder decodeObjectForKey:s_NSNotificationKeyName];
+    id object = [decoder decodeObjectForKey:s_NSNotificationKeyObject];
+    NSDictionary* userInfo = [decoder decodeObjectForKey:s_NSNotificationKeyUserInfo];
+    return [[notificationClass alloc] initWithName:name object:object userInfo:userInfo];
+}
+
+/**
+ @Status Interoperable
+*/
+- (void)encodeWithCoder:(NSCoder*)encoder {
+    [encoder encodeObject:self.name forKey:s_NSNotificationKeyName];
+    [encoder encodeObject:self.object forKey:s_NSNotificationKeyObject];
+    [encoder encodeObject:self.userInfo forKey:s_NSNotificationKeyUserInfo];
+}
+
+/**
+ @Status Interoperable
+*/
+- (id)copyWithZone:(NSZone*)zone {
+    // Since NSNotification is a class cluster, a consumer customizing its storage and behavior must override copyWithZone:.
+    // All other notifications are immutable.
+    return [self retain];
+}
+@end
+
+@implementation _NSConcreteNotification
+@synthesize name = _name, object = _object, userInfo = _userInfo;
+
+- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {
+    // per documentation: ... be sure that your initializer does not call [super init] ...
+    // NSNotification is not meant to be instantiated directly, and its init method raises an exception...
+    _name = [aName copy];
+    _object = [object retain];
+    _userInfo = [info copy];
+    return self;
+}
+
 - (void)dealloc {
-    [_object release];
     [_name release];
+    [_object release];
     [_userInfo release];
 
     [super dealloc];
 }
-
-/**
- @Status Interoperable
- @Notes
-*/
-- (instancetype)initWithName:(NSString*)aName object:(id)object userInfo:(NSDictionary*)info {
-    if ((self = [super init]) != nil) {
-        _object = [object retain];
-        _name = [aName copy];
-        _userInfo = [info copy];
-    }
-    return self;
-}
-
-/**
- @Status Stub
- @Notes
-*/
-- (instancetype)initWithCoder:(NSCoder*)decoder {
-    UNIMPLEMENTED();
-    return StubReturn();
-}
-
-/**
- @Status Stub
- @Notes
-*/
-- (void)encodeWithCoder:(NSCoder*)encoder {
-    UNIMPLEMENTED();
-}
-
-/**
- @Status Stub
- @Notes
-*/
-- (id)copyWithZone:(NSZone*)zone {
-    UNIMPLEMENTED();
-    return StubReturn();
-}
-
 @end

--- a/Frameworks/Foundation/NSNotificationCenter.mm
+++ b/Frameworks/Foundation/NSNotificationCenter.mm
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -14,56 +14,91 @@
 //
 //******************************************************************************
 
-#include "Starboard.h"
+#import <Starboard.h>
 #import <Foundation/NSNotification.h>
 #import <Foundation/NSNotificationCenter.h>
-#include "LoggingNative.h"
+#import <LoggingNative.h>
+
+#import <vector>
 
 static const wchar_t* TAG = L"NSNotificationCenter";
 
-@interface NSNotificationReceiver : NSObject {
+@interface _NSNotificationBlockObserver : NSObject {
+    // Unlike _NSNotificationReceiver below, this object owns strong references to block and queue.
+    // Block notifications are commonly implemented with a weak handle to its owner since the block
+    // can itself cause a retain cycle.
+    StrongId<void (^)(NSNotification* note)> _block;
+    StrongId<NSOperationQueue> _queue;
+}
+@end
+@implementation _NSNotificationBlockObserver
+- (instancetype)initWithBlock:(void (^)(NSNotification* note))block queue:(NSOperationQueue*)queue {
+    if (self = [super init]) {
+        _block = block;
+        _queue = queue;
+    }
+    return self;
+}
+
+- (void)invokeWithNotification:(NSNotification*)note {
+    if (_queue) {
+        // Through observation, it was determined that the reference platform will block
+        // until the notification is fired.
+        [_queue addOperations:@[ [NSBlockOperation blockOperationWithBlock:^{
+                    _block(note);
+                }] ]
+            waitUntilFinished:YES];
+    } else {
+        _block(note);
+    }
+}
+@end
+
+@interface _NSNotificationReceiver : NSObject {
 @public
-    NSObject* object;
-    void (^block)(NSNotification* block);
+    // To avoid retain cycles, NSNotificationCenter does not usually retain its observer/sender...
+    NSObject* observer;
+    // ... unless the observer was created for internal use.
+    BOOL ownsObserver;
+
     SEL selector;
-    NSObject* notificationSender;
-    bool valid;
+
+    NSObject* sender;
+
+    NSString* name;
 }
 @end
 
-@implementation NSNotificationReceiver
+@implementation _NSNotificationReceiver
+- (void)postNotification:(NSNotification*)note {
+    [observer performSelector:selector withObject:note];
+}
+
+- (void)dealloc {
+    if (ownsObserver) {
+        [observer release];
+    }
+
+    [name release];
+    [super dealloc];
+}
 @end
 
-NSNotificationCenter* defaultCenter;
+@interface NSNotificationCenter () {
+    // Dictionary for quick lookups on post
+    StrongId<NSMutableDictionary<NSString*, NSMutableSet<_NSNotificationReceiver*>*>> _observers;
 
-@implementation NSNotificationCenter {
-    NSMutableDictionary* observers;
+    // All known receivers
+    StrongId<NSMutableSet<_NSNotificationReceiver*>> _allReceivers;
 }
-static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* key, bool create = false) {
-    NSMutableArray* ret = [self->observers objectForKey:key];
-    if (ret) {
-        return ret;
-    }
+@end
 
-    if (!create) {
-        return nil;
-    }
-
-    ret = [NSMutableArray new];
-    [self->observers setObject:ret forKey:key];
-    [ret release];
-
-    return ret;
-}
-
+@implementation NSNotificationCenter
 /**
  @Status Interoperable
 */
 + (NSNotificationCenter*)defaultCenter {
-    if (defaultCenter == nil) {
-        defaultCenter = [NSNotificationCenter new];
-    }
-
+    static StrongId<NSNotificationCenter> defaultCenter{[[NSNotificationCenter new] autorelease] };
     return defaultCenter;
 }
 
@@ -71,17 +106,103 @@ static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* k
  @Status Interoperable
 */
 - (instancetype)init {
-    observers = [[NSMutableDictionary alloc] init];
+    if (self = [super init]) {
+        _observers.attach([[NSMutableDictionary alloc] init]);
+        _allReceivers.attach([[NSMutableSet alloc] init]);
+    }
     return self;
+}
+
+// INVARIANT: Called under lock.
+- (NSMutableSet<_NSNotificationReceiver*>*)_receiverSetForNotificationName:(NSString*)notification createIfMissing:(BOOL)create {
+    NSMutableSet<_NSNotificationReceiver*>* receiverSet = [_observers objectForKey:notification];
+    if (receiverSet || !create) {
+        return receiverSet;
+    }
+
+    receiverSet = [NSMutableSet set];
+    [_observers setObject:receiverSet forKey:notification];
+    return receiverSet;
+}
+
+// INVARIANT: Called under lock.
+- (NSSet<_NSNotificationReceiver*>*)_receiversForName:(NSString*)name observer:(id)observer object:(id)object {
+    NSSet<_NSNotificationReceiver*>* searchSet = _allReceivers;
+    if (name) {
+        searchSet = [self _receiverSetForNotificationName:name createIfMissing:NO];
+        if (!searchSet) {
+            return nil;
+        }
+    }
+
+    __block id blockObserver = observer;
+    __block NSString* blockName = name;
+    __block id blockObject = object;
+    return [searchSet objectsPassingTest:^BOOL(_NSNotificationReceiver* receiver, BOOL* stop) {
+        return (blockObserver == nil || receiver->observer == blockObserver) && (blockObject == nil || receiver->sender == blockObject) &&
+               (blockName == nil || [receiver->name isEqual:blockName]);
+    }];
+}
+
+// INVARIANT: Called under lock.
+- (void)_addReceiver:(_NSNotificationReceiver*)receiver {
+    StrongId<NSMutableSet<_NSNotificationReceiver*>> receivers = [self _receiverSetForNotificationName:receiver->name createIfMissing:YES];
+    [receivers addObject:receiver];
+    [_allReceivers addObject:receiver];
+}
+
+// INVARIANT: Called under lock.
+- (void)_removeReceivers:(NSSet<_NSNotificationReceiver*>*)receivers forName:(NSString*)name {
+    if ([receivers count] == 0) {
+        return;
+    }
+
+    // Update the global receiver table ...
+    [_allReceivers minusSet:receivers];
+
+    // ... and the name lookup tables.
+    if (name) {
+        // Fast path: remove these observers from the provided name's table.
+        StrongId<NSMutableSet<_NSNotificationReceiver*>> nameReceivers = [self _receiverSetForNotificationName:name createIfMissing:NO];
+        if (!nameReceivers) {
+            return;
+        }
+
+        [nameReceivers minusSet:receivers];
+
+        if ([nameReceivers count] == 0) {
+            // This can release nameReceivers; it will be retained for the scope of this method.
+            [_observers removeObjectForKey:name];
+        }
+    } else {
+        // Slow path: remove these observers from every name table.
+        NSArray<NSString*>* copiedAllKeys = [[_observers allKeys] copy];
+        for (NSString* key in copiedAllKeys) {
+            StrongId<NSMutableSet<_NSNotificationReceiver*>> nameReceivers = [_observers objectForKey:key];
+            [nameReceivers minusSet:receivers];
+            if ([nameReceivers count] == 0) {
+                [_observers removeObjectForKey:name];
+            }
+        }
+        [copiedAllKeys release];
+    }
 }
 
 /**
  @Status Interoperable
 */
 - (void)postNotificationName:(NSString*)name object:(NSObject*)sender {
-    NSNotification* notification = [[NSNotification alloc] initWithName:name object:sender userInfo:nil];
+    [self postNotificationName:name object:sender userInfo:nil];
+}
+
+/**
+ @Status Interoperable
+*/
+- (void)postNotificationName:(NSString*)name object:(NSObject*)sender userInfo:(NSDictionary*)userInfo {
+    // Since object could be mid-deallocation, this notification must not be leaked into an autorelease pool.
+    StrongId<NSNotification> notification;
+    notification.attach([[NSNotification alloc] initWithName:name object:sender userInfo:userInfo]);
     [self postNotification:notification];
-    [notification release];
 }
 
 /**
@@ -90,140 +211,82 @@ static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* k
 - (void)postNotification:(NSNotification*)notification {
     NSString* name = [notification name];
 
-    NSArray* arr = arrayForObservers(self, name);
-    if (arr == nil) {
+    // This method does not use _receiversForName:(...) above as it treats a nil _notification_ sender as a wildcard.
+    // We want to treat a nil _receiver_ sender as a wildcard.
+    std::vector<StrongId<_NSNotificationReceiver>> validReceivers{ 0 };
+    @synchronized(self) {
+        NSMutableSet<_NSNotificationReceiver*>* receivers = [self _receiverSetForNotificationName:name createIfMissing:NO];
+        if (!receivers) {
+            return;
+        }
+
+        NSObject* sender = [notification object];
+        validReceivers.reserve([receivers count]);
+        for (_NSNotificationReceiver* receiver in receivers) {
+            if (receiver->sender == nil || receiver->sender == sender) {
+                validReceivers.emplace_back(receiver);
+            }
+        }
+    }
+
+    // Notification post happens outside of the lock over self; receivers are allowed to
+    // manipulate the notification center's state.
+
+    // Receivers are retained for the duration of this notification post.
+    for (auto& receiver : validReceivers) {
+        [receiver postNotification:notification];
+    }
+}
+
+- (void)_addObserver:(id)observer selector:(SEL)selector name:(NSString*)name object:(id)object withOwningReference:(BOOL)owningReference {
+    if (!name || !observer || !selector) {
         return;
     }
 
-    NSObject* sender = [notification object];
-    int count = CFArrayGetCount((CFArrayRef)arr);
-    unsigned int numSendTo = 0;
-    id* sendTo = (id*)IwMalloc(count * sizeof(id));
-    for (unsigned int i = 0; i < count; i++) {
-        NSNotificationReceiver* observer = (NSNotificationReceiver*)CFArrayGetValueAtIndex((CFArrayRef)arr, i);
-        if (!observer->valid) {
-            continue;
-        }
-        if (observer->notificationSender != NULL && observer->notificationSender != sender) {
-            continue;
-        }
+    _NSNotificationReceiver* newReceiver = [_NSNotificationReceiver new];
 
-        sendTo[numSendTo] = observer;
-        [sendTo[numSendTo++] retain];
+    newReceiver->observer = observer; // If owningReference, observer bears a +1 internal retain count.
+    newReceiver->ownsObserver = owningReference;
+    newReceiver->selector = selector;
+    newReceiver->sender = object;
+    newReceiver->name = [name copy]; // Contractually released by _NSNotificationReceiver.
+
+    @synchronized(self) {
+        [self _addReceiver:newReceiver];
     }
 
-    for (unsigned int i = 0; i < numSendTo; i++) {
-        NSNotificationReceiver* observer = sendTo[i];
-
-        if (!observer->valid) {
-            [observer release];
-            continue;
-        }
-
-        if (!observer->block) {
-            [observer->object performSelector:observer->selector withObject:notification];
-        } else {
-            observer->block(notification);
-        }
-        [observer release];
-    }
-    IwFree(sendTo);
+    [newReceiver release];
 }
 
 /**
  @Status Interoperable
 */
-- (void)postNotificationName:(NSString*)name object:(NSObject*)sender userInfo:(NSDictionary*)userInfo {
-    NSNotification* notification = [NSNotification notificationWithName:name object:sender userInfo:userInfo];
-
-    [self postNotification:notification];
+- (void)addObserver:(id)observer selector:(SEL)selector name:(NSString*)name object:(id)object {
+    [self _addObserver:observer selector:selector name:name object:object withOwningReference:NO];
 }
 
 /**
  @Status Interoperable
-*/
-- (void)addObserver:(id)observer selector:(SEL)selName name:(NSString*)name object:(id)object {
-    if (name == nil) {
-        return;
-    }
-
-    NSNotificationReceiver* newObserver = [NSNotificationReceiver new];
-
-    newObserver->object = observer;
-    newObserver->selector = selName;
-    newObserver->notificationSender = object;
-    newObserver->valid = true;
-
-    [arrayForObservers(self, name, true) addObject:newObserver];
-    [newObserver release];
-}
-
-/**
- @Status Caveat
- @Notes queue parameter not supported
 */
 - (id<NSObject>)addObserverForName:(NSString*)name
                             object:(id)object
-                             queue:(NSNotificationQueue*)queue
+                             queue:(NSOperationQueue*)queue
                         usingBlock:(void (^)(NSNotification*))block {
-    if (queue != nil) {
-        TraceVerbose(TAG, L"addObserverForName: queue != nil!");
-        assert(0);
-        return nil;
-    }
-
-    NSNotificationReceiver* newObserver = [NSNotificationReceiver new];
-
-    newObserver->object = [NSObject new]; //  Placeholder object for observer
-    newObserver->block = [block copy];
-    newObserver->selector = NULL;
-    newObserver->notificationSender = object;
-    newObserver->valid = true;
-
-    [arrayForObservers(self, name, true) addObject:newObserver];
-    [newObserver release];
-
-    return newObserver->object;
+    // The documentation states that this method returns an opaque object that acts as the observer, and
+    // the returned observer should be able to be removed with `removeObserver:`.
+    // To make that work, we must register this observer object just like a normal observer.
+    _NSNotificationBlockObserver* blockObserver = [[_NSNotificationBlockObserver alloc] initWithBlock:block queue:queue];
+    [self _addObserver:blockObserver selector:@selector(invokeWithNotification:) name:name object:object withOwningReference:YES];
+    return blockObserver;
 }
 
 /**
  @Status Interoperable
 */
 - (void)removeObserver:(id)observer name:(NSString*)name object:(id)object {
-    id arr = arrayForObservers(self, name);
-    if (arr == nil) {
-        return;
-    }
-
-    int numItems = CFArrayGetCount((CFArrayRef)arr);
-
-    for (int i = numItems - 1; i >= 0; i--) {
-        NSNotificationReceiver* curObserver = (NSNotificationReceiver*)CFArrayGetValueAtIndex((CFArrayRef)arr, i);
-
-        if (!curObserver->valid) {
-            continue;
-        }
-        if (curObserver->object != observer) {
-            continue;
-        }
-        if (object != nil && curObserver->notificationSender != object) {
-            continue;
-        }
-
-        curObserver->valid = false;
-        if (curObserver->block) {
-            [curObserver->block release];
-            [curObserver->object release];
-            curObserver->block = nil;
-            curObserver->object = nil;
-        }
-
-        // Remove the object *after* freeing its block and object
-        CFArrayRemoveValueAtIndex((CFMutableArrayRef)arr, i);
-    }
-
-    if (CFArrayGetCount((CFArrayRef)arr) == 0) {
-        [observers removeObjectForKey:name];
+    @synchronized(self) {
+        NSSet<_NSNotificationReceiver*>* receiversToRemove = [self _receiversForName:name observer:observer object:object];
+        [self _removeReceivers:receiversToRemove forName:name];
     }
 }
 
@@ -231,10 +294,9 @@ static NSMutableArray* arrayForObservers(NSNotificationCenter* self, NSString* k
  @Status Interoperable
 */
 - (void)removeObserver:(id)observer {
-    NSArray* copiedAllKeys = [[observers allKeys] copy];
-    for (NSString* curName in copiedAllKeys) {
-        [self removeObserver:observer name:curName object:nil];
+    @synchronized(self) {
+        NSSet<_NSNotificationReceiver*>* receiversToRemove = [self _receiversForName:nil observer:observer object:nil];
+        [self _removeReceivers:receiversToRemove forName:nil];
     }
-    [copiedAllKeys release];
 }
 @end

--- a/tests/unittests/Foundation/NSNotificationTests.mm
+++ b/tests/unittests/Foundation/NSNotificationTests.mm
@@ -15,7 +15,54 @@
 //******************************************************************************
 
 #include <TestFramework.h>
+#import <Starboard/SmartTypes.h>
 #import <Foundation/Foundation.h>
+
+// Avoid "property access result unused" warnings by _consume-ing the value of a property accessor.
+template <typename... T>
+static inline void _consume(T&&...) {
+}
+
+TEST(NSNotification, CanCreate) {
+    EXPECT_OBJCNE(nil, [NSNotification notificationWithName:@"name" object:nil userInfo:nil]);
+}
+
+@interface BadNSNotificationSubclass : NSNotification
+@end
+@implementation BadNSNotificationSubclass
+- (id)init {
+    // NSNotification subclasses are barred from calling [super init].
+    return self;
+}
+@end
+
+TEST(NSNotification, InvalidSubclassThrows) {
+    EXPECT_ANY_THROW([BadNSNotificationSubclass notificationWithName:@"name" object:nil userInfo:nil]);
+
+    BadNSNotificationSubclass* bad = [[BadNSNotificationSubclass alloc] init];
+    EXPECT_ANY_THROW(_consume(bad.name));
+    EXPECT_ANY_THROW(_consume(bad.userInfo));
+    EXPECT_ANY_THROW(_consume(bad.object));
+
+    [bad release];
+}
+
+TEST(NSNotification, CanEncodeAndDecode) {
+    NSNotification* notification = [NSNotification notificationWithName:@"Name1" object:@"Object1" userInfo:@{ @"Key1" : @"Value1" }];
+    NSData* data = nil;
+    ASSERT_NO_THROW(data = [NSKeyedArchiver archivedDataWithRootObject:notification]);
+
+    NSNotification* newNotification = nil;
+    ASSERT_NO_THROW(newNotification = [NSKeyedUnarchiver unarchiveObjectWithData:data]);
+
+    EXPECT_NE(notification,
+              newNotification); // pointer comparison: notifications cannot be compared with isEqual:, and this should be a new instance.
+
+    EXPECT_OBJCEQ(notification.name, newNotification.name);
+    EXPECT_OBJCEQ(notification.object, newNotification.object);
+    EXPECT_OBJCEQ(notification.userInfo, newNotification.userInfo);
+}
+
 @interface TestObjectA : NSObject
 @end
 

--- a/tests/unittests/Foundation/NSNotificationTests.mm
+++ b/tests/unittests/Foundation/NSNotificationTests.mm
@@ -75,5 +75,404 @@ TEST(NSNotification, CanEncodeAndDecode) {
 @end
 
 TEST(NSNotificationCenter, PostNotificationFromDealloc) {
-    TestObjectA* obj = [[TestObjectA new] autorelease];
+    @autoreleasepool {
+        TestObjectA* obj = [[TestObjectA new] autorelease];
+    }
+}
+
+TEST(NSNotificationCenter, BlockRegistrationDeregistration) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    __block int counter = 0;
+
+    id token = [notificationCenter addObserverForName:s_TestNotificationName
+                                               object:nil
+                                                queue:nil
+                                           usingBlock:^(NSNotification* note) {
+                                               ++counter;
+                                               ASSERT_OBJCEQ(s_TestNotificationName, note.name);
+                                           }];
+
+    EXPECT_OBJCNE(nil, token);
+    ASSERT_EQ(0, counter); // Adding a notification should not fire it.
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+    ASSERT_EQ(1, counter);
+
+    [notificationCenter postNotificationName:@"UnrelatedNotification" object:nil];
+    ASSERT_EQ(1, counter); // An unrelated notification should not fire this token.
+
+    [notificationCenter removeObserver:token]; // Unregister this observer from every named notification.
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+    ASSERT_EQ(1, counter); // An unregistered observer should never fire.
+}
+
+// Like the above test, but the block unregisters the observer immediately.
+TEST(NSNotificationCenter, BlockFireOnce) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    __block int counter = 0;
+
+    __block id token = [notificationCenter addObserverForName:s_TestNotificationName
+                                                       object:nil
+                                                        queue:nil
+                                                   usingBlock:^(NSNotification* note) {
+                                                       ++counter;
+                                                       ASSERT_OBJCEQ(s_TestNotificationName, note.name);
+                                                       [notificationCenter removeObserver:token];
+                                                   }];
+
+    EXPECT_OBJCNE(nil, token);
+    ASSERT_EQ(0, counter); // Adding a notification should not fire it.
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+    ASSERT_EQ(1, counter);
+
+    EXPECT_NO_THROW([notificationCenter removeObserver:token]); // Double-unregistering this observer should not fail.
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+    ASSERT_EQ(1, counter); // An unregistered observer should never fire.
+}
+
+TEST(NSNotificationCenter, BlockWithQueue) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    __block int counter = 0;
+
+    NSOperationQueue* queue = [[NSOperationQueue new] autorelease];
+    queue.maxConcurrentOperationCount = 1;
+
+    __block id token = [notificationCenter addObserverForName:s_TestNotificationName
+                                                       object:nil
+                                                        queue:queue
+                                                   usingBlock:^(NSNotification* note) {
+                                                       ++counter;
+                                                       ASSERT_OBJCEQ(s_TestNotificationName, note.name);
+                                                       [notificationCenter removeObserver:token];
+                                                   }];
+
+    [queue addOperationWithBlock:^{
+        ASSERT_EQ(0, counter);
+    }];
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+
+    [queue waitUntilAllOperationsAreFinished];
+
+    ASSERT_EQ_MSG(1, counter, "the block should not have fired; its queue is suspended.");
+}
+
+// NSNotificationTestObserver resopnds to all selectors and keeps track of them.
+@interface NSNotificationTestObserver : NSObject {
+    NSMutableDictionary<NSString*, NSNumber*>* _selectorHits;
+}
+@end
+
+@implementation NSNotificationTestObserver
+- (BOOL)respondsToSelector:(SEL)selector {
+    return YES;
+}
+
+- (NSMethodSignature*)methodSignatureForSelector:(SEL)selector {
+    return [NSMethodSignature signatureWithObjCTypes:"v@:@"];
+}
+
+- (void)forwardInvocation:(NSInvocation*)invocation {
+    NSString* key = NSStringFromSelector(invocation.selector);
+    @synchronized(self) {
+        if (!_selectorHits) {
+            _selectorHits = [NSMutableDictionary new];
+        }
+        _selectorHits[key] = @([_selectorHits[key] unsignedIntegerValue] + 1);
+    }
+}
+
+- (void)dealloc {
+    [_selectorHits release];
+    [super dealloc];
+}
+
+- (NSUInteger)hitsForSelector:(SEL)selector {
+    NSString* key = NSStringFromSelector(selector);
+    return [_selectorHits[key] unsignedIntegerValue];
+}
+
+- (NSUInteger)uniqueHits {
+    return _selectorHits.count;
+}
+
+- (NSUInteger)totalHits {
+    __block NSUInteger count = 0;
+    [_selectorHits enumerateKeysAndObjectsUsingBlock:^(NSString* key, NSNumber* value, BOOL* stop) {
+        count += [value unsignedIntegerValue];
+    }];
+    return count;
+}
+@end
+
+TEST(NSNotificationCenter, SingleNonspecificDelivery) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    NSNotificationTestObserver* observer = [[NSNotificationTestObserver new] autorelease];
+
+    [notificationCenter addObserver:observer selector:@selector(uniqueSelector1:) name:s_TestNotificationName object:nil];
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(uniqueSelector1:)]);
+    EXPECT_EQ(1, [observer uniqueHits]);
+    EXPECT_EQ(1, [observer totalHits]);
+}
+
+TEST(NSNotificationCenter, SingleSpecificDelivery) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    NSNotificationTestObserver* observer = [[NSNotificationTestObserver new] autorelease];
+
+    NSObject* object1 = [[NSObject new] autorelease];
+    NSObject* object2 = [[NSObject new] autorelease];
+
+    [notificationCenter addObserver:observer selector:@selector(listeningForObject1:) name:s_TestNotificationName object:object1];
+    [notificationCenter addObserver:observer selector:@selector(listeningForObject2:) name:s_TestNotificationName object:object2];
+    [notificationCenter addObserver:observer selector:@selector(listeningForNoObject:) name:s_TestNotificationName object:nil];
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:object1];
+    [notificationCenter postNotificationName:s_TestNotificationName object:object2];
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForObject1:)]);
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForObject2:)]);
+    EXPECT_EQ(3, [observer hitsForSelector:@selector(listeningForNoObject:)]);
+    EXPECT_EQ(3, [observer uniqueHits]);
+    EXPECT_EQ(5, [observer totalHits]);
+
+    [notificationCenter removeObserver:observer name:s_TestNotificationName object:object1]; // Remove only the object1 observer.
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:object1];
+    [notificationCenter postNotificationName:s_TestNotificationName object:object2];
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForObject1:)]);
+    EXPECT_EQ(2, [observer hitsForSelector:@selector(listeningForObject2:)]);
+    EXPECT_EQ(6, [observer hitsForSelector:@selector(listeningForNoObject:)]);
+    EXPECT_EQ(3, [observer uniqueHits]);
+    EXPECT_EQ(9, [observer totalHits]);
+
+    [notificationCenter removeObserver:observer
+                                  name:s_TestNotificationName
+                                object:nil]; // Remove both remaining listeners (object=nil: no object criterion)
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:object1];
+    [notificationCenter postNotificationName:s_TestNotificationName object:object2];
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForObject1:)]); // Same values as above.
+    EXPECT_EQ(2, [observer hitsForSelector:@selector(listeningForObject2:)]);
+    EXPECT_EQ(6, [observer hitsForSelector:@selector(listeningForNoObject:)]);
+    EXPECT_EQ(3, [observer uniqueHits]);
+    EXPECT_EQ(9, [observer totalHits]);
+}
+
+TEST(NSNotificationCenter, MultipleNonspecificDelivery) {
+    static NSString* s_TestNotificationName1 = @(GetTestFullName().c_str());
+    static NSString* s_TestNotificationName2 = [@(GetTestFullName().c_str()) stringByAppendingString:@"Two"];
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    NSNotificationTestObserver* observer = [[NSNotificationTestObserver new] autorelease];
+
+    [notificationCenter addObserver:observer selector:@selector(listeningForNotification1:) name:s_TestNotificationName1 object:nil];
+    [notificationCenter addObserver:observer selector:@selector(listeningForNotification2:) name:s_TestNotificationName2 object:nil];
+
+    [notificationCenter postNotificationName:s_TestNotificationName1 object:nil];
+    [notificationCenter postNotificationName:s_TestNotificationName2 object:nil];
+
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForNotification1:)]);
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForNotification2:)]);
+    EXPECT_EQ(2, [observer uniqueHits]);
+    EXPECT_EQ(2, [observer totalHits]);
+
+    [notificationCenter removeObserver:observer name:s_TestNotificationName2 object:nil]; // Remove the notification2 listener.
+
+    [notificationCenter postNotificationName:s_TestNotificationName1 object:nil];
+    [notificationCenter postNotificationName:s_TestNotificationName2 object:nil];
+
+    EXPECT_EQ(2, [observer hitsForSelector:@selector(listeningForNotification1:)]);
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForNotification2:)]);
+    EXPECT_EQ(2, [observer uniqueHits]);
+    EXPECT_EQ(3, [observer totalHits]);
+
+    [notificationCenter removeObserver:observer name:nil object:nil]; // Remove the other remaining listener (name=nil: no name criterion)
+
+    [notificationCenter postNotificationName:s_TestNotificationName1 object:nil];
+    [notificationCenter postNotificationName:s_TestNotificationName2 object:nil];
+
+    EXPECT_EQ(2, [observer hitsForSelector:@selector(listeningForNotification1:)]); // Same values as above.
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForNotification2:)]);
+    EXPECT_EQ(2, [observer uniqueHits]);
+    EXPECT_EQ(3, [observer totalHits]);
+}
+
+TEST(NSNotificationCenter, MultipleSpecificDelivery) {
+    static NSString* s_TestNotificationName1 = @(GetTestFullName().c_str());
+    static NSString* s_TestNotificationName2 = [@(GetTestFullName().c_str()) stringByAppendingString:@"Two"];
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    NSNotificationTestObserver* observer = [[NSNotificationTestObserver new] autorelease];
+
+    NSObject* object1 = [[NSObject new] autorelease];
+    NSObject* object2 = [[NSObject new] autorelease];
+
+    [notificationCenter addObserver:observer
+                           selector:@selector(listeningForNotification1Object1:)
+                               name:s_TestNotificationName1
+                             object:object1];
+    [notificationCenter addObserver:observer
+                           selector:@selector(listeningForNotification2Object1:)
+                               name:s_TestNotificationName2
+                             object:object1];
+    [notificationCenter addObserver:observer
+                           selector:@selector(listeningForNotification1Object2:)
+                               name:s_TestNotificationName1
+                             object:object2];
+    [notificationCenter addObserver:observer
+                           selector:@selector(listeningForNotification2Object2:)
+                               name:s_TestNotificationName2
+                             object:object2];
+
+    [notificationCenter postNotificationName:s_TestNotificationName1 object:object1];
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForNotification1Object1:)]);
+    EXPECT_EQ(1, [observer uniqueHits]);
+    EXPECT_EQ(1, [observer totalHits]);
+
+    [notificationCenter postNotificationName:s_TestNotificationName1 object:object2];
+    EXPECT_EQ(1, [observer hitsForSelector:@selector(listeningForNotification1Object2:)]);
+    EXPECT_EQ(2, [observer uniqueHits]);
+    EXPECT_EQ(2, [observer totalHits]);
+
+    [notificationCenter postNotificationName:s_TestNotificationName2 object:nil];
+    EXPECT_EQ(2, [observer totalHits]); // No more hits: no listeners for nil object.
+
+    [notificationCenter removeObserver:observer name:s_TestNotificationName1 object:nil]; // Remove the notification1 listener entirely.
+
+    [notificationCenter postNotificationName:s_TestNotificationName1 object:object1];
+    EXPECT_EQ(2, [observer totalHits]); // No more hits: all notification1 listeners removed.
+
+    [notificationCenter removeObserver:observer name:nil object:object2]; // Remove the all object2 listeners.
+
+    [notificationCenter postNotificationName:s_TestNotificationName2 object:object2];
+    EXPECT_EQ(2, [observer totalHits]); // No more hits: all object2 listeners removed.
+
+    [notificationCenter postNotificationName:s_TestNotificationName2 object:object1];
+    EXPECT_EQ(3, [observer totalHits]); // One more hit: object1+notification2 still registered.
+}
+
+TEST(NSNotificationCenter, ContentiousDelivery) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    NSNotificationTestObserver* observer = [[NSNotificationTestObserver new] autorelease];
+
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    dispatch_group_t group = dispatch_group_create();
+
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER); // wait to start
+        for (int i = 0; i < 100; ++i) {
+            [notificationCenter addObserver:observer selector:@selector(deliveredNotification:) name:s_TestNotificationName object:nil];
+        }
+    });
+
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER); // wait to start
+        for (int i = 0; i < 100; ++i) {
+            [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+        }
+    });
+
+    dispatch_semaphore_signal(sem);
+    dispatch_semaphore_signal(sem); // Trigger starts
+
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER); // Wait for completion.
+
+    EXPECT_LT(0, observer.totalHits);
+    ASSERT_GE(100 * 100, observer.totalHits);
+}
+
+TEST(NSNotificationCenter, ContentiousDeliveryRemoval) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    NSNotificationTestObserver* observer = [[NSNotificationTestObserver new] autorelease];
+
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    dispatch_group_t group = dispatch_group_create();
+
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER); // wait to start
+        for (int i = 0; i < 100; ++i) {
+            [notificationCenter addObserver:observer selector:@selector(deliveredNotification:) name:s_TestNotificationName object:nil];
+        }
+    });
+
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER); // wait to start
+        for (int i = 0; i < 100; ++i) {
+            [notificationCenter removeObserver:observer];
+        }
+    });
+
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER); // wait to start
+        for (int i = 0; i < 100; ++i) {
+            [notificationCenter postNotificationName:s_TestNotificationName object:nil];
+        }
+    });
+
+    dispatch_semaphore_signal(sem);
+    dispatch_semaphore_signal(sem);
+    dispatch_semaphore_signal(sem); // Trigger starts
+
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER); // Wait for completion.
+
+    // Between 0 and 10000 notifications should have fired; this stress test simply proves that we can manipulate the three states
+    // simultaneously.
+    EXPECT_LE(0, observer.totalHits);
+    ASSERT_GE(100 * 100, observer.totalHits);
+}
+
+TEST(NSNotificationCenter, UserInfo) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    __block int counter = 0;
+
+    __block id token = [notificationCenter addObserverForName:s_TestNotificationName
+                                                       object:nil
+                                                        queue:nil
+                                                   usingBlock:^(NSNotification* note) {
+                                                       ++counter;
+                                                       ASSERT_OBJCEQ(s_TestNotificationName, note.name);
+                                                       ASSERT_OBJCEQ(@{ @"Hello" : @"World" }, note.userInfo);
+                                                       [notificationCenter removeObserver:token];
+                                                   }];
+
+    [notificationCenter postNotificationName:s_TestNotificationName object:nil userInfo:@{ @"Hello" : @"World" }];
+    ASSERT_EQ(1, counter);
+}
+
+TEST(NSNotificationCenter, ManuallyCreatedNotification) {
+    static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
+    NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
+    __block int counter = 0;
+
+    __block NSNotification* notification = [NSNotification notificationWithName:s_TestNotificationName object:nil userInfo:@{}];
+
+    __block id token = [notificationCenter addObserverForName:s_TestNotificationName
+                                                       object:nil
+                                                        queue:nil
+                                                   usingBlock:^(NSNotification* note) {
+                                                       ++counter;
+                                                       ASSERT_OBJCEQ(notification, note);
+                                                       [notificationCenter removeObserver:token];
+                                                   }];
+
+    [notificationCenter postNotification:notification];
+    ASSERT_EQ(1, counter);
 }


### PR DESCRIPTION
This pull request guts and reimplements both **NSNotificationCenter** and **NSNotification**.

NSNotification is supposed to be a class cluster. It it was empirically observed that non-concrete instances could still encode/decode, but would fail with abstract invocation exceptions on the property getter.

NSNotificationCenter is vastly improved. It:
* Uses sets for quick lookup, since notification order bears no guarantees
* Maintains a set of all receivers (for quick name-free removal)
* Maintains a mapping from notification name to interested receivers (for quick dispatch)
* Now supports enqueuing notification blocks on queues
* Fulfills the contractual obligations of `addObserverForName:object:queue:usingBlock:`
* Has no caveats
* Is thread-safe
* Is tested

Fixes #2391.