### PR TITLE
Fix delegate dispatch order/threading in NSURLProtocol

### DIFF
--- a/Frameworks/Foundation/NSBlocks.mm
+++ b/Frameworks/Foundation/NSBlocks.mm
@@ -32,7 +32,6 @@
     Block_release(self);
 }
 
-// VSO 6196093: We are using this internally, but we should move away from it.
 - (void)invoke {
     void (^selfAsBlock)(void) = reinterpret_cast<void (^)(void)>(static_cast<void*>(self));
     selfAsBlock();

--- a/Frameworks/Foundation/NSURLConnection.mm
+++ b/Frameworks/Foundation/NSURLConnection.mm
@@ -126,18 +126,9 @@ static void __dispatchDelegateCallback(NSURLConnection* connection, void (^callb
     } else if (connection->_scheduledRunLoops.size() == 1) {
         // TODO #2469: Cannot currently schedule on more than one runloop
         for (auto pair : connection->_scheduledRunLoops) {
-            [pair.first performSelector:@selector(_invokeBlock:)
-                                 target:connection
-                               argument:callbackBlock
-                                  order:0
-                                  modes:@[ pair.second.get() ]];
+            [pair.first performSelector:@selector(invoke) target:callbackBlock argument:nil order:0 modes:@[ pair.second.get() ]];
         }
     }
-}
-
-// Helper function that just invokes a block
-- (void)_invokeBlock:(void (^)())block {
-    block();
 }
 
 // Body of the thread on which the NSURLProtocol loads

--- a/Frameworks/Foundation/NSURLProtocol.mm
+++ b/Frameworks/Foundation/NSURLProtocol.mm
@@ -81,14 +81,6 @@ static const wchar_t* TAG = L"NSURLProtocol";
     return self;
 }
 
-- (id)scheduleInRunLoop:(id)runLoop forMode:(id)mode {
-    return self;
-}
-
-- (id)unscheduleFromRunLoop:(id)runLoop forMode:(id)mode {
-    return self;
-}
-
 /**
  @Status Interoperable
 */

--- a/Frameworks/Foundation/NSURLProtocol_WinHTTP.mm
+++ b/Frameworks/Foundation/NSURLProtocol_WinHTTP.mm
@@ -443,7 +443,7 @@ static void __dispatchClientCallback(NSURLProtocol_WinHTTP* protocol, void (^cal
 
             if (content) {
                 // we could be cancelled mid-operation, but we need to retain the ability to clean up.
-                __block StrongId<NSURLProtocol_WinHTTP> strongSelf = self;
+                StrongId<NSURLProtocol_WinHTTP> strongSelf = self;
                 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                     [strongSelf _consumeDataStreamForIHttpContent:content.Get()];
                 });

--- a/Frameworks/Foundation/NSURLProtocol_file.h
+++ b/Frameworks/Foundation/NSURLProtocol_file.h
@@ -21,8 +21,6 @@
 - (id)startLoading;
 - (id)stopLoading;
 - (id)statusVersion:(id)versionStr;
-- (id)scheduleInRunLoop:(id)runLoop forMode:(id)mode;
 - (id)_doFileLoad;
-- (id)unscheduleFromRunLoop:(id)runLoop forMode:(id)mode;
 + (BOOL)canInitWithRequest:(id)request;
 @end

--- a/Frameworks/Foundation/NSURLProtocol_file.mm
+++ b/Frameworks/Foundation/NSURLProtocol_file.mm
@@ -76,11 +76,6 @@ static const wchar_t* TAG = L"NSURLProtocol_file";
     return self;
 }
 
-- (id)scheduleInRunLoop:(id)runLoop forMode:(id)mode {
-    [runLoop performSelector:@selector(_doFileLoad) target:self argument:nil order:0 modes:[NSArray arrayWithObject:mode]];
-    return self;
-}
-
 - (id)_doFileLoad {
     NSData* dataReceived = [NSData dataWithContentsOfFile:_path];
 
@@ -89,10 +84,6 @@ static const wchar_t* TAG = L"NSURLProtocol_file";
     [client URLProtocol:self didLoadData:dataReceived];
     [client URLProtocolDidFinishLoading:self];
 
-    return self;
-}
-
-- (id)unscheduleFromRunLoop:(id)runLoop forMode:(id)mode {
     return self;
 }
 

--- a/tests/functionaltests/Tests/NSURLSession.mm
+++ b/tests/functionaltests/Tests/NSURLSession.mm
@@ -281,7 +281,6 @@ class NSURLSessionTests {
 public:
     BEGIN_TEST_CLASS(NSURLSessionTests)
     TEST_CLASS_PROPERTY(L"UAP:AppXManifest", L"NSURL.AppxManifest.xml")
-    TEST_CLASS_PROPERTY(L"ignore", L"true")
     END_TEST_CLASS()
 
     TEST_CLASS_SETUP(NSURLClassSetup) {


### PR DESCRIPTION
- Client callbacks now occur on client thread
- Client callbacks now have guaranteed order
- NSURLConnection/Session, which are built on top of Protocol, now also have guaranteed ordering/correct callback context
- Re-enabled NSURLSession tests
- Removed schedule/unscheduleInRunLoop: from NSURLProtocol - this is not a part of the contract and is unused even internally

Fixes #2521

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2697)
<!-- Reviewable:end -->
