### PR TITLE
Make the NSURLSession tests a bit more reliable

### DIFF
--- a/Frameworks/Foundation/NSURL.mm
+++ b/Frameworks/Foundation/NSURL.mm
@@ -332,6 +332,13 @@ BASE_CLASS_REQUIRED_IMPLS(NSURL, NSURLPrototype, CFURLGetTypeID);
 /**
  @Status Interoperable
 */
+- (NSString*)description {
+    return [self absoluteString];
+}
+
+/**
+ @Status Interoperable
+*/
 - (NSUInteger)hash {
     return [[self relativeString] hash] + [[[self baseURL] relativeString] hash];
 }

--- a/tests/frameworks/include/Helpers/TestHelpers.h
+++ b/tests/frameworks/include/Helpers/TestHelpers.h
@@ -29,6 +29,7 @@
 @interface THBooleanCondition : NSObject
 - (BOOL)waitUntilDate:(NSDate*)limit;
 - (void)broadcast;
+- (void)signal;
 @property (readonly) NSCondition* condition;
 @property (readonly) bool isOpen;
 @end

--- a/tests/helpers/THBooleanCondition.mm
+++ b/tests/helpers/THBooleanCondition.mm
@@ -40,6 +40,13 @@
     return ret;
 }
 
+- (void)signal {
+	[_condition lock];
+	_isOpen = YES;
+	[_condition signal];
+	[_condition unlock];
+}
+
 - (void)broadcast {
     [_condition lock];
     _isOpen = YES;


### PR DESCRIPTION
This pull request:

* Switches NSURLSessionTests to use THBooleanCondition, _which can only trigger once_
* Makes the tests await only a single broadcast from THBooleanCondition for all delegate callbacks
* Removes the delegate callback triggers that do not signal completion
* Rewrites the download/cancel/resume test to not rely on nebulous magic
  * Previously, the test was waiting to receive one callback (out-of-band), then cancelling the task. There
    was a window where the task was still running. The new implementation cancels it immediately in the
    "received data" callback.
  * The test was leaving a 500MB download spinning in the background instead of also cancelling that one
  * The test now makes certain that it has received SOME data before it cancels the task so there is
    definitely something to resume.
* Synchronizes all access to the test helper properties
* Logs which delegate callbacks we've received for easier debugging
* Doesn't try to log an NSDictionary with the `%d` format (:frowning_face:)
* Implements `-[THBooleanCondition signal]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2761)
<!-- Reviewable:end -->
