### PR TITLE
Disable the NSURLSessionTests completely

### DIFF
--- a/tests/functionaltests/Tests/NSURLSession.mm
+++ b/tests/functionaltests/Tests/NSURLSession.mm
@@ -281,6 +281,7 @@ class NSURLSessionTests {
 public:
     BEGIN_TEST_CLASS(NSURLSessionTests)
     TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"NSURL.AppxManifest.xml")
+    TEST_CLASS_PROPERTY(L"ignore", L"true")
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSURLClassSetup) {


### PR DESCRIPTION
NSURLSession and NSURLProtocol need to be adjusted to ensure proper delegate callback order (#2521)