### PR TITLE
Push UIActivityIndicatorView stopAnimating/startAnimating calls to the UIThread

### DIFF
--- a/Frameworks/UIKit/UIActivityIndicatorView.mm
+++ b/Frameworks/UIKit/UIActivityIndicatorView.mm
@@ -22,8 +22,10 @@
 #import <UIKit/UIActivityIndicatorView.h>
 #import <UIKit/UIColor.h>
 
-#import "XamlUtilities.h"
+
 #import "CppWinRTHelpers.h"
+#import "UIViewInternal.h"
+#import "XamlUtilities.h"
 
 #include "COMIncludes.h"
 #import <winrt/Windows.UI.Xaml.Controls.h>
@@ -226,13 +228,15 @@ static const int c_largeSquareLength = 37;
  @Status Interoperable
 */
 - (void)startAnimating {
-    if (_isAnimating) {
-        return;
-    }
+    RunSynchronouslyOnMainThread(^{
+        if (_isAnimating) {
+            return;
+        }
 
-    _isAnimating = YES;
-    [self setHidden:NO];
-    _progressRing.IsActive(true);
+        _isAnimating = YES;
+        [self setHidden:NO];
+        _progressRing.IsActive(true);
+    });
 }
 
 /**
@@ -240,14 +244,16 @@ static const int c_largeSquareLength = 37;
  @Notes Same issue as setHidesWhenStopped.
 */
 - (void)stopAnimating {
-    if (_isAnimating) {
-        _isAnimating = NO;
-    }
+    RunSynchronouslyOnMainThread(^{
+        if (_isAnimating) {
+            _isAnimating = NO;
+        }
 
-    _progressRing.IsActive(false);
-    if (_hidesWhenStopped) {
-        [self setHidden:YES];
-    }
+        _progressRing.IsActive(false);
+        if (_hidesWhenStopped) {
+            [self setHidden:YES];
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
This regression was likely exposed by the recent NSOperationQueue changes (71042590); we were previously getting called back on the UIThread accidentally.

Whether or not this is a proper long term fix will be re-evaluated with the broader backlog task around UIView threading concerns.

Fixes #2577.