### PR TITLE
Fix more format strings

### DIFF
--- a/Frameworks/CoreLocation/CLGeocoder.mm
+++ b/Frameworks/CoreLocation/CLGeocoder.mm
@@ -81,11 +81,11 @@ void createResultsArray(const MapLocationFinderResult& results, NSMutableArray* 
 
         NSString* placemarkName;
         if (!currentAddress.StreetNumber().empty() && !currentAddress.Street().empty()) {
-            placemarkName = [NSString stringWithFormat:@"%S %S", currentAddress.StreetNumber().c_str(), currentAddress.Street().c_str()];
+            placemarkName = [NSString stringWithFormat:@"%S %S", (const unichar*)currentAddress.StreetNumber().c_str(), (const unichar*)currentAddress.Street().c_str()];
         } else if (!currentAddress.Street().empty()) {
             placemarkName = objcwinrt::string(currentAddress.Street());
         } else if (!currentAddress.Town().empty() && !currentAddress.Region().empty()) {
-            placemarkName = [NSString stringWithFormat:@"%S, %S", currentAddress.Town().c_str(), currentAddress.Region().c_str()];
+            placemarkName = [NSString stringWithFormat:@"%S, %S", (const unichar*)currentAddress.Town().c_str(), (const unichar*)currentAddress.Region().c_str()];
         } else if (!currentAddress.Town().empty()) {
             placemarkName = objcwinrt::string(currentAddress.Town());
         } else {

--- a/Frameworks/Foundation/NSPathUtilities.mm
+++ b/Frameworks/Foundation/NSPathUtilities.mm
@@ -39,7 +39,7 @@ NSString* NSFullUserName() {
 // Helper that gets the path for a folder dirName under the current app's AppData/Local... directory,
 // creating the folder if necessary
 NSString* _getCreateAppDataLocalDir(const char* dirName) {
-    auto ret = [NSString stringWithFormat:@"%S/%s", IwGetWritableFolder(), dirName];
+    auto ret = [NSString stringWithFormat:@"%S/%s", (const unichar*)IwGetWritableFolder(), dirName];
     _mkdir([ret cStringUsingEncoding:NSUTF8StringEncoding]);
     return ret;
 }
@@ -47,7 +47,7 @@ NSString* _getCreateAppDataLocalDir(const char* dirName) {
 // Override for when a higher-level directory needs to be created first (eg: Foo1/Foo2/)
 NSString* _getCreateAppDataLocalDir(const char* dirName1, const char* dirName2) {
     _getCreateAppDataLocalDir(dirName1);
-    auto ret = [NSString stringWithFormat:@"%S/%s/%s", IwGetWritableFolder(), dirName1, dirName2];
+    auto ret = [NSString stringWithFormat:@"%S/%s/%s", (const unichar*)IwGetWritableFolder(), dirName1, dirName2];
     _mkdir([ret cStringUsingEncoding:NSUTF8StringEncoding]);
     return ret;
 }


### PR DESCRIPTION
Casting a `wchar_t*` (win32: `short`) to `unichar*` (always: `short`) is safe only on our platform.

This is the format change delta from #2628 to develop that caused #2629 to break.