### PR TITLE
Add blocks_runtime.h to objc modulemap

### DIFF
--- a/tools/include/objc/module.modulemap
+++ b/tools/include/objc/module.modulemap
@@ -1,5 +1,6 @@
 module ObjC [extern_c] {
     umbrella header "objc.h"
     exclude header "*.h"
+    header "blocks_runtime.h"
     export *
 }


### PR DESCRIPTION
Fixes #2122 and #1976

Previously, when compiling as ObjC++ with modules turned on, the
blocks_runtime.h header could not be found