### PR TITLE
Foundation the NSNotificationQueueTests to Move.OnlyNSNotificationQueue

### DIFF
--- a/tests/helpers/THRunLoopSpinner.mm
+++ b/tests/helpers/THRunLoopSpinner.mm
@@ -41,6 +41,9 @@ static void* _helperThreadBody(void* context) {
         [helper->_threadStartedCondition broadcast];
         [helper release];
 
+        NSTimer* spinTimer = [NSTimer timerWithTimeInterval:0.1 target:[NSObject class] selector:@selector(class) userInfo:nil repeats:YES];
+        [loop addTimer:spinTimer forMode:NSDefaultRunLoopMode];
+
         while (!shouldStop) {
             @autoreleasepool {
                 // Spin the runloop for 0.1 seconds. It will usually bail out due to lack of input.

--- a/tests/unittests/Foundation/NSNotificationQueueTests.mm
+++ b/tests/unittests/Foundation/NSNotificationQueueTests.mm
@@ -18,8 +18,10 @@
 #import <TestFramework.h>
 #import <Starboard/SmartTypes.h>
 #import <Helpers/TestHelpers.h>
+#import <Windows.h>
 
-TEST(NSNotificationQueue, PostNow) {
+// NSNotificationQueue has different semantics on Windows.
+OSX_DISABLED_TEST(NSNotificationQueue, PostNow) {
     static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
     NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
     StrongId<THRunLoopSpinner> spinner{ woc::TakeOwnership, [THRunLoopSpinner new] };
@@ -46,7 +48,8 @@ TEST(NSNotificationQueue, PostNow) {
     ASSERT_EQ(1, counter);
 }
 
-TEST(NSNotificationQueue, PostASAP) {
+// NSNotificationQueue has different semantics on Windows.
+OSX_DISABLED_TEST(NSNotificationQueue, PostASAP) {
     static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
     NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
     StrongId<THRunLoopSpinner> spinner{ woc::TakeOwnership, [THRunLoopSpinner new] };
@@ -76,7 +79,8 @@ TEST(NSNotificationQueue, PostASAP) {
     ASSERT_EQ(1, counter);
 }
 
-TEST(NSNotificationQueue, PostWhenIdle) {
+// NSNotificationQueue has different semantics on Windows.
+OSX_DISABLED_TEST(NSNotificationQueue, PostWhenIdle) {
     static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
     NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
     StrongId<THRunLoopSpinner> spinner{ woc::TakeOwnership, [THRunLoopSpinner new] };
@@ -106,7 +110,8 @@ TEST(NSNotificationQueue, PostWhenIdle) {
     ASSERT_EQ(1, counter);
 }
 
-TEST(NSNotificationQueue, AllThreePostingStyles) {
+// NSNotificationQueue has different semantics on Windows.
+OSX_DISABLED_TEST(NSNotificationQueue, AllThreePostingStyles) {
     static NSString* s_TestNotificationName = @(GetTestFullName().c_str());
     NSNotificationCenter* notificationCenter = [[NSNotificationCenter new] autorelease];
     StrongId<THRunLoopSpinner> spinner{ woc::TakeOwnership, [THRunLoopSpinner new] };
@@ -117,7 +122,7 @@ TEST(NSNotificationQueue, AllThreePostingStyles) {
     }];
 
     __block THBooleanCondition* condition = [[THBooleanCondition new] autorelease];
-    __block uint32_t counter = 0;
+    __block long counter = 0;
     [notificationCenter addObserverForName:s_TestNotificationName
                                     object:nil
                                      queue:nil
@@ -138,7 +143,8 @@ TEST(NSNotificationQueue, AllThreePostingStyles) {
     ASSERT_EQ(3, counter);
 }
 
-TEST(NSNotificationQueue, ThreadsHaveDifferentQueues) {
+// NSNotificationQueue has different semantics on Windows.
+OSX_DISABLED_TEST(NSNotificationQueue, ThreadsHaveDifferentQueues) {
     StrongId<THRunLoopSpinner> spinner1{ woc::TakeOwnership, [THRunLoopSpinner new] };
     StrongId<THRunLoopSpinner> spinner2{ woc::TakeOwnership, [THRunLoopSpinner new] };
 


### PR DESCRIPTION
Two things:

1. THRunLoopSpinner does need an input source on OS X (@ms-jihua you were totally right.) That isn't fixed here.
2. NSNotificationQueue is far simpler in WinObjC; the runloop spinner forces the run loop to never be "idle" on OS X, which makes the "three kinds of notification" test fail.'

This fixes the OS X test break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2750)
<!-- Reviewable:end -->
