### PR TITLE
Fix implementation of POST in NSURLConnection

### DIFF
--- a/Frameworks/Foundation/NSURLProtocolInternal.h
+++ b/Frameworks/Foundation/NSURLProtocolInternal.h
@@ -1,0 +1,26 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+#pragma once
+
+#import <Foundation/NSURLProtocol.h>
+
+// Internal extension for NSURLProtocolClient, to support POST
+@protocol _NSURLProtocolClientInternal <NSURLProtocolClient>
+- (void)URLProtocol:(NSURLProtocol*)protocol
+                 didWriteData:(NSInteger)bytesWritten
+            totalBytesWritten:(NSInteger)totalBytesWritten
+    totalBytesExpectedToWrite:(NSInteger)totalBytesExpectedToWrite;
+@end

--- a/Frameworks/Foundation/NSURLProtocol_WinHTTP.mm
+++ b/Frameworks/Foundation/NSURLProtocol_WinHTTP.mm
@@ -168,7 +168,7 @@ static ComPtr<IHttpRequestMessage> _requestMessageForNS(NSURLRequest* nsRequest,
         THROW_IF_FAILED(httpRequestMessage->put_Content(httpContent.Get()));
 
     } else if (NSInputStream* bodyStream = nsRequest.HTTPBodyStream) {
-        // VSO 6693048: Properly support streaming bodies instead of flattening the data up front.
+        // TODO #2721: Properly support streaming bodies instead of flattening the data up front.
         if (bodyStream.streamStatus == NSStreamStatusNotOpen) {
             [bodyStream open];
         }
@@ -285,7 +285,7 @@ static void __dispatchClientCallback(NSURLProtocol_WinHTTP* protocol, void (^cal
         try {
             auto httpRequestMessage = _requestMessageForNS(self.request, _flattenedBodyStream);
 
-            // VSO 6693048: If this properly supports streaming bodies instead of flattening the data up front,
+            // TODO #2721: If this properly supports streaming bodies instead of flattening the data up front,
             // more accurate callbacks can be done
             NSInteger contentSize = self.request.HTTPBody ? self.request.HTTPBody.length : _flattenedBodyStream.size();
             if (contentSize > 0) {

--- a/Frameworks/Foundation/NSURLProtocol_WinHTTP.mm
+++ b/Frameworks/Foundation/NSURLProtocol_WinHTTP.mm
@@ -107,7 +107,10 @@ static ComPtr<IHttpClient> _getHttpClient() {
 #pragma endregion
 
 #pragma region Bridging Helpers
-static ComPtr<IHttpRequestMessage> _requestMessageForNS(NSURLRequest* nsRequest) {
+// Creates an IHttpRequestMessage for a given NSRequest
+// flattenedBodyStream is an in-out std::vector that may used to hold an in-memory copy of body data,
+// and must be kept alive until the message send completes
+static ComPtr<IHttpRequestMessage> _requestMessageForNS(NSURLRequest* nsRequest, std::vector<uint8_t>& flattenedBodyStream) {
     ComPtr<IHttpMethodFactory> httpMethodFactory;
     ComPtr<IHttpMethod> httpMethod;
     THROW_IF_FAILED(GetActivationFactory(Wrappers::HStringReference(RuntimeClass_Windows_Web_Http_HttpMethod).Get(), &httpMethodFactory));
@@ -151,12 +154,28 @@ static ComPtr<IHttpRequestMessage> _requestMessageForNS(NSURLRequest* nsRequest)
         }
     }
 
-    NSData* requestBody = nsRequest.HTTPBody;
-    if (nsRequest.HTTPBodyStream) {
+    ComPtr<IHttpContent> httpContent;
+    if (NSData* requestBody = nsRequest.HTTPBody) {
+        ComPtr<IBuffer> bodyBuffer;
+        THROW_IF_FAILED(BufferFromRawData(bodyBuffer.GetAddressOf(),
+                                          reinterpret_cast<unsigned char*>(const_cast<void*>([requestBody bytes])),
+                                          [requestBody length]));
+
+        ComPtr<IHttpBufferContentFactory> httpBufferContentFactory;
+        THROW_IF_FAILED(GetActivationFactory(Wrappers::HStringReference(RuntimeClass_Windows_Web_Http_HttpBufferContent).Get(),
+                                             &httpBufferContentFactory));
+        THROW_IF_FAILED(httpBufferContentFactory->CreateFromBuffer(bodyBuffer.Get(), &httpContent));
+        THROW_IF_FAILED(httpRequestMessage->put_Content(httpContent.Get()));
+
+    } else if (NSInputStream* bodyStream = nsRequest.HTTPBodyStream) {
         // VSO 6693048: Properly support streaming bodies instead of flattening the data up front.
-        NSInputStream* bodyStream = nsRequest.HTTPBodyStream;
-        std::vector<uint8_t> flattenedBodyStream(kHTTPContentBufferSize);
+        if (bodyStream.streamStatus == NSStreamStatusNotOpen) {
+            [bodyStream open];
+        }
+
+        flattenedBodyStream.resize(kHTTPContentBufferSize);
         ptrdiff_t offset = 0;
+
         while ([bodyStream hasBytesAvailable]) {
             ptrdiff_t read = [bodyStream read:flattenedBodyStream.data() + offset maxLength:flattenedBodyStream.capacity() - offset];
             if (read == 0) {
@@ -164,21 +183,19 @@ static ComPtr<IHttpRequestMessage> _requestMessageForNS(NSURLRequest* nsRequest)
             }
 
             offset += read;
-            if (offset > flattenedBodyStream.capacity()) {
-                flattenedBodyStream.reserve(flattenedBodyStream.capacity() + kHTTPContentBufferSize);
+            if (offset >= flattenedBodyStream.capacity()) {
+                // Need to use resize rather than reserve here: reading into the vector doesn't properly increment the size
+                flattenedBodyStream.resize(flattenedBodyStream.capacity() + kHTTPContentBufferSize);
             }
         }
         [bodyStream close];
 
-        requestBody = [NSData dataWithBytes:flattenedBodyStream.data() length:offset];
-    }
+        // flattenedBodyStream needs to be exactly sized, as the winrt APIs below read in the opposite direction,
+        // adding any unused bytes at the end and truncating the beginning
+        flattenedBodyStream.resize(offset);
 
-    ComPtr<IHttpContent> httpContent;
-    if (requestBody) {
         ComPtr<IBuffer> bodyBuffer;
-        THROW_IF_FAILED(BufferFromRawData(bodyBuffer.GetAddressOf(),
-                                          reinterpret_cast<unsigned char*>(const_cast<void*>([requestBody bytes])),
-                                          [requestBody length]));
+        THROW_IF_FAILED(BufferFromRawData(bodyBuffer.GetAddressOf(), flattenedBodyStream.data(), flattenedBodyStream.size()));
 
         ComPtr<IHttpBufferContentFactory> httpBufferContentFactory;
         THROW_IF_FAILED(GetActivationFactory(Wrappers::HStringReference(RuntimeClass_Windows_Web_Http_HttpBufferContent).Get(),
@@ -212,6 +229,8 @@ static ComPtr<IHttpRequestMessage> _requestMessageForNS(NSURLRequest* nsRequest)
     ComPtr<AsyncHttpOperation> _httpRequestOperation;
     ComPtr<IHttpClient> _httpClient;
     StrongId<NSThread> _clientThread;
+
+    std::vector<uint8_t> _flattenedBodyStream;
 }
 @property (assign, atomic) bool cancelled;
 @end
@@ -264,7 +283,20 @@ static void __dispatchClientCallback(NSURLProtocol_WinHTTP* protocol, void (^cal
         NSError* error = nil;
 
         try {
-            auto httpRequestMessage = _requestMessageForNS(self.request);
+            auto httpRequestMessage = _requestMessageForNS(self.request, _flattenedBodyStream);
+
+            // VSO 6693048: If this properly supports streaming bodies instead of flattening the data up front,
+            // more accurate callbacks can be done
+            NSInteger contentSize = self.request.HTTPBody ? self.request.HTTPBody.length : _flattenedBodyStream.size();
+            if (contentSize > 0) {
+                __dispatchClientCallback(self, ^void() {
+                    [self.client URLProtocol:self
+                                     didWriteData:contentSize
+                                totalBytesWritten:contentSize
+                        totalBytesExpectedToWrite:contentSize];
+                });
+            }
+
             THROW_IF_FAILED(_httpClient->SendRequestWithOptionAsync(httpRequestMessage.Get(),
                                                                     HttpCompletionOption::HttpCompletionOption_ResponseHeadersRead,
                                                                     &_httpRequestOperation));

--- a/include/Foundation/NSURLConnection.h
+++ b/include/Foundation/NSURLConnection.h
@@ -31,7 +31,7 @@
 @class NSURL;
 
 FOUNDATION_EXPORT_CLASS
-@interface NSURLConnection : NSObject <NSURLProtocolClient>
+@interface NSURLConnection : NSObject
 + (BOOL)canHandleRequest:(NSURLRequest*)request;
 @property (readonly, copy) NSURLRequest* originalRequest;
 @property (readonly, copy) NSURLRequest* currentRequest;

--- a/tests/functionaltests/Tests/NSURLConnection.mm
+++ b/tests/functionaltests/Tests/NSURLConnection.mm
@@ -194,10 +194,11 @@ typedef NS_ENUM(NSInteger, NSURLConnectionDelegateType) {
 }
 
 // Does nothing. Used to keep the run loop alive.
-- (void)doNothing{}
+- (void)doNothing {
+}
 
-    // Keeps the run loop on the current thread spinning.
-    - (void)spinRunLoop {
+// Keeps the run loop on the current thread spinning.
+- (void)spinRunLoop {
     @autoreleasepool {
         _loop = [NSRunLoop currentRunLoop];
 
@@ -267,9 +268,8 @@ static void _testRequestWithURL(NSURLConnectionTestHelper* connectionTestHelper)
     [connectionTestHelper.doneCondition unlock];
 
     // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didReceiveResponse should be the 1st delegate to be called!");
+    ASSERT_TRUE_MSG([@(NSURLConnectionDelegateDidReceiveResponse) isEqual:[connectionTestHelper.delegateCallOrder objectAtIndex:0]],
+                    "FAILED: didReceiveResponse should be the 1st delegate to be called!");
     ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
 
     NSURLResponse* response = connectionTestHelper.response;
@@ -281,16 +281,14 @@ static void _testRequestWithURL(NSURLConnectionTestHelper* connectionTestHelper)
     LOG_INFO("Received HTTP response headers: %d", [httpResponse allHeaderFields]);
 
     // Make sure we received data.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveData,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: didReceiveData should be the 2nd delegate to be called!");
+    ASSERT_TRUE_MSG([@(NSURLConnectionDelegateDidReceiveData) isEqual:[connectionTestHelper.delegateCallOrder objectAtIndex:1]],
+                    "FAILED: didReceiveData should be the 2nd delegate to be called!");
     ASSERT_TRUE_MSG((connectionTestHelper.data != nil), "FAILED: We should have received some data!");
     LOG_INFO("Received data: %@", [[NSString alloc] initWithData:connectionTestHelper.data encoding:NSUTF8StringEncoding]);
 
     // Make sure we received a didFinishLoading callback
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidFinishLoading,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:2] integerValue],
-                  "FAILED: didReceiveData should be the 3rd delegate to be called!");
+    ASSERT_TRUE_MSG([@(NSURLConnectionDelegateDidFinishLoading) isEqual:[connectionTestHelper.delegateCallOrder objectAtIndex:2]],
+                    "FAILED: didReceiveData should be the 3rd delegate to be called!");
 
     // Make sure there was no error.
     ASSERT_TRUE_MSG((connectionTestHelper.error == nil), "FAILED: Connection returned error %@!", connectionTestHelper.error);
@@ -312,9 +310,8 @@ static void _testRequestWithURL_Failure(NSURLConnectionTestHelper* connectionTes
     [connectionTestHelper.doneCondition unlock];
 
     // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:0] integerValue],
-                  "FAILED: didReceiveResponse should be the 1st delegate to be called!");
+    ASSERT_TRUE_MSG([@(NSURLConnectionDelegateDidReceiveResponse) isEqual:[connectionTestHelper.delegateCallOrder objectAtIndex:0]],
+                    "FAILED: didReceiveResponse should be the 1st delegate to be called!");
     ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
 
     NSURLResponse* response = connectionTestHelper.response;
@@ -325,12 +322,11 @@ static void _testRequestWithURL_Failure(NSURLConnectionTestHelper* connectionTes
     ASSERT_EQ_MSG(404, [httpResponse statusCode], "FAILED: HTTP status 404 was expected!");
 
     // Make sure we received a didFinishLoading callback
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidFinishLoading,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:1] integerValue],
-                  "FAILED: didReceiveData should be the 2nd delegate to be called!");
+    ASSERT_TRUE_MSG([@(NSURLConnectionDelegateDidFinishLoading) isEqual:[connectionTestHelper.delegateCallOrder objectAtIndex:1]],
+                    "FAILED: didReceiveData should be the 2nd delegate to be called!");
 
     // Make sure we did not receive any data.
-    ASSERT_TRUE_MSG((connectionTestHelper.data == nil), "FAILED: We should not have received any data!");
+    ASSERT_TRUE_MSG((connectionTestHelper.data.length == 0), "FAILED: We should not have received any data!");
 
     // Make sure there was no error.
     ASSERT_TRUE_MSG((connectionTestHelper.error == nil), "FAILED: Connection returned error %@!", connectionTestHelper.error);
@@ -375,9 +371,8 @@ static void _testRequestWithURL_Post(NSURLConnectionTestHelper* connectionTestHe
     size_t index = 0;
 
     // Should have received a number of didSendBodyData callbacks
-    for (;
-         (index < [connectionTestHelper.delegateCallOrder count]) &&
-         ([(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:index] integerValue] == NSURLConnectionDelegateDidSendBodyData);
+    for (; (index < [connectionTestHelper.delegateCallOrder count]) &&
+           ([[connectionTestHelper.delegateCallOrder objectAtIndex:index] isEqual:@(NSURLConnectionDelegateDidSendBodyData)]);
          ++index) {
     }
     ASSERT_LT_MSG(0, index, "FAILED: Should have received one or more didSendBodyData calls.");
@@ -385,9 +380,8 @@ static void _testRequestWithURL_Post(NSURLConnectionTestHelper* connectionTestHe
     ASSERT_GE(data.size(), connectionTestHelper.totalBytesExpectedToWrite);
 
     // Make sure we received a response.
-    ASSERT_EQ_MSG(NSURLConnectionDelegateDidReceiveResponse,
-                  [(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:index] integerValue],
-                  "FAILED: didReceiveResponse should be the 1st delegate to be called after sending body data!");
+    ASSERT_TRUE_MSG([@(NSURLConnectionDelegateDidReceiveResponse) isEqual:[connectionTestHelper.delegateCallOrder objectAtIndex:index]],
+                    "FAILED: didReceiveResponse should be the 1st delegate to be called after sending body data!");
     ASSERT_TRUE_MSG((connectionTestHelper.response != nil), "FAILED: Response cannot be empty!");
 
     NSURLResponse* response = connectionTestHelper.response;
@@ -400,16 +394,14 @@ static void _testRequestWithURL_Post(NSURLConnectionTestHelper* connectionTestHe
 
     // Should have received a number of didReceiveData callbacks
     size_t receivedResponseIndex = index++;
-    for (;
-         (index < [connectionTestHelper.delegateCallOrder count]) &&
-         ([(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:index] integerValue] == NSURLConnectionDelegateDidReceiveData);
+    for (; (index < [connectionTestHelper.delegateCallOrder count]) &&
+           ([[connectionTestHelper.delegateCallOrder objectAtIndex:index] isEqual:@(NSURLConnectionDelegateDidReceiveData)]);
          ++index) {
     }
     ASSERT_LT_MSG(receivedResponseIndex, index, "FAILED: Should have received one or more didReceiveData calls.");
 
     // Should have received a didFinishLoading callback last
-    ASSERT_TRUE_MSG(([(NSNumber*)[connectionTestHelper.delegateCallOrder objectAtIndex:index] integerValue] ==
-                     NSURLConnectionDelegateDidFinishLoading) &&
+    ASSERT_TRUE_MSG([[connectionTestHelper.delegateCallOrder objectAtIndex:index] isEqual:@(NSURLConnectionDelegateDidFinishLoading)] &&
                         (index == [connectionTestHelper.delegateCallOrder count] - 1),
                     "FAILED: didFinishLoading should be the last delegate to be called!");
 


### PR DESCRIPTION
- Fix flawed reading of HTTPBodyStream in NSURLProtocol_WinHTTP
- Add support for
    connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite: and
    connection:didWriteData:totalBytesWritten:expectedTotalBytes:
- Add functional tests

Fixes #2468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2720)
<!-- Reviewable:end -->
