### PR TITLE
Fix #2514 by keeping UIActionSheet alive until it's dismissed

### DIFF
--- a/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
@@ -14,7 +14,7 @@
 //
 //******************************************************************************
 #include <TestFramework.h>
-#import <UIKit/UIActionSheet.h>
+#import <UIKit/UIKit.h>
 #import "UIViewInternal.h"
 
 #include <COMIncludes.h>
@@ -87,6 +87,19 @@ public:
 
             NSInteger otherIndex = [actionSheet firstOtherButtonIndex];
             ASSERT_TRUE(otherIndex == -1);
+        });
+    }
+
+    TEST_METHOD(Show) {
+        FrameworkHelper::RunOnUIThread([]() {
+            StrongId<UIActionSheet> actionSheet = [[UIActionSheet alloc] initWithTitle:@"Title"
+                                                                              delegate:nil
+                                                                     cancelButtonTitle:@"Cancel"
+                                                                destructiveButtonTitle:@"OK"
+                                                                     otherButtonTitles:nil];
+
+            UIView* mainView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
+            [actionSheet showInView:mainView];
         });
     }
 };

--- a/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIActionSheetTests.mm
@@ -92,11 +92,13 @@ public:
 
     TEST_METHOD(Show) {
         FrameworkHelper::RunOnUIThread([]() {
-            StrongId<UIActionSheet> actionSheet = [[UIActionSheet alloc] initWithTitle:@"Title"
-                                                                              delegate:nil
-                                                                     cancelButtonTitle:@"Cancel"
-                                                                destructiveButtonTitle:@"OK"
-                                                                     otherButtonTitles:nil];
+            StrongId<UIActionSheet> actionSheet;
+
+            actionSheet.attach([[UIActionSheet alloc] initWithTitle:@"Title"
+                                                           delegate:nil
+                                                  cancelButtonTitle:@"Cancel"
+                                             destructiveButtonTitle:@"OK"
+                                                  otherButtonTitles:nil]);
 
             UIView* mainView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
             [actionSheet showInView:mainView];


### PR DESCRIPTION
Fixes #2514
UIActionSheet's Show completion handler should hold a strong reference to the UIActionSheet so that it isn't destroyed before the user can interact with it.