### PR TITLE
Fixed issue #2434. FunctionalTests hang - rewrite UICoordinator functional tests using the correct Macro

### DIFF
--- a/tests/functionaltests/Tests/UIKitTests/UIGestureCoordinatorTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIGestureCoordinatorTests.mm
@@ -108,6 +108,25 @@
 }
 @end
 
+// use for UICoordinator Tap Gesture related tests
+@interface TestableTapGestureRecognizer : UITapGestureRecognizer
+- (void)touchesBegan : (NSSet*)touches withEvent : (UIEvent*)event;
+@end
+
+@implementation TestableTapGestureRecognizer
+- (void)touchesBegan:(NSSet*)touches withEvent : (UIEvent*)event {
+    self.state = UIGestureRecognizerStateBegan;
+}
+
+-(BOOL)canBePreventedByGestureRecognizer : (UIGestureRecognizer*)preventingGestureRecognizer {
+    return NO;
+}
+
+-(BOOL)canPreventGestureRecognizer : (UIGestureRecognizer*)preventedGestureRecognizer {
+    return NO;
+}
+@end
+
 // static helper to create a TouchEvent for TouchBegan Phase. and the touch is associated with a view
 // which contains two gestures, one transit to Began when receiving touchBegan
 // The other transit to possible when receiveing touchBegan
@@ -145,190 +164,186 @@ static TestableUITouch* createTestableUITuch(BOOL activeGestureCanPrevent,
     return touch;
 }
 
-TEST(_UIGestureCoordinator, ActiveGestureAllowPossibleGesture) {
-    // conifg activeGesture can NOT prevent other, and possible gesture can NOT be prevented, adding activeGesture first
-    TestableUITouch* touch = createTestableUITuch(NO, NO, YES);
-    _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
-    [cooridnator processGesturesForTouch:touch event:nil touchEventName:@selector(touchesBegan:withEvent:)];
+class UIGestureCoordinatorTests {
+public:
+    BEGIN_TEST_CLASS(UIGestureCoordinatorTests)
+    END_TEST_CLASS()
 
-    // after processGestures, check result is expected, since both gestures say NO to prevent each other
-    // no gesture is prevented, we are looking for one active gesture and one possible gesture
-    NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
-    ASSERT_TRUE([regularGestures count] == 2);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStatePossible);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[1]).state == UIGestureRecognizerStateBegan);
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return FunctionalTestSetupUIApplication();
+    }
 
-    NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
-    ASSERT_TRUE([possibleGesture count] == 1);
-}
+    TEST_CLASS_CLEANUP(UIKitTestsCleanup) {
+        return FunctionalTestCleanupUIApplication();
+    }
 
-TEST(_UIGestureCoordinator, ActiveGesturePreventPossibleGestureHasNotReceivedTouch) {
-    // conifg activeGesture can prevent other, and possible gesture can be prevented, adding possibleGesture first
-    TestableUITouch* touch = createTestableUITuch(YES, YES);
-    _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
-    [cooridnator processGesturesForTouch:touch event:nil touchEventName:@selector(touchesBegan:withEvent:)];
+    TEST_METHOD(UIGestureCoordinator_ActiveGestureAllowPossibleGesture) {
+        // conifg activeGesture can NOT prevent other, and possible gesture can NOT be prevented, adding activeGesture first
+        TestableUITouch* touch = createTestableUITuch(NO, NO, YES);
+        _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
+        [cooridnator processGesturesForTouch : touch event : nil touchEventName : @selector(touchesBegan : withEvent : )];
 
-    // after processGestures, check result is expected,
-    // in this case, since both gestures says YES to prevent each other
-    // and both didn't provide delegates to VOTE, which means they both say NO by default
-    // so we are looking for the active gesture will prevent the possible gesture
-    NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
+        // after processGestures, check result is expected, since both gestures say NO to prevent each other
+        // no gesture is prevented, we are looking for one active gesture and one possible gesture
+        NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
+        ASSERT_TRUE([regularGestures count] == 2);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStatePossible);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[1]).state == UIGestureRecognizerStateBegan);
 
-    // one gesture in active state
-    ASSERT_TRUE([regularGestures count] == 1);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
+        NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
+        ASSERT_TRUE([possibleGesture count] == 1);
+    }
 
-    // no gesture in possible state
-    NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
-    ASSERT_TRUE([possibleGesture count] == 0);
-}
+    TEST_METHOD(UIGestureCoordinator_ActiveGesturePreventPossibleGestureHasNotReceivedTouch) {
+        // conifg activeGesture can prevent other, and possible gesture can be prevented, adding possibleGesture first
+        TestableUITouch* touch = createTestableUITuch(YES, YES);
+        _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
+        [cooridnator processGesturesForTouch : touch event : nil touchEventName : @selector(touchesBegan : withEvent : )];
 
-TEST(_UIGestureCoordinator, ActiveGesturePreventPossibleGestureHasReceivedTouch) {
-    TestableUITouch* touch = createTestableUITuch(YES, YES, NO);
-    _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
-    [cooridnator processGesturesForTouch:touch event:nil touchEventName:@selector(touchesBegan:withEvent:)];
+        // after processGestures, check result is expected,
+        // in this case, since both gestures says YES to prevent each other
+        // and both didn't provide delegates to VOTE, which means they both say NO by default
+        // so we are looking for the active gesture will prevent the possible gesture
+        NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
 
-    // after processGestures, check result is expected,
-    // in this case, since both gestures says YES to prevent each other
-    // and both didn't provide delegates to consult with, which is quivalent of both delegates voting NO
-    // so we are expecting active gesture will prevent the possible gesture
-    NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
+        // one gesture in active state
+        ASSERT_TRUE([regularGestures count] == 1);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
 
-    // one gesture in active state
-    ASSERT_TRUE([regularGestures count] == 1);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
+        // no gesture in possible state
+        NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
+        ASSERT_TRUE([possibleGesture count] == 0);
+    }
 
-    // no gesture in possible state
-    NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
-    ASSERT_TRUE([possibleGesture count] == 0);
-}
+    TEST_METHOD(UIGestureCoordinator_ActiveGesturePreventPossibleGestureHasReceivedTouch) {
+        TestableUITouch* touch = createTestableUITuch(YES, YES, NO);
+        _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
+        [cooridnator processGesturesForTouch : touch event : nil touchEventName : @selector(touchesBegan : withEvent : )];
 
-TEST(_UIGestureCoordinator, DelegateAllowConcurrentGestures) {
-    TestableGestureDelegate* delegateForPossibleGesture = [[[TestableGestureDelegate alloc] initWithReply:YES] autorelease];
-    TestableUITouch* touch = createTestableUITuch(YES, YES, YES, nil, delegateForPossibleGesture);
-    _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
-    [cooridnator processGesturesForTouch:touch event:nil touchEventName:@selector(touchesBegan:withEvent:)];
+        // after processGestures, check result is expected,
+        // in this case, since both gestures says YES to prevent each other
+        // and both didn't provide delegates to consult with, which is quivalent of both delegates voting NO
+        // so we are expecting active gesture will prevent the possible gesture
+        NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
 
-    // after processGestures, check result is expected,
-    // in this case,  both gestures says YES to prevent each other
-    // But one of them provides delegate saying concurrent firing is allowed
-    // so we are looking for the active gesture will not prevent the possible gesture
-    NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
+        // one gesture in active state
+        ASSERT_TRUE([regularGestures count] == 1);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
 
-    // one gesture in possible state, one is active state
-    ASSERT_TRUE([regularGestures count] == 2);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStatePossible);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[1]).state == UIGestureRecognizerStateBegan);
+        // no gesture in possible state
+        NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
+        ASSERT_TRUE([possibleGesture count] == 0);
+    }
 
-    // make sure the delegate is invoked for voting
-    TestableGestureDelegate* d1 = (TestableGestureDelegate*)(((UIGestureRecognizer*)regularGestures[0]).delegate);
-    ASSERT_TRUE(d1 != nil);
-    ASSERT_TRUE([d1 delegateInvoked]);
+    TEST_METHOD(UIGestureCoordinator_DelegateAllowConcurrentGestures) {
+        TestableGestureDelegate* delegateForPossibleGesture = [[[TestableGestureDelegate alloc] initWithReply:YES] autorelease];
+        TestableUITouch* touch = createTestableUITuch(YES, YES, YES, nil, delegateForPossibleGesture);
+        _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
+        [cooridnator processGesturesForTouch : touch event : nil touchEventName : @selector(touchesBegan : withEvent : )];
 
-    // one gesture in possible state
-    NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
-    ASSERT_TRUE([possibleGesture count] == 1);
+        // after processGestures, check result is expected,
+        // in this case,  both gestures says YES to prevent each other
+        // But one of them provides delegate saying concurrent firing is allowed
+        // so we are looking for the active gesture will not prevent the possible gesture
+        NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
 
-    // reset tracking gesture list
-    [cooridnator resetTrackingGestureList];
-    regularGestures = [cooridnator getRegularGestureRecognizers];
+        // one gesture in possible state, one is active state
+        ASSERT_TRUE([regularGestures count] == 2);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStatePossible);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[1]).state == UIGestureRecognizerStateBegan);
 
-    // make sure earlier active and possible gestures are gone
-    ASSERT_TRUE([regularGestures count] == 0);
+        // make sure the delegate is invoked for voting
+        TestableGestureDelegate* d1 = (TestableGestureDelegate*)(((UIGestureRecognizer*)regularGestures[0]).delegate);
+        ASSERT_TRUE(d1 != nil);
+        ASSERT_TRUE([d1 delegateInvoked]);
 
-    possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
-    ASSERT_TRUE([possibleGesture count] == 0);
-}
+        // one gesture in possible state
+        NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
+        ASSERT_TRUE([possibleGesture count] == 1);
 
-TEST(_UIGestureCoordinator, DelegatesForbidConcurrentGestures) {
-    TestableGestureDelegate* delegateForPossibleGesture = [[[TestableGestureDelegate alloc] initWithReply:NO] autorelease];
-    TestableGestureDelegate* delegateForActiveGesture = [[[TestableGestureDelegate alloc] initWithReply:NO] autorelease];
-    TestableUITouch* touch = createTestableUITuch(YES, YES, YES, delegateForActiveGesture, delegateForPossibleGesture);
-    _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
-    [cooridnator processGesturesForTouch:touch event:nil touchEventName:@selector(touchesBegan:withEvent:)];
+        // reset tracking gesture list
+        [cooridnator resetTrackingGestureList];
+        regularGestures = [cooridnator getRegularGestureRecognizers];
 
-    // after processGestures, check result is expected,
-    // in this case,  both gestures says YES to prevent each other
-    // And both provides delegate saying concurrent firing is *not* allowed
-    // so we are looking for the active gesture will not prevent the possible gesture
-    NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
+        // make sure earlier active and possible gestures are gone
+        ASSERT_TRUE([regularGestures count] == 0);
 
-    // make sure only one gesture in active state
-    ASSERT_TRUE([regularGestures count] == 1);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
+        possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
+        ASSERT_TRUE([possibleGesture count] == 0);
+    }
 
-    // make sure its delegate is invoked for voting
-    TestableGestureDelegate* d0 = (TestableGestureDelegate*)(((UIGestureRecognizer*)regularGestures[0]).delegate);
-    ASSERT_TRUE(d0 != nil);
-    ASSERT_TRUE([d0 delegateInvoked]);
+    TEST_METHOD(UIGestureCoordinator_DelegatesForbidConcurrentGestures) {
+        TestableGestureDelegate* delegateForPossibleGesture = [[[TestableGestureDelegate alloc] initWithReply:NO] autorelease];
+        TestableGestureDelegate* delegateForActiveGesture = [[[TestableGestureDelegate alloc] initWithReply:NO] autorelease];
+        TestableUITouch* touch = createTestableUITuch(YES, YES, YES, delegateForActiveGesture, delegateForPossibleGesture);
+        _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
+        [cooridnator processGesturesForTouch : touch event : nil touchEventName : @selector(touchesBegan : withEvent : )];
 
-    // no gesture in possible state
-    NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
-    ASSERT_TRUE([possibleGesture count] == 0);
+        // after processGestures, check result is expected,
+        // in this case,  both gestures says YES to prevent each other
+        // And both provides delegate saying concurrent firing is *not* allowed
+        // so we are looking for the active gesture will not prevent the possible gesture
+        NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
 
-    // reset tracking gesture list
-    [cooridnator resetTrackingGestureList];
-    regularGestures = [cooridnator getRegularGestureRecognizers];
+        // make sure only one gesture in active state
+        ASSERT_TRUE([regularGestures count] == 1);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
 
-    // make sure earlier active gesture is gone
-    ASSERT_TRUE([regularGestures count] == 0);
-}
+        // make sure its delegate is invoked for voting
+        TestableGestureDelegate* d0 = (TestableGestureDelegate*)(((UIGestureRecognizer*)regularGestures[0]).delegate);
+        ASSERT_TRUE(d0 != nil);
+        ASSERT_TRUE([d0 delegateInvoked]);
 
-// use for UICoordinator Tap Gesture related tests
-@interface TestableTapGestureRecognizer : UITapGestureRecognizer
-- (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event;
-@end
+        // no gesture in possible state
+        NSSet* possibleGesture = [cooridnator getGestureRecognizerInPossibleState];
+        ASSERT_TRUE([possibleGesture count] == 0);
 
-@implementation TestableTapGestureRecognizer
-- (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-    self.state = UIGestureRecognizerStateBegan;
-}
+        // reset tracking gesture list
+        [cooridnator resetTrackingGestureList];
+        regularGestures = [cooridnator getRegularGestureRecognizers];
 
-- (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer*)preventingGestureRecognizer {
-    return NO;
-}
+        // make sure earlier active gesture is gone
+        ASSERT_TRUE([regularGestures count] == 0);
+    }
 
-- (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer*)preventedGestureRecognizer {
-    return NO;
-}
-@end
+    TEST_METHOD(UIGestureCoordinator_TapGestureMiscFunctions) {
+        TestableUITouch* touch = [[[TestableUITouch alloc] init] autorelease];
+        touch.phase = UITouchPhaseMoved;
 
-TEST(_UIGestureCoordinator, TapGestureMiscFunctions) {
-    TestableUITouch* touch = [[[TestableUITouch alloc] init] autorelease];
-    touch.phase = UITouchPhaseMoved;
+        UIView* view = [[[UIView alloc] init] autorelease];
+        touch.view = view;
 
-    UIView* view = [[[UIView alloc] init] autorelease];
-    touch.view = view;
+        // config multiple Tap getures with different tap count
+        TestableTapGestureRecognizer* tapGesture = [[[TestableTapGestureRecognizer alloc] init] autorelease];
+        tapGesture.numberOfTapsRequired = 1;
+        [view addGestureRecognizer : tapGesture];
 
-    // config multiple Tap getures with different tap count
-    TestableTapGestureRecognizer* tapGesture = [[[TestableTapGestureRecognizer alloc] init] autorelease];
-    tapGesture.numberOfTapsRequired = 1;
-    [view addGestureRecognizer:tapGesture];
+        tapGesture = [[[TestableTapGestureRecognizer alloc] init] autorelease];
+        tapGesture.numberOfTapsRequired = 10;
+        [view addGestureRecognizer : tapGesture];
 
-    tapGesture = [[[TestableTapGestureRecognizer alloc] init] autorelease];
-    tapGesture.numberOfTapsRequired = 10;
-    [view addGestureRecognizer:tapGesture];
+        tapGesture = [[[TestableTapGestureRecognizer alloc] init] autorelease];
+        tapGesture.numberOfTapsRequired = 1000;
+        [view addGestureRecognizer : tapGesture];
 
-    tapGesture = [[[TestableTapGestureRecognizer alloc] init] autorelease];
-    tapGesture.numberOfTapsRequired = 1000;
-    [view addGestureRecognizer:tapGesture];
+        _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
+        [cooridnator processGesturesForTouch : touch event : nil touchEventName : @selector(touchesBegan : withEvent : )];
 
-    _UIGestureCoordinator* cooridnator = [[[_UIGestureCoordinator alloc] init] autorelease];
-    [cooridnator processGesturesForTouch:touch event:nil touchEventName:@selector(touchesBegan:withEvent:)];
+        // after processGestures, check result is expected,
+        // we should three Tap gestures, two of require multiple taps and max required tap count is 1000
+        ASSERT_TRUE([cooridnator containsTapGestureRequiredMultipleTap]);
+        ASSERT_TRUE([cooridnator maxNubmerOfTapsRequiredInAllTapGestures] == 1000);
 
-    // after processGestures, check result is expected,
-    // we should three Tap gestures, two of require multiple taps and max required tap count is 1000
-    ASSERT_TRUE([cooridnator containsTapGestureRequiredMultipleTap]);
-    ASSERT_TRUE([cooridnator maxNubmerOfTapsRequiredInAllTapGestures] == 1000);
+        NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
+        ASSERT_TRUE([regularGestures count] == 3);
 
-    NSArray* regularGestures = [cooridnator getRegularGestureRecognizers];
-    ASSERT_TRUE([regularGestures count] == 3);
+        // fail all other tap gestures except the first one
+        [cooridnator failOtherTapGesturesExcept : regularGestures[0]];
 
-    // fail all other tap gestures except the first one
-    [cooridnator failOtherTapGesturesExcept:regularGestures[0]];
+        // make sure we still have one tap gesture left
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[1]).state == UIGestureRecognizerStateFailed);
+        ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[2]).state == UIGestureRecognizerStateFailed);
+    }
+};
 
-    // make sure we still have one tap gesture left
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[0]).state == UIGestureRecognizerStateBegan);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[1]).state == UIGestureRecognizerStateFailed);
-    ASSERT_TRUE(((UIGestureRecognizer*)regularGestures[2]).state == UIGestureRecognizerStateFailed);
-}


### PR DESCRIPTION
Rewrite UICoordinator functional tests using the correct Macro.

Previously the test were using UnitTest Macros which might just happen to work. Recent packaging & build changes exposes the issue and we need re-write the tests using functional test macro.

