### PR TITLE
Fix #2533 by making cppwinrt a private dependency

### DIFF
--- a/msvc/sdk-build.props
+++ b/msvc/sdk-build.props
@@ -44,7 +44,9 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Packaging" Version="0.1.186" />
     <PackageReference Include="WinObjC.Language" Version="*" />
-    <PackageReference Include="cppwinrt" Version="*" />
+    <PackageReference Include="cppwinrt" Version="*">
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Fixes #2533
cppwinrt is a build-time dependency for WinObjC. The dependency should
not propagate to other projects that depend on WinObjC.