### PR TITLE
[CoreText] Remove the Foundation dependency from CTFramesetter and CTTypeSetter with code improvements

### DIFF
--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -17,7 +17,6 @@
 
 #import <CoreText/CoreText.h>
 #import <CoreText/CTParagraphStyle.h>
-
 #import "Starboard.h"
 #include <COMIncludes.h>
 #import <DWrite.h>
@@ -46,18 +45,13 @@ inline void _SafeRelease(T** p) {
     }
 }
 
-@interface _CTTypesetter : NSObject {
-@public
-    StrongId<NSAttributedString> _attributedString;
-    StrongId<NSString> _string;
-}
-@end
-
 @interface _CTFramesetter : NSObject {
 @public
     StrongId<_CTTypesetter> _typesetter;
 }
 @end
+
+CFAttributedStringRef _CTTypesetterGetAttributedString(CTTypesetterRef typesetter);
 
 @interface _CTRun : NSObject {
 @public

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -45,12 +45,6 @@ inline void _SafeRelease(T** p) {
     }
 }
 
-@interface _CTFramesetter : NSObject {
-@public
-    StrongId<_CTTypesetter> _typesetter;
-}
-@end
-
 CFAttributedStringRef _CTTypesetterGetAttributedString(CTTypesetterRef typesetter);
 
 @interface _CTRun : NSObject {

--- a/include/CoreText/CTFramesetter.h
+++ b/include/CoreText/CTFramesetter.h
@@ -35,4 +35,4 @@ CORETEXT_EXPORT CTFrameRef CTFramesetterCreateFrame(CTFramesetterRef framesetter
 CORETEXT_EXPORT CTTypesetterRef CTFramesetterGetTypesetter(CTFramesetterRef framesetter);
 CORETEXT_EXPORT CGSize CTFramesetterSuggestFrameSizeWithConstraints(
     CTFramesetterRef framesetter, CFRange stringRange, CFDictionaryRef frameAttributes, CGSize constraints, CFRange* fitRange);
-CORETEXT_EXPORT CFTypeID CTFramesetterGetTypeID() STUB_METHOD;
+CORETEXT_EXPORT CFTypeID CTFramesetterGetTypeID();

--- a/include/CoreText/CTTypesetter.h
+++ b/include/CoreText/CTTypesetter.h
@@ -39,4 +39,4 @@ CORETEXT_EXPORT CFIndex CTTypesetterSuggestClusterBreakWithOffset(CTTypesetterRe
                                                                   CFIndex startIndex,
                                                                   double width,
                                                                   double offset) STUB_METHOD;
-CORETEXT_EXPORT CFTypeID CTTypesetterGetTypeID() NOTINPLAN_METHOD;
+CORETEXT_EXPORT CFTypeID CTTypesetterGetTypeID();


### PR DESCRIPTION
- Implement CTFramesetter and CTTypeSetter via Runtimebase
- Remove member access of CTFramesetter & CTTypeSetter
- Code improvements

Fixes #2355 and  #2358