### PR TITLE
Update NuGet.exe in initialization script to new version.

### DIFF
--- a/scripts/init/Initialize-NuGet.ps1
+++ b/scripts/init/Initialize-NuGet.ps1
@@ -12,7 +12,7 @@ $toolsBetaDir = Join-Path -Resolve $repoRoot ".tools\beta"
 
 # Ensure nuget.exe is up-to-date
 $nugetDownloadName = "nuget.exe"
-. "$PSScriptRoot\Initialize-DownloadLatest.ps1" -OutDir $toolsDir -DownloadUrl "https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe" -DownloadName $nugetDownloadName -Unzip $false
+. "$PSScriptRoot\Initialize-DownloadLatest.ps1" -OutDir $toolsDir -DownloadUrl "https://dist.nuget.org/win-x86-commandline/v4.4.0/nuget.exe" -DownloadName $nugetDownloadName -Unzip $false
 
 # Ensure VSS.NuGet.AuthHelper is up-to-date
 $credProviderDownloadFeed = "https://nuget.org/api/v2/"


### PR DESCRIPTION
NuGet.exe fails to restore packages. Updating to NuGet 4.4 instead of 4.0 resolves the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2809)
<!-- Reviewable:end -->
