### PR TITLE
Implement NSObject Validation KVC methods

### DIFF
--- a/Frameworks/Foundation/NSKeyValueCoding.mm
+++ b/Frameworks/Foundation/NSKeyValueCoding.mm
@@ -54,13 +54,18 @@ NSString* const NSUnionOfArraysKeyValueOperator = @"NSUnionOfArraysKeyValueOpera
 NSString* const NSUnionOfObjectsKeyValueOperator = @"NSUnionOfObjectsKeyValueOperator";
 NSString* const NSUnionOfSetsKeyValueOperator = @"NSUnionOfSetsKeyValueOperator";
 
+static const wchar_t* TAG = L"NSObject (NSKeyValueCoding)";
+
 NSString* _NSKVCSplitKeypath(NSString* keyPath, NSString* __autoreleasing* pRemainder) {
-    static woc::unique_cf<CFCharacterSetRef> dot{CFCharacterSetCreateWithCharactersInRange(nullptr, (CFRange){'.', 1})};
+    static woc::unique_cf<CFCharacterSetRef> dot{ CFCharacterSetCreateWithCharactersInRange(nullptr, (CFRange){ '.', 1 }) };
     CFRange result;
     CFIndex length = CFStringGetLength((CFStringRef)keyPath);
-    if (length > 0 && CFStringFindCharacterFromSet((CFStringRef)keyPath, dot.get(), (CFRange){0, length}, 0, &result)) {
-        *pRemainder = [(NSString*)CFStringCreateWithSubstring(nullptr, (CFStringRef)keyPath, (CFRange){result.location + 1, length - (result.location + 1)}) autorelease];
-        return [(NSString*)CFStringCreateWithSubstring(nullptr, (CFStringRef)keyPath, (CFRange){0, result.location}) autorelease];
+    if (length > 0 && CFStringFindCharacterFromSet((CFStringRef)keyPath, dot.get(), (CFRange){ 0, length }, 0, &result)) {
+        *pRemainder =
+            [(NSString*)CFStringCreateWithSubstring(nullptr,
+                                                    (CFStringRef)keyPath,
+                                                    (CFRange){ result.location + 1, length - (result.location + 1) }) autorelease];
+        return [(NSString*)CFStringCreateWithSubstring(nullptr, (CFStringRef)keyPath, (CFRange){ 0, result.location }) autorelease];
     }
     *pRemainder = nil;
     return keyPath;
@@ -149,23 +154,23 @@ SEL KVCGetterForPropertyName(NSObject* self, const char* key) {
 
 template <typename T>
 static id quickGet(id self, SEL getter) {
-    T ret = ((T (*)(id, SEL))objc_msgSend)(self, getter);
+    T ret = ((T(*)(id, SEL))objc_msgSend)(self, getter);
     return woc::ValueTransformer<T>::get(&ret);
 }
 
 template <>
 id quickGet<id>(id self, SEL getter) {
-    return ((id (*)(id, SEL))objc_msgSend)(self, getter);
+    return ((id(*)(id, SEL))objc_msgSend)(self, getter);
 }
 
 template <>
 id quickGet<Class>(id self, SEL getter) {
-    return ((id (*)(id, SEL))objc_msgSend)(self, getter);
+    return ((id(*)(id, SEL))objc_msgSend)(self, getter);
 }
 
 #define QUICK_GET_CASE(type, name, capitalizedName, encodingChar) \
-    case encodingChar: \
-        *ret = quickGet<type>(self, getter); \
+    case encodingChar:                                            \
+        *ret = quickGet<type>(self, getter);                      \
         return true;
 bool KVCGetViaAccessor(NSObject* self, SEL getter, id* ret) {
     if (!getter) {
@@ -399,12 +404,13 @@ bool quickSet<Class>(id self, SEL setter, id value, const char* valueType) {
 }
 
 #define QUICK_SET_CASE(type, name, capitalizedName, encodingChar) \
-    case encodingChar: \
-        if (quickSet<type>(self, setter, value, valueType)) { \
-            return true; \
-        } \
+    case encodingChar:                                            \
+        if (quickSet<type>(self, setter, value, valueType)) {     \
+            return true;                                          \
+        }                                                         \
         break;
-bool KVCSetViaAccessor(NSObject* self, SEL setter, id value) {
+
+bool KVCSetViaAccessor(NSObject* self, SEL setter, id value, NSString* key) {
     if (!setter) {
         return false;
     }
@@ -414,6 +420,11 @@ bool KVCSetViaAccessor(NSObject* self, SEL setter, id value) {
     // 3 arguments: self, selector, new value.
     if (sig && [sig numberOfArguments] == 3) {
         const char* valueType = [sig getArgumentTypeAtIndex:2];
+
+        if (!value && !(valueType[0] == '@' || valueType[0] == '#')) {
+            [self setNilValueForKey:key];
+            return false;
+        }
 
         switch (valueType[0]) {
             OBJC_APPLY_NUMERIC_TYPE_ENCODINGS(QUICK_SET_CASE);
@@ -436,13 +447,18 @@ bool KVCSetViaAccessor(NSObject* self, SEL setter, id value) {
     return false;
 }
 
-bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value) {
+bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value, NSString* key) {
     if (!ivar) {
         return false;
     }
 
-    uint32_t offset = ivar_getOffset(ivar);
     const char* argType = ivar_getTypeEncoding(ivar);
+    if (!value && !(argType[0] == '@' || argType[0] == '#')) {
+        [self setNilValueForKey:key];
+        return false;
+    }
+
+    uint32_t offset = ivar_getOffset(ivar);
 
     void* destination = reinterpret_cast<char*>(self) + offset;
     if (!woc::dataWithTypeFromValue(destination, argType, value)) {
@@ -454,6 +470,14 @@ bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value) {
     }
 
     return true;
+}
+
+/**
+ @Status Interoperable
+*/
+- (void)setNilValueForKey:(NSString*)key {
+    [NSException raise:NSInvalidArgumentException
+                format:@"-[%s setValue:forKey:]: Attempt to set nil for key %@", class_getName([self class]), key];
 }
 
 /**
@@ -578,30 +602,80 @@ bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value) {
     return StubReturn();
 }
 
-/**
- @Status Stub
- @Notes
-*/
-- (void)setNilValueForKey:(NSString*)key {
-    UNIMPLEMENTED();
+static SEL KVCValidatorForPropertyName(NSObject* self, const char* key) {
+    size_t len = strlen(key);
+    // For the key "example", we must construct the following buffer:
+    // _ _ _ _ _ _ _ _ _ x a m p l e _ _ _ _ _ _ _ \0
+    // and fill it with the following characters:
+    // v a l i d a t e E x a m p l e : e r r o r : \0
+    char* chars = (char*)_alloca(8 + len + 8);
+    strcpy_s(chars + 9, len, key + 1);
+    chars[0] = 'v';
+    chars[1] = 'a';
+    chars[2] = 'l';
+    chars[3] = 'i';
+    chars[4] = 'd';
+    chars[5] = 'a';
+    chars[6] = 't';
+    chars[7] = 'e';
+    chars[8] = toupper(key[0]);
+    chars[8 + len] = ':';
+    chars[8 + len + 1] = 'e';
+    chars[8 + len + 2] = 'r';
+    chars[8 + len + 3] = 'r';
+    chars[8 + len + 4] = 'o';
+    chars[8 + len + 5] = 'r';
+    chars[8 + len + 6] = ':';
+    chars[8 + len + 7] = '\0';
+    SEL sel = sel_getUid(chars);
+    return ([self respondsToSelector:sel]) ? sel : nullptr;
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Interoperable
+ @Notes Invoked validate method must return BOOL
 */
 - (BOOL)validateValue:(id _Nullable*)ioValue forKey:(NSString*)key error:(NSError* _Nullable*)outError {
-    UNIMPLEMENTED();
-    return StubReturn();
+    SEL validationSelector = KVCValidatorForPropertyName(self, [key UTF8String]);
+    if (validationSelector) {
+        NSMethodSignature* sig = [self methodSignatureForSelector:validationSelector];
+        // 4 arguments: self, selector, ioValue, outError
+        if (sig.numberOfArguments == 4) {
+            // Reference platform does not check types, but will segfault when trying to return a value with size larger than BOOL
+            // And we will run into issues with values smaller than BOOL so simply ignore non-BOOL sized returns
+            if (sig.methodReturnLength == sizeof(BOOL)) {
+                return ((BOOL(*)(id, SEL, id*, NSError**))objc_msgSend)(self, validationSelector, ioValue, outError);
+            } else {
+                // But give a warning because this is stricter than the reference platform
+                TraceWarning(TAG,
+                             L"-[%s %s]: expected return type of BOOL but is actually %s",
+                             class_getName([self class]),
+                             sel_getName(validationSelector),
+                             sig.methodReturnType);
+            }
+        }
+    }
+
+    // There is no validation method, so just return YES
+    return YES;
 }
 
 /**
- @Status Stub
- @Notes
+ @Status Interoperable
+ @Notes Invoked validate method must return BOOL
 */
-- (BOOL)validateValue:(id _Nullable*)ioValue forKeyPath:(NSString*)key error:(NSError* _Nullable*)outError {
-    UNIMPLEMENTED();
-    return StubReturn();
+- (BOOL)validateValue:(id _Nullable*)ioValue forKeyPath:(NSString*)inKeyPath error:(NSError* _Nullable*)outError {
+    NSString* key = nil;
+    NSString* restOfKeypath;
+    key = _NSKVCSplitKeypath(inKeyPath, &restOfKeypath);
+
+    if (restOfKeypath) {
+        // We must recurse here, as any class may override validateValue:forKeyPath:error:
+        id val = [self valueForKey:key];
+        return [val validateValue:ioValue forKeyPath:restOfKeypath error:outError];
+    }
+
+    return [self validateValue:ioValue forKey:key error:outError];
 }
 
 @end

--- a/Frameworks/include/NSObject_NSKeyValueCoding-Internal.h
+++ b/Frameworks/include/NSObject_NSKeyValueCoding-Internal.h
@@ -24,5 +24,5 @@ SEL KVCGetterForPropertyName(NSObject* self, const char* key);
 bool KVCGetViaAccessor(NSObject* self, SEL getter, id* ret);
 bool KVCGetViaIvar(id self, struct objc_ivar* ivar, id* ret);
 SEL KVCSetterForPropertyName(NSObject* self, const char* key);
-bool KVCSetViaAccessor(NSObject* self, SEL setter, id value);
-bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value);
+bool KVCSetViaAccessor(NSObject* self, SEL setter, id value, NSString* key = nil);
+bool KVCSetViaIvar(NSObject* self, struct objc_ivar* ivar, id value, NSString* key = nil);

--- a/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj
@@ -307,6 +307,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\Foundation\NSRunLoopTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\Foundation\NSIndexPathTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSNullTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\Foundation\NSObject_NSKeyValueValidation.mm" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\..\..\tests\unittests\Foundation\NSFileManagerUT.txt">

--- a/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj.filters
+++ b/build/Tests/UnitTests/Foundation/Foundation.UnitTests.vcxproj.filters
@@ -144,6 +144,7 @@
     <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\Foundation\NSURLSessionTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\Foundation\NSIndexPathTests.mm" />
     <ClangCompile Include="$(StarboardBasePath)\tests\unittests\Foundation\NSNullTests.mm" />
+    <ClangCompile Include="$(StarboardBasePath)\tests\UnitTests\Foundation\NSObject_NSKeyValueValidation.mm" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\..\..\tests\unittests\Foundation\NSFileManagerUT.txt" />

--- a/include/Foundation/NSKeyValueCoding.h
+++ b/include/Foundation/NSKeyValueCoding.h
@@ -54,10 +54,10 @@ FOUNDATION_EXPORT NSString* const NSUnionOfSetsKeyValueOperator;
 - (NSMutableOrderedSet*)mutableOrderedSetValueForKeyPath:(NSString*)keyPath STUB_METHOD;
 - (void)setValue:(id)value forKeyPath:(NSString*)keyPath;
 - (void)setValuesForKeysWithDictionary:(NSDictionary*)keyedValues;
-- (void)setNilValueForKey:(NSString*)key STUB_METHOD;
+- (void)setNilValueForKey:(NSString*)key;
 - (void)setValue:(id)value forKey:(NSString*)key;
 - (void)setValue:(id)value forUndefinedKey:(NSString*)key;
 + (BOOL)accessInstanceVariablesDirectly;
-- (BOOL)validateValue:(inout id _Nullable*)ioValue forKey:(NSString*)key error:(out NSError* _Nullable*)outError STUB_METHOD;
-- (BOOL)validateValue:(inout id _Nullable*)ioValue forKeyPath:(NSString*)key error:(out NSError* _Nullable*)outError STUB_METHOD;
+- (BOOL)validateValue:(inout id _Nullable*)ioValue forKey:(NSString*)key error:(out NSError* _Nullable*)outError;
+- (BOOL)validateValue:(inout id _Nullable*)ioValue forKeyPath:(NSString*)key error:(out NSError* _Nullable*)outError;
 @end

--- a/tests/UnitTests/Foundation/NSObject_NSKeyValueValidation.mm
+++ b/tests/UnitTests/Foundation/NSObject_NSKeyValueValidation.mm
@@ -1,0 +1,262 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <Foundation/Foundation.h>
+#include <TestFramework.h>
+
+struct smolStruct {
+    char a;
+    char b;
+};
+
+struct yugeStruct {
+    smolStruct a[88];
+    void* b;
+};
+
+@interface ValidationObj : NSObject
++ (instancetype)test;
+
+@property (readwrite, assign) NSObject* obj;
+- (BOOL)validateObj:(NSObject**)value error:(NSError**)outError;
+- (BOOL)validateValid1:(inout NSObject* _Nullable*)value error:(out NSError**)outError;
+- (BOOL)validateValid2:(id*)value error:(NSError**)outError;
+- (BOOL)validateValid3:(id**)value error:(NSError**)outError;
+- (BOOL)validateValid4:(BOOL*)value error:(NSError**)outError;
+- (BOOL)validateValid5:(id)value error:(NSError**)outError;
+- (BOOL)validateValid6:(BOOL)value error:(NSError**)outError;
+- (BOOL)validateValid7:(smolStruct*)value error:(NSError**)outError;
+- (BOOL)validateValid8:(yugeStruct*)value error:(NSError**)outError;
+- (BOOL)validateValid9:(id*)value error:(NSObject**)outError;
+- (BOOL)validateValid10:(id*)value error:(NSError*)outError;
+- (BOOL)validateValid11:(id*)value error:(NSError***)outError;
+- (BOOL)validateValid12:(smolStruct)value error:(NSError**)outError;
+- (BOOL)validateValid13:(yugeStruct)value error:(NSError**)outError;
+- (BOOL)validateValid14:(id*)value error:(smolStruct)outError;
+- (BOOL)validateValid15:(id*)value error:(smolStruct*)outError;
+- (BOOL)validateValid16:(id*)value error:(yugeStruct)outError;
+- (BOOL)validateValid17:(id*)value error:(yugeStruct*)outError;
+
+- (BOOL)validateInvalid1:(id*)value errr:(NSError**)outError;
+- (BOOL)validateInvalid2:(id*)value error:(NSError**)outError someOtherThing:(id)it;
+- (void)validateInvalid3:(id*)value error:(NSError**)outError;
+@end
+
+@implementation ValidationObj
++ (instancetype)test {
+    return [[[self alloc] init] autorelease];
+}
+
+- (BOOL)validateObj:(NSObject**)value error:(NSError**)outError {
+    if (value) {
+        *value = [NSData data];
+        return YES;
+    }
+
+    return NO;
+}
+
+#pragma region valid
+
+- (BOOL)validateValid1:(inout NSObject* _Nullable*)value error:(out NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid2:(id*)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid3:(id**)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid4:(BOOL*)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid5:(id)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid6:(BOOL)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid7:(smolStruct*)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid8:(yugeStruct*)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid9:(id*)value error:(NSObject**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid10:(id*)value error:(NSError*)outError {
+    return NO;
+}
+
+- (BOOL)validateValid11:(id*)value error:(NSError***)outError {
+    return NO;
+}
+
+- (BOOL)validateValid12:(smolStruct)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid13:(yugeStruct)value error:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateValid14:(id*)value error:(smolStruct)outError {
+    return NO;
+}
+
+- (BOOL)validateValid15:(id*)value error:(smolStruct*)outError {
+    return NO;
+}
+
+- (BOOL)validateValid16:(id*)value error:(yugeStruct)outError {
+    return NO;
+}
+
+- (BOOL)validateValid17:(id*)value error:(yugeStruct*)outError {
+    return NO;
+}
+
+#pragma endregion valid
+#pragma region invalid
+
+- (BOOL)validateInvalid1:(id*)value errr:(NSError**)outError {
+    return NO;
+}
+
+- (BOOL)validateInvalid2:(id*)value error:(NSError**)outError someOtherThing:(id)it {
+    return NO;
+}
+
+- (void)validateInvalid3:(id*)value error:(NSError**)outError {
+}
+
+#pragma endregion invalid
+
+@end
+
+TEST(NSObject, ValidateValueForKey) {
+    auto test = [ValidationObj test];
+    NSData* data = nil;
+    NSError* error = nil;
+
+    EXPECT_EQ(NO, [test validateValue:nil forKey:@"obj" error:&error]);
+    EXPECT_EQ(YES, [test validateValue:&data forKey:@"obj" error:&error]);
+    EXPECT_OBJCEQ([NSData data], data);
+}
+
+TEST(NSObject, ValidateValueForKeyShouldReturnNOForInvalidSelectors) {
+    auto test = [ValidationObj test];
+    NSData* data = [NSData data];
+    NSError* error = nil;
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid1" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid2" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid3" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid4" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid5" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid6" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid7" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid8" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid9" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid10" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid11" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid12" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid13" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid14" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid15" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid16" error:&error]);
+    EXPECT_EQ(NO, [test validateValue:&data forKey:@"valid17" error:&error]);
+
+    EXPECT_EQ(YES, [test validateValue:&data forKey:@"invalid1" error:&error]);
+    EXPECT_EQ(YES, [test validateValue:&data forKey:@"invalid2" error:&error]);
+    EXPECT_EQ(YES, [test validateValue:&data forKey:@"invalid3" error:&error]);
+
+    EXPECT_EQ(YES, [test validateValue:&data forKey:@"nonexistent" error:&error]);
+}
+
+@interface ValidationHolder : NSObject {
+    NSObject* ivar;
+}
++ (instancetype)holder;
+@property (readwrite, retain) ValidationObj* obj;
+@property (readwrite, retain) Class cla;
+@property (readwrite) int intVal;
+@end
+
+@implementation ValidationHolder
+
++ (instancetype)holder {
+    return [[[self alloc] init] autorelease];
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _obj = [[ValidationObj alloc] init];
+    }
+
+    return self;
+}
+
+- (void)dealloc {
+    [_obj release];
+    [super dealloc];
+}
+@end
+
+TEST(NSObject, ValidateValueForKeyPath) {
+    ValidationHolder* test = [ValidationHolder holder];
+    NSData* data = nil;
+    NSError* error = nil;
+
+    EXPECT_EQ(NO, [test validateValue:nil forKeyPath:@"obj.obj" error:&error]);
+    EXPECT_EQ(YES, [test validateValue:&data forKeyPath:@"obj.obj" error:&error]);
+    EXPECT_OBJCEQ([NSData data], data);
+}
+
+TEST(NSObject, ValidateValueForKeyPathShouldProperlyFollowKeyPath) {
+    ValidationHolder* test = [ValidationHolder holder];
+    NSData* data = [NSData data];
+    NSError* error = nil;
+    EXPECT_EQ(NO, [test validateValue:&data forKeyPath:@"obj.valid1" error:&error]);
+    EXPECT_EQ(NO, [test.obj validateValue:&data forKeyPath:@"valid1" error:&error]);
+
+    EXPECT_ANY_THROW([test validateValue:&data forKeyPath:@"nonexistent.valid1" error:&error]);
+
+    EXPECT_EQ(YES, [test validateValue:&data forKeyPath:@"obj.invalid1" error:&error]);
+    EXPECT_EQ(YES, [test validateValue:&data forKeyPath:@"obj.nonexistent" error:&error]);
+}
+
+TEST(NSObject, SetNilValueForKey) {
+    ValidationHolder* test = [ValidationHolder holder];
+    EXPECT_ANY_THROW([test setNilValueForKey:@"obj"]);
+    EXPECT_ANY_THROW([test setNilValueForKey:@"intVal"]);
+    EXPECT_ANY_THROW([test setNilValueForKey:@"ivar"]);
+    EXPECT_ANY_THROW([test setNilValueForKey:@"cla"]);
+    EXPECT_ANY_THROW([test setValue:nil forKey:@"intVal"]);
+
+    EXPECT_NO_THROW([test setValue:nil forKey:@"obj"]);
+    EXPECT_NO_THROW([test setValue:nil forKey:@"ivar"]);
+    EXPECT_NO_THROW([test setValue:nil forKey:@"cla"]);
+}


### PR DESCRIPTION
Implements:
setNilValueForKey:
validateValue:forKey:error:
validateValue:forKeyPath:error:

Partially completes #2459, the Set and OrderedSet methods will be implemented in a separate CR because they are only tangentially related and will require a good bit of code.