### PR TITLE
Fix AutoCF's reference-stealing value move constructor

### DIFF
--- a/Frameworks/CoreGraphics/CGColorSpace.mm
+++ b/Frameworks/CoreGraphics/CGColorSpace.mm
@@ -86,8 +86,8 @@ CFTypeID CGColorSpaceGetTypeID() {
  @Status Interoperable
 */
 CGColorSpaceRef CGColorSpaceCreateDeviceRGB() {
-    static const woc::StrongCF<CGColorSpaceRef> sc_rgbColorSpace{ __CGColorSpace::CreateInstance(kCFAllocatorDefault,
-                                                                                                 kCGColorSpaceModelRGB) };
+    static const auto sc_rgbColorSpace =
+        woc::MakeStrongCF<CGColorSpaceRef>(__CGColorSpace::CreateInstance(kCFAllocatorDefault, kCGColorSpaceModelRGB));
 
     return CGColorSpaceRetain(sc_rgbColorSpace);
 }
@@ -96,8 +96,8 @@ CGColorSpaceRef CGColorSpaceCreateDeviceRGB() {
  @Status Interoperable
 */
 CGColorSpaceRef CGColorSpaceCreateDeviceGray() {
-    static const woc::StrongCF<CGColorSpaceRef> sc_grayColorSpace{ __CGColorSpace::CreateInstance(kCFAllocatorDefault,
-                                                                                                  kCGColorSpaceModelMonochrome) };
+    static const auto sc_grayColorSpace =
+        woc::MakeStrongCF<CGColorSpaceRef>(__CGColorSpace::CreateInstance(kCFAllocatorDefault, kCGColorSpaceModelMonochrome));
 
     return CGColorSpaceRetain(sc_grayColorSpace);
 }

--- a/Frameworks/Foundation/NSArray.mm
+++ b/Frameworks/Foundation/NSArray.mm
@@ -1042,7 +1042,7 @@ static CFComparisonResult _CFComparatorFunctionFromComparator(const void* val1, 
 - (BOOL)writeToURL:(NSURL*)aURL atomically:(BOOL)flag {
     CFPropertyListRef plist = static_cast<CFPropertyListRef>(self);
     if (CFPropertyListIsValid(plist, sc_plistFormat)) {
-        auto data = woc::AutoCF<CFDataRef>(CFPropertyListCreateData(nullptr, plist, sc_plistFormat, 0, nullptr));
+        auto data = woc::MakeStrongCF<CFDataRef>(CFPropertyListCreateData(nullptr, plist, sc_plistFormat, 0, nullptr));
         if (data) {
             return [static_cast<NSData*>(data.get()) writeToURL:aURL atomically:flag];
         }

--- a/tests/Benchmark/TextBenchmarkTests.mm
+++ b/tests/Benchmark/TextBenchmarkTests.mm
@@ -66,10 +66,10 @@ protected:
 };
 
 class CTFramesetterCreateFrameTest : public CTFramesetterBase {
-    woc::AutoCF<CGMutablePathRef> m_path;
+    woc::StrongCF<CGMutablePathRef> m_path;
 
 public:
-    CTFramesetterCreateFrameTest(CGSize size) : CTFramesetterBase(size), m_path(CGPathCreateMutable()) {
+    CTFramesetterCreateFrameTest(CGSize size) : CTFramesetterBase(size), m_path(woc::MakeStrongCF(CGPathCreateMutable())) {
         CGPathAddRect(m_path, nullptr, CGRect{ CGPointZero, size });
     }
 
@@ -404,7 +404,7 @@ BENCHMARK_F(CoreText, CTRunDrawRotated);
 
 class ShowGlyphsBase : public TextBenchmarkBase {
 public:
-    ShowGlyphsBase() : m_glyphs(std::extent<decltype(sc_chars)>::value), m_font(std::move(CGFontCreateWithFontName(CFSTR("Arial")))) {
+    ShowGlyphsBase() : m_glyphs(std::extent<decltype(sc_chars)>::value), m_font(woc::MakeStrongCF(CGFontCreateWithFontName(CFSTR("Arial")))) {
         CGContextSetFont(m_context, m_font);
         CGContextSetFontSize(m_context, 20);
 
@@ -561,7 +561,7 @@ class CTFontGetGlyphsTest : public ::benchmark::BenchmarkCaseBase {
     std::vector<CGGlyph> m_glyphs;
 
 public:
-    CTFontGetGlyphsTest() : m_font(CTFontCreateWithName(CFSTR("Arial"), 25, nullptr)), m_glyphs(std::extent<decltype(sc_chars)>::value) {
+    CTFontGetGlyphsTest() : m_font(woc::MakeStrongCF(CTFontCreateWithName(CFSTR("Arial"), 25, nullptr))), m_glyphs(std::extent<decltype(sc_chars)>::value) {
     }
     inline void Run() {
         CTFontGetGlyphsForCharacters(m_font, sc_chars, m_glyphs.data(), m_glyphs.size());


### PR DESCRIPTION
This commit replaces AutoCF<T, L>(T&&) with
AutoCF<T, L>(TakeOwnershipT, const T&) to clear up the confusion between
the const ref constructor (+1 refcount) and the value move constructor
(+0 refcount; reference-stealing).

Fixes #2447.

**NOTE:** This commit introduces changes in `WinObjC.Language`, and proper consumption will require a new package to be built. _However_, the framework-side changes do not depend on the new SmartTypes changes and will function properly without them.