### PR TITLE
bridge UIColor to be treated as a CGColor.

### DIFF
--- a/Frameworks/UIKit/UICGColor.h
+++ b/Frameworks/UIKit/UICGColor.h
@@ -17,6 +17,9 @@
 
 #import <UIKit/UIColor.h>
 
+@interface UICGColorPrototype : UIColor
+@end
+
 @interface _UIColorConcrete : UIColor
 @end
 

--- a/Frameworks/UIKit/UIColor.mm
+++ b/Frameworks/UIKit/UIColor.mm
@@ -44,16 +44,7 @@ static const wchar_t* TAG = L"UIColor";
 
 @implementation UIColor
 
-/**
- @Status Interoperable
-*/
-+ (NSObject*)allocWithZone:(NSZone*)zone {
-    if (self == [UIColor class]) {
-        return [_UIColorConcrete allocWithZone:zone];
-    }
-
-    return [super allocWithZone:zone];
-}
+BASE_CLASS_REQUIRED_IMPLS(UIColor, UICGColorPrototype, CGColorGetTypeID);
 
 /**
  @Status Interoperable

--- a/include/UIKit/UIColor.h
+++ b/include/UIKit/UIColor.h
@@ -75,7 +75,7 @@ UIKIT_EXPORT_CLASS
 - (BOOL)getRed:(CGFloat*)red green:(CGFloat*)green blue:(CGFloat*)blue alpha:(CGFloat*)alpha;
 - (BOOL)getWhite:(CGFloat*)white alpha:(CGFloat*)alpha;
 - (UIColor*)colorWithAlphaComponent:(CGFloat)alpha;
-- (UIColor*)initWithCGColor:(CGColorRef)cgColor STUB_METHOD;
+- (UIColor*)initWithCGColor:(CGColorRef)cgColor;
 - (UIColor*)initWithCIColor:(CIColor*)ciColor STUB_METHOD;
 - (UIColor*)initWithHue:(CGFloat)hue saturation:(CGFloat)saturation brightness:(CGFloat)brightness alpha:(CGFloat)alpha;
 - (UIColor*)initWithPatternImage:(UIImage*)image;

--- a/tests/unittests/UIKit/UIColorTests.mm
+++ b/tests/unittests/UIKit/UIColorTests.mm
@@ -30,3 +30,28 @@ TEST(UIColor, ColorTests) {
     color2 = [UIColor colorWithRed:0 green:0 blue:0 alpha:1];
     EXPECT_OBJCNE(color, color2);
 }
+
+static void __EncodeAndDecodeColor(UIColor* color) {
+    NSMutableData* data = [NSMutableData data];
+
+    StrongId<NSKeyedArchiver> coder{ woc::TakeOwnership, [[NSKeyedArchiver alloc] initForWritingWithMutableData:data] };
+    [color encodeWithCoder:coder];
+    [coder finishEncoding];
+
+    StrongId<NSKeyedUnarchiver> decoder{ woc::TakeOwnership, [[NSKeyedUnarchiver alloc] initForReadingWithData:data] };
+    StrongId<UIColor> decodedColor{ woc::TakeOwnership, [[UIColor alloc] initWithCoder:decoder] };
+    EXPECT_OBJCEQ(color, decodedColor);
+}
+
+TEST(UIColor, EncodeDecodeUIColor) {
+    // GrayScale
+    __EncodeAndDecodeColor([UIColor grayColor]);
+    __EncodeAndDecodeColor([UIColor colorWithWhite:0.5 alpha:0.98]);
+    __EncodeAndDecodeColor([UIColor colorWithWhite:0 alpha:1]);
+    __EncodeAndDecodeColor([UIColor colorWithWhite:1 alpha:1]);
+
+    // RGB
+    __EncodeAndDecodeColor([UIColor redColor]);
+    __EncodeAndDecodeColor([UIColor colorWithRed:1 green:0.5 blue:0.34 alpha:0.89]);
+    __EncodeAndDecodeColor([UIColor colorWithRed:1 green:0.4 blue:0.34 alpha:1.0]);
+}

--- a/tests/unittests/UIKit/UIColorTests.mm
+++ b/tests/unittests/UIKit/UIColorTests.mm
@@ -55,3 +55,36 @@ TEST(UIColor, EncodeDecodeUIColor) {
     __EncodeAndDecodeColor([UIColor colorWithRed:1 green:0.5 blue:0.34 alpha:0.89]);
     __EncodeAndDecodeColor([UIColor colorWithRed:1 green:0.4 blue:0.34 alpha:1.0]);
 }
+
+TEST(UIColor, ColorWithCGColor) {
+    CGColorRef cgColor = CGColorGetConstantColor(kCGColorBlack);
+    UIColor* blackColor = [UIColor blackColor];
+    // NOTE: you should never cast CGColor into a UIColor or vice versa
+    // This is only to support CoreText related attribute functionality
+    EXPECT_OBJCEQ(static_cast<UIColor*>(cgColor), blackColor);
+    EXPECT_TRUE(CGColorEqualToColor(static_cast<CGColorRef>(blackColor), cgColor));
+
+    UIColor* color1 = [UIColor colorWithCGColor:cgColor];
+    EXPECT_OBJCEQ(color1, blackColor);
+
+    color1 = [UIColor colorWithCGColor:[blackColor CGColor]];
+    EXPECT_OBJCEQ(color1, blackColor);
+
+    color1 = [UIColor colorWithCGColor:[[UIColor yellowColor] CGColor]];
+    EXPECT_OBJCEQ(color1, [UIColor yellowColor]);
+
+    auto cgColorRed = woc::MakeStrongCF<CGColorRef>(CGColorCreateGenericRGB(1, 0, 0, 1));
+    color1 = [UIColor colorWithCGColor:cgColorRed];
+    EXPECT_OBJCEQ(color1, [UIColor redColor]);
+    EXPECT_OBJCEQ(color1, [UIColor colorWithRed:1 green:0 blue:0 alpha:1]);
+
+    auto cgColorGray = woc::MakeStrongCF<CGColorRef>(CGColorCreateGenericGray(0.5, 1));
+    color1 = [UIColor colorWithCGColor:cgColorGray];
+    EXPECT_OBJCEQ(color1, [UIColor grayColor]);
+    EXPECT_OBJCNE(color1, [UIColor colorWithRed:1 green:0 blue:0 alpha:1]);
+    EXPECT_OBJCEQ(color1, [UIColor colorWithWhite:0.5 alpha:1]);
+}
+
+TEST(UIColor, SameColorInDifferentColorSpaces) {
+    EXPECT_OBJCNE([UIColor colorWithWhite:0.5 alpha:1], [UIColor colorWithRed:0.5 green:0.5 blue:0.5 alpha:1]);
+}

--- a/tests/unittests/UIKit/UIColorTests.mm
+++ b/tests/unittests/UIKit/UIColorTests.mm
@@ -17,7 +17,7 @@
 #include <TestFramework.h>
 #import <UIKit/UIColor.h>
 
-TEST(UIColorTest, ColorTests) {
+TEST(UIColor, ColorTests) {
     UIColor* color = [UIColor redColor];
     UIColor* color2 = [UIColor colorWithRed:1 green:0 blue:0 alpha:1];
     EXPECT_OBJCEQ(color, color2);
@@ -29,43 +29,4 @@ TEST(UIColorTest, ColorTests) {
     color = [UIColor blackColor];
     color2 = [UIColor colorWithRed:0 green:0 blue:0 alpha:1];
     EXPECT_OBJCNE(color, color2);
-}
-
-TEST(UIColorTest, NamedUIColorMethods) {
-    UIColor* color = [UIColor redColor];
-
-    NSUInteger retainCount = [color retainCount];
-    ASSERT_TRUE_MSG(retainCount == NSUIntegerMax, "Failed: RetainCount not correct for UICachedColor");
-
-    [color release];
-    [color release];
-    [color release];
-    [color release];
-    retainCount = [color retainCount];
-    ASSERT_TRUE_MSG(retainCount == NSUIntegerMax, "Failed: RetainCount not correct for UICachedColor");
-
-    [color retain];
-    [color retain];
-    [color retain];
-    [color retain];
-    retainCount = [color retainCount];
-    ASSERT_TRUE_MSG(retainCount == NSUIntegerMax, "Failed: RetainCount not correct for UICachedColor");
-
-    color = [UIColor blueColor];
-    retainCount = [color retainCount];
-    ASSERT_TRUE_MSG(retainCount == NSUIntegerMax, "Failed: RetainCount not correct for UICachedColor");
-
-    [color release];
-    [color release];
-    [color release];
-    [color release];
-    retainCount = [color retainCount];
-    ASSERT_TRUE_MSG(retainCount == NSUIntegerMax, "Failed: RetainCount not correct for UICachedColor");
-
-    [color retain];
-    [color retain];
-    [color retain];
-    [color retain];
-    retainCount = [color retainCount];
-    ASSERT_TRUE_MSG(retainCount == NSUIntegerMax, "Failed: RetainCount not correct for UICachedColor");
 }


### PR DESCRIPTION
This is to support cases in CoreText where an attribute can take a CGColor or UIColor.
Fixes #2656, #2649, #2671