### PR TITLE
[APIAnalyzer] Fix the headers to import and annotate properly 

### DIFF
--- a/include/UIKit/UIPasteboard.h
+++ b/include/UIKit/UIPasteboard.h
@@ -49,7 +49,7 @@ UIKIT_EXPORT_CLASS
 @property (readonly, nonatomic) NSString* name;
 @property (getter=isPersistent, nonatomic) BOOL persistent STUB_PROPERTY;
 @property (readonly, nonatomic) NSInteger changeCount STUB_PROPERTY;
-- (NSArray*)pasteboardTypes STUB_METHOD;
+- (NSArray*)pasteboardTypes;
 - (BOOL)containsPasteboardTypes:(NSArray*)pasteboardTypes;
 - (NSData*)dataForPasteboardType:(NSString*)pasteboardType;
 - (id)valueForPasteboardType:(NSString*)pasteboardType STUB_METHOD;

--- a/include/UIKit/UIPickerViewDelegate.h
+++ b/include/UIKit/UIPickerViewDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -17,6 +17,7 @@
 #pragma once
 
 #import <UIKit/UIKitExport.h>
+#import <CoreGraphics/CGBase.h>
 #import <Foundation/Foundation.h>
 
 @class UIPickerView;

--- a/include/UIKit/UIPopoverPresentationControllerDelegate.h
+++ b/include/UIKit/UIPopoverPresentationControllerDelegate.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2011, The Iconfactory. All rights reserved.
  *
- * Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+ * Copyright (c) Microsoft. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,6 +32,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CGBase.h>
 
 @class UIPopoverPresentationController, UIView;
 

--- a/include/UIKit/UIPress.h
+++ b/include/UIKit/UIPress.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CGBase.h>
 
 @class UIResponder;
 @class UIWindow;

--- a/include/UIKit/UIPrintInteractionControllerDelegate.h
+++ b/include/UIKit/UIPrintInteractionControllerDelegate.h
@@ -1,6 +1,6 @@
 //******************************************************************************
 //
-// Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 //
 // This code is licensed under the MIT License (MIT).
 //
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKitExport.h>
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CGBase.h>
 
 @class UIViewController;
 @class UIPrintInteractionController;

--- a/include/UIKit/UITableViewCell.h
+++ b/include/UIKit/UITableViewCell.h
@@ -110,7 +110,7 @@ UIKIT_EXPORT_CLASS
 @property (nonatomic) UITableViewCellAccessoryType editingAccessoryType;
 @property (nonatomic, getter=isSelected) BOOL selected;
 @property (nonatomic, getter=isHighlighted) BOOL highlighted;
-@property (nonatomic, getter=isEditing) BOOL editing STUB_PROPERTY;
+@property (nonatomic, getter=isEditing) BOOL editing;
 @property (readonly, nonatomic) UITableViewCellEditingStyle editingStyle STUB_PROPERTY;
 @property (nonatomic, readonly) BOOL showingDeleteConfirmation STUB_PROPERTY;
 @property (nonatomic, readonly, copy) NSString* reuseIdentifier;

--- a/include/UIKit/UIView.h
+++ b/include/UIKit/UIView.h
@@ -341,7 +341,7 @@ UIKIT_EXPORT_CLASS
 @property (nonatomic, readonly) UIWindow* window;
 @property (nonatomic, retain) UIColor* tintColor STUB_PROPERTY;
 @property (nonatomic, strong) UIView* maskView STUB_PROPERTY;
-@property (readonly, copy, nonatomic) NSArray* layoutGuides STUB_PROPERTY;
+@property (readonly, copy, nonatomic) NSArray* layoutGuides;
 @property (readonly, getter=isFocused, nonatomic) BOOL focused STUB_PROPERTY;
 @property (readonly, nonatomic) NSArray* constraints;
 @property (readonly, nonatomic, strong) UILayoutGuide* readableContentGuide STUB_PROPERTY;


### PR DESCRIPTION
This fixes the following issues:
1. CGBase.h is no longer imported via Foundation.h, so some of the headers need CGBase.h to be imported.
2. Fix some Annotation mismatches

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2716)
<!-- Reviewable:end -->
