### PR TITLE
vsimporter shouldn't add empty groups with no Label to proj files

### DIFF
--- a/tools/vsimporter/src/vswriter/VCProject.cpp
+++ b/tools/vsimporter/src/vswriter/VCProject.cpp
@@ -319,6 +319,15 @@ bool VCProject::writeTemplate(const std::string& filePath, const LabelHandlerFnM
     pugi::xml_node projRoot = projDoc.first_child();
 
     for (pugi::xml_node child = projRoot.first_child(); child; child = child.next_sibling()) {
+        // Delete empty (no children) vsimporter-only groups on previous node
+        if (child.previous_sibling()) {
+            pugi::xml_attribute preLabelAttr = child.previous_sibling().attribute("Label");
+            pugi::xml_attribute preVSImporterAttr = child.previous_sibling().attribute("VSImporterLabel");
+            if (preLabelAttr.empty() && preVSImporterAttr.empty() && !child.previous_sibling().first_child()) {
+                projRoot.remove_child(child.previous_sibling());
+            }
+        }
+
         // Check each child for a VSImporterLabel attribute
         pugi::xml_attribute sblabelAttr = child.attribute("VSImporterLabel");
         std::string sblabelValue = sblabelAttr.value();


### PR DESCRIPTION
fixes #2054

## Short Summary
#### vsimporter should keep empty groups if they are generic Visual Studio project file groups. 
Ex. This node should remain in the final proj file:  
`<ImportGroup Label="ExtensionSettings" VSImporterLabel="BuildExtensionProperties"  />`
#### However, if the group's only purpose is for vsimporter and the group is empty, it should be removed.
Ex. This node should be removed in the final proj file:
`<ItemGroup VSImporterLabel="ProjectReferences" />`

## Justification
I compared each of our generated project files to their equivalent type if you were to do File->New->Project.     

|    vsimporter Project Template    |    Visual Studio Default Templates Comparison     |
| :------------------- | :------------------------------------------------------------- |
|  Aggregate           |  None                                                          |
|  App                 |  Visual C++ --> Blank App (Universal Windows)                  |
|  Bundle              |  None                                                          |
|  Package             |  NuGet --> Package Project                                     |
|  Shared Headers      |  Visual C++ --> Shared Items Project                           |
|  Static Library      |  Visual C++ --> Static Library (Universal Windows)             |
|  WinRT               |  Visual C++ --> Windows Runtime Component (Universal Windows)  |

In summary, the equivalent projects also left empty (no child elements) groups/nodes in the project file. My thought is that Visual Studio likes to have them in case it wants to add customization later. Therefore, it's okay that vsimporter adds in empty groups that are the generic VS groups. 

For example, these four groups should stay in the StaticLibrary Project file even if they are empty:
```
<ImportGroup Label="ExtensionSettings" /> (middle of file)
<ImportGroup Label="Shared" />
<PropertyGroup Label="UserMacros" />
<ImportGroup Label="ExtensionTargets" /> (bottom of file)
```

On the other hand, these two groups should be removed from the StaticLibrary Project file if they are empty:
```
<ItemGroup VSImporterLabel="ProjectReferences" />
<ItemGroup VSImporterLabel="ProjectItems">
```

General rule: Do not keep empty groups unless it has a Label attribute and no VSImporterLabel attribute.
