### PR TITLE
Update UIProgressView to use backing XAML controls

### DIFF
--- a/Frameworks/UIKit.Xaml/ObjCXamlControls.h
+++ b/Frameworks/UIKit.Xaml/ObjCXamlControls.h
@@ -113,6 +113,30 @@ UIKIT_XAML_EXPORT void XamlSetActivityIndicatorViewWidthValue(const Microsoft::W
                                                               double width);
 
 ////////////////////////////////////////////////////////////////////////////////////
+// ProgressView.xaml.cpp
+////////////////////////////////////////////////////////////////////////////////////
+
+// Returns a UIKit::Xaml::ProgressView as an IInspectable
+UIKIT_XAML_EXPORT void XamlCreateProgressView(IInspectable** created);
+
+// Retrieves the UIKit::Xaml::ProgressView's backing ProgressBar as an IInspetable
+UIKIT_XAML_EXPORT IInspectable* XamlGetInternalProgressBar(const Microsoft::WRL::ComPtr<IInspectable>& progressVewInspectable);
+
+// Retrieves the Value property value, denoting the ProgressView's progress
+UIKIT_XAML_EXPORT double XamlGetProgressViewValue(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable);
+
+// Sets the Value property value to update the progress of the ProgressView
+UIKIT_XAML_EXPORT void XamlSetProgressViewValue(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable, double value);
+
+// Sets the Foreground property value to set the progress fill color of the ProgressView
+UIKIT_XAML_EXPORT void XamlSetProgressViewForegroundValue(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable,
+                                                          const Microsoft::WRL::ComPtr<IInspectable>& inspectableForegroundBrush);
+
+// Sets the Background property value to set the track color of the ProgressView
+UIKIT_XAML_EXPORT void XamlSetProgressViewBackgroundValue(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable,
+                                                          const Microsoft::WRL::ComPtr<IInspectable>& inspectableForegroundBrush);
+
+////////////////////////////////////////////////////////////////////////////////////
 // ScrollView.xaml.cpp
 ////////////////////////////////////////////////////////////////////////////////////
 

--- a/Frameworks/UIKit.Xaml/ProgressView.xaml
+++ b/Frameworks/UIKit.Xaml/ProgressView.xaml
@@ -1,0 +1,19 @@
+﻿<Grid
+    x:Class="UIKit.Xaml.ProgressView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UIKit.Xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Name="Root">
+    <ProgressBar Name="progressBar"
+                 IsIndeterminate="False"
+                 Minimum="0.0"
+                 Maximum="1.0"
+                 Height="{x:Bind Height, Mode=OneWay}"
+                 Width="{x:Bind Width, Mode=OneWay}"
+                 Value="{Binding ElementName=Root, Path=ProgressView_Value, Mode=OneWay}"
+                 Foreground="{Binding ElementName=Root, Path=ProgressView_Foreground, Mode=OneWay}"
+                 Background="{Binding ElementName=Root, Path=ProgressView_Background, Mode=OneWay}"/>
+</Grid>

--- a/Frameworks/UIKit.Xaml/ProgressView.xaml
+++ b/Frameworks/UIKit.Xaml/ProgressView.xaml
@@ -7,8 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     x:Name="Root">
-    <ProgressBar Name="progressBar"
-                 IsIndeterminate="False"
+    <ProgressBar x:Name="progressBar"
                  Minimum="0.0"
                  Maximum="1.0"
                  Height="{x:Bind Height, Mode=OneWay}"

--- a/Frameworks/UIKit.Xaml/ProgressView.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/ProgressView.xaml.cpp
@@ -1,0 +1,111 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+// clang-format does not like C++/CX
+// clang-format off
+#include "pch.h"
+#include "ProgressView.xaml.h"
+
+#include "ObjCXamlControls.h"
+
+using namespace Microsoft::WRL;
+using namespace Platform;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+
+namespace UIKit {
+namespace Xaml {
+
+DependencyProperty^ ProgressView::s_valueProperty = nullptr;
+DependencyProperty^ ProgressView::s_foregroundProperty = nullptr;
+DependencyProperty^ ProgressView::s_backgroundProperty = nullptr;
+Platform::Boolean ProgressView::s_dependencyPropertiesRegistered = false;
+
+ProgressView::ProgressView() {
+    InitializeComponent();
+    _RegisterDependencyProperties();
+}
+
+void ProgressView::_RegisterDependencyProperties() {
+    if (!s_dependencyPropertiesRegistered) {
+        s_dependencyPropertiesRegistered = true;
+
+        // TODO: These Dependency Properties should be attached to ProgressView once type info is exposed to the tests. See #2607
+        s_valueProperty = DependencyProperty::RegisterAttached("ProgressView_Value",
+            double::typeid,
+            FrameworkElement::typeid,
+            nullptr);
+
+        s_foregroundProperty = DependencyProperty::RegisterAttached("ProgressView_Foreground",
+            Media::Brush::typeid,
+            FrameworkElement::typeid,
+            nullptr);
+
+        s_backgroundProperty = DependencyProperty::RegisterAttached("ProgressView_Background",
+            Media::Brush::typeid,
+            FrameworkElement::typeid,
+            nullptr);
+    }
+}
+
+Windows::UI::Xaml::Controls::ProgressBar^ ProgressView::InternalProgressBar::get() {
+    return progressBar;
+}
+
+} /* Xaml*/
+} /* UIKit*/
+
+////////////////////////////////////////////////////////////////////////////////////
+// ObjectiveC Interop
+////////////////////////////////////////////////////////////////////////////////////
+UIKIT_XAML_EXPORT void XamlCreateProgressView(IInspectable** created) {
+    Microsoft::WRL::ComPtr<IInspectable> inspectable = InspectableFromObject(ref new UIKit::Xaml::ProgressView());
+    *created = inspectable.Detach();
+}
+
+UIKIT_XAML_EXPORT IInspectable* XamlGetInternalProgressBar(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable) {
+    auto progressView = safe_cast<UIKit::Xaml::ProgressView^>(reinterpret_cast<Platform::Object^>(progressViewInspectable.Get()));
+    return InspectableFromObject(progressView->InternalProgressBar).Detach();
+}
+
+UIKIT_XAML_EXPORT double XamlGetProgressViewValue(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable) {
+    auto progressView = safe_cast<UIKit::Xaml::ProgressView^>(reinterpret_cast<Platform::Object^>(progressViewInspectable.Get()));
+    return progressView->ProgressView_Value;
+}
+
+UIKIT_XAML_EXPORT void XamlSetProgressViewValue(const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable, double value) {
+    auto progressView = safe_cast<UIKit::Xaml::ProgressView^>(reinterpret_cast<Platform::Object^>(progressViewInspectable.Get()));
+    progressView->ProgressView_Value = value;
+}
+
+UIKIT_XAML_EXPORT void XamlSetProgressViewForegroundValue(
+    const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable,
+    const Microsoft::WRL::ComPtr<IInspectable>& inspectableForegroundBrush) {
+
+    auto progressView = safe_cast<UIKit::Xaml::ProgressView^>(reinterpret_cast<Platform::Object^>(progressViewInspectable.Get()));
+    auto color = safe_cast<Media::Brush^>(reinterpret_cast<Platform::Object^>(inspectableForegroundBrush.Get()));
+    progressView->ProgressView_Foreground = color;
+}
+
+UIKIT_XAML_EXPORT void XamlSetProgressViewBackgroundValue(
+    const Microsoft::WRL::ComPtr<IInspectable>& progressViewInspectable,
+    const Microsoft::WRL::ComPtr<IInspectable>& inspectableForegroundBrush) {
+
+    auto progressView = safe_cast<UIKit::Xaml::ProgressView^>(reinterpret_cast<Platform::Object^>(progressViewInspectable.Get()));
+    auto color = safe_cast<Media::Brush^>(reinterpret_cast<Platform::Object^>(inspectableForegroundBrush.Get()));
+    progressView->ProgressView_Background = color;
+}
+
+// clang-format on

--- a/Frameworks/UIKit.Xaml/ProgressView.xaml.h
+++ b/Frameworks/UIKit.Xaml/ProgressView.xaml.h
@@ -1,0 +1,75 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+// clang-format does not like C++/CX
+// clang-format off
+#pragma once
+
+#include "ProgressView.g.h"
+#include "ObjCXamlControls.h"
+
+namespace UIKit {
+namespace Xaml {
+
+[Windows::Foundation::Metadata::WebHostHidden]
+public ref class ProgressView sealed {
+public:
+    ProgressView();
+
+    // TODO: Properties should be renamed to eliminate the name prefix once their corresponding Dependency Properties are fixed. See #2607
+    property double ProgressView_Value {
+        double get() {
+            return (double)GetValue(s_valueProperty);
+        }
+        void set(double value) {
+            SetValue(s_valueProperty, value);
+        }
+    }
+
+    property Windows::UI::Xaml::Media::Brush^ ProgressView_Foreground {
+        Windows::UI::Xaml::Media::Brush^ get() {
+            return (Windows::UI::Xaml::Media::Brush^)GetValue(s_foregroundProperty);
+        }
+        void set(Windows::UI::Xaml::Media::Brush^ value) {
+            SetValue(s_foregroundProperty, value);
+        }
+    }
+
+    property Windows::UI::Xaml::Media::Brush^ ProgressView_Background {
+        Windows::UI::Xaml::Media::Brush^ get() {
+            return (Windows::UI::Xaml::Media::Brush^)GetValue(s_backgroundProperty);
+        }
+        void set(Windows::UI::Xaml::Media::Brush^ value) {
+            SetValue(s_backgroundProperty, value);
+        }
+    }
+
+internal:
+    property Windows::UI::Xaml::Controls::ProgressBar^ InternalProgressBar {
+        Windows::UI::Xaml::Controls::ProgressBar^ get();
+    }
+
+    static void _RegisterDependencyProperties();
+
+private:
+    static Windows::UI::Xaml::DependencyProperty^ s_valueProperty;
+    static Windows::UI::Xaml::DependencyProperty^ s_foregroundProperty;
+    static Windows::UI::Xaml::DependencyProperty^ s_backgroundProperty;
+    static Platform::Boolean s_dependencyPropertiesRegistered;
+};
+
+} /* Xaml*/
+} /* UIKit*/
+// clang-format on

--- a/Frameworks/UIKit/UIProgressView.mm
+++ b/Frameworks/UIKit/UIProgressView.mm
@@ -14,49 +14,39 @@
 //
 //******************************************************************************
 
-#include "Starboard.h"
-#include "UIKit/UIKit.h"
-#include "CoreGraphics/CoreGraphics.h"
-#include "UIKit/UIColor.h"
-#include "UIKit/UIImage.h"
-#include "UIKit/UIImageView.h"
+#import "AssertARCEnabled.h"
+#import <Starboard.h>
+#import <StubReturn.h>
+
+#import <UIKit/NSObject+UIKitAdditions.h>
+#import <UIKit/UIProgressView.h>
+#include <UIKit/UIColor.h>
+#include <UIKit/UIImage.h>
+
+#import "UIViewInternal.h"
+#import "XamlControls.h"
+#import "XamlUtilities.h"
+#import "CppWinRTHelpers.h"
+
+using namespace winrt::Windows::UI::Xaml;
+
+static const wchar_t* TAG = L"UIProgressView";
+
+static void* ProgressViewObservedProgressContext = &ProgressViewObservedProgressContext;
+
+// NOTE: These sizes match what iOS uses natively
+static const double c_defaultStyleHeight = 2.0;
+static const double c_barStyleHeight = 2.5;
 
 @implementation UIProgressView {
     float _value;
-    UIImageView *_progressBackground, *_progressForeground;
-    idretaintype(UIImage) _trackImage;
-}
+    UIProgressViewStyle _progressViewStyle;
 
-static void sizeViews(UIProgressView* self, bool animated) {
-    CGRect bounds;
-    bounds = [self bounds];
-
-    if (animated) {
-        [UIView beginAnimations:@"MoveView" context:nil];
-        [UIView setAnimationDuration:0.25f];
-        [UIView setAnimationDelegate:nil];
-    }
-
-    CGRect newFrame;
-    newFrame.origin.x = 0;
-    newFrame.origin.y = 0;
-    newFrame.size.width = bounds.size.width;
-    newFrame.size.height = 8;
-    [self->_progressBackground setFrame:newFrame];
-
-    newFrame.size.width = bounds.size.width * self->_value;
-    if (newFrame.size.width > bounds.size.width) {
-        newFrame.size.width = bounds.size.width;
-    }
-    if (newFrame.size.width < 8) {
-        newFrame.size.width = 8;
-    }
-
-    [self->_progressForeground setFrame:newFrame];
-
-    if (animated) {
-        [UIView commitAnimations];
-    }
+    StrongId<NSProgress> _observedProgress;
+    StrongId<UIColor> _trackTint;
+    StrongId<UIColor> _progressTint;
+    StrongId<UIImage> _trackImage;
+    StrongId<UIImage> _progressImage;
 }
 
 /**
@@ -64,32 +54,25 @@ static void sizeViews(UIProgressView* self, bool animated) {
  @Notes May not be fully implemented
 */
 - (instancetype)initWithCoder:(NSCoder*)coder {
-    [super initWithCoder:coder];
+    if (self = [super initWithCoder:coder]) {
+        if ([coder containsValueForKey:@"UIProgressViewStyle"]) {
+            [self setProgressViewStyle:(UIProgressViewStyle)[coder decodeInt32ForKey:@"UIProgressViewStyle"]];
+        } else {
+            [self setProgressViewStyle:UIProgressViewStyleDefault];
+        }
 
-    CGRect frame;
-    frame = [self frame];
-
-    UIImage* background = [[UIImage imageNamed:@"/img/progress-background@2x.png"] stretchableImageWithLeftCapWidth:5 topCapHeight:0];
-    UIImage* foreground = [[UIImage imageNamed:@"/img/progress-foreground@2x.png"] stretchableImageWithLeftCapWidth:5 topCapHeight:0];
-
-    CGRect progressFrame;
-
-    progressFrame.origin.x = 0;
-    progressFrame.origin.y = 0;
-    progressFrame.size.width = frame.size.width;
-    progressFrame.size.height = 8;
-
-    _progressBackground = [[[UIImageView alloc] initWithFrame:progressFrame] autorelease];
-    [_progressBackground setImage:background];
-
-    progressFrame.size.width = 8;
-    _progressForeground = [[[UIImageView alloc] initWithFrame:progressFrame] autorelease];
-    [_progressForeground setImage:foreground];
-
-    [self addSubview:_progressBackground];
-    [self addSubview:_progressForeground];
-
-    sizeViews(self, false);
+        CGRect frame = CGRectZero;
+        if ([coder containsValueForKey:@"UIFrameX"]) {
+            frame.origin.x = [coder decodeInt32ForKey:@"UIFrameX"];
+        }
+        if ([coder containsValueForKey:@"UIFrameY"]) {
+            frame.origin.y = [coder decodeInt32ForKey:@"UIFrameY"];
+        }
+        if ([coder containsValueForKey:@"UIFrameWidth"]) {
+            frame.size.width = [coder decodeInt32ForKey:@"UIFrameWidth"];
+        }
+        [self setFrame:frame];
+    }
 
     return self;
 }
@@ -98,51 +81,123 @@ static void sizeViews(UIProgressView* self, bool animated) {
  @Status Interoperable
 */
 - (instancetype)initWithFrame:(CGRect)frame {
-    [super initWithFrame:frame];
-
-    [self setOpaque:FALSE];
-    [self setUserInteractionEnabled:FALSE];
-
-    UIImage* background = [[UIImage imageNamed:@"/img/progress-background@2x.png"] stretchableImageWithLeftCapWidth:5 topCapHeight:0];
-    UIImage* foreground = [[UIImage imageNamed:@"/img/progress-foreground@2x.png"] stretchableImageWithLeftCapWidth:5 topCapHeight:0];
-
-    CGRect progressFrame;
-
-    progressFrame.origin.x = 0;
-    progressFrame.origin.y = 0;
-    progressFrame.size.width = frame.size.width;
-    progressFrame.size.height = 8;
-
-    _progressBackground = [[[UIImageView alloc] initWithFrame:progressFrame] autorelease];
-    [_progressBackground setImage:background];
-
-    progressFrame.size.width = 8;
-    _progressForeground = [[[UIImageView alloc] initWithFrame:progressFrame] autorelease];
-    [_progressForeground setImage:foreground];
-
-    [self addSubview:_progressBackground];
-    [self addSubview:_progressForeground];
-
-    sizeViews(self, false);
+    if (self = [super initWithFrame:frame]) {
+        [self setProgressViewStyle:UIProgressViewStyleDefault];
+    }
 
     return self;
 }
 
 /**
- @Status Caveat
- @Notes style not supported
+ @Status Interoperable
+*/
+- (void)setFrame:(CGRect)frame {
+    CGRect updatedFrame = [self _limitFrameHeight:frame];
+    [super setFrame:updatedFrame];
+}
+
+/**
+ @Status Interoperable
 */
 - (instancetype)initWithProgressViewStyle:(UIProgressViewStyle)style {
-    [self init];
+    if (self = [super init]) {
+        [self setProgressViewStyle:style];
+    }
 
     return self;
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (void)setProgressViewStyle:(UIProgressViewStyle)style {
-    UNIMPLEMENTED();
+
+    // Ensure the default style is always set for anything other than the bar style, to ignore invalid styles
+    if (style == UIProgressViewStyleBar) {
+        _progressViewStyle = UIProgressViewStyleBar;
+    } else {
+        _progressViewStyle = UIProgressViewStyleDefault;
+    }
+
+    // Set track and progress fill appropriately
+    [self _updateProgressStyle];
+    [self _updateTrackStyle];
+
+    // Ensure the frame gets updated for this style
+    [self setFrame:[self frame]];
+}
+
+/**
+ Constricts the frame height to match the size iOS uses natively.
+ NOTE: On iOS, the UIProgressView height is always limited in this way.
+*/
+- (CGRect)_limitFrameHeight:(CGRect)frame {
+    double styleHeight;
+
+    // It is safe to only check for the default style here because the style is guaranteed to be valid by setProgresViewStyle
+    if (_progressViewStyle == UIProgressViewStyleDefault) {
+        styleHeight = c_defaultStyleHeight;
+    } else {
+        styleHeight = c_barStyleHeight;
+    }
+
+    return CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, styleHeight);
+}
+
+/**
+ @Status Interoperable
+*/
+- (UIProgressViewStyle)progressViewStyle {
+    return _progressViewStyle;
+}
+
+/**
+ @Status Interoperable
+*/
+- (void)setObservedProgress:(NSProgress*)progress {
+    if (progress) {
+        _observedProgress = progress;
+
+        [_observedProgress addObserver:self
+                            forKeyPath:@"fractionCompleted"
+                               options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial
+                               context:ProgressViewObservedProgressContext];
+    } else {
+        [_observedProgress removeObserver:self forKeyPath:@"fractionCompleted" context:ProgressViewObservedProgressContext];
+
+        _observedProgress = nil;
+    }
+}
+
+/**
+ @Status Interoperable
+*/
+- (NSProgress*)observedProgress {
+    return _observedProgress;
+}
+
+/**
+ @Status Interoperable
+*/
+- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context {
+
+    // Ensure this notification was meant for us, otherwise send it to super
+    if (context == (void*)ProgressViewObservedProgressContext) {
+
+        // Ensure the value changed
+        if ([[change objectForKey:NSKeyValueChangeKindKey] integerValue] == NSKeyValueChangeSetting) {
+            NSValue* newValue = [change objectForKey:NSKeyValueChangeNewKey];
+
+            // Ensure we got a value, and it is of the expected type
+            if (newValue && strncmp([newValue objCType], @encode(double), 1) == 0) {
+                double fractionCompleted = 0.0;
+                [newValue getValue:&fractionCompleted];
+                [self setProgress:fractionCompleted];
+            }
+        }
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
 }
 
 /**
@@ -150,7 +205,7 @@ static void sizeViews(UIProgressView* self, bool animated) {
 */
 - (void)setProgress:(float)progress {
     _value = progress;
-    sizeViews(self, false);
+    XamlControls::SetProgressViewValue([self _winrtXamlElement], _value);
 }
 
 /**
@@ -158,28 +213,27 @@ static void sizeViews(UIProgressView* self, bool animated) {
  @Notes animation parameter not supported
 */
 - (void)setProgress:(float)progress animated:(BOOL)animated {
-    _value = progress;
-    sizeViews(self, animated);
+    [self setProgress:progress];
 }
 
 /**
  @Status Interoperable
 */
-- (void)setProgressImage:(UIImage*)image {
-}
-
-/**
- @Status Stub
-*/
 - (void)setProgressTintColor:(UIColor*)color {
-    UNIMPLEMENTED();
+    _progressTintColor = color;
+    _progressImage = nil;
+
+    [self _updateProgressStyle];
 }
 
 /**
- @Status Stub
+ @Status Interoperable
 */
 - (void)setTrackTintColor:(UIColor*)color {
-    UNIMPLEMENTED();
+    _trackTintColor = color;
+    _trackImage = nil;
+
+    [self _updateTrackStyle];
 }
 
 /**
@@ -187,6 +241,19 @@ static void sizeViews(UIProgressView* self, bool animated) {
 */
 - (void)setTrackImage:(UIImage*)image {
     _trackImage = image;
+    _trackTintColor = nil;
+
+    [self _updateTrackStyle];
+}
+
+/**
+ @Status Interoperable
+*/
+- (void)setProgressImage:(UIImage*)image {
+    _progressImage = image;
+    _progressTintColor = nil;
+
+    [self _updateProgressStyle];
 }
 
 /**
@@ -199,23 +266,108 @@ static void sizeViews(UIProgressView* self, bool animated) {
 /**
  @Status Interoperable
 */
+- (UIImage*)progressImage {
+    return _progressImage;
+}
+
+/**
+ @Status Interoperable
+*/
 - (float)progress {
-    return _value;
+    return XamlControls::GetProgressViewValue([self _winrtXamlElement]);
 }
 
 /**
- @Status Interoperable
+ Updates the progress fill based on if we have set a tint, image, or neither.
 */
-- (void)layoutSubviews {
-    sizeViews(self, false);
+- (void)_updateProgressStyle {
+    if (_progressImage) {
+        [self _setProgressViewForegroundImage:_progressImage];
+    } else {
+        UIColor* progressColor;
+
+        // Use the tint color if set, otherwise use the default
+        if (_progressTintColor) {
+            progressColor = _progressTintColor;
+        } else {
+
+            // This matches what iOS uses natively
+            progressColor = [UIColor colorWithRed:0.5 green:0.48 blue:1.0 alpha:1.0];
+        }
+
+        [self _setProgressViewForegroundColor:progressColor];
+    }
 }
 
 /**
- @Status Interoperable
+ Updates the track based on if we have set a tint, image, or neither.
 */
+- (void)_updateTrackStyle {
+    if (_trackImage) {
+        [self _setProgressViewBackgroundImage:_trackImage];
+    } else {
+        UIColor* trackColor;
+
+        // Use the tint color if set, otherwise use the default for the current style
+        if (_trackTintColor) {
+            trackColor = _trackTintColor;
+
+            // It is safe to only check for the default style here because the style is guaranteed to be valid by setProgresViewStyle
+        } else if (_progressViewStyle == UIProgressViewStyleDefault) {
+
+            // These colors match what iOS uses natively
+            trackColor = [UIColor colorWithWhite:0.72 alpha:1.0];
+        } else {
+            trackColor = [UIColor whiteColor];
+        }
+
+        [self _setProgressViewBackgroundColor:trackColor];
+    }
+}
+
+/**
+ Sets the backing XAML control's foreground to the given color
+*/
+- (void)_setProgressViewForegroundColor:(UIColor*)color {
+    winrt::Windows::UI::Color convertedColor = XamlUtilities::ConvertUIColorToWUColor(color);
+    Media::SolidColorBrush brush = convertedColor;
+    XamlControls::SetProgressViewForegroundValue([self _winrtXamlElement], brush);
+}
+
+/**
+ Sets the backing XAML control's foreground to the given image
+*/
+- (void)_setProgressViewForegroundImage:(UIImage*)image {
+    Media::ImageBrush brush = XamlUtilities::ConvertUIImageToWUXMImageBrush(image);
+    XamlControls::SetProgressViewForegroundValue([self _winrtXamlElement], brush);
+}
+
+/**
+ Sets the backing XAML control's background to the given color
+*/
+- (void)_setProgressViewBackgroundColor:(UIColor*)color {
+    winrt::Windows::UI::Color convertedColor = XamlUtilities::ConvertUIColorToWUColor(color);
+    Media::SolidColorBrush brush = convertedColor;
+    XamlControls::SetProgressViewBackgroundValue([self _winrtXamlElement], brush);
+}
+
+/**
+ Sets the backing XAML control's background to the given image
+*/
+- (void)_setProgressViewBackgroundImage:(UIImage*)image {
+    Media::ImageBrush brush = XamlUtilities::ConvertUIImageToWUXMImageBrush(image);
+    XamlControls::SetProgressViewBackgroundValue([self _winrtXamlElement], brush);
+}
+
+/**
+ Microsoft Extension
+*/
++ (RTObject*)createXamlElement {
+    return objcwinrt::to_rtobj(XamlControls::CreateProgressView());
+}
+
 - (void)dealloc {
-    _trackImage = nil;
-
-    [super dealloc];
+    [_observedProgress removeObserver:self forKeyPath:@"fractionCompleted" context:ProgressViewObservedProgressContext];
 }
+
 @end

--- a/Frameworks/UIKit/XamlControls.h
+++ b/Frameworks/UIKit/XamlControls.h
@@ -89,6 +89,24 @@ void SetActivityIndicatorViewHeightValue(const winrt::Windows::UI::Xaml::Framewo
 void SetActivityIndicatorViewWidthValue(const winrt::Windows::UI::Xaml::FrameworkElement& activityIndicatorInspectable, double width);
 
 ////////////////////////////////////////////////////////////////////////////////////
+// ProgressView
+////////////////////////////////////////////////////////////////////////////////////
+winrt::Windows::UI::Xaml::Controls::Grid CreateProgressView();
+
+winrt::Windows::UI::Xaml::Controls::ProgressBar XamlGetInternalProgressBar(
+    const winrt::Windows::UI::Xaml::Controls::Grid& progressViewInspectable);
+
+double GetProgressViewValue(const winrt::Windows::UI::Xaml::FrameworkElement& progressViewInspectable);
+
+void SetProgressViewValue(const winrt::Windows::UI::Xaml::FrameworkElement& progressViewInspectable, double value);
+
+void SetProgressViewForegroundValue(const winrt::Windows::UI::Xaml::FrameworkElement& progressViewInspectable,
+                                    const winrt::Windows::UI::Xaml::Media::Brush& foregroundColorBrush);
+
+void SetProgressViewBackgroundValue(const winrt::Windows::UI::Xaml::FrameworkElement& progressViewInspectable,
+                                    const winrt::Windows::UI::Xaml::Media::Brush& backgroundColorBrush);
+
+////////////////////////////////////////////////////////////////////////////////////
 // Button
 ////////////////////////////////////////////////////////////////////////////////////
 winrt::Windows::UI::Xaml::Controls::Button CreateButton();

--- a/Frameworks/UIKit/XamlControls.mm
+++ b/Frameworks/UIKit/XamlControls.mm
@@ -66,6 +66,36 @@ void SetActivityIndicatorViewWidthValue(const FrameworkElement& activityIndicato
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
+// ProgressView
+////////////////////////////////////////////////////////////////////////////////////
+Controls::Grid CreateProgressView() {
+    ComPtr<IInspectable> inspectable;
+    XamlCreateProgressView(&inspectable);
+    return objcwinrt::from_insp<Controls::Grid>(inspectable);
+}
+
+Controls::ProgressBar XamlGetInternalProgressBar(const Controls::Grid& progressViewControl) {
+    ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(progressViewControl)));
+    return objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+}
+
+double GetProgressViewValue(const FrameworkElement& progressViewControl) {
+    return XamlGetProgressViewValue(objcwinrt::to_insp(progressViewControl));
+}
+
+void SetProgressViewValue(const FrameworkElement& progressViewControl, double value) {
+    XamlSetProgressViewValue(objcwinrt::to_insp(progressViewControl), value);
+}
+
+void SetProgressViewForegroundValue(const FrameworkElement& progressViewControl, const Media::Brush& foregroundColorBrush) {
+    XamlSetProgressViewForegroundValue(objcwinrt::to_insp(progressViewControl), objcwinrt::to_insp(foregroundColorBrush));
+}
+
+void SetProgressViewBackgroundValue(const FrameworkElement& progressViewControl, const Media::Brush& backgroundColorBrush) {
+    XamlSetProgressViewBackgroundValue(objcwinrt::to_insp(progressViewControl), objcwinrt::to_insp(backgroundColorBrush));
+}
+
+////////////////////////////////////////////////////////////////////////////////////
 // Button
 ////////////////////////////////////////////////////////////////////////////////////
 Controls::Button CreateButton() {

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -288,6 +288,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIButtonWithControlsViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UILabelViewController.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIProgressViewController.h" />
   </ItemGroup>
   <ItemGroup>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\AppDelegate.mm">
@@ -318,6 +319,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\ToastNotificationTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIViewTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIActivityIndicatorTests.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIProgressViewTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIButtonTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIScrollViewTests.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UILabelTests.mm" />
@@ -347,6 +349,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UILabelViewController.m" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIScrollViewController.m" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.m" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIProgressViewController.m" />
   </ItemGroup>
   <ItemGroup>
     <Media Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\AssetsLibraryTests\AssetsLibraryTestVideo.mp4" />

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj.filters
@@ -61,6 +61,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.h">
        <Filter>Tests\ExternalUXResources</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIProgressViewController.h">
+       <Filter>Tests\ExternalUXResources</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\FunctionalTests.cpp" />
@@ -131,6 +134,9 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIActivityIndicatorTests.mm">
       <Filter>Tests\UIKitTests</Filter>
     </ClangCompile>
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIProgressViewTests.mm">
+      <Filter>Tests\UIKitTests</Filter>
+    </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\tests\functionaltests\Tests\UIKitTests\UIScrollViewTests.mm">
       <Filter>Tests\UIKitTests</Filter>
     </ClangCompile>
@@ -170,6 +176,9 @@
       <Filter>Tests\ExternalUXResources</Filter>
     </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.m">
+       <Filter>Tests\ExternalUXResources</Filter>
+    </ClangCompile>
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIProgressViewController.m">
        <Filter>Tests\ExternalUXResources</Filter>
     </ClangCompile>
   </ItemGroup>

--- a/build/UIKit.Xaml/dll/UIKit.Xaml.vcxproj
+++ b/build/UIKit.Xaml/dll/UIKit.Xaml.vcxproj
@@ -161,6 +161,9 @@
       <DependentUpon>ContentDialog.xaml</DependentUpon>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ObjCXamlControls.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ProgressView.xaml.h">
+      <DependentUpon>ProgressView.xaml</DependentUpon>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\pch.cpp">
@@ -179,8 +182,11 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Layer.xaml.cpp">
       <DependentUpon>Layer.xaml</DependentUpon>
     </ClCompile>
-    <ClCompile Include="..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml.cpp">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml.cpp">
       <DependentUpon>ActivityIndicatorView.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ProgressView.xaml.cpp">
+      <DependentUpon>ProgressView.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ScrollView.xaml.cpp">
       <DependentUpon>ScrollView.xaml</DependentUpon>
@@ -205,7 +211,7 @@
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Layer.xaml">
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml">
       <SubType>Designer</SubType>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ScrollView.xaml">
@@ -221,6 +227,9 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Themes\Generic.xaml" />
+    <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ProgressView.xaml">
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(StarboardBasePath)\msvc\sdk-build.targets" />

--- a/build/UIKit.Xaml/dll/UIKit.Xaml.vcxproj.filters
+++ b/build/UIKit.Xaml/dll/UIKit.Xaml.vcxproj.filters
@@ -16,7 +16,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Layer.xaml.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Label.xaml.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ILayer.cpp" />
-    <ClCompile Include="..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ProgressView.xaml.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Button.xaml.h" />
@@ -29,7 +30,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Label.xaml.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ILayer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ObjCXamlControls.h" />
-    <ClInclude Include="..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ProgressView.xaml.h" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Button.xaml" />
@@ -40,6 +42,7 @@
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ContentDialog.xaml" />
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Layer.xaml" />
     <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\Label.xaml" />
-    <Page Include="..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml" />
+    <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ActivityIndicatorView.xaml" />
+    <Page Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit.Xaml\ProgressView.xaml" />
   </ItemGroup>
 </Project>

--- a/build/UIKit/lib/UIKitLib.vcxproj
+++ b/build/UIKit/lib/UIKitLib.vcxproj
@@ -142,7 +142,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIDatePicker.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPinchGestureRecognizer.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIProgressView.mm">
-      <ObjectiveCARC Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ObjectiveCARC>
+      <ObjectiveCARC>true</ObjectiveCARC>
     </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UITableViewCellContentView.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UITextView.mm" />

--- a/build/UIKit/lib/UIKitLib.vcxproj
+++ b/build/UIKit/lib/UIKitLib.vcxproj
@@ -141,7 +141,9 @@
     </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIDatePicker.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIPinchGestureRecognizer.mm" />
-    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIProgressView.mm" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIProgressView.mm">
+      <ObjectiveCARC Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ObjectiveCARC>
+    </ClangCompile>
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UITableViewCellContentView.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UITextView.mm" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\Frameworks\UIKit\UIToolbar.mm" />

--- a/include/UIKit/UIProgressView.h
+++ b/include/UIKit/UIProgressView.h
@@ -37,19 +37,18 @@ typedef enum {
     UIProgressViewStyleBar,
 } UIProgressViewStyle;
 
-@class UIImage;
-
 UIKIT_EXPORT_CLASS
 @interface UIProgressView : UIView
 
 - (id)initWithProgressViewStyle:(UIProgressViewStyle)style;
 - (void)setProgress:(float)progress animated:(BOOL)animated;
 
-@property (nonatomic) UIProgressViewStyle progressViewStyle STUB_PROPERTY;
+@property (nonatomic) UIProgressViewStyle progressViewStyle;
 @property (nonatomic) float progress;
-@property (nonatomic, retain) UIImage* progressImage;
-@property (nonatomic, retain) UIImage* trackImage;
-@property (nonatomic, retain) UIColor* progressTintColor STUB_PROPERTY;
-@property (nonatomic, retain) UIColor* trackTintColor;
+@property (readwrite, nonatomic, strong) NSProgress* observedProgress;
+@property (readwrite, nonatomic, strong) UIImage* progressImage;
+@property (readwrite, nonatomic, strong) UIImage* trackImage;
+@property (readwrite, nonatomic, strong) UIColor* progressTintColor;
+@property (readwrite, nonatomic, strong) UIColor* trackTintColor;
 
 @end

--- a/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj
+++ b/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
@@ -179,6 +179,15 @@
     </AppxManifest>
     <Xml Include="default.rd.xml" />
     <None Include="XAMLCatalog_TemporaryKey.pfx" />
+    <None Include="project.json" />
+    <Image Include="..\..\XAMLCatalog\Images\progress-fill-sample.png">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+    </Image>
+    <Image Include="..\..\XAMLCatalog\Images\progress-track-sample.png">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+    </Image>
     <Image Include="Assets\LockScreenLogo.scale-200.png" />
     <Image Include="Assets\SplashScreen.scale-200.png" />
     <Image Include="Assets\Square150x150Logo.scale-200.png" />
@@ -208,6 +217,7 @@
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIButtonWithControlsViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UILabelViewController.h" />
+    <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIProgressViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIScrollViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UISliderViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController.h" />
@@ -223,6 +233,7 @@
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIButtonWithControlsViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UILabelViewController.m" />
+    <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIProgressViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIScrollViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UISliderViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController.m" />
@@ -250,6 +261,7 @@
       <DeploymentContent>false</DeploymentContent>
     </Text>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
   <!-- Begin NuGet Section -->

--- a/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj.filters
+++ b/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj.filters
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Common">
       <UniqueIdentifier>{15cb5cc4-3ef7-46f9-b26d-d17129ef9036}</UniqueIdentifier>
@@ -87,6 +87,9 @@
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UILabelViewController.h">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIProgressViewController.h">
+      <Filter>XAMLCatalog\UIKitControls</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIScrollViewController.h">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClInclude>
@@ -132,9 +135,12 @@
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UILabelViewController.m">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClangCompile>
+    <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIProgressViewController.m">
+      <Filter>XAMLCatalog\UIKitControls</Filter>
+    </ClangCompile>
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIScrollViewController.m">
       <Filter>XAMLCatalog\UIKitControls</Filter>
-    </ClangCompile>    
+    </ClangCompile>
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UISliderViewController.m">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClangCompile>
@@ -184,5 +190,27 @@
     <Font Include="..\..\XAMLCatalog\Fonts\WinObjC.ttf" />
     <Font Include="..\..\XAMLCatalog\Fonts\WinObjC-Bold.ttf" />
     <Font Include="..\..\XAMLCatalog\Fonts\WinObjC-Italic.ttf" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="App.xaml.cpp" />
+    <ClCompile Include="pch.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="App.xaml.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Image Include="..\..\XAMLCatalog\Images\progress-fill-sample.png">
+      <Filter>Images</Filter>
+    </Image>
+    <Image Include="..\..\XAMLCatalog\Images\progress-track-sample.png">
+      <Filter>Images</Filter>
+    </Image>
   </ItemGroup>
 </Project>

--- a/samples/XAMLCatalog/XAMLCatalog.xcodeproj/project.pbxproj
+++ b/samples/XAMLCatalog/XAMLCatalog.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		822F85C01D8F908C001DC8A5 /* yellow_background.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 822F85BD1D8F908C001DC8A5 /* yellow_background.jpg */; };
 		96857DC01D598FB300EB1FD0 /* MiscellaneousViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96857DBD1D598FB300EB1FD0 /* MiscellaneousViewController.m */; };
 		A5180F451E89656400BADAD5 /* UIScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A5180F441E89656400BADAD5 /* UIScrollViewController.m */; };
+		DE93EADB1EB3F65400CCE388 /* UIProgressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DE93EADA1EB3F65400CCE388 /* UIProgressViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -79,6 +80,8 @@
 		96857DBD1D598FB300EB1FD0 /* MiscellaneousViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MiscellaneousViewController.m; sourceTree = "<group>"; };
 		A5180F431E89656400BADAD5 /* UIScrollViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIScrollViewController.h; path = UIKitControls/UIScrollViewController.h; sourceTree = "<group>"; };
 		A5180F441E89656400BADAD5 /* UIScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UIScrollViewController.m; path = UIKitControls/UIScrollViewController.m; sourceTree = "<group>"; };
+		DE93EAD91EB3F65400CCE388 /* UIProgressViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIProgressViewController.h; path = UIKitControls/UIProgressViewController.h; sourceTree = "<group>"; };
+		DE93EADA1EB3F65400CCE388 /* UIProgressViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UIProgressViewController.m; path = UIKitControls/UIProgressViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +114,8 @@
 				234767211E2EE058006D97CB /* UITextFieldViewController.m */,
 				234767221E2EE058006D97CB /* UIViewViewController.h */,
 				234767231E2EE058006D97CB /* UIViewViewController.m */,
+				DE93EAD91EB3F65400CCE388 /* UIProgressViewController.h */,
+				DE93EADA1EB3F65400CCE388 /* UIProgressViewController.m */,
 			);
 			name = UIKitControls;
 			sourceTree = "<group>";
@@ -270,6 +275,7 @@
 				2347672C1E2EE090006D97CB /* UIButtonWithControlsViewController.m in Sources */,
 				234767281E2EE058006D97CB /* UITextFieldViewController.m in Sources */,
 				234767251E2EE058006D97CB /* UIActivityIndicatorViewController.m in Sources */,
+				DE93EADB1EB3F65400CCE388 /* UIProgressViewController.m in Sources */,
 				239EBAEB1E39559C00C845D0 /* TestEnabledUITextField.mm in Sources */,
 				6EEB8A411CE4F4050021021E /* StoryBoardViewController.m in Sources */,
 				6EEB8A3B1CE4F4050021021E /* AppDelegate.m in Sources */,

--- a/samples/XAMLCatalog/XAMLCatalog/Images/progress-fill-sample.png
+++ b/samples/XAMLCatalog/XAMLCatalog/Images/progress-fill-sample.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41c3b2ecffd93e7202209157816d3ab6f2552b6fec72dc2d15e553a17d6392b4
+size 160

--- a/samples/XAMLCatalog/XAMLCatalog/Images/progress-track-sample.png
+++ b/samples/XAMLCatalog/XAMLCatalog/Images/progress-track-sample.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:147e3c169ab101926a6edffded0593755c742138c9f3a8c330028244fc1c867a
+size 160

--- a/samples/XAMLCatalog/XAMLCatalog/ProgrammaticViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/ProgrammaticViewController.m
@@ -20,6 +20,7 @@
 #import "UIActivityIndicatorViewController.h"
 #import "UIButtonWithControlsViewController.h"
 #import "UILabelViewController.h"
+#import "UIProgressViewController.h"
 #import "UIScrollViewController.h"
 #import "UISliderViewController.h"
 #import "UITextFieldViewController.h"
@@ -37,6 +38,9 @@
 
     // UIActivityIndicatorView
     [self addMenuItemViewController:[[UIActivityIndicatorViewController alloc] init] andTitle:@"UIActivityIndicatorView"];
+    
+    // UIProgressView
+    [self addMenuItemViewController:[[UIProgressViewController alloc] init] andTitle:@"UIProgressView"];
 
     // UIButton
     [self addMenuItemViewController:[[UIButtonWithControlsViewController alloc] init]

--- a/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UIProgressViewController.h
+++ b/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UIProgressViewController.h
@@ -1,0 +1,47 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <UIKit/UIKit.h>
+
+@interface UIProgressViewController : UIViewController
+
+@property (nonatomic) UIProgressView* progressView;
+@property (nonatomic) NSProgress* progress;
+
+@property (nonatomic) UIButton* pauseButton;
+@property (nonatomic) UIButton* startButton;
+
+@property (nonatomic) UITextField* progressValue;
+@property (nonatomic) UIButton* setProgressButton;
+
+@property (nonatomic) UIButton* fillSelectButton;
+@property (nonatomic) UIButton* trackSelectButton;
+
+@property (nonatomic) UIButton* styleSelectButton;
+
+@property (nonatomic) UITextField* redFillComponent;
+@property (nonatomic) UITextField* greenFillComponent;
+@property (nonatomic) UITextField* blueFillComponent;
+@property (nonatomic) UITextField* alphaFillComponent;
+@property (nonatomic) UIButton* setFillTintButton;
+
+@property (nonatomic) UITextField* redTrackComponent;
+@property (nonatomic) UITextField* greenTrackComponent;
+@property (nonatomic) UITextField* blueTrackComponent;
+@property (nonatomic) UITextField* alphaTrackComponent;
+@property (nonatomic) UIButton* setTrackTintButton;
+
+@end

--- a/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UIProgressViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UIProgressViewController.m
@@ -1,0 +1,276 @@
+//******************************************************************************
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import "UIProgressViewController.h"
+
+@implementation UIProgressViewController {
+    NSNumberFormatter* decimalFormat;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Xaml ProgressView";
+
+    self.view.backgroundColor = [UIColor whiteColor];
+
+    [self _setup];
+    [self updateFillTextFields];
+    [self updateTrackTextFields];
+}
+
+- (void)_setup {
+    // Formatter used by input fields
+    decimalFormat = [[NSNumberFormatter alloc] init];
+    decimalFormat.positiveFormat = @"0.##";
+
+    // Get screen width for placement
+    int screenWidth = [[UIScreen mainScreen] bounds].size.width;
+
+    // Setup ProgressView
+    _progressView = [[UIProgressView alloc] initWithFrame:CGRectMake((screenWidth / 2) - 150, 70, 300, 10)];
+    [self.view addSubview:_progressView];
+
+    // Setup observed progress button
+    _startButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _startButton.frame = CGRectMake((screenWidth / 2) - 150, 110, 300, 20);
+    [_startButton setTitle:@"Set With Observed Progress" forState:UIControlStateNormal];
+    [_startButton addTarget:self action:@selector(startButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_startButton];
+
+    // Setup progress value input field
+    _progressValue = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) - 25, 140, 50, 30)];
+    [_progressValue setBorderStyle:UITextBorderStyleLine];
+    [_progressValue setText:@"0.0"];
+    [self.view addSubview:_progressValue];
+
+    // Setup button for setting progress
+    _setProgressButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _setProgressButton.frame = CGRectMake((screenWidth / 2) - 50, 170, 100, 20);
+    [_setProgressButton setTitle:@"Set Progress" forState:UIControlStateNormal];
+    [_setProgressButton addTarget:self action:@selector(setProgressButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_setProgressButton];
+
+    // Setup fill image/tint toggle button
+    _fillSelectButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _fillSelectButton.frame = CGRectMake((screenWidth / 2) - 50, 200, 100, 20);
+    [_fillSelectButton setTitle:@"Image Fill" forState:UIControlStateNormal];
+    [_fillSelectButton addTarget:self action:@selector(fillSelectButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_fillSelectButton];
+
+    // Setup track image/tint toggle button
+    _trackSelectButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _trackSelectButton.frame = CGRectMake((screenWidth / 2) - 50, 230, 100, 20);
+    [_trackSelectButton setTitle:@"Image Track" forState:UIControlStateNormal];
+    [_trackSelectButton addTarget:self action:@selector(trackSelectButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_trackSelectButton];
+
+    // Setup style toggle button
+    _styleSelectButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _styleSelectButton.frame = CGRectMake((screenWidth / 2) - 50, 260, 100, 20);
+    [_styleSelectButton setTitle:@"Bar Style" forState:UIControlStateNormal];
+    [_styleSelectButton addTarget:self action:@selector(styleSelectButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_styleSelectButton];
+
+    // Setup fill tint input fields
+    _redFillComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) - 55, 300, 50, 30)];
+    _greenFillComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) - 55, 335, 50, 30)];
+    _blueFillComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) - 55, 370, 50, 30)];
+    _alphaFillComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) - 55, 405, 50, 30)];
+    _redFillComponent.backgroundColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:.25];
+    _greenFillComponent.backgroundColor = [UIColor colorWithRed:0 green:1 blue:0 alpha:.25];
+    _blueFillComponent.backgroundColor = [UIColor colorWithRed:0 green:0 blue:1 alpha:.25];
+    _alphaFillComponent.backgroundColor = [UIColor colorWithWhite:.5 alpha:.25];
+    [_redFillComponent setBorderStyle:UITextBorderStyleLine];
+    [_greenFillComponent setBorderStyle:UITextBorderStyleLine];
+    [_blueFillComponent setBorderStyle:UITextBorderStyleLine];
+    [_alphaFillComponent setBorderStyle:UITextBorderStyleLine];
+    [self.view addSubview:_redFillComponent];
+    [self.view addSubview:_greenFillComponent];
+    [self.view addSubview:_blueFillComponent];
+    [self.view addSubview:_alphaFillComponent];
+
+    // Setup fill tint button
+    _setFillTintButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _setFillTintButton.frame = CGRectMake((screenWidth / 2) - 55, 435, 50, 20);
+    [_setFillTintButton setTitle:@"Set Fill" forState:UIControlStateNormal];
+    [_setFillTintButton addTarget:self action:@selector(setFillTintButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_setFillTintButton];
+
+    // Setup track tint input fields
+    _redTrackComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) + 5, 300, 50, 30)];
+    _greenTrackComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) + 5, 335, 50, 30)];
+    _blueTrackComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) + 5, 370, 50, 30)];
+    _alphaTrackComponent = [[UITextField alloc] initWithFrame:CGRectMake((screenWidth / 2) + 5, 405, 50, 30)];
+    _redTrackComponent.backgroundColor = [UIColor colorWithRed:1 green:0 blue:0 alpha:.25];
+    _greenTrackComponent.backgroundColor = [UIColor colorWithRed:0 green:1 blue:0 alpha:.25];
+    _blueTrackComponent.backgroundColor = [UIColor colorWithRed:0 green:0 blue:1 alpha:.25];
+    _alphaTrackComponent.backgroundColor = [UIColor colorWithWhite:.5 alpha:.25];
+    [_redTrackComponent setBorderStyle:UITextBorderStyleLine];
+    [_greenTrackComponent setBorderStyle:UITextBorderStyleLine];
+    [_blueTrackComponent setBorderStyle:UITextBorderStyleLine];
+    [_alphaTrackComponent setBorderStyle:UITextBorderStyleLine];
+    [self.view addSubview:_redTrackComponent];
+    [self.view addSubview:_greenTrackComponent];
+    [self.view addSubview:_blueTrackComponent];
+    [self.view addSubview:_alphaTrackComponent];
+
+    // Setup track tint button
+    _setTrackTintButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    _setTrackTintButton.frame = CGRectMake((screenWidth / 2), 435, 75, 20);
+    [_setTrackTintButton setTitle:@"Set Track" forState:UIControlStateNormal];
+    [_setTrackTintButton addTarget:self action:@selector(setTrackTintButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
+    [self.view addSubview:_setTrackTintButton];
+}
+
+// Updates progress with observed progress
+- (void)startButtonPressed:(UIButton*)sender {
+    if (_progressView.observedProgress) {
+        [_progressView setObservedProgress:nil];
+        [sender setTitle:@"Set With Observed Progress" forState:UIControlStateNormal];
+    } else {
+        _progress = [NSProgress progressWithTotalUnitCount:4];
+        [_progressView setObservedProgress:_progress];
+        [_progress setCompletedUnitCount:3];
+        [sender setTitle:@"Remove Observed Progress" forState:UIControlStateNormal];
+    }
+}
+
+// Toggles the progress fill between tint and image
+- (void)fillSelectButtonPressed:(UIButton*)sender {
+    if (!_progressView.progressImage) {
+        [_progressView setProgressImage:[UIImage imageNamed:@"progress-fill-sample.png"]];
+        [sender setTitle:@"Tint Fill" forState:UIControlStateNormal];
+    } else {
+        [_progressView setProgressImage:nil];
+        [sender setTitle:@"Image Fill" forState:UIControlStateNormal];
+    }
+
+    [self updateFillTextFields];
+}
+
+// Toggles the track between tint and image
+- (void)trackSelectButtonPressed:(UIButton*)sender {
+    if (!_progressView.trackImage) {
+        [_progressView setTrackImage:[UIImage imageNamed:@"progress-track-sample.png"]];
+        [sender setTitle:@"Tint Track" forState:UIControlStateNormal];
+    } else {
+        [_progressView setTrackImage:nil];
+        [sender setTitle:@"Image Track" forState:UIControlStateNormal];
+    }
+
+    [self updateTrackTextFields];
+}
+
+// Toggles between the two UIProgressViewStyles
+- (void)styleSelectButtonPressed:(UIButton*)sender {
+    if (_progressView.progressViewStyle == UIProgressViewStyleDefault) {
+        [_progressView setProgressViewStyle:UIProgressViewStyleBar];
+        [sender setTitle:@"Default Style" forState:UIControlStateNormal];
+    } else {
+        [_progressView setProgressViewStyle:UIProgressViewStyleDefault];
+        [sender setTitle:@"Bar Style" forState:UIControlStateNormal];
+    }
+
+    [self updateFillTextFields];
+    [self updateFillTextFields];
+}
+
+// Sets the progress value from the input field
+- (void)setProgressButtonPressed:(UIButton*)sender {
+    [_progressView setProgress:[_progressValue.text floatValue]];
+}
+
+// Sets the fill tint from the input fields
+- (void)setFillTintButtonPressed:(UIButton*)sender {
+    [_progressView setProgressTintColor:[UIColor colorWithRed:[_redFillComponent.text floatValue]
+                                                        green:[_greenFillComponent.text floatValue]
+                                                         blue:[_blueFillComponent.text floatValue]
+                                                        alpha:[_alphaFillComponent.text floatValue]]];
+
+    [_fillSelectButton setTitle:@"Image Fill" forState:UIControlStateNormal];
+}
+
+// Sets the track tint from the input fields
+- (void)setTrackTintButtonPressed:(UIButton*)sender {
+    [_progressView setTrackTintColor:[UIColor colorWithRed:[_redTrackComponent.text floatValue]
+                                                     green:[_greenTrackComponent.text floatValue]
+                                                      blue:[_blueTrackComponent.text floatValue]
+                                                     alpha:[_alphaTrackComponent.text floatValue]]];
+
+    [_trackSelectButton setTitle:@"Image Track" forState:UIControlStateNormal];
+}
+
+// Updates the fill tint text fields from the current ProgressView fill tint
+- (void)updateFillTextFields {
+    NSArray* components = [self getRGBAColorComponents:_progressView.progressTintColor];
+    [_redFillComponent setText:[decimalFormat stringFromNumber:components[0]]];
+    [_greenFillComponent setText:[decimalFormat stringFromNumber:components[1]]];
+    [_blueFillComponent setText:[decimalFormat stringFromNumber:components[2]]];
+    [_alphaFillComponent setText:[decimalFormat stringFromNumber:components[3]]];
+}
+
+// Updates the track tint text fields from the current ProgressView track tint
+- (void)updateTrackTextFields {
+    NSArray* components = [self getRGBAColorComponents:_progressView.trackTintColor];
+    [_redTrackComponent setText:[decimalFormat stringFromNumber:components[0]]];
+    [_greenTrackComponent setText:[decimalFormat stringFromNumber:components[1]]];
+    [_blueTrackComponent setText:[decimalFormat stringFromNumber:components[2]]];
+    [_alphaTrackComponent setText:[decimalFormat stringFromNumber:components[3]]];
+}
+
+// Extracts the RGBA components from the provided UIColor
+- (NSArray*)getRGBAColorComponents:(UIColor*)color {
+    CGColorRef colorRef = color.CGColor;
+    CGColorSpaceRef colorSpace = CGColorGetColorSpace(colorRef);
+    CGColorSpaceModel colorSpaceModel = CGColorSpaceGetModel(colorSpace);
+    const CGFloat* components = CGColorGetComponents(colorRef);
+    float red, green, blue, alpha;
+
+    switch (colorSpaceModel) {
+        case kCGColorSpaceModelMonochrome:
+            red = components[0];
+            green = components[0];
+            blue = components[0];
+            alpha = components[1];
+            break;
+        case kCGColorSpaceModelRGB:
+            red = components[0];
+            green = components[1];
+            blue = components[2];
+            alpha = components[3];
+            break;
+
+        default:
+            red = 0.0;
+            green = 0.0;
+            blue = 0.0;
+            alpha = 0.0;
+            break;
+    }
+
+    return [NSArray arrayWithObjects:[NSNumber numberWithFloat:red],
+                                     [NSNumber numberWithFloat:green],
+                                     [NSNumber numberWithFloat:blue],
+                                     [NSNumber numberWithFloat:alpha],
+                                     nil];
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+@end

--- a/tests/functionaltests/Tests/Default.AppXManifest.xml
+++ b/tests/functionaltests/Tests/Default.AppXManifest.xml
@@ -39,6 +39,7 @@
         <ActivatableClass ActivatableClassId="UIKit.Xaml.UIKit_Xaml_XamlTypeInfo.XamlMetaDataProvider" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="UIKit.Xaml.Slider" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="UIKit.Xaml.ActivityIndicatorView" ThreadingModel="both" />
+        <ActivatableClass ActivatableClassId="UIKit.Xaml.ProgressView" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="UIKit.Xaml.Item" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="UIKit.Xaml.Button" ThreadingModel="both" />
         <ActivatableClass ActivatableClassId="UIKit.Xaml.Label" ThreadingModel="both" />

--- a/tests/functionaltests/Tests/UIKitTests/UIProgressViewTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIProgressViewTests.mm
@@ -1,0 +1,928 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#include <TestFramework.h>
+#import <UIKit/UIProgressView.h>
+#import "UIViewInternal.h"
+#import "FunctionalTestHelpers.h"
+#import "UXTestHelpers.h"
+#include "CppWinRTHelpers.h"
+
+#import "UIKitControls/UIProgressViewController.h"
+
+#include <COMIncludes.h>
+#import <WRLHelpers.h>
+#import <ErrorHandling.h>
+#import <RawBuffer.h>
+#import <wrl/client.h>
+#import <wrl/implements.h>
+#import <wrl/async.h>
+#import <wrl/wrappers/corewrappers.h>
+#import <windows.foundation.h>
+#import <winrt/Windows.UI.Xaml.h>
+#import <winrt/Windows.UI.Xaml.Controls.h>
+#include <COMIncludes_end.h>
+
+#include "ObjCXamlControls.h"
+
+using namespace UXTestAPI;
+using namespace winrt::Windows::UI::Xaml;
+
+class UIProgressViewTests {
+private:
+    // These sizes match iOS and what should be used in UIProgressView
+    static constexpr double c_expectedDefaultStyleHeight() {
+        return 2.0;
+    }
+    static constexpr double c_expectedBarStyleHeight() {
+        return 2.5;
+    }
+
+    // Set in the XAMLCatalog UIActivitiIndicatorViewController
+    static const int c_expectedInitialFrameWidth = 300;
+
+    // These colors match iOS and what should be used in UIProgressView
+    static UIColor* expectedStyleForegroundColor() {
+        return [UIColor colorWithRed:0.5 green:0.48 blue:1.0 alpha:1.0];
+    }
+    static UIColor* expectedDefaultStyleBackgroundColor() {
+        return [UIColor colorWithWhite:0.72 alpha:1.0];
+    }
+    static UIColor* expectedBarStyleBackgroundColor() {
+        return [UIColor whiteColor];
+    }
+
+    // These are sample images used for testing setting an image as foreground/background
+    static NSString* expectedProgressFillImageName() {
+        return @"progress-fill-sample.png";
+    }
+    static NSString* expectedTrackImageName() {
+        return @"progress-track-sample.png";
+    }
+
+public:
+    BEGIN_TEST_CLASS(UIProgressViewTests)
+    END_TEST_CLASS()
+
+    TEST_CLASS_SETUP(UIKitTestsSetup) {
+        return FunctionalTestSetupUIApplication();
+    }
+
+    TEST_CLASS_CLEANUP(UIKitTestsCleanup) {
+        return FunctionalTestCleanupUIApplication();
+    }
+
+    TEST_METHOD(CreateXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            Microsoft::WRL::ComPtr<IInspectable> xamlElement;
+            XamlCreateProgressView(&xamlElement);
+            ASSERT_TRUE(xamlElement);
+        });
+    }
+
+    TEST_METHOD(GetXamlElement) {
+        FrameworkHelper::RunOnUIThread([]() {
+            UIView* view = [[[UIProgressView alloc] init] autorelease];
+            FrameworkElement backingElement = [view _winrtXamlElement];
+            ASSERT_TRUE(backingElement);
+        });
+    }
+
+    TEST_METHOD(UIProgressView_GetInternalControl) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+        });
+    }
+
+    TEST_METHOD(UIProgressView_VerifyInitialState) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Should start in the default style
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+
+            // Foreground color should match initial style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+
+            // Background color should match initial style
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Other properties should start as nil
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+            EXPECT_EQ(nil, progressView.observedProgress);
+
+            // Initial progress value should be zero
+            EXPECT_EQ(0, progressBar.Value());
+
+            // Height should match initial style
+            EXPECT_EQ(c_expectedDefaultStyleHeight(), progressBar.Height());
+
+            // Initial element size is set in the controller
+            EXPECT_EQ(c_expectedInitialFrameWidth, xamlElement.Width());
+        });
+    }
+
+    /*  Verifies visual elements are set according to the UIProgressViewStyleBar style */
+    TEST_METHOD(UIProgressView_SetBarStyle) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Should start in the default style
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+
+            // Switch to bar style
+            [progressView setProgressViewStyle:UIProgressViewStyleBar];
+            EXPECT_EQ(UIProgressViewStyleBar, progressView.progressViewStyle);
+
+            // Style colors should match colors for the bar style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedBarStyleBackgroundColor()));
+
+            // Height should match bar style
+            EXPECT_EQ(c_expectedBarStyleHeight(), progressBar.Height());
+
+            // Width should not change
+            EXPECT_EQ(c_expectedInitialFrameWidth, xamlElement.Width());
+
+            // Other styling properties should not change
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Verifies visual elements are set appropriately switching between the two styles */
+    TEST_METHOD(UIProgressView_SetDefaultStyleAfterBarStyle) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Should start in the default style
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+
+            // Switch to bar style
+            [progressView setProgressViewStyle:UIProgressViewStyleBar];
+            EXPECT_EQ(UIProgressViewStyleBar, progressView.progressViewStyle);
+
+            // Switch back to default style
+            [progressView setProgressViewStyle:UIProgressViewStyleDefault];
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+
+            // Style colors should match colors for the default style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Height should match default style
+            EXPECT_EQ(c_expectedDefaultStyleHeight(), progressBar.Height());
+
+            // Width should not change
+            EXPECT_EQ(c_expectedInitialFrameWidth, xamlElement.Width());
+        });
+    }
+
+    /*  Attempts to set a style that is not one of the two officially supported styles:
+            UIProgressViewStyleDefault
+            UIProgressViewStyleBar
+
+        The style should default to UIProgressViewStyleDefault
+    */
+    TEST_METHOD(UIProgressView_SetInvalidStyle) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Should start in the default style
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+
+            // Attempt to set invalid style
+            [progressView setProgressViewStyle:(UIProgressViewStyle)2];
+
+            // Style should be set to the default style
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+
+            // Style colors should match colors for the default style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Height should match default style
+            EXPECT_EQ(c_expectedDefaultStyleHeight(), progressBar.Height());
+
+            // Width should not change
+            EXPECT_EQ(c_expectedInitialFrameWidth, xamlElement.Width());
+        });
+    }
+
+    /* Height should be capped to the default height for the current style */
+    TEST_METHOD(UIProgressView_SetHeight) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Height should match default style
+            EXPECT_EQ(c_expectedDefaultStyleHeight(), progressBar.Height());
+
+            // Attempt to increase height
+            [progressView setFrame:CGRectMake(progressView.frame.origin.x,
+                                              progressView.frame.origin.y,
+                                              progressView.frame.size.width,
+                                              progressView.frame.size.height + 1)];
+
+            // Height should match default style
+            EXPECT_EQ(c_expectedDefaultStyleHeight(), progressBar.Height());
+
+            // Attempt to decrease height
+            [progressView setFrame:CGRectMake(progressView.frame.origin.x,
+                                              progressView.frame.origin.y,
+                                              progressView.frame.size.width,
+                                              progressView.frame.size.height - 1)];
+
+            // Height should match default style
+            EXPECT_EQ(c_expectedDefaultStyleHeight(), progressBar.Height());
+        });
+    }
+
+    /*  Use a tint color for the progress fill */
+    TEST_METHOD(UIProgressView_SetProgressTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for progress fill
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setProgressTintColor:expectedTintColor];
+
+            // Progress tint should be set
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedTintColor));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Use a tint color for the track */
+    TEST_METHOD(UIProgressView_SetTrackTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for track
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setTrackTintColor:expectedTintColor];
+
+            // Track tint should be set
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedTintColor));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Use an image for the progress fill */
+    TEST_METHOD(UIProgressView_SetProgressImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for progress fill
+            UIImage* expectedImage = [UIImage imageNamed:expectedProgressFillImageName()];
+            [progressView setProgressImage:expectedImage];
+
+            // Progress image should be set
+            auto actualImageBrush = progressBar.Foreground().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Use an image for the track */
+    TEST_METHOD(UIProgressView_SetTrackImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for track
+            UIImage* expectedImage = [UIImage imageNamed:expectedTrackImageName()];
+            [progressView setTrackImage:expectedImage];
+
+            // Track image should be set
+            auto actualImageBrush = progressBar.Background().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+        });
+    }
+
+    /*  Clearing the tint should reset to the colors for the current style */
+    TEST_METHOD(UIProgressView_ClearProgressTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for progress fill
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setProgressTintColor:expectedTintColor];
+
+            // Progress tint should be set
+            auto progressBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(progressBrush, expectedTintColor));
+
+            // Clear the tint
+            [progressView setProgressTintColor:nil];
+
+            // Style colors should match colors for the default style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Clearing the tint should reset to the colors for the current style */
+    TEST_METHOD(UIProgressView_ClearTrackTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for track
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setTrackTintColor:expectedTintColor];
+
+            // Track tint should be set
+            auto trackBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(trackBrush, expectedTintColor));
+
+            // Clear the tint
+            [progressView setTrackTintColor:nil];
+
+            // Style colors should match colors for the default style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Clearing the image should reset to the colors for the current style */
+    TEST_METHOD(UIProgressView_ClearProgressImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for progress fill
+            UIImage* expectedImage = [UIImage imageNamed:expectedProgressFillImageName()];
+            [progressView setProgressImage:expectedImage];
+
+            // Progress image should be set
+            auto actualImageBrush = progressBar.Foreground().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Clear the image
+            [progressView setProgressImage:nil];
+
+            // Style colors should match colors for the default style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Clearing the image should reset to the colors for the current style */
+    TEST_METHOD(UIProgressView_ClearTrackImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for track
+            UIImage* expectedImage = [UIImage imageNamed:expectedTrackImageName()];
+            [progressView setTrackImage:expectedImage];
+
+            // Track image should be set
+            auto actualImageBrush = progressBar.Background().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Clear the image
+            [progressView setTrackImage:nil];
+
+            // Style colors should match colors for the default style
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedStyleForegroundColor()));
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedDefaultStyleBackgroundColor()));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Tint should always be cleared after an image is set */
+    TEST_METHOD(UIProgressView_SetTrackImageAfterTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for track
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setTrackTintColor:expectedTintColor];
+
+            // Track tint should be set
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedTintColor));
+
+            // Set image for track
+            UIImage* expectedImage = [UIImage imageNamed:expectedTrackImageName()];
+            [progressView setTrackImage:expectedImage];
+
+            // Track image should be set
+            auto actualImageBrush = progressBar.Background().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+        });
+    }
+
+    /*  Tint should always be cleared after an image is set */
+    TEST_METHOD(UIProgressView_SetProgressImageAfterTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for progress fill
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setProgressTintColor:expectedTintColor];
+
+            // Progress tint should be set
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedTintColor));
+
+            // Set image for progress fill
+            UIImage* expectedImage = [UIImage imageNamed:expectedProgressFillImageName()];
+            [progressView setProgressImage:expectedImage];
+
+            // Progress image should be set
+            auto actualImageBrush = progressBar.Foreground().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Image should always be cleared after a tint is set */
+    TEST_METHOD(UIProgressView_SetTrackTintAfterImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for track
+            UIImage* expectedImage = [UIImage imageNamed:expectedTrackImageName()];
+            [progressView setTrackImage:expectedImage];
+
+            // Track image should be set
+            auto actualImageBrush = progressBar.Background().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Set tint color for track
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setTrackTintColor:expectedTintColor];
+
+            // Track tint should be set
+            auto solidBackgroundBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidBackgroundBrush, expectedTintColor));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.progressImage);
+            EXPECT_EQ(nil, progressView.trackImage);
+        });
+    }
+
+    /*  Image should always be cleared after a tint is set */
+    TEST_METHOD(UIProgressView_SetProgressTintAfterImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for progress fill
+            UIImage* expectedImage = [UIImage imageNamed:expectedProgressFillImageName()];
+            [progressView setProgressImage:expectedImage];
+
+            // Progress image should be set
+            auto actualImageBrush = progressBar.Foreground().as<Media::ImageBrush>();
+            auto actualImageBitmapSource = actualImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualImageBitmapSource.PixelWidth(), (int)expectedImage.size.width);
+            EXPECT_EQ(actualImageBitmapSource.PixelHeight(), (int)expectedImage.size.height);
+
+            // Set tint color for progress fill
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setProgressTintColor:expectedTintColor];
+
+            // Progress tint should be set
+            auto solidForegroundBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(solidForegroundBrush, expectedTintColor));
+
+            // Other styling properties should not change
+            EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+            EXPECT_EQ(nil, progressView.trackImage);
+            EXPECT_EQ(nil, progressView.progressImage);
+        });
+    }
+
+    /*  Tint should remain set after a style is applied */
+    TEST_METHOD(UIProgressView_SetStyleAfterTint) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set tint color for progress fill
+            UIColor* expectedTintColor = [UIColor redColor];
+            [progressView setProgressTintColor:expectedTintColor];
+
+            // Progress tint should be set
+            auto progressBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(progressBrush, expectedTintColor));
+
+            // Set tint color for track
+            [progressView setTrackTintColor:expectedTintColor];
+
+            // Track tint should be set
+            auto trackBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(trackBrush, expectedTintColor));
+
+            // Switch back to default style
+            [progressView setProgressViewStyle:UIProgressViewStyleBar];
+            EXPECT_EQ(UIProgressViewStyleBar, progressView.progressViewStyle);
+
+            // Progress tint should still be set
+            progressBrush = progressBar.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(progressBrush, expectedTintColor));
+
+            // Track tint should still be set
+            trackBrush = progressBar.Background().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(trackBrush, expectedTintColor));
+
+            // Other styling properties should not change
+            EXPECT_EQ(nil, progressView.trackImage);
+            EXPECT_EQ(nil, progressView.progressImage);
+        });
+    }
+
+    /*  Image remain set after a style is applied */
+    TEST_METHOD(UIProgressView_SetStyleAfterImage) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set image for progress fill
+            UIImage* expectedProgressImage = [UIImage imageNamed:expectedProgressFillImageName()];
+            [progressView setProgressImage:expectedProgressImage];
+
+            // Progress image should be set
+            auto actualProgressImageBrush = progressBar.Foreground().as<Media::ImageBrush>();
+            auto actualProgressImageBitmapSource = actualProgressImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualProgressImageBitmapSource.PixelWidth(), (int)expectedProgressImage.size.width);
+            EXPECT_EQ(actualProgressImageBitmapSource.PixelHeight(), (int)expectedProgressImage.size.height);
+
+            // Set image for track
+            UIImage* expectedTrackImage = [UIImage imageNamed:expectedTrackImageName()];
+            [progressView setTrackImage:expectedTrackImage];
+
+            // Track image should be set
+            auto actualTrackImageBrush = progressBar.Background().as<Media::ImageBrush>();
+            auto actualTrackImageBitmapSource = actualTrackImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualTrackImageBitmapSource.PixelWidth(), (int)expectedTrackImage.size.width);
+            EXPECT_EQ(actualTrackImageBitmapSource.PixelHeight(), (int)expectedTrackImage.size.height);
+
+            // Set to bar style
+            [progressView setProgressViewStyle:UIProgressViewStyleBar];
+            EXPECT_EQ(UIProgressViewStyleBar, progressView.progressViewStyle);
+
+            // Progress image should be still set
+            actualProgressImageBrush = progressBar.Foreground().as<Media::ImageBrush>();
+            actualProgressImageBitmapSource = actualProgressImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualProgressImageBitmapSource.PixelWidth(), (int)expectedProgressImage.size.width);
+            EXPECT_EQ(actualProgressImageBitmapSource.PixelHeight(), (int)expectedProgressImage.size.height);
+
+            // Track image should be still set
+            actualTrackImageBrush = progressBar.Background().as<Media::ImageBrush>();
+            actualTrackImageBitmapSource = actualTrackImageBrush.ImageSource().as<Media::Imaging::BitmapSource>();
+            EXPECT_EQ(actualTrackImageBitmapSource.PixelWidth(), (int)expectedTrackImage.size.width);
+            EXPECT_EQ(actualTrackImageBitmapSource.PixelHeight(), (int)expectedTrackImage.size.height);
+
+            // Other styling properties should not change
+            EXPECT_EQ(nil, progressView.progressTintColor);
+            EXPECT_EQ(nil, progressView.trackTintColor);
+        });
+    }
+
+    /*  Manually set the progress value directly */
+    TEST_METHOD(UIProgressView_SetProgressValue) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Set the progress value
+            float expectedProgressValue = 0.5;
+            [progressView setProgress:expectedProgressValue];
+
+            // Progress value should be updated
+            EXPECT_EQ(expectedProgressValue, progressView.progress);
+        });
+    }
+
+    /*  Provide an NSProgress instance to observe.
+        The progress value should be set automatically based on the completion fraction of the observed NSProgress instance.
+    */
+    TEST_METHOD(UIProgressView_SetProgressValueWithObservedProgress) {
+        StrongId<UIProgressViewController> progressViewVC;
+        progressViewVC.attach([[UIProgressViewController alloc] init]);
+
+        UXTestAPI::ViewControllerPresenter testHelper(progressViewVC, 2);
+        UIProgressView* progressView = [progressViewVC progressView];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            FrameworkElement xamlElement = [progressView _winrtXamlElement];
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetInternalProgressBar(objcwinrt::to_insp(xamlElement)));
+            auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
+            ASSERT_TRUE(progressBar);
+
+            // Progress values
+            float totalProgressUnitCount = 4.0;
+            float completedProgressUnitCount = 3.0;
+            float expectedProgressValue = completedProgressUnitCount / totalProgressUnitCount;
+
+            // Set the observed progress
+            NSProgress* progress = [NSProgress progressWithTotalUnitCount:totalProgressUnitCount];
+            [progressView setObservedProgress:progress];
+
+            // Progress value should still be zero
+            EXPECT_EQ(0, progressView.progress);
+
+            // Update the completed count
+            [progress setCompletedUnitCount:completedProgressUnitCount];
+
+            // Progress value should be updated
+            EXPECT_EQ(expectedProgressValue, progressView.progress);
+        });
+    }
+};

--- a/tests/functionaltests/Tests/UIKitTests/UIProgressViewTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UIProgressViewTests.mm
@@ -128,6 +128,11 @@ public:
             auto progressBar = objcwinrt::from_insp<Controls::ProgressBar>(inspectable);
             ASSERT_TRUE(progressBar);
 
+            // Ensure ProgressBar properties are as expected
+            EXPECT_EQ(0, progressBar.Minimum());
+            EXPECT_EQ(1, progressBar.Maximum());
+            EXPECT_FALSE(progressBar.IsIndeterminate());
+
             // Should start in the default style
             EXPECT_EQ(UIProgressViewStyleDefault, progressView.progressViewStyle);
 


### PR DESCRIPTION
This adds a backing XAML control to, and completes the implementation for, UIProgressView.