### PR TITLE
Fix failing tests on reference platform

### DIFF
--- a/tests/unittests/Foundation/NSFileHandleTestFile.txt
+++ b/tests/unittests/Foundation/NSFileHandleTestFile.txt
@@ -1,1 +1,0 @@
-The Quick Brown Fox.

--- a/tests/unittests/Foundation/NSFileManagerTests.mm
+++ b/tests/unittests/Foundation/NSFileManagerTests.mm
@@ -210,8 +210,7 @@ TEST(NSFileManager, MoveFileViaURL) {
 }
 
 TEST(NSFileManager, DirectoryWithUTF16Chars) {
-    wchar_t* specialFolder = L"oÖo winobjc";
-    NSString* directoryName = [NSString stringWithCharacters:(const unichar*)specialFolder length:wcslen(specialFolder) * sizeof(wchar_t)];
+    NSString* directoryName = @"oÖo winobjc";
     NSString* testPath = getPathToFile(directoryName);
 
     EXPECT_TRUE([[NSFileManager defaultManager] createDirectoryAtPath:testPath attributes:nil]);

--- a/tests/unittests/Foundation/NSSetTests.mm
+++ b/tests/unittests/Foundation/NSSetTests.mm
@@ -192,7 +192,9 @@ TEST(NSSet, MakeObjectsPerformSelector) {
     EXPECT_TRUE([otherSet containsObject:@6]);
 }
 
-TEST(NSSet, ObjectsWithOptionsPassingTest) {
+// Reference platform is not guaranteed to run concurrently so this can fail
+// Still keep to guarantee properly support concurrency
+OSX_DISABLED_TEST(NSSet, ObjectsWithOptionsPassingTest) {
     NSSet* set = [NSSet setWithObjects:@1, @2, @3, @4, @5, nil];
 
     // Verify that the NSEnumerationConcurrent option executes the blocks concurrently

--- a/tests/unittests/Foundation/NSURLTests.m
+++ b/tests/unittests/Foundation/NSURLTests.m
@@ -206,7 +206,8 @@ TEST(NSURL, URLByAppendingPathExtension) {
     ASSERT_OBJCEQ_MSG(fileURLString, newFileURLString, "File URLs do not match!");
 }
 
-TEST(NSURL, CheckResourceIsReachable) {
+// Reference platform has bug on some machines where currentDirectoryPath returns the incorrect path
+OSX_DISABLED_TEST(NSURL, CheckResourceIsReachable) {
     NSFileManager* manager = [NSFileManager defaultManager];
     NSString* originalPath = [manager currentDirectoryPath];
     // construct target URL using current directory and relative URL

--- a/tests/unittests/Foundation/NSURLTests.m
+++ b/tests/unittests/Foundation/NSURLTests.m
@@ -213,9 +213,7 @@ TEST(NSURL, CheckResourceIsReachable) {
     EXPECT_TRUE_MSG([targetURL checkResourceIsReachableAndReturnError:nullptr], "The target URL %@ exists", targetURL);
 
     NSURL* targetURLNonExist = [NSURL URLWithString:@"data/foo.txt" relativeToURL:baseURL];
-    EXPECT_FALSE_MSG([targetURLNonExist checkResourceIsReachableAndReturnError:nullptr],
-                     "The target %@URL does not exist",
-                     targetURLNonExist);
+    EXPECT_FALSE_MSG([targetURLNonExist checkResourceIsReachableAndReturnError:nullptr], "The target %@ does not exist", targetURLNonExist);
 }
 
 TEST(NSURL, GetFileSystemRepresentation) {

--- a/tests/unittests/Foundation/NSURLTests.m
+++ b/tests/unittests/Foundation/NSURLTests.m
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -206,42 +206,16 @@ TEST(NSURL, URLByAppendingPathExtension) {
     ASSERT_OBJCEQ_MSG(fileURLString, newFileURLString, "File URLs do not match!");
 }
 
-// Reference platform has bug on some machines where currentDirectoryPath returns the incorrect path
-OSX_DISABLED_TEST(NSURL, CheckResourceIsReachable) {
-    NSFileManager* manager = [NSFileManager defaultManager];
-    NSString* originalPath = [manager currentDirectoryPath];
-    // construct target URL using current directory and relative URL
-    // get test startup full path
-    wchar_t startUpPath[_MAX_PATH];
+TEST(NSURL, CheckResourceIsReachable) {
     auto fullPath = GetCurrentTestDirectory();
-    std::mbstowcs(startUpPath, fullPath.c_str(), _MAX_PATH);
-
-// File systems differ between platforms - Windows needs separate handling for drive character, etc
-#if TARGET_OS_WIN32
-    // construct the start up dir
-    wchar_t drive[_MAX_DRIVE];
-    wchar_t dir[_MAX_DIR];
-    ASSERT_TRUE(::_wsplitpath_s(startUpPath, drive, _countof(drive), dir, _countof(dir), nullptr, 0, nullptr, 0) == 0);
-    ASSERT_TRUE(::_wmakepath_s(startUpPath, _countof(startUpPath), drive, dir, L"", L"") == 0);
-
-    // change current dir to app start up path
-    ASSERT_TRUE(SetCurrentDirectoryW(startUpPath) != 0);
-#else
-    char tempBuffer[_MAX_PATH];
-    wcstombs(tempBuffer, startUpPath, _MAX_PATH);
-
-    ASSERT_TRUE(chdir(dirname(tempBuffer)) == 0);
-#endif
-
-    NSURL* baseURL = [NSURL fileURLWithPath:[manager currentDirectoryPath]];
+    NSURL* baseURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:fullPath.c_str()]];
     NSURL* targetURL = [NSURL URLWithString:@"data/NSFileManagerUT.txt" relativeToURL:baseURL];
-    ASSERT_TRUE_MSG([targetURL checkResourceIsReachableAndReturnError:nullptr], "The target URL %@ exists", targetURL);
+    EXPECT_TRUE_MSG([targetURL checkResourceIsReachableAndReturnError:nullptr], "The target URL %@ exists", targetURL);
 
     NSURL* targetURLNonExist = [NSURL URLWithString:@"data/foo.txt" relativeToURL:baseURL];
-    ASSERT_FALSE_MSG([targetURLNonExist checkResourceIsReachableAndReturnError:nullptr],
+    EXPECT_FALSE_MSG([targetURLNonExist checkResourceIsReachableAndReturnError:nullptr],
                      "The target %@URL does not exist",
                      targetURLNonExist);
-    ASSERT_TRUE([manager changeCurrentDirectoryPath:originalPath]);
 }
 
 TEST(NSURL, GetFileSystemRepresentation) {

--- a/tests/unittests/Foundation/ReferenceFoundation/TestNSBundle.mm
+++ b/tests/unittests/Foundation/ReferenceFoundation/TestNSBundle.mm
@@ -44,7 +44,9 @@ TEST(NSBundle, Paths) {
     // #endif
 
     ASSERT_OBJCEQ([bundle pathForAuxiliaryExecutable:@"no_such_file"], nil);
-    ASSERT_OBJCEQ(bundle.appStoreReceiptURL, nil);
+
+    // WINOBJC: Disable because no longer correct on reference platform
+    //ASSERT_OBJCEQ(bundle.appStoreReceiptURL, nil);
 }
 
 TEST(NSBundle, Resources) {


### PR DESCRIPTION
Removes a couple of tests from ReferenceFoundation that are no longer passing.
NSSet enumerateWithOptions will not always respect NSEnumerateConcurrent so can cause a deadlock 🐙 
NSURLSessionConfiguration TLSMaximumSupportedProtocol has been updated on the reference platform to reflect documented value
NSURL URLByDeletingPathExtension has a bug on the reference platform where it will improperly delete non-pathextensions.
Another test failed because the file it was looking for is in a different directory on OSX.
NSFileManagerTests was using a Lstring literal as a w_char* to create an NSString which failed on the reference platform.

Fixes #1725