### PR TITLE
Fix execution order of operations in NSOperationQueue

### DIFF
--- a/Frameworks/Foundation/NSOperationInternal.h
+++ b/Frameworks/Foundation/NSOperationInternal.h
@@ -18,5 +18,6 @@
 
 @interface NSOperation ()
 @property (nonatomic, assign, getter=_completionQueue, setter=_setCompletionQueue:) dispatch_queue_t _completionQueue;
-- (BOOL)_markInQueue;
+- (unsigned int)_queueIndex;
+- (BOOL)_canAddToQueueAsIndex:(unsigned int)queueIndex;
 @end

--- a/Frameworks/Foundation/NSOperationQueue.mm
+++ b/Frameworks/Foundation/NSOperationQueue.mm
@@ -251,8 +251,6 @@ static char _NSOperationQueue_IsReadyContext;
         } else {
             [self _setDispatchQueueUsingQualityOfService];
         }
-
-        _operationIndex;
     }
     return self;
 }

--- a/Frameworks/Foundation/NSOperationQueue.mm
+++ b/Frameworks/Foundation/NSOperationQueue.mm
@@ -252,7 +252,7 @@ static char _NSOperationQueue_IsReadyContext;
             [self _setDispatchQueueUsingQualityOfService];
         }
 
-        _operationIndex = 0;
+        _operationIndex;
     }
     return self;
 }


### PR DESCRIPTION
"An operation queue executes its queued operation objects based on their priority and readiness.
If all of the queued operation objects have the same priority and are ready to execute when they are put in the queue—
that is, their ready method returns YES—they are executed in the order in which they were submitted to the queue."