### PR TITLE
Force the NSURLConnection delegate queue to be serial

### DIFF
--- a/tests/functionaltests/Tests/NSURLConnectionTests.mm
+++ b/tests/functionaltests/Tests/NSURLConnectionTests.mm
@@ -128,6 +128,8 @@ typedef NS_ENUM(NSInteger, NSURLConnectionDelegateType) {
 - (instancetype)init {
     if (self = [super init]) {
         _operationQueue = [NSOperationQueue new];
+        // This class cannot handle out-of-order delegate callbacks. Force all delegate callbacks to be serialized.
+        _operationQueue.maxConcurrentOperationCount = 1;
     }
     return self;
 }


### PR DESCRIPTION
This is the root cause of #2756 and the test fixture hang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2757)
<!-- Reviewable:end -->
