### PR TITLE
Prevent invalid pointer read for projects with no build phase

### DIFF
--- a/tools/vsimporter/src/SBFrameworksBuildPhase.cpp
+++ b/tools/vsimporter/src/SBFrameworksBuildPhase.cpp
@@ -81,7 +81,7 @@ void SBFrameworksBuildPhase::writeVCProjectFiles(VCProject& proj) const {
     // We don't support linking with frameworks when building bundles
     TargetProductType productType = m_parentTarget.getProductType();
     if (productType == TargetBundle) {
-        if (!m_phase->getBuildFileList().empty()) {
+        if (m_phase && !m_phase->getBuildFileList().empty()) {
             SBLog::warning() << "Ignoring all frameworks in \"" << m_parentTarget.getName() << "\" bundle target." << std::endl;
             TELEMETRY_EVENT(L"VSImporterLinkingFrameworksWithBundles");
         }

--- a/tools/vsimporter/src/SBHeadersBuildPhase.cpp
+++ b/tools/vsimporter/src/SBHeadersBuildPhase.cpp
@@ -34,17 +34,16 @@ SBHeadersBuildPhase::SBHeadersBuildPhase(const PBXHeadersBuildPhase* phase, cons
 
 void SBHeadersBuildPhase::writeVCProjectFiles(VCProject& proj) const {
     TargetProductType productType = m_parentTarget.getProductType();
-    if (productType != TargetStaticLib) {
-        return;
-    }
 
     // Process public headers
-    const BuildSettings& projBS = m_parentTarget.getProject().getBuildSettings();
-    const BuildFileList& buildFiles = m_phase->getBuildFileList();
-    for (size_t i = 0; i < buildFiles.size(); i++) {
-        if (buildFiles[i]->getAttributes() & ATTR_PUBLIC) {
-            VCItemHint itemHint = { "ClInclude", "", "Public Headers" };
-            addBuildFileToVS(buildFiles[i], proj, projBS, &itemHint);
+    if (productType == TargetStaticLib && m_phase) {
+        const BuildSettings& projBS = m_parentTarget.getProject().getBuildSettings();
+        const BuildFileList& buildFiles = m_phase->getBuildFileList();
+        for (size_t i = 0; i < buildFiles.size(); i++) {
+            if (buildFiles[i]->getAttributes() & ATTR_PUBLIC) {
+                VCItemHint itemHint = { "ClInclude", "", "Public Headers" };
+                addBuildFileToVS(buildFiles[i], proj, projBS, &itemHint);
+            }
         }
     }
 }

--- a/tools/vsimporter/src/SBResourcesBuildPhase.cpp
+++ b/tools/vsimporter/src/SBResourcesBuildPhase.cpp
@@ -126,25 +126,28 @@ void SBResourcesBuildPhase::writeVCProjectFiles(VCProject& proj) const {
     }
 
     // Process build files
-    const BuildSettings& projBS = m_parentTarget.getProject().getBuildSettings();
-    const BuildFileList& buildFiles = m_phase->getBuildFileList();
-    sbAssertWithTelemetry(buildFiles.size() == m_buildFileTargets.size(), "Inconsistent number of Resource build files");
-    for (size_t i = 0; i < buildFiles.size(); i++) {
-        // Construct a path for Bundle build products, relative to the SolutionDir,
-        // instead of using the Xcode path
-        String pathOverride;
-        if (m_buildFileTargets[i]) {
-            String productFileName = sb_basename(buildFiles[i]->getFile()->getFullPath());
-            String productFileType = buildFiles[i]->getFile()->getFileType();
-            if (productFileType == "wrapper.cfbundle") {
-                pathOverride = "$(SolutionDir)$(Configuration)\\" + productFileName;
-            } else {
-                SBLog::warning() << "Unexpected build product in ResourceBuildPhase: " << productFileName << std::endl;
+    if (m_phase) {
+        const BuildSettings& projBS = m_parentTarget.getProject().getBuildSettings();
+        const BuildFileList& buildFiles = m_phase->getBuildFileList();
+        sbAssertWithTelemetry(buildFiles.size() == m_buildFileTargets.size(), "Inconsistent number of Resource build files");
+        for (size_t i = 0; i < buildFiles.size(); i++) {
+            // Construct a path for Bundle build products, relative to the SolutionDir,
+            // instead of using the Xcode path
+            String pathOverride;
+            if (m_buildFileTargets[i]) {
+                String productFileName = sb_basename(buildFiles[i]->getFile()->getFullPath());
+                String productFileType = buildFiles[i]->getFile()->getFileType();
+                if (productFileType == "wrapper.cfbundle") {
+                    pathOverride = "$(SolutionDir)$(Configuration)\\" + productFileName;
+                }
+                else {
+                    SBLog::warning() << "Unexpected build product in ResourceBuildPhase: " << productFileName << std::endl;
+                }
             }
-        }
 
-        VCItemHint itemHint = { "SBResourceCopy", pathOverride, "" };
-        addBuildFileToVS(buildFiles[i], proj, projBS, &itemHint);
+            VCItemHint itemHint = { "SBResourceCopy", pathOverride, "" };
+            addBuildFileToVS(buildFiles[i], proj, projBS, &itemHint);
+        }
     }
 
     // Process all Info.plist files

--- a/tools/vsimporter/src/SBSourcesBuildPhase.cpp
+++ b/tools/vsimporter/src/SBSourcesBuildPhase.cpp
@@ -41,7 +41,7 @@ void SBSourcesBuildPhase::writeVCProjectFiles(VCProject& proj) const {
     // We don't support source compilation when building bundles
     TargetProductType productType = m_parentTarget.getProductType();
     if (productType == TargetBundle) {
-        if (!m_phase->getBuildFileList().empty()) {
+        if (m_phase && !m_phase->getBuildFileList().empty()) {
             SBLog::warning() << "Ignoring all source files in \"" << m_parentTarget.getName() << "\" bundle target." << std::endl;
         }
         return;


### PR DESCRIPTION
vsimporter can have an invalid pointer read when m_phase is NULL. Therefore, we need to check the validity of m_phase before use.

Projects are allowed to have no build phase to associate to m_phase.
For example, if there are no resources to build then there would be no
resource build phase enabling m_phase to remain NULL.

Some portions of vsimporter rely on m_phase to be NULL, so we must do a
check when we actually want to access it.