### PR TITLE
This change Implement UITextField tests following new functional test paradigm

### DIFF
--- a/Frameworks/UIKit.Xaml/TextField.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/TextField.xaml.cpp
@@ -118,7 +118,6 @@ void TextField::_SwitchToMode(bool secure) {
         // switch to Non-secure mode, create a textbox as backingControl
         _backingControl = ref new Controls::TextBox();
     }
-
     _backingControl->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &UIKit::Xaml::TextField::OnBackingControlLoaded); 
     _gotFocusHandlerRegistrationToken = _backingControl->GotFocus += ref new Windows::UI::Xaml::RoutedEventHandler(this, &TextField::OnGotFocus);
     _lostFocusHandlerRegistrationToken = _backingControl->LostFocus += ref new Windows::UI::Xaml::RoutedEventHandler(this, &UIKit::Xaml::TextField::OnLostFocus);
@@ -167,9 +166,16 @@ void TextField::OnBackingControlLoaded(Platform::Object ^sender, Windows::UI::Xa
         Windows::UI::Xaml::Data::Binding^ binding = ref new Windows::UI::Xaml::Data::Binding();
         binding->Mode = Windows::UI::Xaml::Data::BindingMode::TwoWay;
         binding->ElementName = "Root";
-        binding->Path = ref new Windows::UI::Xaml::PropertyPath("Text");
+        binding->Path = ref new Windows::UI::Xaml::PropertyPath("TextField_Text");
         binding->UpdateSourceTrigger = Windows::UI::Xaml::Data::UpdateSourceTrigger::PropertyChanged;
         passwordBox->SetBinding(Controls::PasswordBox::PasswordProperty, binding);
+
+        // one way binding background to inner passwordbox background
+        binding = ref new Windows::UI::Xaml::Data::Binding();
+        binding->Mode = Windows::UI::Xaml::Data::BindingMode::OneWay;
+        binding->ElementName = "Root";
+        binding->Path = ref new Windows::UI::Xaml::PropertyPath("Background");
+        passwordBox->SetBinding(Controls::PasswordBox::BackgroundProperty, binding);
 
         passwordBox->PlaceholderText = _placeholder;
         passwordBox->InputScope = _FindBestFitInputScope();
@@ -178,10 +184,17 @@ void TextField::OnBackingControlLoaded(Platform::Object ^sender, Windows::UI::Xa
         auto textBox = safe_cast<Controls::TextBox^>(_backingControl);
         Windows::UI::Xaml::Data::Binding^ binding = ref new Windows::UI::Xaml::Data::Binding();
         binding->ElementName = "Root";
-        binding->Path = ref new Windows::UI::Xaml::PropertyPath("Text");
+        binding->Path = ref new Windows::UI::Xaml::PropertyPath("TextField_Text");
         binding->Mode = Windows::UI::Xaml::Data::BindingMode::TwoWay;
         binding->UpdateSourceTrigger = Windows::UI::Xaml::Data::UpdateSourceTrigger::PropertyChanged;
         textBox->SetBinding(Controls::TextBox::TextProperty, binding);
+
+        // one way binding background to inner textbox background
+        binding = ref new Windows::UI::Xaml::Data::Binding();
+        binding->Mode = Windows::UI::Xaml::Data::BindingMode::OneWay;
+        binding->ElementName = "Root";
+        binding->Path = ref new Windows::UI::Xaml::PropertyPath("Background");
+        textBox->SetBinding(Controls::TextBox::BackgroundProperty, binding);
 
         textBox->PlaceholderText = _placeholder;
         textBox->TextAlignment = _textAlignment;
@@ -190,7 +203,6 @@ void TextField::OnBackingControlLoaded(Platform::Object ^sender, Windows::UI::Xa
 
     _backingControl->IsEnabled = _enabled;
     _backingControl->Foreground = _foreground;
-    _backingControl->Background = Background;
 
     _SetTextVerticalAlignment();
     _SetBorderStyle();
@@ -219,9 +231,10 @@ void TextField::_RegisterDependencyProperties() {
     if (!s_dependencyPropertiesRegistered) {
         s_dependencyPropertiesRegistered = true;
 
-        s_textProperty = DependencyProperty::RegisterAttached("Text",
+        // TODO: These Dependency Properties should be attached to TextField instead of FrameworkElement once #2607 is fixed
+        s_textProperty = DependencyProperty::RegisterAttached("TextField_Text",
             Platform::String::typeid,
-            TextField::typeid,
+            FrameworkElement::typeid,
             nullptr);
     }
 }
@@ -252,11 +265,11 @@ Private::CoreAnimation::LayerProperty^ TextField::GetBorderThicknessProperty() {
 }
 
 TextBox^ TextField::TextBox::get() {
-    return safe_cast<Windows::UI::Xaml::Controls::TextBox^>(_backingControl);
+    return dynamic_cast<Windows::UI::Xaml::Controls::TextBox^>(_backingControl);
 }
 
 PasswordBox^ TextField::PasswordBox::get() {
-    return safe_cast<Windows::UI::Xaml::Controls::PasswordBox^>(_backingControl);
+    return dynamic_cast<Windows::UI::Xaml::Controls::PasswordBox^>(_backingControl);
 }
 
 void TextField::KillFocus() {
@@ -412,6 +425,12 @@ void TextField::_SetForeground() {
     }
 }
 
+void TextField::_SetBackgournd() {
+    if (_backingControl) {
+        _backingControl->Background = Background;
+    }
+}
+
 void TextField::_SetTextAlignment() {
     if (_backingControl) {
         if (!_secureEntry) {
@@ -469,12 +488,12 @@ UIKIT_XAML_EXPORT bool XamlGetTextFieldSecureTextEntryValue(const Microsoft::WRL
 // Set the UIKit::Xaml::TextField's Text property
 UIKIT_XAML_EXPORT void XamlSetTextFieldText(const Microsoft::WRL::ComPtr<IInspectable>&  inspectableTextField, const std::wstring& text) {
     auto textField = safe_cast<UIKit::Xaml::TextField^>(reinterpret_cast<Platform::Object^>(inspectableTextField.Get()));
-    textField->Text = Platform::StringReference(text.c_str());
+    textField->TextField_Text = Platform::StringReference(text.c_str());
     if (!textField->SecureEntry) {
         // this is to set the selection to the end of of text so that
         // to ensure when user tap into TextBox, the caret is at
         // the end of the TextBox. 
-        textField->TextBox->SelectionStart = textField->Text->Length();
+        textField->TextBox->SelectionStart = textField->TextField_Text->Length();
         textField->TextBox->SelectionLength = 0;
     } else {
         UNIMPLEMENTED_WITH_MSG("XAML passwordbox currently does not allow set selection programmatically");
@@ -484,7 +503,7 @@ UIKIT_XAML_EXPORT void XamlSetTextFieldText(const Microsoft::WRL::ComPtr<IInspec
 // Get the UIKit::Xaml::TextField's Text property
 UIKIT_XAML_EXPORT IInspectable* XamlGetTextFieldText(const Microsoft::WRL::ComPtr<IInspectable>& inspectableTextField) {
     auto textField = safe_cast<UIKit::Xaml::TextField^>(reinterpret_cast<Platform::Object^>(inspectableTextField.Get()));
-    Platform::Object^ propVal = Windows::Foundation::PropertyValue::CreateString(textField->Text);
+    Platform::Object^ propVal = Windows::Foundation::PropertyValue::CreateString(textField->TextField_Text);
     return InspectableFromObject(propVal).Detach();
 }
 

--- a/Frameworks/UIKit.Xaml/TextField.xaml.cpp
+++ b/Frameworks/UIKit.Xaml/TextField.xaml.cpp
@@ -425,7 +425,7 @@ void TextField::_SetForeground() {
     }
 }
 
-void TextField::_SetBackgournd() {
+void TextField::_SetBackground() {
     if (_backingControl) {
         _backingControl->Background = Background;
     }

--- a/Frameworks/UIKit.Xaml/TextField.xaml.h
+++ b/Frameworks/UIKit.Xaml/TextField.xaml.h
@@ -57,7 +57,7 @@ public:
     // Accessor for the LayerProperty that manages the BorderThickness of this TextField
     virtual Private::CoreAnimation::LayerProperty^ GetBorderThicknessProperty();
 
-    property Platform::String^ Text
+    property Platform::String^ TextField_Text
     {
         Platform::String^ get()
         {
@@ -243,6 +243,7 @@ private:
     void _SetInputScope();
     void _SetEnabled();
     void _SetForeground();
+    void _SetBackgournd();
     void _SetTextAlignment();
 
     // Find the best inputScope given current security entry mode and inputscope

--- a/Frameworks/UIKit.Xaml/TextField.xaml.h
+++ b/Frameworks/UIKit.Xaml/TextField.xaml.h
@@ -243,7 +243,7 @@ private:
     void _SetInputScope();
     void _SetEnabled();
     void _SetForeground();
-    void _SetBackgournd();
+    void _SetBackground();
     void _SetTextAlignment();
 
     // Find the best inputScope given current security entry mode and inputscope

--- a/Frameworks/UIKit/UISlider.mm
+++ b/Frameworks/UIKit/UISlider.mm
@@ -56,6 +56,9 @@ static const double c_defaultStepFrequency = 0.1;
     _xamlSlider.Minimum(0.0f);
     _xamlSlider.Value(0.0f);
 
+    // by default, no tool tip for slider on reference platform
+    _xamlSlider.IsThumbToolTipEnabled(false);
+
     [self _updateStepFrequency];
     [self setContinuous:YES];
     [self _registerForEventsWithXaml];

--- a/Frameworks/UIKit/UITextField.mm
+++ b/Frameworks/UIKit/UITextField.mm
@@ -253,12 +253,25 @@ NSString* const UITextFieldTextDidEndEditingNotification = @"UITextFieldTextDidE
     StrongId<UIFont> targetFont = _font;
 
     if (self.adjustsFontSizeToFitWidth) {
-        float adjustedFontSize = XamlUtilities::FindMaxFontSizeToFit([self bounds],
+        CGRect adjustedBounds;
+        adjustedBounds = [self bounds];
+
+        // This is padding between inner text control and outter control
+        // need to use adjustedBound (inner bound for text control) to fit the text.
+        const CGFloat padding = 16.0;
+        if (adjustedBounds.size.width > padding) {
+            adjustedBounds = CGRectMake(adjustedBounds.origin.x,
+                                        adjustedBounds.origin.y,
+                                        adjustedBounds.size.width - padding,
+                                        adjustedBounds.size.height);
+        }
+
+        float adjustedFontSize = XamlUtilities::FindMaxFontSizeToFit(adjustedBounds,
                                                                      XamlControls::GetTextFieldText(_textField),
                                                                      _font,
                                                                      1,
                                                                      _minimumFontSize,
-                                                                     [_font pointSize]);
+                                                                     std::max(_minimumFontSize, [_font pointSize]));
         if (adjustedFontSize != [_font pointSize]) {
             targetFont = [_font fontWithSize:adjustedFontSize];
         }

--- a/build/Tests/FunctionalTests/FunctionalTests.vcxproj
+++ b/build/Tests/FunctionalTests/FunctionalTests.vcxproj
@@ -346,6 +346,7 @@
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIButtonWithControlsViewController.m" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UILabelViewController.m" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIScrollViewController.m" />
+    <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UITextFieldViewController2.m" />
     <ClangCompile Include="$(MSBuildThisFileDirectory)..\..\..\samples\XAMLCatalog\XAMLCatalog\UIKitControls\UIActivityIndicatorViewController.m" />
   </ItemGroup>
   <ItemGroup>

--- a/include/UIKit/UITextField.h
+++ b/include/UIKit/UITextField.h
@@ -118,9 +118,9 @@ UIKIT_EXPORT_CLASS
 
 // UITextInputTraits protocol defined properties,  Managing the Keyboard Behavior
 @property (nonatomic) UITextAutocapitalizationType autocapitalizationType NOTINPLAN_PROPERTY;
-@property (nonatomic) UITextAutocorrectionType autocorrectionType;
-@property (nonatomic) UITextSpellCheckingType spellCheckingType;
-@property (nonatomic) BOOL enablesReturnKeyAutomatically;
+@property (nonatomic) UITextAutocorrectionType autocorrectionType NOTINPLAN_PROPERTY;
+@property (nonatomic) UITextSpellCheckingType spellCheckingType NOTINPLAN_PROPERTY;
+@property (nonatomic) BOOL enablesReturnKeyAutomatically NOTINPLAN_PROPERTY;
 @property (nonatomic) UIKeyboardAppearance keyboardAppearance NOTINPLAN_PROPERTY;
 @property (nonatomic) UIKeyboardType keyboardType;
 @property (nonatomic) UIReturnKeyType returnKeyType NOTINPLAN_PROPERTY;

--- a/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj
+++ b/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj
@@ -211,6 +211,7 @@
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIScrollViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UISliderViewController.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController.h" />
+    <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController2.h" />
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIViewViewController.h" />
     <ClangCompile Include="..\..\XAMLCatalog\AppDelegate.m" />
     <ClangCompile Include="..\..\XAMLCatalog\CustomTextControlViewController.m" />
@@ -226,6 +227,7 @@
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIScrollViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UISliderViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController.m" />
+    <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController2.m" />
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIViewViewController.m" />
     <ClangCompile Include="..\..\XAMLCatalog\main.m" />
     <SBInfoPlistCopy Include="..\..\XAMLCatalog\Info.plist">

--- a/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj.filters
+++ b/samples/XAMLCatalog/XAMLCatalog.vsimporter/XAMLCatalog-WinStore10/XAMLCatalog.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController.h">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController2.h">
+      <Filter>XAMLCatalog\UIKitControls</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\XAMLCatalog\UIKitControls\UIViewViewController.h">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClInclude>
@@ -139,6 +142,9 @@
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClangCompile>
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController.m">
+      <Filter>XAMLCatalog\UIKitControls</Filter>
+    </ClangCompile>
+    <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UITextFieldViewController2.m">
       <Filter>XAMLCatalog\UIKitControls</Filter>
     </ClangCompile>
     <ClangCompile Include="..\..\XAMLCatalog\UIKitControls\UIViewViewController.m">

--- a/samples/XAMLCatalog/XAMLCatalog.xcodeproj/project.pbxproj
+++ b/samples/XAMLCatalog/XAMLCatalog.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		822F85C01D8F908C001DC8A5 /* yellow_background.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 822F85BD1D8F908C001DC8A5 /* yellow_background.jpg */; };
 		96857DC01D598FB300EB1FD0 /* MiscellaneousViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96857DBD1D598FB300EB1FD0 /* MiscellaneousViewController.m */; };
 		A5180F451E89656400BADAD5 /* UIScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A5180F441E89656400BADAD5 /* UIScrollViewController.m */; };
+		A5BFFF791ECA7A0E00B798AE /* UITextFieldViewController2.m in Sources */ = {isa = PBXBuildFile; fileRef = A5BFFF781ECA7A0E00B798AE /* UITextFieldViewController2.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -79,6 +80,8 @@
 		96857DBD1D598FB300EB1FD0 /* MiscellaneousViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MiscellaneousViewController.m; sourceTree = "<group>"; };
 		A5180F431E89656400BADAD5 /* UIScrollViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UIScrollViewController.h; path = UIKitControls/UIScrollViewController.h; sourceTree = "<group>"; };
 		A5180F441E89656400BADAD5 /* UIScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UIScrollViewController.m; path = UIKitControls/UIScrollViewController.m; sourceTree = "<group>"; };
+		A5BFFF771ECA7A0E00B798AE /* UITextFieldViewController2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UITextFieldViewController2.h; path = UIKitControls/UITextFieldViewController2.h; sourceTree = "<group>"; };
+		A5BFFF781ECA7A0E00B798AE /* UITextFieldViewController2.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UITextFieldViewController2.m; path = UIKitControls/UITextFieldViewController2.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +98,8 @@
 		2324634F1CE69E2C00B7AAE4 /* UIKitControls */ = {
 			isa = PBXGroup;
 			children = (
+				A5BFFF771ECA7A0E00B798AE /* UITextFieldViewController2.h */,
+				A5BFFF781ECA7A0E00B798AE /* UITextFieldViewController2.m */,
 				A5180F431E89656400BADAD5 /* UIScrollViewController.h */,
 				A5180F441E89656400BADAD5 /* UIScrollViewController.m */,
 				234767181E2EE058006D97CB /* UIActionSheetViewController.h */,
@@ -269,6 +274,7 @@
 			files = (
 				2347672C1E2EE090006D97CB /* UIButtonWithControlsViewController.m in Sources */,
 				234767281E2EE058006D97CB /* UITextFieldViewController.m in Sources */,
+				A5BFFF791ECA7A0E00B798AE /* UITextFieldViewController2.m in Sources */,
 				234767251E2EE058006D97CB /* UIActivityIndicatorViewController.m in Sources */,
 				239EBAEB1E39559C00C845D0 /* TestEnabledUITextField.mm in Sources */,
 				6EEB8A411CE4F4050021021E /* StoryBoardViewController.m in Sources */,

--- a/samples/XAMLCatalog/XAMLCatalog/ProgrammaticViewController.m
+++ b/samples/XAMLCatalog/XAMLCatalog/ProgrammaticViewController.m
@@ -23,6 +23,7 @@
 #import "UIScrollViewController.h"
 #import "UISliderViewController.h"
 #import "UITextFieldViewController.h"
+#import "UITextFieldViewController2.h"
 #import "UIViewViewController.h"
 #import "CustomTextControlViewController.h"
 #import "MiscellaneousViewController.h"
@@ -53,6 +54,9 @@
 
     // UITextField
     [self addMenuItemViewController:[[UITextFieldViewController alloc] init] andTitle:@"UITextField"];
+
+    // UITextField2
+    [self addMenuItemViewController:[[UITextFieldViewController2 alloc] init] andTitle : @"UITextField2"];
 
     // UIViewViewController
     [self addMenuItemViewController:[[UIViewViewController alloc] init] andTitle:@"UIView"];

--- a/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UITextFieldViewController2.h
+++ b/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UITextFieldViewController2.h
@@ -1,0 +1,78 @@
+//******************************************************************************
+//
+// Copyright Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#pragma once
+
+#import "MenuTableViewController.h"
+#import "TestEnabledUITextField.h"
+
+@interface UITextFieldViewController2 : UIViewController <UITextFieldDelegate>
+
+//
+// get/set label in the VC
+//
+// this is UITextFeild that this VC is manipulating through the the controls below
+@property (nonatomic) UITextField* textField;
+
+//
+// getting/setting the config that impact UITextField
+//
+// config the text that the UITextField display
+@property (nonatomic) TestEnabledUITextField* text;
+
+// config the Placeholder that the UITextField display
+@property (nonatomic) TestEnabledUITextField* placeholder;
+
+// slide us to config font size
+@property (nonatomic) UISlider* fontSize;
+
+// fontSizeLabel to show current current font size
+@property (nonatomic) UILabel* fontSizeLabel;
+
+// config x/y/width/height for bounding rect
+@property (nonatomic) TestEnabledUITextField* x;
+@property (nonatomic) TestEnabledUITextField* y;
+@property (nonatomic) TestEnabledUITextField* w;
+@property (nonatomic) TestEnabledUITextField* h;
+
+// config the text alignment
+@property (nonatomic) TestEnabledUITextField* textAlignment;
+
+// config borderStyle for UITextField
+@property (nonatomic) TestEnabledUITextField* borderStyle;
+
+// config Input for UITextField
+@property (nonatomic) TestEnabledUITextField* keyboardType;
+
+// config r/g/b component for foreground
+@property (nonatomic) UISlider* fr;
+@property (nonatomic) UISlider* fg;
+@property (nonatomic) UISlider* fb;
+
+// config r/g/b component for background
+@property (nonatomic) UISlider* br;
+@property (nonatomic) UISlider* bg;
+@property (nonatomic) UISlider* bb;
+
+// switch to turn on/off secureEntry Mode
+@property (nonatomic) UISwitch* secureEntry;
+
+// switch to turn on/off setAdjustFontSizeToFitWidth
+@property (nonatomic) UISwitch* autoShrink;
+
+// config the minimumFontSize when setAdjustFontSizeToFitWidth to YES
+@property (nonatomic) TestEnabledUITextField* minimumFontSize;
+
+@end

--- a/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UITextFieldViewController2.m
+++ b/samples/XAMLCatalog/XAMLCatalog/UIKitControls/UITextFieldViewController2.m
@@ -1,0 +1,282 @@
+//******************************************************************************
+//
+// Copyright Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <UIkit/UISlider.h>
+#import "UITextFieldViewController2.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+
+@implementation UITextFieldViewController2 {
+    int _eventId;
+    MenuTableViewController* _menuTVC;
+}
+
+// setting up the controls to update the UILabel config
+- (void)_setup {
+    _menuTVC = [[MenuTableViewController alloc] init];
+    _menuTVC.view.frame = CGRectMake(0.0f, 108.0f, 200.0f, 0.0f /* setting it to 0 allows vertical scrolling */);
+    _menuTVC.tableView.allowsSelection = NO;
+    [self.view addSubview:_menuTVC.view];
+
+    self.text = [[UITextField alloc] initWithFrame:CGRectMake(105.0f, 20.0f, 400.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.text andTitle:@"text on textField"];
+
+    self.placeholder = [[UITextField alloc] initWithFrame:CGRectMake(105.0f, 20.0f, 400.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.placeholder andTitle:@"Placeholder on textField"];
+
+    self.fontSize = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.fontSize.minimumValue = 4.01f;
+    self.fontSize.maximumValue = 80;
+
+    [_menuTVC addMenuItemView:self.fontSize andTitle:@"Font Size"];
+
+    self.fontSizeLabel = [[UILabel alloc] initWithFrame:CGRectMake(297.0f, 57.0f, 53.0f, 25.0f)];
+    [_menuTVC addMenuItemView:self.fontSizeLabel andTitle:@"current Font Size"];
+
+    self.autoShrink = [[UISwitch alloc] initWithFrame:CGRectMake(310.0f, 131.0f, 51.0f, 31.0f)];
+    [_menuTVC addMenuItemView:self.autoShrink andTitle:@"Adjust font size to fit width"];
+
+    self.minimumFontSize = [[UITextField alloc] initWithFrame:CGRectMake(80.0f, 167.0f, 56.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.minimumFontSize andTitle:@"Minimum font size"];
+
+    self.secureEntry = [[UISwitch alloc] initWithFrame:CGRectMake(310.0f, 131.0f, 51.0f, 31.0f)];
+    [_menuTVC addMenuItemView:self.secureEntry andTitle:@"Change Secure Entry Mode"];
+
+    self.textAlignment = [[UITextField alloc] initWithFrame:CGRectMake(74.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.textAlignment andTitle:@"Setting Text Alignment [0-2]"];
+
+    self.borderStyle = [[UITextField alloc] initWithFrame:CGRectMake(74.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.borderStyle andTitle:@"Setting Border Style[0-3]"];
+
+    self.keyboardType = [[UITextField alloc] initWithFrame:CGRectMake(74.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.keyboardType andTitle:@"Set keyboard type[0-11]"];
+
+    self.fr = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.fr.minimumValue = 0.0f;
+    self.fr.maximumValue = 255.0f;
+    [_menuTVC addMenuItemView:self.fr andTitle:@"Text Color red"];
+
+    self.fg = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.fg.minimumValue = 0.0f;
+    self.fg.maximumValue = 255.0f;
+    [_menuTVC addMenuItemView:self.fg andTitle:@"Text Color blue"];
+
+    self.fb = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.fb.minimumValue = 0.0f;
+    self.fb.maximumValue = 255.0f;
+    [_menuTVC addMenuItemView:self.fb andTitle:@"Text Color green"];
+
+    self.br = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.br.minimumValue = 0.0f;
+    self.br.maximumValue = 255.0f;
+    [_menuTVC addMenuItemView:self.br andTitle:@"background red"];
+
+    self.bg = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.bg.minimumValue = 0.0f;
+    self.bg.maximumValue = 255.0f;
+    [_menuTVC addMenuItemView:self.bg andTitle:@"background green"];
+
+    self.bb = [[UISlider alloc] initWithFrame:CGRectMake(101.0f, 54.0f, 187.0f, 31.0f)];
+    self.bb.minimumValue = 0.0f;
+    self.bb.maximumValue = 255.0f;
+    [_menuTVC addMenuItemView:self.bb andTitle:@"background blue"];
+
+    self.x = [[UITextField alloc] initWithFrame:CGRectMake(74.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.x andTitle:@"Bounding Rect origin x"];
+
+    self.y = [[UITextField alloc] initWithFrame:CGRectMake(141.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.y andTitle:@"Bounding Rect origin y"];
+
+    self.w = [[UITextField alloc] initWithFrame:CGRectMake(211.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.w andTitle:@"Bounding Rect width"];
+
+    self.h = [[UITextField alloc] initWithFrame:CGRectMake(293.0f, 92.0f, 45.0f, 30.0f)];
+    [_menuTVC addMenuItemView:self.h andTitle:@"Bounding Rect height"];
+
+    self.textField = [[UITextField alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 353.0f, 107.0f)];
+    [self.view addSubview:self.textField];
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.view.backgroundColor = [UIColor whiteColor];
+    self.view.frame = CGRectMake(0.0f, 0.0f, 200.0f, 0.0f);
+
+    // creating control default value using textField value
+    [self _setup];
+
+    self.view.frame = CGRectMake(0.0f, 0.0f, 800.0f, 600.0f);
+    self.view.backgroundColor = [UIColor grayColor];
+
+    self.text.text = self.textField.text;
+    self.placeholder.text = self.textField.placeholder;
+    self.fontSize.value = self.textField.font.pointSize;
+    self.x.text = [NSString stringWithFormat:@"%3.0f", self.textField.frame.origin.x];
+    self.y.text = [NSString stringWithFormat:@"%3.0f", self.textField.frame.origin.y];
+    self.w.text = [NSString stringWithFormat:@"%3.0f", self.textField.frame.size.width];
+    self.h.text = [NSString stringWithFormat:@"%3.0f", self.textField.frame.size.height];
+    self.autoShrink.on = self.textField.adjustsFontSizeToFitWidth;
+    self.minimumFontSize.text = [NSString stringWithFormat:@"%3.0f", self.textField.minimumFontSize];
+    self.secureEntry.on = self.textField.secureTextEntry;
+    self.textAlignment.text = [NSString stringWithFormat:@"%d", self.textField.textAlignment];
+    self.borderStyle.text = [NSString stringWithFormat:@"%d", self.textField.borderStyle];
+    self.keyboardType.text = [NSString stringWithFormat:@"%d", self.textField.keyboardType];
+
+    CGFloat r, g, b, a;
+    [self.textField.textColor getRed:&r green:&g blue:&b alpha:&a];
+    self.fr.value = r;
+    self.fg.value = g;
+    self.fb.value = b;
+
+    [self.textField.backgroundColor getRed:&r green:&g blue:&b alpha:&a];
+    self.br.value = r;
+    self.bg.value = g;
+    self.bb.value = b;
+
+    self.text.delegate = self;
+    [self.text addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.placeholder.delegate = self;
+    [self.placeholder addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.x.delegate = self;
+    self.x.keyboardType = UIKeyboardTypeNumberPad;
+    [self.x addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.y.delegate = self;
+    self.y.keyboardType = UIKeyboardTypeNumberPad;
+    [self.y addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.w.delegate = self;
+    self.w.keyboardType = UIKeyboardTypeNumberPad;
+    [self.w addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.h.delegate = self;
+    self.h.keyboardType = UIKeyboardTypeNumberPad;
+    [self.h addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.minimumFontSize.delegate = self;
+    self.minimumFontSize.keyboardType = UIKeyboardTypeDecimalPad;
+    [self.minimumFontSize addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    [self.fontSize addTarget:self action:@selector(fontSizeChanged:) forControlEvents:UIControlEventValueChanged];
+    self.fontSize.continuous = YES;
+
+    [self.autoShrink addTarget:self action:@selector(autoShrinkChanged:) forControlEvents:UIControlEventValueChanged];
+    [self.secureEntry addTarget:self action:@selector(secureEntryModeChanged:) forControlEvents:UIControlEventValueChanged];
+
+    self.textAlignment.delegate = self;
+    self.textAlignment.keyboardType = UIKeyboardTypeNumberPad;
+    [self.textAlignment addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.borderStyle.delegate = self;
+    self.borderStyle.keyboardType = UIKeyboardTypeNumberPad;
+    [self.borderStyle addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    self.keyboardType.delegate = self;
+    self.keyboardType.keyboardType = UIKeyboardTypeNumberPad;
+    [self.keyboardType addTarget:self action:@selector(textFieldEditDidEnd:) forControlEvents:UIControlEventEditingDidEnd];
+
+    [self.fr addTarget:self action:@selector(colorChanged:) forControlEvents:UIControlEventValueChanged];
+    self.fr.continuous = YES;
+
+    [self.fg addTarget:self action:@selector(colorChanged:) forControlEvents:UIControlEventValueChanged];
+    self.fg.continuous = YES;
+
+    [self.fb addTarget:self action:@selector(colorChanged:) forControlEvents:UIControlEventValueChanged];
+    self.fb.continuous = YES;
+
+    [self.br addTarget:self action:@selector(colorChanged:) forControlEvents:UIControlEventValueChanged];
+    self.br.continuous = YES;
+
+    [self.bg addTarget:self action:@selector(colorChanged:) forControlEvents:UIControlEventValueChanged];
+    self.bg.continuous = YES;
+
+    [self.bb addTarget:self action:@selector(colorChanged:) forControlEvents:UIControlEventValueChanged];
+    self.bb.continuous = YES;
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField*)textField {
+    [textField resignFirstResponder];
+    return YES;
+}
+
+- (void)autoShrinkChanged:(UISwitch*)autoShrinkSwtich {
+    self.minimumFontSize.enabled = self.minimumFontSize.enabled = self.autoShrink.on;
+    self.textField.adjustsFontSizeToFitWidth = self.autoShrink.on;
+}
+
+- (void)secureEntryModeChanged:(UISwitch*)secureEntryModeSwtich {
+    self.textField.secureTextEntry = self.secureEntry.on;
+}
+
+- (void)fontSizeChanged:(UISlider*)slider {
+    self.textField.font = [self.textField.font fontWithSize:slider.value];
+    self.fontSizeLabel.text = [NSString stringWithFormat:@"%5.2f", slider.value];
+}
+
+- (void)colorChanged:(UISlider*)slider {
+    if (slider == self.fr || slider == self.fg || slider == self.fb) {
+        self.textField.textColor = [UIColor colorWithRed:self.fr.value green:self.fg.value blue:self.fb.value alpha:1];
+    } else {
+        self.textField.backgroundColor = [UIColor colorWithRed:self.br.value green:self.bg.value blue:self.bb.value alpha:1];
+    }
+}
+
+- (void)textFieldEditDidEnd:(UITextField*)sender {
+    if (sender == self.text) {
+        // update textField text
+        self.textField.text = sender.text;
+    } else if (sender == self.placeholder) {
+        self.textField.placeholder = sender.text;
+    } else if (sender == self.x) {
+        // update bound rect x
+        CGRect rect = self.textField.frame;
+        rect.origin.x = [self.x.text floatValue];
+        self.textField.frame = rect;
+    } else if (sender == self.y) {
+        // update bound rect y
+        CGRect rect = self.textField.frame;
+        rect.origin.y = [self.y.text floatValue];
+        self.textField.frame = rect;
+    } else if (sender == self.w) {
+        // update bound rect width
+        CGRect rect = self.textField.frame;
+        rect.size.width = [self.w.text floatValue];
+        self.textField.frame = rect;
+    } else if (sender == self.h) {
+        // update bound rect height
+        CGRect rect = self.textField.frame;
+        rect.size.height = [self.h.text floatValue];
+        self.textField.frame = rect;
+    } else if (sender == self.minimumFontSize) {
+        // update minimum font size
+        self.textField.minimumFontSize = [self.minimumFontSize.text floatValue];
+    } else if (sender == self.textAlignment) {
+        self.textField.textAlignment = (UITextAlignment)([self.textAlignment.text intValue]);
+    } else if (sender == self.borderStyle) {
+        self.textField.borderStyle = (UITextBorderStyle)([self.borderStyle.text intValue]);
+    } else if (sender == self.keyboardType) {
+        self.textField.keyboardType = (UIKeyboardType)([self.keyboardType.text intValue]);
+    }
+}
+
+@end

--- a/tests/functionaltests/Tests/UIKitTests/UILabelTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UILabelTests.mm
@@ -468,37 +468,37 @@ public:
 
             auto colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, label.textColor));
 
             // verify setting color to others
             label.textColor = [UIColor redColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, label.textColor));
 
             label.textColor = [UIColor greenColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, label.textColor));
 
             // verify setting highlightedColor without changing UILabel state to highlighted state
             // the label's text color should not change
             label.highlightedTextColor = [UIColor blueColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, label.textColor));
 
             // now change the UILabel's state to be highlighted, and textblock's foreground should be using highlightedTextColor
             label.highlighted = YES;
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.highlightedTextColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, label.highlightedTextColor));
 
             // now change the UILabel's state to be normal, verify textBlock's forground return to use original textColor
             label.highlighted = NO;
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, label.textColor));
         });
     }
 

--- a/tests/functionaltests/Tests/UIKitTests/UILabelTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UILabelTests.mm
@@ -86,24 +86,6 @@ public:
         startTests(labelVC);
     }
 
-    bool compareRGBAValues(UIColor* col1, UIColor* col2) {
-        if (col1 == nullptr && col2 == nullptr) {
-            return true;
-        }
-
-        if (!col1 || !col2) {
-            return false;
-        }
-
-        CGFloat r1, g1, b1, a1;
-        [col1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-
-        CGFloat r2, g2, b2, a2;
-        [col2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-
-        return (r1 == r2) && (g1 == g2) && (b1 == b2) && (a1 == a2);
-    }
-
     void startTests(UILabelViewController* self) {
         testId = 0;
 
@@ -486,37 +468,37 @@ public:
 
             auto colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             // verify setting color to others
             label.textColor = [UIColor redColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             label.textColor = [UIColor greenColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             // verify setting highlightedColor without changing UILabel state to highlighted state
             // the label's text color should not change
             label.highlightedTextColor = [UIColor blueColor];
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
 
             // now change the UILabel's state to be highlighted, and textblock's foreground should be using highlightedTextColor
             label.highlighted = YES;
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.highlightedTextColor));
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.highlightedTextColor));
 
             // now change the UILabel's state to be normal, verify textBlock's forground return to use original textColor
             label.highlighted = NO;
             colorBrush = textBlock.Foreground().as<Media::SolidColorBrush>();
             ASSERT_TRUE(colorBrush);
-            EXPECT_TRUE(compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), label.textColor));
         });
     }
 

--- a/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
@@ -17,6 +17,10 @@
 #import <UIKit/UITextField.h>
 #import "UIViewInternal.h"
 
+#import "FunctionalTestHelpers.h"
+#import "UXTestHelpers.h"
+#import "CppWinRTHelpers.h"
+
 #include <COMIncludes.h>
 #import <WRLHelpers.h>
 #import <ErrorHandling.h>
@@ -26,9 +30,11 @@
 #import <wrl/async.h>
 #import <wrl/wrappers/corewrappers.h>
 #import <windows.foundation.h>
+#import <winrt/Windows.UI.Xaml.h>
 #import <winrt/Windows.UI.Xaml.Controls.h>
 #include <COMIncludes_end.h>
 
+#import "UIKitControls/UITextFieldViewController2.h"
 #include "ObjCXamlControls.h"
 
 using namespace winrt::Windows::UI::Xaml;
@@ -46,23 +52,405 @@ public:
         return FunctionalTestCleanupUIApplication();
     }
 
-    TEST_METHOD(CreateXamlElement) {
-        FrameworkHelper::RunOnUIThread([]() {
-            // TODO: Switch to UIKit.Xaml projections when they're available.
-            Microsoft::WRL::ComPtr<IInspectable> xamlElement;
-            XamlCreateTextField(&xamlElement);
-            ASSERT_TRUE(xamlElement);
+    TEST_METHOD(UITextField_VerifyText) {
+        // verify setting UITextField text property is reflected on xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        __block UITextField* textField = [textFieldlVC textField];
+        auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+        Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+        auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+        EXPECT_TRUE(textBox);
+
+        __block auto uxEvent = UXTestAPI::UXEvent::CreateManual();
+        __block auto xamlSubscriber = std::make_shared<UXTestAPI::XamlEventSubscription>();
+
+        __block NSString* expectedText = @"short string";
+        dispatch_sync(dispatch_get_main_queue(), ^{
+
+            // Register RAII event subscription handler
+            xamlSubscriber->Set(textBox,
+                                Controls::TextBox::TextProperty(),
+                                ^(const DependencyObject& sender, const DependencyProperty& dp) {
+                                    NSString* text = UXTestAPI::NSStringFromPropertyValue(sender.GetValue(dp));
+                                    LOG_INFO("XAML text: %@", text);
+
+                                    // Validation
+                                    if ([expectedText isEqualToString:objcwinrt::string(textBox.Text())]) {
+                                        uxEvent->Set();
+                                    }
+                                });
+
+            textField.text = expectedText;
+        });
+        EXPECT_TRUE_MSG(uxEvent->Wait(2), "FAILED: Waiting for property changed event state timed out!");
+
+        uxEvent->Reset();
+        xamlSubscriber->Reset();
+        expectedText = @"this is a long string for testing";
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // Register RAII event subscription handler
+            xamlSubscriber->Set(textBox,
+                                Controls::TextBox::TextProperty(),
+                                ^(const DependencyObject& sender, const DependencyProperty& dp) {
+                                    NSString* text = UXTestAPI::NSStringFromPropertyValue(sender.GetValue(dp));
+                                    LOG_INFO("XAML text: %@", text);
+                                    // Validation
+                                    if ([expectedText isEqualToString:objcwinrt::string(textBox.Text())]) {
+                                        uxEvent->Set();
+                                    }
+                                });
+
+            textField.text = expectedText;
+        });
+        EXPECT_TRUE_MSG(uxEvent->Wait(2), "FAILED: Waiting for property changed event state timed out!");
+
+        uxEvent->Reset();
+        xamlSubscriber->Reset();
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // Register RAII event subscription handler
+            xamlSubscriber->Set(textBox,
+                                Controls::TextBox::TextProperty(),
+                                ^(const DependencyObject& sender, const DependencyProperty& dp) {
+                                    NSString* text = UXTestAPI::NSStringFromPropertyValue(sender.GetValue(dp));
+                                    // Validation
+                                    if (textBox.Text().empty()) {
+                                        uxEvent->Set();
+                                    }
+                                });
+
+            textField.text = nil;
+        });
+        EXPECT_TRUE_MSG(uxEvent->Wait(2), "FAILED: Waiting for property changed event state timed out!");
+    }
+
+    TEST_METHOD(UITextField_VerifyPlaceholder) {
+        // verify setting UITextField placeholder property is reflected on xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // get the backing xaml element
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+            EXPECT_TRUE(textBox);
+
+            textField.placeholder = @"placerholder";
+            EXPECT_OBJCEQ(objcwinrt::string(textBox.PlaceholderText()), textField.placeholder);
+
+            textField.placeholder = @"this is a long placeholder for testing.";
+            EXPECT_OBJCEQ(objcwinrt::string(textBox.PlaceholderText()), textField.placeholder);
+
+            textField.placeholder = nil;
+            EXPECT_TRUE(textBox.PlaceholderText().empty());
         });
     }
 
-    TEST_METHOD(GetXamlElement) {
-        FrameworkHelper::RunOnUIThread([]() {
-            UIView* view = [[[UITextField alloc] init] autorelease];
-            FrameworkElement backingElement = [view _winrtXamlElement];
-            ASSERT_TRUE(backingElement);
+    TEST_METHOD(UITextField_VerifySecureTextEntry) {
+        // verify setting UITextField SeucreTextEntry results backing xaml element change
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
 
-            // TODO: Fix up when UITextField moves fully to XAML
-            ASSERT_TRUE(backingElement.as<FrameworkElement>());
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // by default, non-secure mode, verify textbox exists
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+            EXPECT_TRUE(textBox);
+
+            // switching to secure entry mode
+            textField.secureTextEntry = YES;
+            Microsoft::WRL::ComPtr<IInspectable> inspectable2(XamlGetTextFieldPasswordBox(objcwinrt::to_insp(grid)));
+
+            // get the backing passwordBox, which should not be nil
+            auto passwordBox = objcwinrt::from_insp<Controls::PasswordBox>(inspectable2);
+            EXPECT_TRUE(passwordBox);
+
+            // get the backing textbox, which should be nil
+            textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable2);
+            EXPECT_TRUE(textBox == nullptr);
+
+            // switching back to non-secure entry mode, make sure textbox exist
+            textField.secureTextEntry = NO;
+            Microsoft::WRL::ComPtr<IInspectable> inspectable3(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable3);
+            EXPECT_TRUE(textBox);
+
+            passwordBox = objcwinrt::from_insp<Controls::PasswordBox>(inspectable3);
+            EXPECT_TRUE(passwordBox == nullptr);
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyTextAlignment) {
+        // verify setting UITextField TextAlignment is reflected on backing xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // get the backing xaml element, which is Grid contains TextBox or passwordBox
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+            EXPECT_TRUE(textBox);
+
+            // verify default value is left
+            EXPECT_TRUE(textBox.TextAlignment() == TextAlignment::Left);
+
+            // verify setting alignment to others
+            textField.textAlignment = UITextAlignmentRight;
+            EXPECT_TRUE(textBox.TextAlignment() == TextAlignment::Right);
+
+            textField.textAlignment = UITextAlignmentCenter;
+            EXPECT_TRUE(textBox.TextAlignment() == TextAlignment::Center);
+
+            textField.textAlignment = UITextAlignmentLeft;
+            EXPECT_TRUE(textBox.TextAlignment() == TextAlignment::Left);
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyTextColor) {
+        // verify setting UITextField TextColor is reflected on backing xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+            EXPECT_TRUE(textBox);
+
+            // Verify default textcolor
+            auto colorBrush = textBox.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), textField.textColor));
+
+            // Verify changing textcolor to blue
+            textField.textColor = [UIColor blueColor];
+            colorBrush = textBox.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), textField.textColor));
+
+            // Verify changing textcolor to red
+            textField.textColor = [UIColor redColor];
+            colorBrush = textBox.Foreground().as<Media::SolidColorBrush>();
+            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), textField.textColor));
+
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyBackgroundColor) {
+        // verify setting UITextField backgroundColor is reflected on backing xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        __block auto uxEvent = UXTestAPI::UXEvent::CreateManual();
+        __block auto xamlSubscriber = std::make_shared<UXTestAPI::XamlEventSubscription>();
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+
+            // Register RAII event subscription handler
+            xamlSubscriber->Set(textBox,
+                                Controls::Control::BackgroundProperty(),
+                                ^(const DependencyObject& sender, const DependencyProperty& dp) {
+                                    // Validation
+                                    auto colorBrush = textBox.Background().as<Media::SolidColorBrush>();
+                                    if (UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()),
+                                                                     textField.backgroundColor)) {
+                                        uxEvent->Set();
+                                    }
+                                });
+
+            LOG_INFO("set background to red");
+            textField.backgroundColor = [UIColor redColor];
+        });
+        EXPECT_TRUE_MSG(uxEvent->Wait(2), "FAILED: Waiting for property changed event state timed out!");
+        uxEvent->Reset();
+        xamlSubscriber->Reset();
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+
+            // Register RAII event subscription handler
+            xamlSubscriber->Set(textBox,
+                                Controls::Control::BackgroundProperty(),
+                                ^(const DependencyObject& sender, const DependencyProperty& dp) {
+                                    // Validation
+                                    auto colorBrush = textBox.Background().as<Media::SolidColorBrush>();
+                                    if (UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()),
+                                                                     textField.backgroundColor)) {
+                                        uxEvent->Set();
+                                    }
+                                });
+
+            LOG_INFO("set background to blue");
+            textField.backgroundColor = [UIColor blueColor];
+        });
+        EXPECT_TRUE_MSG(uxEvent->Wait(2), "FAILED: Waiting for property changed event state timed out!");
+        uxEvent->Reset();
+        xamlSubscriber->Reset();
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+
+            // Register RAII event subscription handler
+            xamlSubscriber->Set(textBox,
+                                Controls::Control::BackgroundProperty(),
+                                ^(const DependencyObject& sender, const DependencyProperty& dp) {
+                                    // Validation
+                                    auto colorBrush = textBox.Background().as<Media::SolidColorBrush>();
+                                    if (UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()),
+                                                                     textField.backgroundColor)) {
+                                        uxEvent->Set();
+                                    }
+                                });
+
+            LOG_INFO("set background to Green");
+            textField.backgroundColor = [UIColor greenColor];
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyEditingState) {
+        // verify UITextField Editing state
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            EXPECT_TRUE([textField becomeFirstResponder]);
+            EXPECT_TRUE(textField.editing);
+            EXPECT_TRUE([textField resignFirstResponder]);
+            EXPECT_TRUE(!textField.editing);
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyBorderStyle) {
+        // verify setting UITextField borderStyle is reflected on backing xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // get the backing xaml element, which is Grid contains TextBox or passwordBox
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+            EXPECT_TRUE(textBox);
+
+            // setting borerstyle to No border
+            textField.borderStyle = UITextBorderStyleNone;
+            Thickness actualThickness = textBox.BorderThickness();
+            LOG_INFO("Actual border width top=%f, left=%f, bottom=%f, right=%f",
+                     actualThickness.Top,
+                     actualThickness.Left,
+                     actualThickness.Bottom,
+                     actualThickness.Right);
+
+            Thickness expectedThickness = ThicknessHelper::FromUniformLength(0.0f);
+            EXPECT_TRUE(actualThickness.Left == expectedThickness.Left && actualThickness.Top == expectedThickness.Top &&
+                        actualThickness.Bottom == expectedThickness.Bottom && actualThickness.Right == expectedThickness.Right);
+
+            textField.borderStyle = UITextBorderStyleLine;
+            actualThickness = textBox.BorderThickness();
+            LOG_INFO("Actual border width top=%f, left=%f, bottom=%f, right=%f",
+                     actualThickness.Top,
+                     actualThickness.Left,
+                     actualThickness.Bottom,
+                     actualThickness.Right);
+
+            expectedThickness = ThicknessHelper::FromUniformLength(1.0f);
+            EXPECT_TRUE(actualThickness.Left == expectedThickness.Left && actualThickness.Top == expectedThickness.Top &&
+                        actualThickness.Bottom == expectedThickness.Bottom && actualThickness.Right == expectedThickness.Right);
+
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyKeyboardType) {
+        // verify setting UITextField keyboardType is reflected on backing xaml element
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // get the backing xaml element, which is Grid contains TextBox or passwordBox
+            auto grid = [textField _winrtXamlElement].as<Controls::Grid>();
+            Microsoft::WRL::ComPtr<IInspectable> inspectable(XamlGetTextFieldTextBox(objcwinrt::to_insp(grid)));
+            auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
+            EXPECT_TRUE(textBox);
+
+            // verify default keyboard type
+            EXPECT_TRUE(textField.keyboardType == UIKeyboardTypeDefault);
+
+            // set keyboardtype to UIKeyboardTypeURL
+            textField.keyboardType = UIKeyboardTypeURL;
+            EXPECT_TRUE(textBox.InputScope().Names().GetAt(0).NameValue() == Input::InputScopeNameValue::Url);
+
+            // set keyboardtype to UIKeyboardTypeNumberPad
+            textField.keyboardType = UIKeyboardTypeNumberPad;
+            EXPECT_TRUE(textBox.InputScope().Names().GetAt(0).NameValue() == Input::InputScopeNameValue::Digits);
+
+            // set keyboardtype to UIKeyboardTypePhonePad
+            textField.keyboardType = UIKeyboardTypePhonePad;
+            EXPECT_TRUE(textBox.InputScope().Names().GetAt(0).NameValue() == Input::InputScopeNameValue::TelephoneNumber);
+
+            // set keyboardtype to UIKeyboardTypeDecimalPad
+            textField.keyboardType = UIKeyboardTypeDecimalPad;
+            EXPECT_TRUE(textBox.InputScope().Names().GetAt(0).NameValue() == Input::InputScopeNameValue::Number);
+        });
+    }
+
+    TEST_METHOD(UITextField_VerifyFontSize) {
+        StrongId<UITextFieldViewController2> textFieldlVC;
+        textFieldlVC.attach([[UITextFieldViewController2 alloc] init]);
+        UXTestAPI::ViewControllerPresenter testHelper(textFieldlVC, 2);
+
+        UITextField* textField = [textFieldlVC textField];
+
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            // change font size and verify label font has changed
+            textField.font = [textField.font fontWithSize:100];
+            ASSERT_TRUE([textField.font pointSize] == 100);
+
+            // set adjust font size to be TRUE, verify font size didn't change
+            [textField setAdjustsFontSizeToFitWidth:YES];
+            ASSERT_TRUE([textField.font pointSize] == 100);
+
+            // turn off auto-fit and change font size to be very small
+            [textField setAdjustsFontSizeToFitWidth:NO];
+            textField.font = [textField.font fontWithSize:1];
+
+            // verify font didn't scale up when turn on autofit again
+            [textField setAdjustsFontSizeToFitWidth:YES];
+            ASSERT_TRUE([textField.font pointSize] == 1);
         });
     }
 };

--- a/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
+++ b/tests/functionaltests/Tests/UIKitTests/UITextFieldTests.mm
@@ -142,7 +142,7 @@ public:
             auto textBox = objcwinrt::from_insp<Controls::TextBox>(inspectable);
             EXPECT_TRUE(textBox);
 
-            textField.placeholder = @"placerholder";
+            textField.placeholder = @"placeholder";
             EXPECT_OBJCEQ(objcwinrt::string(textBox.PlaceholderText()), textField.placeholder);
 
             textField.placeholder = @"this is a long placeholder for testing.";
@@ -237,17 +237,17 @@ public:
 
             // Verify default textcolor
             auto colorBrush = textBox.Foreground().as<Media::SolidColorBrush>();
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), textField.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, textField.textColor));
 
             // Verify changing textcolor to blue
             textField.textColor = [UIColor blueColor];
             colorBrush = textBox.Foreground().as<Media::SolidColorBrush>();
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), textField.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, textField.textColor));
 
             // Verify changing textcolor to red
             textField.textColor = [UIColor redColor];
             colorBrush = textBox.Foreground().as<Media::SolidColorBrush>();
-            EXPECT_TRUE(UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()), textField.textColor));
+            EXPECT_TRUE(UXTestAPI::IsRGBAEqual(colorBrush, textField.textColor));
 
         });
     }
@@ -274,8 +274,7 @@ public:
                                 ^(const DependencyObject& sender, const DependencyProperty& dp) {
                                     // Validation
                                     auto colorBrush = textBox.Background().as<Media::SolidColorBrush>();
-                                    if (UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()),
-                                                                     textField.backgroundColor)) {
+                                    if (UXTestAPI::IsRGBAEqual(colorBrush, textField.backgroundColor)) {
                                         uxEvent->Set();
                                     }
                                 });
@@ -298,8 +297,7 @@ public:
                                 ^(const DependencyObject& sender, const DependencyProperty& dp) {
                                     // Validation
                                     auto colorBrush = textBox.Background().as<Media::SolidColorBrush>();
-                                    if (UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()),
-                                                                     textField.backgroundColor)) {
+                                    if (UXTestAPI::IsRGBAEqual(colorBrush, textField.backgroundColor)) {
                                         uxEvent->Set();
                                     }
                                 });
@@ -322,8 +320,7 @@ public:
                                 ^(const DependencyObject& sender, const DependencyProperty& dp) {
                                     // Validation
                                     auto colorBrush = textBox.Background().as<Media::SolidColorBrush>();
-                                    if (UXTestAPI::compareRGBAValues(UXTestAPI::ConvertWUColorToUIColor(colorBrush.Color()),
-                                                                     textField.backgroundColor)) {
+                                    if (UXTestAPI::IsRGBAEqual(colorBrush, textField.backgroundColor)) {
                                         uxEvent->Set();
                                     }
                                 });

--- a/tests/functionaltests/UXTestHelpers.h
+++ b/tests/functionaltests/UXTestHelpers.h
@@ -135,6 +135,4 @@ private:
 
 UIColor* ConvertWUColorToUIColor(const winrt::Windows::UI::Color& wuColor);
 
-bool compareRGBAValues(UIColor* col1, UIColor* col2);
-
 } // namespace UXTestAPI

--- a/tests/functionaltests/UXTestHelpers.h
+++ b/tests/functionaltests/UXTestHelpers.h
@@ -86,7 +86,9 @@ public:
     XamlEventSubscription(const XamlEventSubscription& other) = delete; // no copy
     XamlEventSubscription& operator=(const XamlEventSubscription& other) = delete;
 
-    void Set(const winrt::Windows::UI::Xaml::DependencyObject& xamlObject, const winrt::Windows::UI::Xaml::DependencyProperty& propertyToObserve, XamlEventBlock callbackHandler);
+    void Set(const winrt::Windows::UI::Xaml::DependencyObject& xamlObject,
+             const winrt::Windows::UI::Xaml::DependencyProperty& propertyToObserve,
+             XamlEventBlock callbackHandler);
     void Reset();
 
 private:
@@ -132,5 +134,7 @@ private:
 }; // class UXEvent
 
 UIColor* ConvertWUColorToUIColor(const winrt::Windows::UI::Color& wuColor);
+
+bool compareRGBAValues(UIColor* col1, UIColor* col2);
 
 } // namespace UXTestAPI

--- a/tests/functionaltests/UXTestHelpers.mm
+++ b/tests/functionaltests/UXTestHelpers.mm
@@ -217,22 +217,4 @@ UIColor* ConvertWUColorToUIColor(const winrt::Windows::UI::Color& wuColor) {
     return [UIColor colorWithRed:r green:g blue:b alpha:a];
 }
 
-bool compareRGBAValues(UIColor* col1, UIColor* col2) {
-    if (col1 == nullptr && col2 == nullptr) {
-        return true;
-    }
-
-    if (!col1 || !col2) {
-        return false;
-    }
-
-    CGFloat r1, g1, b1, a1;
-    [col1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
-
-    CGFloat r2, g2, b2, a2;
-    [col2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
-
-    return (r1 == r2) && (g1 == g2) && (b1 == b2) && (a1 == a2);
-}
-
 } // namespace UXTestAPI

--- a/tests/functionaltests/UXTestHelpers.mm
+++ b/tests/functionaltests/UXTestHelpers.mm
@@ -132,7 +132,9 @@ ViewControllerPresenter::~ViewControllerPresenter() {
 //
 // XamlEventSubscription methods
 //
-void XamlEventSubscription::Set(const DependencyObject& xamlObject, const DependencyProperty& propertyToObserve, XamlEventBlock callbackHandler) {
+void XamlEventSubscription::Set(const DependencyObject& xamlObject,
+                                const DependencyProperty& propertyToObserve,
+                                XamlEventBlock callbackHandler) {
     Reset();
 
     _xamlObject = xamlObject;
@@ -140,9 +142,11 @@ void XamlEventSubscription::Set(const DependencyObject& xamlObject, const Depend
     _eventBlock = [callbackHandler copy];
 
     // Register callback and wait for the property changed event to trigger
-    _callbackToken = _xamlObject.RegisterPropertyChangedCallback(_propertyToObserve, objcwinrt::callback([this] (const DependencyObject& sender, const DependencyProperty& prop) {
-        this->_eventBlock(sender, prop);
-    }));
+    _callbackToken = _xamlObject.RegisterPropertyChangedCallback(_propertyToObserve,
+                                                                 objcwinrt::callback([this](const DependencyObject& sender,
+                                                                                            const DependencyProperty& prop) {
+                                                                     this->_eventBlock(sender, prop);
+                                                                 }));
 }
 
 void XamlEventSubscription::Reset() {
@@ -211,6 +215,24 @@ UIColor* ConvertWUColorToUIColor(const winrt::Windows::UI::Color& wuColor) {
     CGFloat b = wuColor.B / 255.0;
     CGFloat a = wuColor.A / 255.0;
     return [UIColor colorWithRed:r green:g blue:b alpha:a];
+}
+
+bool compareRGBAValues(UIColor* col1, UIColor* col2) {
+    if (col1 == nullptr && col2 == nullptr) {
+        return true;
+    }
+
+    if (!col1 || !col2) {
+        return false;
+    }
+
+    CGFloat r1, g1, b1, a1;
+    [col1 getRed:&r1 green:&g1 blue:&b1 alpha:&a1];
+
+    CGFloat r2, g2, b2, a2;
+    [col2 getRed:&r2 green:&g2 blue:&b2 alpha:&a2];
+
+    return (r1 == r2) && (g1 == g2) && (b1 == b2) && (a1 == a2);
 }
 
 } // namespace UXTestAPI


### PR DESCRIPTION
1. Implement UITextField functional tests using new functional test paradigm
2. Fixed a couple of issues found in the process
   1.) Background color was not binding correctly earlier
   2.) adding a const padding 16.0 represents textbox and its container control, 16 is the actual value through experiements.
   3.)In order for test to know about the dependency properties (#2607), I have to register the DP on frameworkElement, instead of TextField, similar to others. To void potential conflict, also rename it from Text to TextField_Text.
   4.)Per request, make UISlider tooltips disabled by default
   5.) Keep legacy UIText Field Test because it has some test for interactions which is still valuable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2706)
<!-- Reviewable:end -->
