### PR TITLE
Ensure dlls from Frameworks Core nuget package does not get copied for unit tests.

### DIFF
--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -4,6 +4,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <ItemsProjectGuid>{EE68A240-536D-4557-AB96-D164E93059A1}</ItemsProjectGuid>
+    <UseWinObjCFrameworksCore>false</UseWinObjCFrameworksCore>
     <CopyStarboardLibraries>true</CopyStarboardLibraries>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(TargetOsAndVersion)\</OutDir>
   </PropertyGroup>

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -4,7 +4,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <ItemsProjectGuid>{EE68A240-536D-4557-AB96-D164E93059A1}</ItemsProjectGuid>
-    <UseWinObjCFrameworksCore>false</UseWinObjCFrameworksCore>
+    <UseWinObjCFrameworksCorePackage>false</UseWinObjCFrameworksCorePackage>
     <CopyStarboardLibraries>true</CopyStarboardLibraries>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(TargetOsAndVersion)\</OutDir>
   </PropertyGroup>

--- a/build/Tests/Tests.Shared/Tests.Shared.vcxitems
+++ b/build/Tests/Tests.Shared/Tests.Shared.vcxitems
@@ -4,7 +4,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <HasSharedItems>true</HasSharedItems>
     <ItemsProjectGuid>{EE68A240-536D-4557-AB96-D164E93059A1}</ItemsProjectGuid>
-    <UseWinObjCFrameworksCorePackage>false</UseWinObjCFrameworksCorePackage>
+    <CopyWinObjCFrameworksCorePackage>false</CopyWinObjCFrameworksCorePackage>
     <CopyStarboardLibraries>true</CopyStarboardLibraries>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(TargetOsAndVersion)\</OutDir>
   </PropertyGroup>

--- a/build/WinObjC.Frameworks.Core/WinObjC.Frameworks.Core.targets
+++ b/build/WinObjC.Frameworks.Core/WinObjC.Frameworks.Core.targets
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
+      <UseWinObjCFrameworksCore Condition="'$(UseWinObjCFrameworksCore)' == ''">true</UseWinObjCFrameworksCore>
       <TargetOsAndVersion Condition="'$(TargetOsAndVersion)' == ''">Universal Windows</TargetOsAndVersion>
     </PropertyGroup>
     <!-- Make sure that the output artifacts are included in the build. This means adding include paths and link libraries for it.
@@ -9,7 +10,7 @@
          accidentally stomp it and get really confused. This is contrary to a configurable type property that a consumer may want / need to adjust. 
          To depend on this package means the consumer gets these things.  -->
 
-    <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary'">
+    <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary' And '$(UseWinObjCFrameworksCore)' == 'true'">
       <_ReferencesFromPackage Include="$(MSBuildThisFileDirectory)\lib\$(TargetOsAndVersion)\$(PlatformTarget)\*.winmd"/>    
       <_ReferencesFromPackage Include="$(MSBuildThisFileDirectory)\lib\$(TargetOsAndVersion)\$(PlatformTarget)\$(Configuration)\*.winmd"/>
 
@@ -28,7 +29,7 @@
       <_ContentFilesFromPackage Include="$(MSBuildThisFileDirectory)\content\**\*.*" />
     </ItemGroup>
 
-    <ItemDefinitionGroup>
+    <ItemDefinitionGroup Condition="'$(UseWinObjCFrameworksCore)' == 'true'">
         <ClangCompile>
           <InternalSystemIncludePaths>$(MSBuildThisFileDirectory)\include\;%(InternalSystemIncludePaths);</InternalSystemIncludePaths>
         </ClangCompile>
@@ -39,7 +40,7 @@
     </ItemDefinitionGroup>
 
   
-  <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary'">
+  <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary' And '$(UseWinObjCFrameworksCore)' == 'true'">
     
     <Reference Include="@(_ReferencesFromPackage)">
       <Implementation>%(Filename).dll</Implementation>

--- a/build/WinObjC.Frameworks.Core/WinObjC.Frameworks.Core.targets
+++ b/build/WinObjC.Frameworks.Core/WinObjC.Frameworks.Core.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-      <UseWinObjCFrameworksCore Condition="'$(UseWinObjCFrameworksCore)' == ''">true</UseWinObjCFrameworksCore>
+      <CopyWinObjCFrameworksCorePackage Condition="'$(CopyWinObjCFrameworksCorePackage)' == ''">true</CopyWinObjCFrameworksCorePackage>
       <TargetOsAndVersion Condition="'$(TargetOsAndVersion)' == ''">Universal Windows</TargetOsAndVersion>
     </PropertyGroup>
     <!-- Make sure that the output artifacts are included in the build. This means adding include paths and link libraries for it.
@@ -10,7 +10,7 @@
          accidentally stomp it and get really confused. This is contrary to a configurable type property that a consumer may want / need to adjust. 
          To depend on this package means the consumer gets these things.  -->
 
-    <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary' And '$(UseWinObjCFrameworksCore)' == 'true'">
+    <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary' And '$(CopyWinObjCFrameworksCorePackage)' == 'true'">
       <_ReferencesFromPackage Include="$(MSBuildThisFileDirectory)\lib\$(TargetOsAndVersion)\$(PlatformTarget)\*.winmd"/>    
       <_ReferencesFromPackage Include="$(MSBuildThisFileDirectory)\lib\$(TargetOsAndVersion)\$(PlatformTarget)\$(Configuration)\*.winmd"/>
 
@@ -29,7 +29,7 @@
       <_ContentFilesFromPackage Include="$(MSBuildThisFileDirectory)\content\**\*.*" />
     </ItemGroup>
 
-    <ItemDefinitionGroup Condition="'$(UseWinObjCFrameworksCore)' == 'true'">
+    <ItemDefinitionGroup Condition="'$(CopyWinObjCFrameworksCorePackage)' == 'true'">
         <ClangCompile>
           <InternalSystemIncludePaths>$(MSBuildThisFileDirectory)\include\;%(InternalSystemIncludePaths);</InternalSystemIncludePaths>
         </ClangCompile>
@@ -40,7 +40,7 @@
     </ItemDefinitionGroup>
 
   
-  <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary' And '$(UseWinObjCFrameworksCore)' == 'true'">
+  <ItemGroup Condition="'$(ConfigurationType)' != 'StaticLibrary' And '$(CopyWinObjCFrameworksCorePackage)' == 'true'">
     
     <Reference Include="@(_ReferencesFromPackage)">
       <Implementation>%(Filename).dll</Implementation>


### PR DESCRIPTION
The Unit tests reference Frameworks Core Projects as a project reference, so they do not need
the dlls from the nuget package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2760)
<!-- Reviewable:end -->
