### PR TITLE
Fix #2682 (Islandwood News AV on launch)

### DIFF
--- a/Frameworks/UIKit/UIWebView.mm
+++ b/Frameworks/UIKit/UIWebView.mm
@@ -363,13 +363,16 @@ static void _initUIWebView(UIWebView* self) {
     [color getRed:&r green:&g blue:&b alpha:&a];
 
     // XAML WebView transparency is not used unless it's set to the transparent system color.
-    if (a != 1.0f) {
-        _xamlWebControl.DefaultBackgroundColor(winrt::Windows::UI::Colors::Transparent());
-    } else {
-        _xamlWebControl.DefaultBackgroundColor(winrt::Windows::UI::ColorHelper::FromArgb(255,
-                                                                         (unsigned char)(r * 255.0),
-                                                                         (unsigned char)(g * 255.0),
-                                                                         (unsigned char)(b * 255.0)));
+    if (_xamlWebControl) {
+        if (a != 1.0f) {
+            _xamlWebControl.DefaultBackgroundColor(winrt::Windows::UI::Colors::Transparent());
+        }
+        else {
+            _xamlWebControl.DefaultBackgroundColor(winrt::Windows::UI::ColorHelper::FromArgb(255,
+                (unsigned char)(r * 255.0),
+                (unsigned char)(g * 255.0),
+                (unsigned char)(b * 255.0)));
+        }
     }
 }
 


### PR DESCRIPTION
This is one of side effect after switching to C++/WinRT

the code used projection used to be:
[_xamlWebControl setDefaultBackgroundColor:[WUColors transparent]];

and xamlWebControl  is totally ok to be nil.

Without projection
_xamlWebControl.DefaultBackgroundColor(winrt::Windows::UI::Colors::Transparent());
it is not ok xamlWebControl is nullptr.  it will causes av.