### PR TITLE
Improve shields on README.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
 # Welcome to the Windows Bridge for iOS Project
 The Windows Bridge for iOS (also referred to as WinObjC) is a Microsoft open-source project that provides an Objective-C development environment for Visual Studio and support for iOS APIs. The bridge allows you to create Universal Windows Platform (UWP) apps that will run on many Windows devices by re-using your Objective-C code and iOS APIs alongside Windows 10 features like Cortana and Windows Notifications.
 
+[license-badge]: https://img.shields.io/github/license/microsoft/winobjc.svg?style=flat-square
+[license-link]: https://github.com/Microsoft/WinObjC/blob/master/license.txt
+[![license][license-badge]][license-link]
+
 [develop-build-badge]:        https://img.shields.io/vso/build/winobjc/03960378-fe55-4577-a8cc-1a874f7cf008/109.svg?style=flat-square
+[master-build-badge]:        https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat-square
 [github-rel]:                 https://github.com/Microsoft/WinObjC/releases/latest
-[github-rel-badge]:           https://img.shields.io/github/tag/microsoft/winobjc.svg?style=flat-square
+[github-rel-badge]:           https://img.shields.io/github/tag/microsoft/winobjc.svg?style=flat-square&label=release&colorB=007ec6
 [choco]:                      https://chocolatey.org/packages/winobjc-tools
-[choco-badge]:                https://img.shields.io/chocolatey/v/winobjc-tools.svg?style=flat-square                 
+[choco-badge]:                https://img.shields.io/chocolatey/v/winobjc-tools.svg?style=flat-square&colorB=007ec6                 
 [choco-badge-pre]:            https://img.shields.io/chocolatey/vpre/winobjc-tools.svg?style=flat-square
 [nuget-frmwrk]:               https://www.nuget.org/packages/WinObjC.Frameworks
-[nuget-frmwrk-badge]:         https://img.shields.io/nuget/v/WinObjC.Frameworks.svg?style=flat-square
+[nuget-frmwrk-badge]:         https://img.shields.io/nuget/v/WinObjC.Frameworks.svg?style=flat-square&colorB=007ec6
 [nuget-frmwrk-badge-pre]:     https://img.shields.io/nuget/vpre/WinObjC.Frameworks.svg?style=flat-square
 [nuget-lang]:                 https://www.nuget.org/packages/WinObjC.Language
-[nuget-lang-badge]:           https://img.shields.io/nuget/v/WinObjC.Language.svg?style=flat-square
+[nuget-lang-badge]:           https://img.shields.io/nuget/v/WinObjC.Language.svg?style=flat-square&colorB=007ec6
 [nuget-lang-badge-pre]:       https://img.shields.io/nuget/vpre/WinObjC.Language.svg?style=flat-square
 
+## Build and Release Status
 |                      |           Stable (master)                        |            Pre-release (develop)          |
 | -------------------: | :----------------------------------------------: | :---------------------------------------: |
-|           **Build**  |                  -                               |       ![VSTS][develop-build-badge]        |
+|           **Build**  |       ![VSTS][master-build-badge]                |       ![VSTS][develop-build-badge]        |
 |  **GitHub Release**  |[![Github Release][github-rel-badge]][github-rel] |               -                           |
 |    **winobjc-tools** |     [![Tools][choco-badge]][choco]               |   [![Tools][choco-badge-pre]][choco]      |
 | **WinObjC.Language** |[![Language][nuget-lang-badge]][nuget-lang]       |[![Language][nuget-lang-badge-pre]][nuget-lang]   |

--- a/license.txt
+++ b/license.txt
@@ -1,8 +1,0 @@
-Windows Bridge for iOS
-
-Copyright (c) Microsoft Corporation
-All rights reserved. 
-MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
https://github.com/bbowman/WinObjC/tree/bbowman/readmeColors shows the changes. The license currently can't be detected by github (uses default branch which is master for shield) but you can see what it would like on the master branch of my fork:

[license-badge]: https://img.shields.io/github/license/microsoft/winobjc.svg?style=flat-square
[license-link]: https://github.com/Microsoft/WinObjC/blob/master/license.txt
[![license][license-badge]][license-link]

And you see the MIT license logo dealio in the upper right of the page.