### PR TITLE
Fix 2618 by forcing RTObjCInterop library to be included

### DIFF
--- a/Frameworks/UIKit/ForceInclusion.mm
+++ b/Frameworks/UIKit/ForceInclusion.mm
@@ -25,6 +25,7 @@
 #include "UIClassSwapper.h"
 #include "../QuartzCore/CATransaction.h"
 #include "../Foundation/NSColor.h"
+#import <UWP/InteropBase.h>
 
 extern "C" void NSObjForceinclude();
 void NSStringForceinclude();
@@ -47,6 +48,7 @@ void ForceInclusion() {
     [UISwitch class];
     [UISlider class];
     [UIProxyObject class];
+    [RTObject class];
     NSStringForceinclude();
     NSIndexPathForceInclude();
     NSValueForceinclude();


### PR DESCRIPTION
Fixes #2618, #2619
The RTObjCInterop library is needed even if projections aren't being used, because UI elements sometimes get manipulated as RTObjects. This change ensures that RTObjCInterop.dll is included in the app package.