### PR TITLE
Peg cppwinrt to version 2017.4.6.1

### DIFF
--- a/msvc/sdk-build.props
+++ b/msvc/sdk-build.props
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Packaging" Version="0.1.186" />
     <PackageReference Include="WinObjC.Language" Version="*" />
-    <PackageReference Include="cppwinrt" Version="*">
+    <PackageReference Include="cppwinrt" Version="2017.4.6.1">
         <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/msvc/ut-build.props
+++ b/msvc/ut-build.props
@@ -23,6 +23,6 @@
   <ItemGroup>
     <PackageReference Include="WinObjC.Language" Version="*" />
     <PackageReference Include="Taef.Redist.Wlk" Version="1.0.170206001-nativeTargets" />
-    <PackageReference Include="cppwinrt" Version="*" />
+    <PackageReference Include="cppwinrt" Version="2017.4.6.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Version 2017.8.25.1 was published last week, which introduces some breaking changes and requires VS2017 15.3.
For the time being, we will continue to consume 2017.4.6.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2795)
<!-- Reviewable:end -->
