### PR TITLE
Redo Any CPU build multiplexing

### DIFF
--- a/build/BuildSupport/TestPlatformMultiplexer.msbuildproj
+++ b/build/BuildSupport/TestPlatformMultiplexer.msbuildproj
@@ -82,7 +82,7 @@
     </MSBuild>
   </Target>
 
-    <!-- 
+  <!-- 
     In the above BuildForSinglePlatform target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
   -->
   <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(ShouldCauseTestsToBuild)' == 'true'">

--- a/build/BuildSupport/TestPlatformMultiplexer.msbuildproj
+++ b/build/BuildSupport/TestPlatformMultiplexer.msbuildproj
@@ -48,7 +48,7 @@
 
   <!-- This is where the fun starts. Any custom generic msbuild project goop goes here. -->
   <ItemGroup>
-    <!-- Add the nuprojs as project reference under AnyCPU so there isn't parallel contention to build thge same project. 
+    <!-- Add the nuprojs as project reference under AnyCPU so there isn't parallel contention to build the same project. 
          Since this project and the .nuprojs do build multiplexing internally, separate processes could wind up building
          frameworks at the same time. This is avoided by causing the nuprojs to be built first and getting that multiplexing out of the way. -->
     <ProjectReference Condition="'$(Platform)' == 'AnyCPU'" Include="$(SolutionDir)\**\*.nuproj" />
@@ -81,4 +81,16 @@
          Properties="Platform=%(_PlatformToBuild.Identity)">
     </MSBuild>
   </Target>
+
+    <!-- 
+    In the above BuildForSinglePlatform target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+  -->
+  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(ShouldCauseTestsToBuild)' == 'true'">
+    <ItemGroup>
+      <ProjectReference>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);ShouldCauseTestsToBuild;</GlobalPropertiesToRemove>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/build/BuildSupport/TestPlatformMultiplexer.msbuildproj
+++ b/build/BuildSupport/TestPlatformMultiplexer.msbuildproj
@@ -83,7 +83,9 @@
   </Target>
 
   <!-- 
-    In the above BuildForSinglePlatform target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+    In the above BuildForSinglePlatform target, several properties are injected into this project so that this project knows 
+    if its being multiplexed or not. Don't pass on this extra information to project references as it can cause issues with MSBuild 
+    knowing if a project is already built.
   -->
   <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(ShouldCauseTestsToBuild)' == 'true'">
     <ItemGroup>

--- a/common/winobjc.nuproj.common.props
+++ b/common/winobjc.nuproj.common.props
@@ -9,6 +9,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <UpdateAssemblyInfo>false</UpdateAssemblyInfo>
     <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
+    <GetPackageContentsDependsOn>ResolveReferences;$(GetPackageContentsDependsOn)</GetPackageContentsDependsOn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,7 +17,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <_CoreCompileOverrideDependsOn Condition="'$(SkipGetPackageContentsForOtherPlatforms)' != 'true'">Pack</_CoreCompileOverrideDependsOn>
     <IsPackable Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">false</IsPackable>
   </PropertyGroup>
 

--- a/common/winobjc.nuproj.common.targets
+++ b/common/winobjc.nuproj.common.targets
@@ -37,7 +37,9 @@
   </Target>
 
   <!-- 
-    In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+    In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows 
+    if its being multiplexed or not. Don't pass on this extra information to project references as it can cause issues with MSBuild 
+    knowing if a project is already built.
   -->
   <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences">
     <PropertyGroup>
@@ -46,7 +48,7 @@
     </PropertyGroup>
     <ItemGroup>
       <ProjectReference>
-        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemove);;</GlobalPropertiesToRemove>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemove);</GlobalPropertiesToRemove>
       </ProjectReference>
     </ItemGroup>
   </Target>

--- a/common/winobjc.nuproj.common.targets
+++ b/common/winobjc.nuproj.common.targets
@@ -38,20 +38,16 @@
 
   <!-- 
     In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
-
-    Additionally, remove any .nuproj to .nuproj project references when going around the second time. This is because GetPackageContents will pass
-    through a BuildingPackage global property. This property will trigger a rebuild of the dependent nuproj's dependencies because of GetPackageContents
-    depending on ResolveReferences. This is all very confusing.
   -->
-  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">
+  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences">
+    <PropertyGroup>
+      <_GlobalPropertiesToRemove>BuildingPackage;</_GlobalPropertiesToRemove>
+      <_GlobalPropertiesToRemove Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">$(_GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;</_GlobalPropertiesToRemove>
+    </PropertyGroup>
     <ItemGroup>
       <ProjectReference>
-        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;</GlobalPropertiesToRemove>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemove);;</GlobalPropertiesToRemove>
       </ProjectReference>
-
-      <!-- Don't evaluate nuproj to nuproj project references again in the multiplex'ed case. They were already evaluated before and nuprojs dependencies 
-           don't need multiplexed since its just ends up as a nuget dep. -->
-      <ProjectReference Remove="*.nuproj" />
     </ItemGroup>
   </Target>
 

--- a/common/winobjc.nuproj.common.targets
+++ b/common/winobjc.nuproj.common.targets
@@ -38,12 +38,20 @@
 
   <!-- 
     In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+
+    Additionally, remove any .nuproj to .nuproj project references when going around the second time. This is because GetPackageContents will pass
+    through a BuildingPackage global property. This property will trigger a rebuild of the dependent nuproj's dependencies because of GetPackageContents
+    depending on ResolveReferences. This is all very confusing.
   -->
   <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">
     <ItemGroup>
       <ProjectReference>
         <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;</GlobalPropertiesToRemove>
       </ProjectReference>
+
+      <!-- Don't evaluate nuproj to nuproj project references again in the multiplex'ed case. They were already evaluated before and nuprojs dependencies 
+           don't need multiplexed since its just ends up as a nuget dep. -->
+      <ProjectReference Remove="*.nuproj" />
     </ItemGroup>
   </Target>
 

--- a/common/winobjc.nuproj.common.targets
+++ b/common/winobjc.nuproj.common.targets
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="CoreCompile" DependsOnTargets="$(_CoreCompileOverrideDependsOn)" />
-
   <Target Name="AddSingleConfigBuildOutput"  Returns="@(_PackageContentsForPlat)"> 
     <MSBuild Projects="$(SolutionPath)"
        Targets="GetSolutionConfigurationContents"
@@ -14,7 +12,7 @@
 
     <MSBuild Projects="$(MSBuildProjectFile)"
        Targets="GetPackageContents"
-       Properties="SkipGetPackageContentsForOtherPlatforms=true;BuildingInsideVisualStudio=false;BuildProjectReferences=true;Configuration=$(Configuration);Platform=$(Platform);CurrentSolutionConfigurationContents=%(_SolutionConfigurationContents.Identity);GetPackageContentsDependsOn=Build;$(GetPackageContentsDependsOn)">
+       Properties="SkipGetPackageContentsForOtherPlatforms=true;BuildingInsideVisualStudio=false;BuildProjectReferences=true;Configuration=$(Configuration);Platform=$(Platform);CurrentSolutionConfigurationContents=%(_SolutionConfigurationContents.Identity);">
       <Output TaskParameter="TargetOutputs" ItemName="_PackageContentsForPlat" />
     </MSBuild>
   </Target>
@@ -36,6 +34,17 @@
       <PackageFile Include="@(_OtherPackageContents)" />
     </ItemGroup>
 
+  </Target>
+
+  <!-- 
+    In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+  -->
+  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">
+    <ItemGroup>
+      <ProjectReference>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;</GlobalPropertiesToRemove>
+      </ProjectReference>
+    </ItemGroup>
   </Target>
 
   <PropertyGroup>

--- a/msvc/sdk-build.props
+++ b/msvc/sdk-build.props
@@ -35,6 +35,7 @@
     <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'==''">10.0.10586.0</WindowsTargetPlatformMinVersion>
     <EnableDotNetNativeCompatibleProfile Condition="'$(EnableDotNetNativeCompatibleProfile)'==''">true</EnableDotNetNativeCompatibleProfile>
     <IncludeOutputsInPackage>false</IncludeOutputsInPackage>
+    <IncludeFrameworkReferencesInPackage>false</IncludeFrameworkReferencesInPackage>
     <TargetOsAndVersion Condition="'$(TargetOsAndVersion)' == ''">Universal Windows</TargetOsAndVersion>
     <TargetFramework>uap10.0</TargetFramework>
   </PropertyGroup>

--- a/msvc/sdk-build.targets
+++ b/msvc/sdk-build.targets
@@ -34,14 +34,6 @@
     <PackageContentBasePath Condition="'$(ShouldAssignPackageContentBasePath)' == 'true' and '$(HasConfigurationSpecificPackageContents)' == 'true'">$(PackageContentBasePath)\$(Configuration)</PackageContentBasePath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ConfigurationType)' == 'DynamicLibrary' or '$(ConfigurationType)' == 'Application'">
-      <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);$(ComputeLinkInputsTargets)</GetPackageContentsDependsOn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(AppContainerApplication)' == 'true'">
-      <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);_GenerateProjectPriFileCore</GetPackageContentsDependsOn>
-  </PropertyGroup>
-
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents" DependsOnTargets="$(GetPackageContentsDependsOn)" Condition="'$(ConfigurationType)' == 'DynamicLibrary' or '$(ConfigurationType)' == 'Application'">
     <ItemGroup>
       <!-- Public include folder for project  -->

--- a/msvc/sdk-build.targets
+++ b/msvc/sdk-build.targets
@@ -39,6 +39,11 @@
       <!-- Public include folder for project  -->
       <_IncludeFiles Include="$(MSBuildThisFileDirectory)..\include\$(ProjectName)\**\*.*"/>
 
+      <!-- Since GetPackageContents runs in a second pass outside of the normal build, add a tmp Link item -->
+      <Link Include="tmp" Condition="'@(Link)'==''">
+       <DeleteSoon>true</DeleteSoon>
+      </Link>
+      
       <_ImportLibraryFileNames Include="@(Link -> '%(ImportLibrary)')">
       </_ImportLibraryFileNames>
 
@@ -61,6 +66,7 @@
         <PackagePath>$(PackageContentBasePath)\%(Filename)%(Extension)</PackagePath>
       </PackageFile>
 
+      <Link Remove="@(Link)" Condition="'%(Link.DeleteSoon)'=='true'" />
     </ItemGroup>
     
     <PropertyGroup>

--- a/tools/WinObjC.Packaging/WinObjC.Packageable.props
+++ b/tools/WinObjC.Packaging/WinObjC.Packageable.props
@@ -11,6 +11,7 @@
     <!-- NuGet specific properties -->
     <IncludeOutputsInPackage>false</IncludeOutputsInPackage>
     <IncludeContentInPackage>false</IncludeContentInPackage>
+    <IncludeFrameworkReferencesInPackage>false</IncludeFrameworkReferencesInPackage>
 
     <!-- Packaging defaults from WinObjC.Packaging -->
     <IncludeDefaultPackageContents Condition="'$(IncludeDefaultPackageContents)' == ''">true</IncludeDefaultPackageContents>

--- a/tools/WinObjC.Packaging/WinObjC.Packageable.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packageable.targets
@@ -29,12 +29,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);$(ComputeLinkInputsTargets)</GetPackageContentsDependsOn>
     <GetPackageContentsDependsOn Condition="'$(ConfigurationType)' == 'StaticLibrary'">$(GetPackageContentsDependsOn);FindPublicHeaders</GetPackageContentsDependsOn>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(AppContainerApplication)' == 'true'">
-      <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);_GenerateProjectPriFileCore</GetPackageContentsDependsOn>
   </PropertyGroup>
 
   <!-- Add MSBuild outputs into the package -->

--- a/tools/WinObjC.Packaging/WinObjC.Packageable.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packageable.targets
@@ -54,8 +54,18 @@
 
     <!-- WinRT Projects -->
     <ItemGroup Condition="'$(ConfigurationType)' == 'DynamicLibrary'">
+      <!-- Since GetPackageContents runs in a second pass outside of the normal build, add a tmp Link item -->
+      <Link Include="tmp" Condition="'@(Link)'==''">
+       <DeleteSoon>true</DeleteSoon>
+      </Link>
+
       <!-- .dll -->
-      <_BuiltProjectOutputImportLib Include="@(BuiltProjectOutputGroupKeyOutput -> '%(FinalOutputPath)')" />
+      <_BuiltProjectOutputDynamicLib Include="@(BuiltProjectOutputGroupKeyOutput -> '%(FinalOutputPath)')" />
+      <PackageFile Include="@(_BuiltProjectOutputDynamicLib->Distinct())" Condition="Exists('%(FullPath)')">
+        <PackagePath>$(PackageContentBasePath)\%(Filename)%(Extension)</PackagePath>
+      </PackageFile>
+      <!-- .dll import lib -->
+      <_BuiltProjectOutputImportLib Include="@(Link -> '%(ImportLibrary)')" />
       <PackageFile Include="@(_BuiltProjectOutputImportLib->Distinct())" Condition="Exists('%(FullPath)')">
         <PackagePath>$(PackageContentBasePath)\%(Filename)%(Extension)</PackagePath>
       </PackageFile>
@@ -71,6 +81,8 @@
       <PackageFile Include="$(ProjectPriFullPath)" Condition="Exists('$(ProjectPriFullPath)') and Exists('@(WinMDFullPath)')">
         <PackagePath>$(PackageContentBasePath)\%(Filename)%(Extension)</PackagePath>
       </PackageFile>
+
+      <Link Remove="@(Link)" Condition="'%(Link.DeleteSoon)'=='true'" />
     </ItemGroup>
 
     <!-- Bundle Projects -->

--- a/tools/WinObjC.Packaging/WinObjC.Packager.props
+++ b/tools/WinObjC.Packaging/WinObjC.Packager.props
@@ -16,5 +16,7 @@
 
     <!-- WinObjC.Packaging specific properties -->
     <PresetPackageContents Condition="'$(PresetPackageContents)' == ''">true</PresetPackageContents>
+
+    <GetPackageContentsDependsOn>ResolveReferences;$(GetPackageContentsDependsOn)</GetPackageContentsDependsOn>
   </PropertyGroup>
 </Project>

--- a/tools/WinObjC.Packaging/WinObjC.Packager.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packager.targets
@@ -42,12 +42,20 @@
 
   <!-- 
     In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+
+    Additionally, remove any .nuproj to .nuproj project references when going around the second time. This is because GetPackageContents will pass
+    through a BuildingPackage global property. This property will trigger a rebuild of the dependent nuproj's dependencies because of GetPackageContents
+    depending on ResolveReferences. This is all very confusing.
   -->
   <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">
     <ItemGroup>
       <ProjectReference>
         <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;IsPackable;</GlobalPropertiesToRemove>
       </ProjectReference>
+
+      <!-- Don't evaluate nuproj to nuproj project references again in the multiplex'ed case. They were already evaluated before and nuprojs dependencies 
+           don't need multiplexed since its just ends up as a nuget dep. -->
+      <ProjectReference Remove="*.nuproj" />
     </ItemGroup>
   </Target>
 

--- a/tools/WinObjC.Packaging/WinObjC.Packager.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packager.targets
@@ -42,20 +42,14 @@
 
   <!-- 
     In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
-
-    Additionally, remove any .nuproj to .nuproj project references when going around the second time. This is because GetPackageContents will pass
-    through a BuildingPackage global property. This property will trigger a rebuild of the dependent nuproj's dependencies because of GetPackageContents
-    depending on ResolveReferences. This is all very confusing.
   -->
-  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">
+  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences">
+    <_GlobalPropertiesToRemove>BuildingPackage;</_GlobalPropertiesToRemove>
+    <_GlobalPropertiesToRemove Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">$(_GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;IsPackable;</_GlobalPropertiesToRemove>
     <ItemGroup>
       <ProjectReference>
-        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;IsPackable;</GlobalPropertiesToRemove>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);</GlobalPropertiesToRemove>
       </ProjectReference>
-
-      <!-- Don't evaluate nuproj to nuproj project references again in the multiplex'ed case. They were already evaluated before and nuprojs dependencies 
-           don't need multiplexed since its just ends up as a nuget dep. -->
-      <ProjectReference Remove="*.nuproj" />
     </ItemGroup>
   </Target>
 

--- a/tools/WinObjC.Packaging/WinObjC.Packager.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packager.targets
@@ -7,11 +7,6 @@
 -->
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <_CoreCompileOverrideDependsOn Condition="'$(SkipGetPackageContentsForOtherPlatforms)' != 'true'">Pack</_CoreCompileOverrideDependsOn>
-  </PropertyGroup>
-
-  <Target Name="CoreCompile" DependsOnTargets="$(_CoreCompileOverrideDependsOn)" />
 
   <Target Name="AddSingleConfigBuildOutput"  Returns="@(_PackageContentsForPlat)">
     <MSBuild Projects="$(SolutionPath)"
@@ -24,7 +19,7 @@
 
     <MSBuild Projects="$(MSBuildProjectFile)"
        Targets="GetPackageContents"
-       Properties="SkipGetPackageContentsForOtherPlatforms=true;BuildingInsideVisualStudio=false;BuildProjectReferences=true;IsPackable=false;Configuration=$(Configuration);Platform=$(Platform);CurrentSolutionConfigurationContents=%(_SolutionConfigurationContents.Identity);GetPackageContentsDependsOn=Build;$(GetPackageContentsDependsOn)">
+       Properties="SkipGetPackageContentsForOtherPlatforms=true;BuildingInsideVisualStudio=false;BuildProjectReferences=true;IsPackable=false;Configuration=$(Configuration);Platform=$(Platform);CurrentSolutionConfigurationContents=%(_SolutionConfigurationContents.Identity);">
       <Output TaskParameter="TargetOutputs" ItemName="_PackageContentsForPlat" />
     </MSBuild>
   </Target>
@@ -42,6 +37,17 @@
 
     <ItemGroup>
       <PackageFile Include="@(_OtherPackageContents)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- 
+    In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+  -->
+  <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences" Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">
+    <ItemGroup>
+      <ProjectReference>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;IsPackable;</GlobalPropertiesToRemove>
+      </ProjectReference>
     </ItemGroup>
   </Target>
 

--- a/tools/WinObjC.Packaging/WinObjC.Packager.targets
+++ b/tools/WinObjC.Packaging/WinObjC.Packager.targets
@@ -41,14 +41,16 @@
   </Target>
 
   <!-- 
-    In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows if its being multiplexed or not. Don't pass on this extra information to project references as it can issues with MSBuild knowing if a project is already built.
+    In the above AddSingleConfigBuildOutput target, several properties are injected into this project so that this project knows 
+    if its being multiplexed or not. Don't pass on this extra information to project references as it can cause issues with MSBuild 
+    knowing if a project is already built.
   -->
   <Target Name="RemoveGlobalPropertiesFromMultiplexing" BeforeTargets="BeforeResolveReferences">
     <_GlobalPropertiesToRemove>BuildingPackage;</_GlobalPropertiesToRemove>
     <_GlobalPropertiesToRemove Condition="'$(SkipGetPackageContentsForOtherPlatforms)' == 'true'">$(_GlobalPropertiesToRemove);SkipGetPackageContentsForOtherPlatforms;IsPackable;</_GlobalPropertiesToRemove>
     <ItemGroup>
       <ProjectReference>
-        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);</GlobalPropertiesToRemove>
+        <GlobalPropertiesToRemove>%(ProjectReference.GlobalPropertiesToRemove);$(_GlobalPropertiesToRemove);</GlobalPropertiesToRemove>
       </ProjectReference>
     </ItemGroup>
   </Target>

--- a/tools/WinObjCRT/dll/WinObjCRT.vcxproj
+++ b/tools/WinObjCRT/dll/WinObjCRT.vcxproj
@@ -58,7 +58,7 @@
     <None Include="Project.json" />
   </ItemGroup>
 
-    <Target Name="AddSingleConfigBuildOutput"  Returns="@(_PackageContentsForPlat)"> 
+    <Target Name="AddSingleConfigBuildOutput"  Returns="@(_PackageContentsForConfig)"> 
       <MSBuild Projects="$(SolutionPath)"
          Targets="GetSolutionConfigurationContents"
          Properties="Configuration=$(Configuration);Platform=$(PlatformTarget)">
@@ -70,7 +70,7 @@
       <MSBuild Projects="$(MSBuildProjectFile)"
          Targets="GetPackageContents"
          Properties="SkipGetPackageContentsForOtherConfigs=true;BuildingInsideVisualStudio=false;BuildProjectReferences=true;Configuration=$(Configuration);Platform=$(Platform);CurrentSolutionConfigurationContents=%(_SolutionConfigurationContents.Identity);GetPackageContentsDependsOn=Build;$(GetPackageContentsDependsOn);">
-        <Output TaskParameter="TargetOutputs" ItemName="_PackageContentsForPlat" />
+        <Output TaskParameter="TargetOutputs" ItemName="_PackageContentsForConfig" />
       </MSBuild>
     </Target>
 

--- a/tools/common/common-build.props
+++ b/tools/common/common-build.props
@@ -11,6 +11,7 @@
     <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'==''">10.0.10586.0</WindowsTargetPlatformMinVersion>
     <EnableDotNetNativeCompatibleProfile Condition="'$(EnableDotNetNativeCompatibleProfile)'==''">true</EnableDotNetNativeCompatibleProfile>
     <IncludeOutputsInPackage>false</IncludeOutputsInPackage>
+    <IncludeFrameworkReferencesInPackage>false</IncludeFrameworkReferencesInPackage>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(TargetOsAndVersion)\</OutDir>

--- a/tools/common/common-build.targets
+++ b/tools/common/common-build.targets
@@ -10,10 +10,6 @@
     <PackageContentBasePath Condition="'$(ShouldAssignPackageContentBasePath)' == 'true' and '$(HasConfigurationSpecificPackageContents)' == 'true'">$(PackageContentBasePath)\$(Configuration)</PackageContentBasePath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ConfigurationType)' == 'DynamicLibrary' or '$(ConfigurationType)' == 'Application'">
-      <GetPackageContentsDependsOn>$(GetPackageContentsDependsOn);$(ComputeLinkInputsTargets)</GetPackageContentsDependsOn>
-  </PropertyGroup>
-
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents"  DependsOnTargets="$(GetPackageContentsDependsOn)" Condition="'$(ConfigurationType)' == 'DynamicLibrary' or '$(ConfigurationType)' == 'Application'">
     <ItemGroup>
       <_ImportLibraryFileNames Include="@(Link -> '%(ImportLibrary)')">

--- a/tools/common/common-build.targets
+++ b/tools/common/common-build.targets
@@ -11,7 +11,13 @@
   </PropertyGroup>
 
   <Target Name="AddBuiltOutput" BeforeTargets="GetPackageContents"  DependsOnTargets="$(GetPackageContentsDependsOn)" Condition="'$(ConfigurationType)' == 'DynamicLibrary' or '$(ConfigurationType)' == 'Application'">
+    
     <ItemGroup>
+      <!-- Since GetPackageContents runs in a second pass outside of the normal build, add a tmp Link item -->
+      <Link Include="tmp" Condition="'@(Link)'==''">
+       <DeleteSoon>true</DeleteSoon>
+      </Link>
+
       <_ImportLibraryFileNames Include="@(Link -> '%(ImportLibrary)')">
       </_ImportLibraryFileNames>
       
@@ -26,6 +32,8 @@
       <PackageFile Include="@(WinMDFullPath)" Condition="'@(WinMDFullPath)' != ''">
         <PackagePath>$(PackageContentBasePath)\%(Filename)%(Extension)</PackagePath>
       </PackageFile>
+
+      <Link Remove="@(Link)" Condition="'%(Link.DeleteSoon)'=='true'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
The problem with the existing implementation is two fold:

1. MSBuild isn't as smart as I thought.
2. I'm not as smart as I thought.

more seriously the two issues were:

1. GetPackageContents was not correctly invoking ResolveReferences
2. Global property differences between .nuproj build multiplexing and test multiplexing
   was triggering incorrect rebuilds.

In the new mechanism, the build of all frameworks will be complete before GetPackageContents is invoked on that framework. This is because GetPackageContents *for .nuproj projects* now depends on ResolveReferences. This means that inside of GetPackageContents, no build resolution is needed so *for .vcxproj projects*, it does NOT depend on ResolveReference. This makes GetPackageContents a little more lightweight. Additionally, when multiplexing any "multiplex only" global properties are removed before invoking project reference builds to uniformly invoke them.