### PR TITLE
Fix endless loop if index set is nil

### DIFF
--- a/Frameworks/Foundation/NSArray.mm
+++ b/Frameworks/Foundation/NSArray.mm
@@ -818,14 +818,21 @@ static CFComparisonResult _CFComparatorFunctionFromComparator(const void* val1, 
  @Status Interoperable
 */
 - (NSArray*)objectsAtIndexes:(NSIndexSet*)indexes {
-    unsigned idx = [indexes firstIndex];
-    id ret = [NSMutableArray array];
-    unsigned count = [self count];
+    NSUInteger idx = NSNotFound;
+    id ret = nil;
+    NSUInteger count = [self count];
+
+	if (indexes == nil)
+		[NSException raise:NSInvalidArgumentException format:@"No index set"];
+	else {
+		ret = [NSMutableArray array];
+		idx = [indexes firstIndex];
+	}
 
     while (idx != NSNotFound) {
         if (idx >= count) {
             TraceCritical(TAG, L"objectsAtIndexes: index > count (%d > %d), throwing exception", idx, count);
-            [NSException raise:@"Array out of bounds" format:@""];
+			[NSException raise:NSRangeException format:@"Index out of bounds"];
             return nil;
         }
         [ret addObject:[self objectAtIndex:idx]];


### PR DESCRIPTION
Raises an invalid arg exception per Apple implementation and docs.