### PR TITLE
Fix some NSArray/NSMutableArray issues

### DIFF
--- a/Frameworks/Foundation/NSArray.mm
+++ b/Frameworks/Foundation/NSArray.mm
@@ -192,17 +192,7 @@ BASE_CLASS_REQUIRED_IMPLS(NSArray, NSArrayPrototype, CFArrayGetTypeID);
  @Status Interoperable
 */
 - (NSUInteger)indexOfObject:(id)obj {
-    int count = [self count];
-
-    for (int i = 0; i < count; i++) {
-        id value = [self objectAtIndex:i];
-
-        if ([obj isEqual:value]) {
-            return i;
-        }
-    }
-
-    return NSNotFound;
+    return [self indexOfObject:obj inRange:NSRange{ 0, self.count }];
 }
 
 /**

--- a/Frameworks/Foundation/NSCFArray.mm
+++ b/Frameworks/Foundation/NSCFArray.mm
@@ -17,6 +17,7 @@
 #include "Starboard.h"
 #include "CFHelpers.h"
 #include "CFFoundationInternal.h"
+#include "ForFoundationOnly.h"
 #include <CoreFoundation/CFArray.h>
 #include "NSCFArray.h"
 #include "BridgeHelpers.h"
@@ -84,7 +85,9 @@ BRIDGED_MUTABLE_CLASS_FOR_CODER(CFArrayRef, _CFArrayIsMutable, NSArray, NSMutabl
 - (id)objectAtIndex:(NSUInteger)index {
     if (index >= CFArrayGetCount((CFArrayRef)self)) {
         [NSException raise:@"Array out of bounds"
-                    format:@"objectAtIndex: index > count (%lu > %lu), throwing exception\n", (unsigned long)index, (unsigned long)CFArrayGetCount((CFArrayRef)self)];
+                    format:@"objectAtIndex: index > count (%lu > %lu), throwing exception\n",
+                           (unsigned long)index,
+                           (unsigned long)CFArrayGetCount((CFArrayRef)self)];
         return nil;
     }
     return (id)CFArrayGetValueAtIndex((CFArrayRef)self, index);
@@ -111,13 +114,18 @@ BRIDGED_MUTABLE_CLASS_FOR_CODER(CFArrayRef, _CFArrayIsMutable, NSArray, NSMutabl
     CFRange range;
     range.location = index;
     range.length = 1;
-    CFArrayReplaceValues(static_cast<CFMutableArrayRef>(self), range, (const void**)(&obj), 1);
+    _CFArrayReplaceValues(static_cast<CFMutableArrayRef>(self), range, (const void**)(&obj), 1);
 }
 
 - (void)insertObject:(NSObject*)objAddr atIndex:(NSUInteger)index {
     BRIDGED_THROW_IF_IMMUTABLE(_CFArrayIsMutable, CFArrayRef);
     NS_COLLECTION_THROW_IF_NULL_REASON(objAddr, [NSString stringWithFormat:@"*** %@ object cannot be nil", NSStringFromSelector(_cmd)]);
     CFArrayInsertValueAtIndex(static_cast<CFMutableArrayRef>(self), index, reinterpret_cast<const void*>(objAddr));
+}
+
+- (void)exchangeObjectAtIndex:(NSUInteger)atIndex withObjectAtIndex:(NSUInteger)withIndex {
+    BRIDGED_THROW_IF_IMMUTABLE(_CFArrayIsMutable, CFArrayRef);
+    CFArrayExchangeValuesAtIndices(static_cast<CFMutableArrayRef>(self), atIndex, withIndex);
 }
 
 - (void)removeAllObjects {

--- a/Frameworks/Foundation/NSCFCollectionSupport.h
+++ b/Frameworks/Foundation/NSCFCollectionSupport.h
@@ -38,4 +38,16 @@ CFHashCode _NSCFCallbackHash(const void* value);
         }                                                                                                        \
     } while (false)
 
+#define NS_COLLECTION_VALIDATE_RANGE(range, count)                                                 \
+    do {                                                                                           \
+        if (range.location + range.length > (count)) {                                             \
+            [NSException raise:NSInvalidArgumentException                                          \
+                        format:@"*** %s: Range {%lu, %lu} out of bounds; legal range is {0, %lu}", \
+                               __PRETTY_FUNCTION__,                                                \
+                               (unsigned long)range.location,                                      \
+                               (unsigned long)range.length,                                        \
+                               (unsigned long)(count)];                                            \
+        }                                                                                          \
+    } while (false)
+
 #endif // __OBJC__

--- a/include/Foundation/NSMutableArray.h
+++ b/include/Foundation/NSMutableArray.h
@@ -42,7 +42,7 @@ FOUNDATION_EXPORT_CLASS
 - (void)removeObjectAtIndex:(NSUInteger)index;
 - (void)removeObjectsAtIndexes:(NSIndexSet*)indexes;
 - (void)removeObjectIdenticalTo:(ObjectType)anObject;
-- (void)removeObjectIdenticalTo:(ObjectType)anObject inRange:(NSRange)aRange STUB_METHOD;
+- (void)removeObjectIdenticalTo:(ObjectType)anObject inRange:(NSRange)aRange;
 - (void)removeObjectsFromIndices:(NSUInteger*)indices numIndices:(NSUInteger)count STUB_METHOD;
 - (void)removeObjectsInArray:(NSArray<ObjectType>*)otherArray;
 - (void)removeObjectsInRange:(NSRange)aRange;


### PR DESCRIPTION
* `removeObject:inRange:` was originally finding the first instance of the
  object in the range, and then doing an array-wide search-and-remove
  every time it found one. This was very clearly wrong.
  This method was also augmented to do batch removals where possible.
* `removeObject:` is supposed to remove every instance of the found object.
  It wasn't doing so. Fixes #2771.
* `removeObjectIdenticalTo:` is supposed to remove every instance of the
  found object. It also wasn't doing so.
* `removeObjectIdenticalTo:inRange:` wasn't implemented.
* `exchangeObjectAtIndex:withObjectAtIndex:` was not using its CF
  optimized implementation.
* Methods that mutated ranges were not bounds-checking those ranges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2773)
<!-- Reviewable:end -->
