### PR TITLE
Remove Foundation from CTLine

### DIFF
--- a/Frameworks/CoreText/CTFrame.mm
+++ b/Frameworks/CoreText/CTFrame.mm
@@ -38,7 +38,7 @@ CFRange CTFrameGetStringRange(CTFrameRef frame) {
     CFIndex len = CFArrayGetCount(frame->_lines);
 
     for (CFIndex index = 0; index < len; ++index) {
-        _CTLine* line = static_cast<_CTLine*>(CFArrayGetValueAtIndex(frame->_lines, index));
+        CTLineRef line = static_cast<CTLineRef>(CFArrayGetValueAtIndex(frame->_lines, index));
         count += line->_strRange.length;
     }
 
@@ -54,7 +54,7 @@ CFRange CTFrameGetVisibleStringRange(CTFrameRef frame) {
     CFIndex count = 0;
     for (size_t index = 0; index < frame->_lineOrigins.size(); ++index) {
         if (frame->_lineOrigins[index].y < frame->_frameRect.size.height) {
-            _CTLine* line = static_cast<_CTLine*>(CFArrayGetValueAtIndex(frame->_lines, index));
+            CTLineRef line = static_cast<CTLineRef>(CFArrayGetValueAtIndex(frame->_lines, index));
             count += line->_strRange.length;
         }
     }
@@ -104,13 +104,12 @@ void CTFrameDraw(CTFrameRef frame, CGContextRef ctx) {
     std::vector<GlyphRunData> runs;
 
     for (size_t i = 0; i < frame->_lineOrigins.size() && (frame->_lineOrigins[i].y < frame->_frameRect.size.height); ++i) {
-        _CTLine* line = static_cast<_CTLine*>(CFArrayGetValueAtIndex(frame->_lines, i));
+        CTLineRef line = static_cast<CTLineRef>(CFArrayGetValueAtIndex(frame->_lines, i));
 
         CGPoint relativePosition = frame->_lineOrigins[i];
-
         CFIndex len = CFArrayGetCount(line->_runs);
         for (size_t j = 0; j < len; ++j) {
-            __CTRun* curRun = const_cast<__CTRun*>(static_cast<CTRunRef>(CFArrayGetValueAtIndex(line->_runs, j)));
+            __CTRun* curRun = static_cast<__CTRun*>(const_cast<void*>(CFArrayGetValueAtIndex(line->_runs, j)));
             if (j > 0) {
                 // Adjusts x position relative to the last run drawn
                 relativePosition.x += curRun->_relativeXOffset;

--- a/Frameworks/CoreText/CTFramesetter.mm
+++ b/Frameworks/CoreText/CTFramesetter.mm
@@ -103,7 +103,7 @@ CTFrameRef CTFramesetterCreateFrame(CTFramesetterRef framesetter, CFRange range,
         (lineBreakMode == kCTLineBreakByClipping || lineBreakMode == kCTLineBreakByTruncatingHead ||
          lineBreakMode == kCTLineBreakByTruncatingTail || lineBreakMode == kCTLineBreakByTruncatingMiddle)) {
         for (size_t i = 0; i < ret->_lineOrigins.size(); ++i) {
-            _CTLine* line = static_cast<_CTLine*>(CFArrayGetValueAtIndex(ret->_lines, i));
+            CTLineRef line = static_cast<CTLineRef>(CFArrayGetValueAtIndex(ret->_lines, i));
             if (line->_width > frameRect.size.width) {
                 ret->_lineOrigins[i].x -= line->_relativeXOffset;
             }

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -428,10 +428,8 @@ CGRect CTLineGetBoundsWithOptions(CTLineRef line, CTLineBoundsOptions options) {
 }
 
 /**
- @Status NotInPlan
- @Notes this would require us to move to using bridged type implementation, seems of little value at this point
+ @Status Interoperable
 */
 CFTypeID CTLineGetTypeID() {
-    UNIMPLEMENTED();
-    return StubReturn();
+    return __CTLine::GetTypeID();
 }

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -142,7 +142,7 @@ static CFMutableAttributedStringRef __CTLineGetTruncatedStringFromSourceLine(CTL
 */
 CTLineRef CTLineCreateWithAttributedString(CFAttributedStringRef string) {
     RETURN_NULL_IF(!string);
-    return _DWriteGetLine(string);
+    return _DWriteCreateLine(string);
 }
 
 /**

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -298,39 +298,41 @@ CGRect CTLineGetImageBounds(CTLineRef line, CGContextRef context) {
     return { CGContextGetTextPosition(context), { width, ascent - descent } };
 }
 
-/**
- @Status Interoperable
-*/
-double CTLineGetTypographicBounds(CTLineRef lineRef, CGFloat* ascent, CGFloat* descent, CGFloat* leading) {
-    _CTLine* line = static_cast<_CTLine*>(lineRef);
-
-    __CTLine* line = const_cast<__CTLine*>(lineRef);
-    RETURN_RESULT_IF((!line) || (CFArrayGetCount(line->_runs) == 0), 0);
+double __CTLine::GetTypographicBounds(CGFloat* ascent, CGFloat* descent, CGFloat* leading) const {
+    RETURN_RESULT_IF((CFArrayGetCount(_runs) == 0), 0);
 
     // Created with impossible values -FLT_MAX which signify they need to be populated
-    if ((line->_ascent == -FLT_MAX || line->_descent == -FLT_MAX || line->_leading == -FLT_MAX) && (ascent || descent || leading)) {
-        CFIndex count = CFArrayGetCount(line->_runs);
+    if ((_ascent == -FLT_MAX || _descent == -FLT_MAX || _leading == -FLT_MAX) && (ascent || descent || leading)) {
+        CFIndex count = CFArrayGetCount(_runs);
         for (CFIndex i = 0; i < count; ++i) {
-            CTRunRef run = static_cast<CTRunRef>(CFArrayGetValueAtIndex(line->_runs, i));
+            CTRunRef run = static_cast<CTRunRef>(CFArrayGetValueAtIndex(_runs, i));
             CGFloat newAscent, newDescent, newLeading;
             CTRunGetTypographicBounds(run, { 0, 0 }, &newAscent, &newDescent, &newLeading);
-            line->_ascent = std::max(line->_ascent, newAscent);
-            line->_descent = std::max(line->_descent, newDescent);
-            line->_leading = std::max(line->_leading, newLeading);
+            _ascent = std::max(_ascent, newAscent);
+            _descent = std::max(_descent, newDescent);
+            _leading = std::max(_leading, newLeading);
         }
     }
 
     if (ascent) {
-        *ascent = line->_ascent;
+        *ascent = _ascent;
     }
     if (descent) {
-        *descent = line->_descent;
+        *descent = _descent;
     }
     if (leading) {
-        *leading = line->_leading;
+        *leading = _leading;
     }
 
-    return line->_width;
+    return _width;
+}
+
+/**
+ @Status Interoperable
+*/
+double CTLineGetTypographicBounds(CTLineRef line, CGFloat* ascent, CGFloat* descent, CGFloat* leading) {
+    RETURN_RESULT_IF((!line), 0);
+    return line->GetTypographicBounds(ascent, descent, leading);
 }
 
 /**

--- a/Frameworks/CoreText/CTLine.mm
+++ b/Frameworks/CoreText/CTLine.mm
@@ -176,7 +176,7 @@ CTLineRef CTLineCreateTruncatedLine(CTLineRef sourceLine, double width, CTLineTr
     }
 
     // get an CFMutableAttributedString string from truncationToken by looping across its runs and extracting the run attribuets.
-    CFMutableAttributedStringRef stringFromToken = CFAttributedStringCreateMutable(kCFAllocatorDefault, 0);
+    auto stringFromToken = woc::MakeStrongCF<CFMutableAttributedStringRef>(CFAttributedStringCreateMutable(kCFAllocatorDefault, 0));
     CFArrayRef tokenRuns = CTLineGetGlyphRuns(truncationToken);
     if (tokenRuns != nil) {
         CFIndex numberOfRuns = CFArrayGetCount(tokenRuns);
@@ -216,7 +216,6 @@ CTLineRef CTLineCreateTruncatedLine(CTLineRef sourceLine, double width, CTLineTr
         default:
             return nil;
     }
-    CFRelease(stringFromToken);
     return CTLineCreateWithAttributedString(static_cast<CFAttributedStringRef>(finalString));
 }
 

--- a/Frameworks/CoreText/CTTypesetter.mm
+++ b/Frameworks/CoreText/CTTypesetter.mm
@@ -103,7 +103,8 @@ CFIndex CTTypesetterSuggestLineBreakWithOffset(CTTypesetterRef typesetter, CFInd
                                        CGRectMake(offset, 0, width, FLT_MAX));
 
     if (CFArrayGetCount(frame->_lines) > 0) {
-        return static_cast<_CTLine*>(CFArrayGetValueAtIndex(frame->_lines, 0))->_strRange.length;
+        CTLineRef line = static_cast<CTLineRef>(CFArrayGetValueAtIndex(frame->_lines, 0));
+        return line->_strRange.length;
     }
 
     return 0;

--- a/Frameworks/CoreText/CTTypesetter.mm
+++ b/Frameworks/CoreText/CTTypesetter.mm
@@ -17,9 +17,7 @@
 #import <CoreText/CTTypesetter.h>
 #import <StubReturn.h>
 #import "CoreTextInternal.h"
-#import "UIFontInternal.h"
 #import "DWriteWrapper_CoreText.h"
-#import <Foundation/NSAttributedString.h>
 #import <algorithm>
 #import <CFCppBase.h>
 #import "LoggingNative.h"
@@ -100,9 +98,9 @@ CFIndex CTTypesetterSuggestLineBreak(CTTypesetterRef typesetter, CFIndex startIn
  @Status Interoperable
 */
 CFIndex CTTypesetterSuggestLineBreakWithOffset(CTTypesetterRef typesetter, CFIndex index, double width, double offset) {
-      CTFrameRef frame = _DWriteGetFrame(typesetter->AttributedString(),
-                                      CFRangeMake(index, CFAttributedStringGetLength(typesetter->AttributedString()) - index),
-                                      CGRectMake(offset, 0, width, FLT_MAX));
+    CTFrameRef frame = _DWriteGetFrame(typesetter->AttributedString(),
+                                       CFRangeMake(index, CFAttributedStringGetLength(typesetter->AttributedString()) - index),
+                                       CGRectMake(offset, 0, width, FLT_MAX));
 
     if (CFArrayGetCount(frame->_lines) > 0) {
         return static_cast<_CTLine*>(CFArrayGetValueAtIndex(frame->_lines, 0))->_strRange.length;

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -47,7 +47,7 @@ bool _CloneDWriteGlyphRun(_In_ DWRITE_GLYPH_RUN const* src, _Outptr_ DWRITE_GLYP
 
 CGSize _DWriteGetFrameSize(CFAttributedStringRef string, CFRange range, CGSize maxSize, CFRange* fitRange);
 CTFrameRef _DWriteGetFrame(CFAttributedStringRef string, CFRange range, CGRect frameSize);
-_CTLine* _DWriteGetLine(CFAttributedStringRef string);
+CTLineRef _DWriteCreateLine(CFAttributedStringRef string);
 
 // DWriteWrapper functions relating to CTFont, CTFontDescriptor
 CFNumberRef _CFNumberCreateFromSymbolicTraits(CTFontSymbolicTraits symbolicTraits);

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.h
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.h
@@ -27,13 +27,7 @@
 #import <DWrite_3.h>
 #import <wrl/client.h>
 #include <COMIncludes_End.h>
-
-#import <Foundation/NSObject.h>
-#import <Foundation/NSArray.h>
-#import <Foundation/NSString.h>
 #import <vector>
-
-#define NSMakeRangeFromCF(cfr) NSMakeRange(cfr.location == kCFNotFound ? NSNotFound : cfr.location, cfr.length)
 
 // Based off DWRITE_GLYPH_RUN_DESCRIPTION structure
 struct _DWriteGlyphRunDescription {

--- a/Frameworks/CoreText/DWriteWrapper_CoreText.mm
+++ b/Frameworks/CoreText/DWriteWrapper_CoreText.mm
@@ -393,14 +393,14 @@ public:
  *
  * @return Unmutable array of _CTLine objects created with the requested parameters.
  */
-static _CTLine* _DWriteGetLine(CFAttributedStringRef string) {
+static CTLineRef _DWriteCreateLine(CFAttributedStringRef string) {
     CFRange range = CFRangeMake(0, CFAttributedStringGetLength(string));
     CTFrameRef frame = _DWriteGetFrame(string, range, CGRectMake(0, 0, FLT_MAX, FLT_MAX));
     if (CFArrayGetCount(frame->_lines) > 0) {
-        return [static_cast<_CTLine*>(CFArrayGetValueAtIndex(frame->_lines, 0)) retain];
+        return static_cast<CTLineRef>(CFRetain(CFArrayGetValueAtIndex(frame->_lines, 0)));
     }
 
-    return [_CTLine new];
+    return _CTLineCreate();
 }
 
 /**
@@ -445,7 +445,7 @@ static CTFrameRef _DWriteGetFrame(CFAttributedStringRef string, CFRange range, C
     float prevYPosForDraw = 0;
 
     while (i < numOfGlyphRuns) {
-        _CTLine* line = [[_CTLine new] autorelease];
+        auto line = woc::MakeStrongCF<__CTLine*>(const_cast<__CTLine*>(_CTLineCreate()));
 
         auto runs = woc::MakeStrongCF<CFMutableArrayRef>(CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks));
         uint32_t stringRange = 0;

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -18,7 +18,7 @@
 #import <CoreText/CoreText.h>
 #import <CoreText/CTParagraphStyle.h>
 #import <CFCppBase.h>
-#import "Starboard.h"
+#import <Starboard.h>
 #include <COMIncludes.h>
 #import <DWrite.h>
 #import <wrl/client.h>
@@ -48,16 +48,35 @@ inline void _SafeRelease(T** p) {
 
 CFAttributedStringRef _CTTypesetterGetAttributedString(CTTypesetterRef typesetter);
 
-@interface _CTLine : NSObject {
-@public
+#pragma region CTLine
+struct __CTLine : CoreFoundation::CppBase<__CTLine> {
+    __CTLine() : _runs(woc::TakeOwnership, CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks)) {
+    }
+
+    __CTLine(const __CTLine& other)
+        : _strRange(other._strRange),
+          _width(other._width),
+          _ascent(other._ascent),
+          _descent(other._descent),
+          _leading(other._leading),
+          _glyphCount(other._glyphCount),
+          _relativeXOffset(other._relativeXOffset),
+          _runs(woc::TakeOwnership, CFArrayCreateMutableCopy(kCFAllocatorDefault, 0, other._runs)) {
+    }
+
     CFRange _strRange;
     CGFloat _relativeXOffset;
     CGFloat _width;
-    NSUInteger _glyphCount;
+    CFIndex _glyphCount;
     woc::StrongCF<CFMutableArrayRef> _runs;
-    CGFloat _ascent, _descent, _leading;
-}
-@end
+    CGFloat _ascent;
+    CGFloat _descent;
+    CGFloat _leading;
+};
+
+CTLineRef _CTLineCreate();
+
+#pragma endregion CTLine
 
 #pragma region CTFrame
 struct __CTFrame : CoreFoundation::CppBase<__CTFrame> {

--- a/Frameworks/include/CoreTextInternal.h
+++ b/Frameworks/include/CoreTextInternal.h
@@ -64,14 +64,16 @@ struct __CTLine : CoreFoundation::CppBase<__CTLine> {
           _runs(woc::TakeOwnership, CFArrayCreateMutableCopy(kCFAllocatorDefault, 0, other._runs)) {
     }
 
+    double GetTypographicBounds(CGFloat* ascent, CGFloat* descent, CGFloat* leading) const;
+
     CFRange _strRange;
     CGFloat _relativeXOffset;
     CGFloat _width;
     CFIndex _glyphCount;
     woc::StrongCF<CFMutableArrayRef> _runs;
-    CGFloat _ascent;
-    CGFloat _descent;
-    CGFloat _leading;
+    mutable CGFloat _ascent;
+    mutable CGFloat _descent;
+    mutable CGFloat _leading;
 };
 
 CTLineRef _CTLineCreate();

--- a/include/CoreText/CTFont.h
+++ b/include/CoreText/CTFont.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTFontCollection.h
+++ b/include/CoreText/CTFontCollection.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTFrame.h
+++ b/include/CoreText/CTFrame.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTFramesetter.h
+++ b/include/CoreText/CTFramesetter.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTGlyphInfo.h
+++ b/include/CoreText/CTGlyphInfo.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTLine.h
+++ b/include/CoreText/CTLine.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -19,7 +19,6 @@
 
 #import <CoreFoundation/CFArray.h>
 #import <CoreFoundation/CFAttributedString.h>
-
 #import <CoreGraphics/CGContext.h>
 #import <CoreGraphics/CGGeometry.h>
 
@@ -56,4 +55,4 @@ CORETEXT_EXPORT double CTLineGetTypographicBounds(CTLineRef line, CGFloat* ascen
 CORETEXT_EXPORT double CTLineGetTrailingWhitespaceWidth(CTLineRef line) STUB_METHOD;
 CORETEXT_EXPORT CFIndex CTLineGetStringIndexForPosition(CTLineRef line, CGPoint position);
 CORETEXT_EXPORT CGFloat CTLineGetOffsetForStringIndex(CTLineRef line, CFIndex charIndex, CGFloat* secondaryOffset);
-CORETEXT_EXPORT CFTypeID CTLineGetTypeID() NOTINPLAN_METHOD;
+CORETEXT_EXPORT CFTypeID CTLineGetTypeID();

--- a/include/CoreText/CTStringAttributes.h
+++ b/include/CoreText/CTStringAttributes.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CTTextTab.h
+++ b/include/CoreText/CTTextTab.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CoreText.h
+++ b/include/CoreText/CoreText.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //

--- a/include/CoreText/CoreTextExport.h
+++ b/include/CoreText/CoreTextExport.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //


### PR DESCRIPTION
- Implementation of CTLine via runtime based
- Reduced/Removed Attributed string creation in loops
- Implemented CFAttribute functions to append and insert attributed string
- Implemented NSAttributes in terms of CFAttributes
- Fixed memory leaks
- Code improvements
- Increased perf

Fixes #2357,#2451

![image](https://cloud.githubusercontent.com/assets/18413092/25298242/43c8a97e-26a8-11e7-9c44-619f4bb6c1d0.png)