### PR TITLE
Exit gracefully when readPlist fails

### DIFF
--- a/tools/vsimporter/src/SBResourcesBuildPhase.cpp
+++ b/tools/vsimporter/src/SBResourcesBuildPhase.cpp
@@ -49,7 +49,12 @@ static void parsePlist(const String& plistPath, VCProject& proj) {
     StringSet registeredUrlSchemes;
 
     boost::any plist;
-    readPlist(plistPath.c_str(), plist);
+    try {
+        readPlist(plistPath.c_str(), plist);
+    } catch (const std::exception& e) {
+        SBLog::error() << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
 
     dictionary_type* dict = any_cast<dictionary_type>(&plist);
     if (dict == nullptr) {

--- a/tools/vsimporter/src/vswriter/VSTemplateProject.cpp
+++ b/tools/vsimporter/src/vswriter/VSTemplateProject.cpp
@@ -169,6 +169,7 @@ static std::vector<String> getCacheFolders(const String& entitlementsPath) {
         pDict = boost::any_cast<Plist::dictionary_type>(&pAny);
     } catch (const std::exception& e) {
         SBLog::error() << e.what() << std::endl;
+        exit(EXIT_FAILURE);
     }
 
     if (pDict) {


### PR DESCRIPTION
We should catch exceptions from PlistCpp so that vsimporter can exit gracefully.