### PR TITLE
Implement CGColor independent of UIColor

### DIFF
--- a/Frameworks/CoreGraphics/CGColor.mm
+++ b/Frameworks/CoreGraphics/CGColor.mm
@@ -235,3 +235,19 @@ CGPatternRef CGColorGetPattern(CGColorRef color) {
 CFTypeID CGColorGetTypeID() {
     return __CGColor::GetTypeID();
 }
+
+/**
+ @Status Interoperable
+*/
+CGColorRef CGColorCreateGenericRGB(CGFloat red, CGFloat green, CGFloat blue, CGFloat alpha) {
+    static const auto colorspace_rgb = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceRGB());
+    return __CGColor::CreateInstance(kCFAllocatorDefault, colorspace_rgb, red, green, blue, alpha);
+}
+
+/**
+ @Status Interoperable
+*/
+CGColorRef CGColorCreateGenericGray(CGFloat gray, CGFloat alpha) {
+    static const auto colorspace_grayscale = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceGray());
+    return __CGColor::CreateInstance(kCFAllocatorDefault, colorspace_grayscale, gray, gray, gray, alpha);
+}

--- a/Frameworks/CoreGraphics/CGColor.mm
+++ b/Frameworks/CoreGraphics/CGColor.mm
@@ -228,3 +228,10 @@ CGPatternRef CGColorGetPattern(CGColorRef color) {
     RETURN_NULL_IF(!color);
     return color->Pattern();
 }
+
+/**
+ @Status Interoperable
+*/
+CFTypeID CGColorGetTypeID() {
+    return __CGColor::GetTypeID();
+}

--- a/Frameworks/CoreGraphics/CGColor.mm
+++ b/Frameworks/CoreGraphics/CGColor.mm
@@ -251,3 +251,22 @@ CGColorRef CGColorCreateGenericGray(CGFloat gray, CGFloat alpha) {
     static const auto colorspace_grayscale = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceGray());
     return __CGColor::CreateInstance(kCFAllocatorDefault, colorspace_grayscale, gray, gray, gray, alpha);
 }
+
+/**
+ @Status Stub
+*/
+CGColorRef CGColorCreateGenericCMYK(CGFloat cyan, CGFloat magenta, CGFloat yellow, CGFloat black, CGFloat alpha) {
+    UNIMPLEMENTED();
+    return StubReturn();
+}
+
+/**
+ @Status Stub
+*/
+CGColorRef CGColorCreateCopyByMatchingToColorSpace(CGColorSpaceRef,
+                                                   CGColorRenderingIntent intent,
+                                                   CGColorRef color,
+                                                   CFDictionaryRef options) {
+    UNIMPLEMENTED();
+    return StubReturn();
+}

--- a/Frameworks/CoreGraphics/CGColorSpace.mm
+++ b/Frameworks/CoreGraphics/CGColorSpace.mm
@@ -158,7 +158,7 @@ CGColorSpaceRef CGColorSpaceCreateWithName(CFStringRef name) {
 @Status Interoperable
 */
 CGColorSpaceModel CGColorSpaceGetModel(CGColorSpaceRef colorSpace) {
-    RETURN_RESULT_IF_NULL(colorSpace, kCGColorSpaceModelRGB);
+    RETURN_RESULT_IF_NULL(colorSpace, kCGColorSpaceModelUnknown);
     return colorSpace->ColorSpaceModel();
 }
 

--- a/Frameworks/CoreGraphics/CGGradient.mm
+++ b/Frameworks/CoreGraphics/CGGradient.mm
@@ -25,7 +25,6 @@
 #import <LoggingNative.h>
 #import "CGColorSpaceInternal.h"
 #import "CGGradientInternal.h"
-#import "UIColorInternal.h"
 
 static const wchar_t* TAG = L"CGGradient";
 

--- a/Frameworks/UIKit/StarboardXaml/LayerProxy.mm
+++ b/Frameworks/UIKit/StarboardXaml/LayerProxy.mm
@@ -85,10 +85,12 @@ void* LayerProxy::GetPropertyValue(const char* name) {
         return [NSValue valueWithCATransform3D:trans];
     } else if (strcmp(name, "borderColor") == 0) {
         LayerColor color = _GetBorderColor();
-        return [UIColor colorWithRed:color.r green:color.g blue:color.b alpha:color.a];
+        CGColorRef colorRef = CGColorCreateGenericRGB(color.r, color.g, color.b, color.a);
+        CFAutorelease(colorRef);
+        return static_cast<void*>(colorRef);
     } else if (strcmp(name, "borderWidth") == 0) {
         return [NSNumber numberWithFloat:_GetBorderWidth()];
-    } 
+    }
 
     FAIL_FAST_HR(E_NOTIMPL);
     return nil;
@@ -174,22 +176,22 @@ void LayerProxy::UpdateProperty(const char* name, void* value) {
     } else if (strcmp(name, "backgroundColor") == 0) {
         LayerColor layerColor;
         if (newValue) {
-            const __CGColorQuad* color = [(UIColor*)newValue _getColors];
-            layerColor.r = color->r;
-            layerColor.g = color->g;
-            layerColor.b = color->b;
-            layerColor.a = color->a;
+            const CGFloat* color = CGColorGetComponents(static_cast<CGColorRef>(newValue));
+            layerColor.r = color[0];
+            layerColor.g = color[1];
+            layerColor.b = color[2];
+            layerColor.a = color[3];
         }
 
         _SetBackgroundColor(layerColor);
     } else if (strcmp(name, "borderColor") == 0) {
         LayerColor layerColor;
         if (newValue) {
-            const __CGColorQuad* color = [(UIColor*)newValue _getColors];
-            layerColor.r = color->r;
-            layerColor.g = color->g;
-            layerColor.b = color->b;
-            layerColor.a = color->a;
+            const CGFloat* color = CGColorGetComponents(static_cast<CGColorRef>(newValue));
+            layerColor.r = color[0];
+            layerColor.g = color[1];
+            layerColor.b = color[2];
+            layerColor.a = color[3];
         }
 
         _SetBorderColor(layerColor);

--- a/Frameworks/UIKit/UICGColor.h
+++ b/Frameworks/UIKit/UICGColor.h
@@ -1,0 +1,21 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#pragma once
+
+#import <UIKit/UIColor.h>
+
+@interface _UIColorConcrete : UIColor
+@end

--- a/Frameworks/UIKit/UICGColor.h
+++ b/Frameworks/UIKit/UICGColor.h
@@ -19,3 +19,6 @@
 
 @interface _UIColorConcrete : UIColor
 @end
+
+@interface _UIColorConcreteConst : _UIColorConcrete
+@end

--- a/Frameworks/UIKit/UICGColor.mm
+++ b/Frameworks/UIKit/UICGColor.mm
@@ -240,3 +240,27 @@ rgb hsv2rgb(hsv in) {
 }
 
 @end
+
+// Const colors are expected to be a singleton
+@implementation _UIColorConcreteConst
+
+- (id)autorelease {
+    return self;
+}
+
+- (id)retain {
+    return self;
+}
+
+- (oneway void)release {
+}
+
+- (NSUInteger)retainCount {
+    return NSUIntegerMax;
+}
+
+- (void)dealloc {
+    [super dealloc];
+}
+
+@end

--- a/Frameworks/UIKit/UICGColor.mm
+++ b/Frameworks/UIKit/UICGColor.mm
@@ -1,0 +1,242 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "UICGColor.h"
+#import "CGPatternInternal.h"
+#import <CFFoundationInternal.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <BridgeHelpers.h>
+#import <UIKit/UIGraphics.h>
+#import "UIColorInternal.h"
+
+#pragma region helpers
+
+static const wchar_t* TAG = L"UIColor";
+
+#if defined(WIN32) || defined(WINPHONE)
+int isnan(double x) {
+    return x != x;
+}
+#ifndef NAN
+static const unsigned long __nan[2] = { 0xffffffff, 0x7fffffff };
+#define NAN (*(const float*)__nan)
+#endif
+#endif
+
+hsv rgb2hsv(rgb in) {
+    hsv out;
+    double min, max, delta;
+
+    min = in.r < in.g ? in.r : in.g;
+    min = min < in.b ? min : in.b;
+
+    max = in.r > in.g ? in.r : in.g;
+    max = max > in.b ? max : in.b;
+
+    out.v = max; // v
+    delta = max - min;
+    if (max > 0.0) {
+        out.s = (delta / max); // s
+    } else {
+        // r = g = b = 0                        // s = 0, v is undefined
+        out.s = 0.0;
+        out.h = NAN; // its now undefined
+        return out;
+    }
+    if (in.r >= max) { // > is bogus, just keeps compilor happy
+        out.h = (in.g - in.b) / delta; // between yellow & magenta
+    } else if (in.g >= max) {
+        out.h = 2.0 + (in.b - in.r) / delta; // between cyan & yellow
+    } else {
+        out.h = 4.0 + (in.r - in.g) / delta; // between magenta & cyan
+    }
+
+    out.h *= 60.0; // degrees
+
+    if (out.h < 0.0) {
+        out.h += 360.0;
+    }
+
+    return out;
+}
+
+rgb hsv2rgb(hsv in) {
+    double hh, p, q, t, ff;
+    long i;
+    rgb out;
+
+    if (in.s <= 0.0) { // < is bogus, just shuts up warnings
+        if (isnan(in.h)) { // in.h == NAN
+            out.r = in.v;
+            out.g = in.v;
+            out.b = in.v;
+            return out;
+        }
+        // error - should never happen
+        out.r = 0.0;
+        out.g = 0.0;
+        out.b = 0.0;
+        return out;
+    }
+    hh = in.h;
+    if (hh >= 360.0) {
+        hh = 0.0;
+    }
+    hh /= 60.0;
+    i = (long)hh;
+    ff = hh - i;
+    p = in.v * (1.0 - in.s);
+    q = in.v * (1.0 - (in.s * ff));
+    t = in.v * (1.0 - (in.s * (1.0 - ff)));
+
+    switch (i) {
+        case 0:
+            out.r = in.v;
+            out.g = t;
+            out.b = p;
+            break;
+        case 1:
+            out.r = q;
+            out.g = in.v;
+            out.b = p;
+            break;
+        case 2:
+            out.r = p;
+            out.g = in.v;
+            out.b = t;
+            break;
+
+        case 3:
+            out.r = p;
+            out.g = q;
+            out.b = in.v;
+            break;
+        case 4:
+            out.r = t;
+            out.g = p;
+            out.b = in.v;
+            break;
+        case 5:
+        default:
+            out.r = in.v;
+            out.g = p;
+            out.b = q;
+            break;
+    }
+    return out;
+}
+
+#pragma endregion helpers
+
+#pragma region Inits
+
+@implementation _UIColorConcrete {
+    woc::StrongCF<CGColorRef> _cgColor;
+}
+
+- (instancetype)initWithHue:(CGFloat)h saturation:(CGFloat)s brightness:(CGFloat)v alpha:(CGFloat)a {
+    hsv in;
+    rgb out;
+
+    in.h = h * 360.0f;
+    in.s = s;
+    in.v = v;
+
+    out = hsv2rgb(in);
+
+    return [self initWithRed:static_cast<float>(out.r) green:static_cast<float>(out.g) blue:static_cast<float>(out.b) alpha:a];
+}
+
+- (instancetype)initWithRed:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b alpha:(CGFloat)a {
+    if (self = [super init]) {
+        _cgColor.attach(CGColorCreateGenericRGB(r, g, b, a));
+    }
+
+    return self;
+}
+
+- (instancetype)initWithWhite:(CGFloat)gray alpha:(CGFloat)alpha {
+    if (self = [super init]) {
+        _cgColor.attach(CGColorCreateGenericGray(gray, alpha));
+    }
+
+    return self;
+}
+
+- (instancetype)initWithPatternImage:(UIImage*)image {
+    CGImageRef img = static_cast<CGImageRef>([image CGImage]);
+    if (img == nullptr) {
+        [self release];
+        return nil;
+    }
+
+    if (self = [super init]) {
+        auto pattern = woc::MakeStrongCF<CGPatternRef>(_CGPatternCreateFromImage(img));
+        _cgColor.attach(CGColorCreateWithPattern(CGImageGetColorSpace(img), pattern, nullptr));
+    }
+
+    return self;
+}
+
+- (instancetype)initWithCGColor:(CGColorRef)cgColor {
+    if (cgColor == nullptr) {
+        [self release];
+        return nil;
+    }
+
+    if (self = [super init]) {
+        _cgColor = cgColor;
+    }
+
+    return self;
+}
+
+#pragma endregion Inits
+
+- (void)set {
+    //  Set current context color
+    if (UIGraphicsGetCurrentContext()) {
+        CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _cgColor);
+        CGContextSetStrokeColorWithColor(UIGraphicsGetCurrentContext(), _cgColor);
+    } else {
+        TraceVerbose(TAG, L"UIColor::set - context not set");
+    }
+}
+
+- (void)setFill {
+    //  Set current context color
+    if (UIGraphicsGetCurrentContext()) {
+        CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _cgColor);
+    } else {
+        TraceVerbose(TAG, L"UIColor::setFill - context not set");
+    }
+}
+
+- (void)setStroke {
+    //  Set current context color
+    CGContextSetStrokeColorWithColor(UIGraphicsGetCurrentContext(), _cgColor);
+}
+
+- (UIColor*)colorWithAlphaComponent:(CGFloat)alpha {
+    auto color = woc::MakeStrongCF<CGColorRef>(CGColorCreateCopyWithAlpha(_cgColor, alpha));
+    return [UIColor colorWithCGColor:color];
+}
+
+- (CGColorRef)CGColor {
+    return _cgColor;
+}
+
+@end

--- a/Frameworks/UIKit/UINavigationBar.mm
+++ b/Frameworks/UIKit/UINavigationBar.mm
@@ -146,7 +146,7 @@ static void setBackground(UINavigationBar* self) {
 
     [super initWithFrame:pos];
 
-    [[self layer] setBackgroundColor:(CGColorRef)[UIColor whiteColor]];
+    [[self layer] setBackgroundColor:CGColorGetConstantColor(kCGColorWhite)];
     _font = [UIFont boldSystemFontOfSize:18];
     (_backButton)
         .attach([[UIBarButtonItem alloc] initWithTitle:@"Back" style:UIBarButtonItemStylePlain target:self action:@selector(backClicked)]);
@@ -653,7 +653,7 @@ static void setTitleLabelAttributes(UINavigationBar* self) {
     size.height = 10.0f;
     UIGraphicsBeginImageContextWithOptions(size, 1, 2.0f);
     CGContextRef ctx = UIGraphicsGetCurrentContext();
-    CGContextSetFillColorWithColor(ctx, (CGColorRef)(UIColor*)_barTintColor);
+    CGContextSetFillColorWithColor(ctx, [(UIColor*)_barTintColor CGColor]);
     CGRect rct = { 0, 0, 0, 0 };
     rct.size = size;
     CGContextFillRect(ctx, rct);

--- a/Frameworks/UIKit/UITableViewCell.mm
+++ b/Frameworks/UIKit/UITableViewCell.mm
@@ -1090,10 +1090,11 @@ static UIView* getCurrentAccessoryView(UITableViewCell* self) {
 
 - (void)_addBottomBorder:(UITableView*)parentTable {
     if (_borderView == nil) {
-        const __CGColorQuad* color = [[parentTable backgroundColor] _getColors];
+        const CGFloat* color = CGColorGetComponents([[parentTable backgroundColor] CGColor]);
+
         UIColor* backgroundColor = nil;
 
-        if ((color == nullptr) || (color->a == 0.0f) || (color->r == 1.0f && color->g == 1.0f && color->b == 1.0f && color->a == 1.0f)) {
+        if ((color == nullptr) || (color[3] == 0.0f) || (color[0] == 1.0f && color[1] == 1.0f && color[2] == 1.0f && color[3] == 1.0f)) {
             backgroundColor = [UIColor grayColor];
         } else {
             backgroundColor = [UIColor whiteColor];

--- a/Frameworks/include/BridgeHelpers.h
+++ b/Frameworks/include/BridgeHelpers.h
@@ -132,7 +132,7 @@ static inline bool shouldUseConcreteClass(Class self, Class base, Class derived)
 
 // Helper macro for implementing allocWithZone
 #define ALLOC_PROTOTYPE_SUBCLASS_WITH_ZONE(NSBridgedType, NSBridgedPrototypeType)                            \
-    (NSObject*) allocWithZone : (NSZone*)zone {                                                              \
+    (NSObject*)allocWithZone : (NSZone*)zone {                                                               \
         if (self == [NSBridgedType class]) {                                                                 \
             static StrongId<NSBridgedPrototypeType> prototype = [NSBridgedPrototypeType allocWithZone:zone]; \
             return prototype;                                                                                \

--- a/Frameworks/include/CGColorInternal.h
+++ b/Frameworks/include/CGColorInternal.h
@@ -1,0 +1,40 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#pragma once
+
+#include <CoreGraphics/CGColor.h>
+
+struct __CGColorQuad {
+    CGFloat r;
+    CGFloat g;
+    CGFloat b;
+    CGFloat a;
+
+    bool operator==(const __CGColorQuad& other) const {
+        return (r == other.r) && (g == other.g) && (b == other.b) && (a == other.a);
+    }
+
+    void Clear() {
+        r = g = b = a = 0.0f;
+    }
+
+    void SetColorComponents(CGFloat red, CGFloat green, CGFloat blue, CGFloat alpha) {
+        r = red;
+        g = green;
+        b = blue;
+        a = alpha;
+    }
+};

--- a/Frameworks/include/UIColorInternal.h
+++ b/Frameworks/include/UIColorInternal.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,27 +17,25 @@
 #pragma once
 
 #import <UIKit/UIColor.h>
+#import <CFCppBase.h>
+#import "CGColorInternal.h"
 #import <CoreGraphics/CoreGraphics.h>
 
 typedef struct {
-    CGFloat r;
-    CGFloat g;
-    CGFloat b;
-    CGFloat a;
-} __CGColorQuad;
+    double r; // percent
+    double g; // percent
+    double b; // percent
+} rgb;
 
-inline void _ClearColorQuad(__CGColorQuad& color) {
-    color.r = 0.0f;
-    color.g = 0.0f;
-    color.b = 0.0f;
-    color.a = 0.0f;
-}
+typedef struct {
+    double h; // angle in degrees
+    double s; // percent
+    double v; // percent
+} hsv;
 
-@interface UIColor (Internal) {
-}
-+ (UIColor*)_colorWithCGPattern:(CGPatternRef)pattern;
+hsv rgb2hsv(rgb in);
+rgb hsv2rgb(hsv in);
+
+@interface UIColor (Internal)
 + (UIColor*)_windowsTableViewCellSelectionBackgroundColor;
-- (const __CGColorQuad*)_getColors;
-- (BrushType)_type;
-@property (nonatomic, assign) CGColorSpaceRef colorSpace;
 @end

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -77,6 +77,8 @@ LIBRARY CoreGraphics
         CGColorGetConstantColor
         CGColorCreateGenericRGB
         CGColorCreateGenericGray
+        CGColorCreateGenericCMYK
+        CGColorCreateCopyByMatchingToColorSpace
 
         ; CGColorSpace Reference.mm
         kCGColorSpaceGenericGray DATA

--- a/build/CoreGraphics/dll/CoreGraphics.def
+++ b/build/CoreGraphics/dll/CoreGraphics.def
@@ -55,6 +55,7 @@ LIBRARY CoreGraphics
         _DWriteRegisterFontsWithDatas
         _DWriteUnregisterFontsWithDatas
         _DWriteGetAllFonts
+        
 
         ; CGColor.mm
         kCGColorBlack DATA
@@ -74,6 +75,8 @@ LIBRARY CoreGraphics
         CGColorGetPattern
         CGColorGetTypeID
         CGColorGetConstantColor
+        CGColorCreateGenericRGB
+        CGColorCreateGenericGray
 
         ; CGColorSpace Reference.mm
         kCGColorSpaceGenericGray DATA

--- a/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics.Drawing/CoreGraphics.Drawing.UnitTests.vcxproj
@@ -40,9 +40,6 @@
     <ProjectReference Include="..\..\..\ImageIO\dll\ImageIO.vcxproj">
       <Project>{81B44F5A-DA8C-4699-BB4D-2C6DA20DD324}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\UIKit\dll\UIKit.vcxproj">
-       <Project>{43D2CFE5-0711-4E61-8F5C-F8D3B65D3A49}</Project>
-    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DE51CDE9-F326-49B6-8C5B-35D5B091878C}</ProjectGuid>

--- a/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/CoreGraphics/CoreGraphics.UnitTests.vcxproj
@@ -40,9 +40,6 @@
     <ProjectReference Include="..\..\..\CoreImage\dll\CoreImage.vcxproj">
       <Project>{3EFCDFF3-6013-448F-8611-534D0F819D6B}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\UIKit\dll\UIKit.vcxproj">
-      <Project>{43D2CFE5-0711-4E61-8F5C-F8D3B65D3A49}</Project>
-    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DA6C01EA-A22E-4807-BACE-63C5C6ABAE77}</ProjectGuid>

--- a/build/UIKit/lib/UIKitLib.vcxproj
+++ b/build/UIKit/lib/UIKitLib.vcxproj
@@ -48,6 +48,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIButtonContent.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIClassSwapper.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIColor.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UICGColor.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIControl.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIDevice.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIDocument.mm" />

--- a/include/CoreGraphics/CGColor.h
+++ b/include/CoreGraphics/CGColor.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -40,3 +40,5 @@ COREGRAPHICS_EXPORT size_t CGColorGetNumberOfComponents(CGColorRef color);
 COREGRAPHICS_EXPORT const CGFloat* CGColorGetComponents(CGColorRef color);
 COREGRAPHICS_EXPORT CGPatternRef CGColorGetPattern(CGColorRef color);
 COREGRAPHICS_EXPORT CFTypeID CGColorGetTypeID();
+COREGRAPHICS_EXPORT CGColorRef CGColorCreateGenericRGB(CGFloat red, CGFloat green, CGFloat blue, CGFloat alpha);
+COREGRAPHICS_EXPORT CGColorRef CGColorCreateGenericGray(CGFloat gray, CGFloat alpha);

--- a/include/CoreGraphics/CGColor.h
+++ b/include/CoreGraphics/CGColor.h
@@ -42,3 +42,10 @@ COREGRAPHICS_EXPORT CGPatternRef CGColorGetPattern(CGColorRef color);
 COREGRAPHICS_EXPORT CFTypeID CGColorGetTypeID();
 COREGRAPHICS_EXPORT CGColorRef CGColorCreateGenericRGB(CGFloat red, CGFloat green, CGFloat blue, CGFloat alpha);
 COREGRAPHICS_EXPORT CGColorRef CGColorCreateGenericGray(CGFloat gray, CGFloat alpha);
+// TODO #2614: Support the newly added apis
+COREGRAPHICS_EXPORT CGColorRef CGColorCreateGenericCMYK(CGFloat cyan, CGFloat magenta, CGFloat yellow, CGFloat black, CGFloat alpha)
+    STUB_METHOD;
+COREGRAPHICS_EXPORT CGColorRef CGColorCreateCopyByMatchingToColorSpace(CGColorSpaceRef,
+                                                                       CGColorRenderingIntent intent,
+                                                                       CGColorRef color,
+                                                                       CFDictionaryRef options) STUB_METHOD;

--- a/include/UIKit/UIColor.h
+++ b/include/UIKit/UIColor.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2011, The Iconfactory. All rights reserved.
- * Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+ * Copyright (c) Microsoft. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -33,15 +33,14 @@
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CGColor.h>
 #import <UIKit/UIKitExport.h>
+#import <UIKit/UIImage.h>
 
-@class UIImage, CIColor;
-
-enum BrushType { solidBrush, patternBrush, cgPatternBrush };
+@class CIColor;
 
 UIKIT_EXPORT_CLASS
 @interface UIColor : NSObject <NSCopying, NSObject, NSSecureCoding>
 
-@property (nonatomic, readonly) CGColorRef CGColor;
+@property (nonatomic, readonly) CGColorRef CGColor NS_RETURNS_INNER_POINTER;
 @property (readonly, nonatomic) CIColor* CIColor STUB_PROPERTY;
 
 + (UIColor*)blackColor;

--- a/tests/functionaltests/Tests/UIKitTests/UILabelTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UILabelTests.mm
@@ -86,6 +86,24 @@ public:
         startTests(labelVC);
     }
 
+    bool compareRGBAValues(UIColor* col1, UIColor* col2) {
+        if (col1 == nullptr && col2 == nullptr) {
+            return true;
+        }
+
+        if (!col1 || !col2) {
+            return false;
+        }
+
+        CGFloat r1, g1, b1, a1;
+        [col1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
+
+        CGFloat r2, g2, b2, a2;
+        [col2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+
+        return (r1 == r2) && (g1 == g2) && (b1 == b2) && (a1 == a2);
+    }
+
     void startTests(UILabelViewController* self) {
         testId = 0;
 
@@ -329,7 +347,7 @@ public:
         });
     }
 
-#if 0  // Test temporarily broken
+#if 0 // Test temporarily broken
     TEST_METHOD(UILabel_VerifyLineBreakMode) {
         StrongId<UILabelViewController> labelVC;
         labelVC.attach([[UILabelViewController alloc] init]);
@@ -468,37 +486,37 @@ public:
 
             auto colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_OBJCEQ(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor);
+            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             // verify setting color to others
             label.textColor = [UIColor redColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_OBJCEQ(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor);
+            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             label.textColor = [UIColor greenColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_OBJCEQ(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor);
+            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             // verify setting highlightedColor without changing UILabel state to highlighted state
             // the label's text color should not change
             label.highlightedTextColor = [UIColor blueColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_OBJCEQ(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor);
+            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             // now change the UILabel's state to be highlighted, and textblock's foreground should be using highlightedTextColor
             label.highlighted = YES;
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_OBJCEQ(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.highlightedTextColor);
+            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.highlightedTextColor));
 
             // now change the UILabel's state to be normal, verify textBlock's forground return to use original textColor
             label.highlighted = NO;
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_OBJCEQ(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor);
+            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
         });
     }
 

--- a/tests/unittests/CoreGraphics.drawing/CGContextDrawing_GradientTests.cpp
+++ b/tests/unittests/CoreGraphics.drawing/CGContextDrawing_GradientTests.cpp
@@ -16,11 +16,6 @@
 
 #include "DrawingTest.h"
 
-// TODO #2243: Remove the UIKit dependency
-#if WINOBJC
-#include <UIKit/UIColor.h>
-#endif
-
 #pragma region LinearGradient
 
 static void _drawLinearGradient(CGContextRef context,
@@ -67,10 +62,6 @@ DRAW_TEST_F(CGGradient, LinearGradient, UIKitMimicTest<PixelByPixelImageComparat
 DRAW_TEST_F(CGGradient, LinearGradientDrawWithCGColor, UIKitMimicTest<PixelByPixelImageComparator<PixelComparisonModeMask<64>>>) {
     CGFloat locations[2] = { 0, 1 };
     CGFloat components[8] = { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0 };
-
-#if WINOBJC
-    [UIColor class];
-#endif
 
     auto colorspace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceRGB());
 

--- a/tests/unittests/CoreGraphics/CGColorTests.mm
+++ b/tests/unittests/CoreGraphics/CGColorTests.mm
@@ -18,11 +18,6 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <vector>
 
-// TODO #2243: Remove the UIKit dependency
-#if WINOBJC
-#include <UIKit/UIColor.h>
-#endif
-
 #define EXPECT_EQ_COMPONENTS(a, b) \
     EXPECT_EQ((a)[0], (b)[0]);     \
     EXPECT_EQ((a)[1], (b)[1]);     \
@@ -30,9 +25,6 @@
     EXPECT_EQ((a)[3], (b)[3])
 
 TEST(CGColor, CGColorGetComponents) {
-#if WINOBJC
-    [UIColor class];
-#endif
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -58,10 +50,6 @@ TEST(CGColor, CGColorGetComponents) {
 }
 
 TEST(CGColor, CGColorEquals) {
-#if WINOBJC
-    [UIColor class];
-#endif
-
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -93,9 +81,6 @@ TEST(CGColor, CGColorEquals) {
 }
 
 TEST(CGColor, GetColorSpace) {
-#if WINOBJC
-    [UIColor class];
-#endif
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
     CGColorSpaceRef clrRgb = CGColorSpaceCreateDeviceRGB();
@@ -117,9 +102,6 @@ TEST(CGColor, GetColorSpace) {
 }
 
 TEST(CGColor, GetConstantColor) {
-#if WINOBJC
-    [UIColor class];
-#endif
     auto grayColorSpace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceGray());
 
     CFStringRef colors[] = { kCGColorWhite, kCGColorBlack, kCGColorClear };
@@ -132,9 +114,6 @@ TEST(CGColor, GetConstantColor) {
 }
 
 TEST(CGColor, CGColorSpaceCreateIndexed) {
-#if WINOBJC
-    [UIColor class];
-#endif
     auto rgbColorSpace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceRGB());
 
     static const unsigned char tableVal[] = { 255, 255, 255, 0, 0, 0, 212, 255, 154 };

--- a/tests/unittests/CoreGraphics/CGColorTests.mm
+++ b/tests/unittests/CoreGraphics/CGColorTests.mm
@@ -49,6 +49,24 @@ TEST(CGColor, CGColorGetComponents) {
     CGColorSpaceRelease(clrRgb);
 }
 
+TEST(CGColor, CGGenericGray) {
+    CGFloat colors[] = { 0.5, 1 };
+
+    auto grayColorSpace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceGray());
+    auto col1 = woc::MakeStrongCF<CGColorRef>(CGColorCreate(grayColorSpace, colors));
+    auto col2 = woc::MakeStrongCF<CGColorRef>(CGColorCreateGenericGray(colors[0], colors[1]));
+    EXPECT_TRUE(CGColorEqualToColor(col1, col2));
+}
+
+TEST(CGColor, CGGenericRGB) {
+    CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
+
+    auto rgbColorSpace = woc::MakeStrongCF<CGColorSpaceRef>(CGColorSpaceCreateDeviceRGB());
+    auto col1 = woc::MakeStrongCF<CGColorRef>(CGColorCreate(rgbColorSpace, colors));
+    auto col2 = woc::MakeStrongCF<CGColorRef>(CGColorCreateGenericRGB(colors[0], colors[1], colors[2], colors[3]));
+    EXPECT_TRUE(CGColorEqualToColor(col1, col2));
+}
+
 TEST(CGColor, CGColorEquals) {
     CGFloat colors[] = { 1, 0, 0, 1 }; // bright red
 
@@ -56,7 +74,7 @@ TEST(CGColor, CGColorEquals) {
     CGColorRef clr1 = CGColorCreate(clrRgb, colors);
     CGColorRef clr2 = CGColorCreateCopy(clr1);
     CGColorRef clr3 = CGColorCreateCopyWithAlpha(clr1, 0.9);
-    CGColorRef clr4 = CGColorCreate(clrRgb, colors);
+    CGColorRef clr4 = CGColorCreateGenericRGB(colors[0], colors[1], colors[2], colors[3]);
 
     EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr1)));
     EXPECT_EQ(CGColorSpaceGetModel(clrRgb), CGColorSpaceGetModel(CGColorGetColorSpace(clr2)));

--- a/tests/unittests/UIKit/UIColorTests.mm
+++ b/tests/unittests/UIKit/UIColorTests.mm
@@ -17,6 +17,20 @@
 #include <TestFramework.h>
 #import <UIKit/UIColor.h>
 
+TEST(UIColorTest, ColorTests) {
+    UIColor* color = [UIColor redColor];
+    UIColor* color2 = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
+    EXPECT_OBJCEQ(color, color2);
+
+    color = [UIColor blackColor];
+    color2 = [UIColor colorWithWhite:0 alpha:1];
+    EXPECT_OBJCEQ(color, color2);
+
+    color = [UIColor blackColor];
+    color2 = [UIColor colorWithRed:0 green:0 blue:0 alpha:1];
+    EXPECT_OBJCNE(color, color2);
+}
+
 TEST(UIColorTest, NamedUIColorMethods) {
     UIColor* color = [UIColor redColor];
 


### PR DESCRIPTION
- [x]  Implement CGColor independent of UIColor
- [x] Implement UIColor as a class cluster
- [x]  Removal of BrushTypes
- [x]  Overall code improvements
- [x]  Support for grayscale 
- [x]  Remove UIColor usage from CALayer
- [x] Update UIKit to properly confirm to UIColor 
#2614, 
The current changes, which touch CoreGraphics, help remove the dependencies CoreGraphics.UnitTests & CoreGraphics.DrawingTests had on UIKit. CoreGraphics.UnitTests & CoreGraphics.DrawingTests pass.

fixes #2243, #2524