### PR TITLE
Add support for NSUncaughtExceptionHandler

### DIFF
--- a/Frameworks/Foundation/NSException.cl.cpp
+++ b/Frameworks/Foundation/NSException.cl.cpp
@@ -1,0 +1,65 @@
+#include <windows.h>
+#include <type_traits>
+#include "NSExceptionInternal.h"
+
+// From ucrt's throw.cpp.
+#define EH_EXCEPTION_NUMBER ('msc' | 0xE0000000)
+#define EH_MAGIC_NUMBER1 0x19930520
+
+template <typename T, typename U>
+static std::add_const_t<std::decay_t<T>> rebase_and_cast(uintptr_t base, U value) {
+    return reinterpret_cast<std::add_const_t<std::decay_t<T>>>(base + (uintptr_t)(value));
+}
+
+// _ThrowInfo, _CatchableTypeArray, _CatchableType and _TypeDescriptor (nee std::type_info) are defined by CL at compile time.
+extern "C" LONG WINAPI _NSWindowsUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* ExceptionInfo) {
+    const EXCEPTION_RECORD* ex = ExceptionInfo->ExceptionRecord;
+
+    // An exception thrown by libobjc2 goes through _CxxThrowException, which populates the EXCEPTION_RECORD with the magic C++
+    // exception number (0xE0000000 ORed with the bytes 'msc' (in platform endianness)) and the exception parameters with
+    // a _ThrowInfo*, another magic number, and the object being thrown.
+    if (ex->ExceptionCode == EH_EXCEPTION_NUMBER && ex->ExceptionInformation[0] == EH_MAGIC_NUMBER1 && ex->NumberParameters >= 3) {
+        // On some platforms, thrown exception catch data are relative virtual addresses off the module base.
+        uintptr_t moduleBase = ex->NumberParameters >= 4 ? ex->ExceptionInformation[3] : 0;
+
+        auto throwInfo = reinterpret_cast<_ThrowInfo*>(ex->ExceptionInformation[2]);
+        if (throwInfo && throwInfo->pCatchableTypeArray) {
+            auto catchableTypes = rebase_and_cast<_CatchableTypeArray*>(moduleBase, throwInfo->pCatchableTypeArray);
+            // _ThrowInfo contains a handful of useful things that we completely ignore as we bumble towards the catchable type array.
+            // libobjc2 populates the catchable type array with a list of mangled Objective-C class names that aid the exception catcher
+            // in determining which exception type was thrown. Here we walk that list of types to find one containing NSException.
+            //
+            // This _will_ cause an issue if a clever developer C++-throws a value of a type with NSException in its name that derives from
+            // a type with objc_object in its name.
+
+            bool foundNSException = false;
+            bool foundobjc_object = false;
+            for (int i = 0; i < catchableTypes->nCatchableTypes; ++i) {
+                const _CatchableType* catchableType =
+                    rebase_and_cast<_CatchableType*>(moduleBase, catchableTypes->arrayOfCatchableTypes[i]);
+                const _TypeDescriptor* typeDescriptor = rebase_and_cast<_TypeDescriptor*>(moduleBase, catchableType->pType);
+                if (strstr(typeDescriptor->name, "NSException") != nullptr) {
+                    // We're using strstr because:
+                    // 1. Our exception classes are not mangled properly, but we do not want this code to break when they are.
+                    // 2. The buffer is guaranteed to be null-terminated.
+                    foundNSException = true;
+                    continue;
+                } else if (strstr(typeDescriptor->name, "objc_object") != nullptr) {
+                    foundobjc_object = true;
+                    // objc_object should always be after NSException*.
+                    break;
+                }
+            }
+
+            if (foundNSException && foundobjc_object) {
+                _NSExceptionCallUnhandledExceptionHandler(*reinterpret_cast<void**>(ex->ExceptionInformation[1]));
+                // EXCEPTION_EXECUTE_HANDLER instructs the exception handler to continue (and abort the app.)
+                return EXCEPTION_EXECUTE_HANDLER;
+            }
+        }
+    }
+
+    // EXCEPTION_CONTINUE_SEARCH instructs the exception handler to continue searching for appropriate exception handlers.
+    // Since this is the last one, it is not likely to find any more.
+    return EXCEPTION_CONTINUE_SEARCH;
+}

--- a/Frameworks/Foundation/NSException.mm
+++ b/Frameworks/Foundation/NSException.mm
@@ -14,16 +14,18 @@
 //
 //******************************************************************************
 
-#include "Starboard.h"
-#include "StubReturn.h"
-#import "Foundation/NSException.h"
-#import "NSLogging.h"
-#include <winstring.h>
+#import <Starboard.h>
+#import <StubReturn.h>
+#import <Foundation/NSException.h>
+#import <NSLogging.h>
+#import <winstring.h>
 
 #include <COMIncludes.h>
-#include <roerrorapi.h>
-#include "wrl\wrappers\corewrappers.h"
+#import <roerrorapi.h>
+#import <wrl/wrappers/corewrappers.h>
 #include <COMIncludes_End.h>
+
+#import "NSExceptionInternal.h"
 
 static const wchar_t* TAG = L"NSException";
 NSString* const NSRangeException = @"NSRangeExcepton";
@@ -38,20 +40,31 @@ NSString* const NSObjectInaccessibleException = @"NSObjectInaccessibleException"
 NSString* const NSMallocException = @"NSMallocException";
 NSString* const WinObjCException = @"WinObjC Exception"; // not exported
 
+// The uncaught exception handler is not thread-specific.
+static NSUncaughtExceptionHandler* s_uncaughtExceptionHandler = nullptr;
+
+// Entry point used by NSException_Win32.cpp after C++ ThrowInfo unboxing.
+void _NSExceptionCallUnhandledExceptionHandler(void* untypedException) {
+    auto handler = NSGetUncaughtExceptionHandler();
+    if (handler) {
+        // The machinery that calls this function only calls it for exceptions whose type descriptors
+        // contain NSException* and objc_object*, making this cast safe.
+        handler(reinterpret_cast<NSException*>(untypedException));
+    }
+}
 /**
- @Status Stub
+ @Status Interoperable
 */
-void NSSetUncaughtExceptionHandler(NSUncaughtExceptionHandler*) {
-    UNIMPLEMENTED();
+void NSSetUncaughtExceptionHandler(NSUncaughtExceptionHandler* handler) {
+    InterlockedExchangePointer(reinterpret_cast<void**>(&s_uncaughtExceptionHandler), reinterpret_cast<void*>(handler));
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Interoperable
 */
 NSUncaughtExceptionHandler* NSGetUncaughtExceptionHandler() {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return reinterpret_cast<NSUncaughtExceptionHandler*>(
+        InterlockedCompareExchangePointer(reinterpret_cast<void**>(&s_uncaughtExceptionHandler), nullptr, nullptr));
 }
 
 @implementation NSException
@@ -261,3 +274,7 @@ NSUncaughtExceptionHandler* NSGetUncaughtExceptionHandler() {
     }
 }
 @end
+
+static __attribute__((constructor)) void _initExceptionHandling() {
+    SetUnhandledExceptionFilter(&_NSWindowsUnhandledExceptionFilter);
+}

--- a/Frameworks/Foundation/NSExceptionInternal.h
+++ b/Frameworks/Foundation/NSExceptionInternal.h
@@ -1,0 +1,40 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#pragma once
+
+#include <Windows.h>
+
+#ifndef _M_ARM
+#ifndef _STDCALL
+#define _STDCALL __stdcall
+#endif
+#endif
+
+#ifndef _STDCALL
+#define _STDCALL
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+long _STDCALL _NSWindowsUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* ExceptionInfo);
+void _NSExceptionCallUnhandledExceptionHandler(void* /* treated as NSException* */);
+
+#ifdef __cplusplus
+}
+#endif

--- a/build/Foundation/lib/FoundationLib.vcxproj
+++ b/build/Foundation/lib/FoundationLib.vcxproj
@@ -26,7 +26,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\_NSInvocation.x86.mm">
       <ExcludedFromBuild Condition="'$(Platform)'!='Win32'">true</ExcludedFromBuild>
     </ClangCompile>
-    <ClangCompile Include="..\..\..\Frameworks\Foundation\_NSInvocation.arm.mm">
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\_NSInvocation.arm.mm">
       <ExcludedFromBuild Condition="'$(Platform)'!='ARM'">true</ExcludedFromBuild>
     </ClangCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\_NSInvocation.arm.asm">
@@ -34,6 +34,7 @@
       <PreprocessToFile>true</PreprocessToFile>
       <ExcludedFromBuild Condition="'$(Platform)'!='ARM'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\NSException.cl.cpp" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\CFBridgeBase.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\CFHelpers.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\Foundation\NSArray.mm" />

--- a/include/Foundation/NSException.h
+++ b/include/Foundation/NSException.h
@@ -69,8 +69,8 @@ FOUNDATION_EXPORT_CLASS
 
 typedef void NSUncaughtExceptionHandler(NSException* exception);
 
-FOUNDATION_EXPORT NSUncaughtExceptionHandler* NSGetUncaughtExceptionHandler(void) STUB_METHOD;
-FOUNDATION_EXPORT void NSSetUncaughtExceptionHandler(NSUncaughtExceptionHandler*) STUB_METHOD;
+FOUNDATION_EXPORT NSUncaughtExceptionHandler* NSGetUncaughtExceptionHandler(void);
+FOUNDATION_EXPORT void NSSetUncaughtExceptionHandler(NSUncaughtExceptionHandler*);
 
 typedef struct NSExceptionFrame {
     jmp_buf state;


### PR DESCRIPTION
This commit introduces support for Foundation's last line of defense against uncaught exceptions. The application is being torn down, and there's nothing a consumer can do to stop it.

They can now at least log something.

This change cannot be automatically tested, and it cannot be tested with an attached debugger.
This was tested manually on x86.

### x86

WOCCatalog was augmented to contain the following snippet:

```patch
diff --git a/samples/WOCCatalog/WOCCatalog/main.m b/samples/WOCCatalog/WOCCatalog/main.m
index 28f4a68fc..136b8748e 100644
--- a/samples/WOCCatalog/WOCCatalog/main.m
+++ b/samples/WOCCatalog/WOCCatalog/main.m
@@ -17,8 +17,15 @@
 #import <UIKit/UIKit.h>
 #import "AppDelegate.h"

+extern __declspec(dllimport) __stdcall int MessageBoxA(void*,char*,char*,unsigned int);
+#pragma comment(lib, "user32")
+void eh(NSException* ex) {
+    MessageBoxA(0, [[ex reason] UTF8String], "Caught ourselves an NSException!", 0);
+}
+
 int main(int argc, char * argv[]) {
     @autoreleasepool {
+        NSSetUncaughtExceptionHandler(&eh);
```

#### Result
![image](https://cloud.githubusercontent.com/assets/14316954/24772595/c7179efe-1ac6-11e7-8b25-075489d02923.png)

### ARM

There's no user32 or MessageBox on ARM, and since we're in an exception handler it would be dangerous to try to create any UI or interact too much with COM and WinRT.

Since named exception catch is already broken on ARM (#352), this likely does not work. No tests (including file writing tests) succeeded.

Fixes #2373.