### PR TITLE
Change NSOperation to dealloc safely without init

### DIFF
--- a/tests/unittests/Foundation/NSOperationTests.mm
+++ b/tests/unittests/Foundation/NSOperationTests.mm
@@ -693,6 +693,10 @@ TEST(NSOperation, NSBlockOperationInQueue) {
     ASSERT_FALSE([operation isExecuting]);
 }
 
+TEST(NSOperation, DeallocWithoutInit) {
+    ASSERT_NO_THROW([[NSOperation alloc] release]);
+}
+
 TEST(NSOperation, QueuePriority) {
     NSOperation* op = [[NSOperation new] autorelease];
 


### PR DESCRIPTION
- Only removeObserver: if addObserver: was actually called
- Remove an unnecessary mutex locking in dealloc

Fixes #2490