### PR TITLE
update winmd2objc to use proper version of nuget and gitversiontask

### DIFF
--- a/tools/winmd2objc/lib/CodeGen.cpp
+++ b/tools/winmd2objc/lib/CodeGen.cpp
@@ -2326,8 +2326,7 @@ wstring generateNugetProject(const map<wstring, pair<wstring, vector<shared_ptr<
     }
 
     referenceBlock += LR"~(
-    <PackageReference Include="GitVersionTask" Version="*" />
-    <PackageReference Include="Nuget.Build.Packaging" Version="*" />
+    <PackageReference Include="Nuget.Build.Packaging" Version="0.1.186" />
     <PackageReference Include="WinObjC.Packaging" Version="*" />
 )~";
     referenceBlock += LR"~(  </ItemGroup>)~";
@@ -2433,7 +2432,7 @@ void generateVCXProj(const pair<wstring, pair<wstring, vector<shared_ptr<NameSpa
     // clang-format off
     wstring packageReferences = LR"~(
   <ItemGroup>
-    <PackageReference Include="Nuget.Build.Packaging" Version="*" />
+    <PackageReference Include="Nuget.Build.Packaging" Version="0.1.186" />
     <PackageReference Include="WinObjC.Language" Version="*" />
     <PackageReference Include="WinObjC.Frameworks.UWP.Core" Version="*" />)~";
     for (auto& nugetInfo : nugetDependencies) {


### PR DESCRIPTION
update winmd2objc to use proper versions of nuget and gitversiontask

- Nuget build 0.1.186 is the build that has been well tested with our repo, there are breaking changes in newer versions.
- GitVersionTask should use the same version as the common target, this is to make sure we don't have version mismatches


#2687,#2688

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2722)
<!-- Reviewable:end -->
