### PR TITLE
Implement OSSpinLock in WOCStdLib

### DIFF
--- a/build/Tests/UnitTests/WOCStdLib/WOCStdLib.UnitTests.vcxproj
+++ b/build/Tests/UnitTests/WOCStdLib/WOCStdLib.UnitTests.vcxproj
@@ -204,7 +204,8 @@
     <ClangCompile Include="..\..\..\..\tests\unittests\WOCStdLib\mach\mach_task_info_test.mm" />
     <ClangCompile Include="..\..\..\..\tests\unittests\WOCStdLib\mach\mach_test.mm" />
     <ClangCompile Include="..\..\..\..\tests\unittests\WOCStdLib\inettests.mm" />
+    <ClangCompile Include="..\..\..\..\tests\UnitTests\WOCStdLib\OSSpinLockTest.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Import Project="$(StarboardBasePath)\common\winobjc.packagereference.override.targets" Condition="Exists('$(StarboardBasePath)\common\winobjc.packagereference.override.targets')"/>
+  <Import Project="$(StarboardBasePath)\common\winobjc.packagereference.override.targets" Condition="Exists('$(StarboardBasePath)\common\winobjc.packagereference.override.targets')" />
 </Project>

--- a/tests/UnitTests/Foundation/DispatchTests.mm
+++ b/tests/UnitTests/Foundation/DispatchTests.mm
@@ -28,173 +28,173 @@ static int destructorCount = 0;
 
 // Create a 1 second end time for the test to timeout.
 static dispatch_time_t _createEndTestTime() {
-    return dispatch_time(DISPATCH_TIME_NOW, 1000000000000);
+	return dispatch_time(DISPATCH_TIME_NOW, 1000000000000);
 }
 
-static void destructor(void* x) {
+static void destructor(void* x){
     destructorCount++;
 }
 
 TEST(DispatchTests, SimpleSpecific) {
     dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-    dispatch_group_t group = dispatch_group_create();
+	dispatch_group_t group = dispatch_group_create();
 
-    dispatch_queue_set_specific(queue, key, context, nullptr);
+	dispatch_queue_set_specific(queue, key, context, nullptr);
 
-    dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
+	dispatch_group_async(group, queue, ^{
+		EXPECT_EQ(context, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue, key, context2, nullptr);
     });
-
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
-
-    EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
-
+	
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    
+	EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
+    
     dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(context2, dispatch_get_specific(key));
+		EXPECT_EQ(context2, dispatch_get_specific(key));
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-    dispatch_release(group);
-    dispatch_release(queue);
+	dispatch_release(group);
+	dispatch_release(queue);
 }
 
 TEST(DispatchTests, MultipleSpecificKeys) {
     dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-    dispatch_group_t group = dispatch_group_create();
+	dispatch_group_t group = dispatch_group_create();
 
     dispatch_queue_set_specific(queue, key, context, nullptr);
-    dispatch_queue_set_specific(queue, key2, context2, nullptr);
-
+	dispatch_queue_set_specific(queue, key2, context2, nullptr);
+    
     dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
-        EXPECT_EQ(context2, dispatch_get_specific(key2));
+		EXPECT_EQ(context, dispatch_get_specific(key));
+		EXPECT_EQ(context2, dispatch_get_specific(key2));
         dispatch_queue_set_specific(queue, key, context2, nullptr);
-        dispatch_queue_set_specific(queue, key2, context, nullptr);
+		dispatch_queue_set_specific(queue, key2, context, nullptr);
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    
+	EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
+	EXPECT_EQ(context, dispatch_queue_get_specific(queue, key2));
 
-    EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
-    EXPECT_EQ(context, dispatch_queue_get_specific(queue, key2));
-
-    dispatch_queue_set_specific(queue, key3, context3, nullptr);
-
+	dispatch_queue_set_specific(queue, key3, context3, nullptr);
+    
     dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(context2, dispatch_get_specific(key));
-        EXPECT_EQ(context, dispatch_get_specific(key2));
-        EXPECT_EQ(context3, dispatch_get_specific(key3));
+		EXPECT_EQ(context2, dispatch_get_specific(key));
+		EXPECT_EQ(context, dispatch_get_specific(key2));
+		EXPECT_EQ(context3, dispatch_get_specific(key3));
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-    dispatch_release(queue);
-    dispatch_release(group);
+	dispatch_release(queue);
+	dispatch_release(group);
 }
 
 TEST(DispatchTests, SpecificDestructor) {
-    dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-    dispatch_group_t group = dispatch_group_create();
+	dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
+	dispatch_group_t group = dispatch_group_create();
 
     dispatch_queue_set_specific(queue, key, context, destructor);
 
-    EXPECT_EQ(0, destructorCount);
-
+	EXPECT_EQ(0, destructorCount);
+    
     dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(dispatch_get_specific(key), context);
+		EXPECT_EQ(dispatch_get_specific(key), context);
         dispatch_queue_set_specific(queue, key, context2, destructor);
-        EXPECT_EQ(1, destructorCount);
+		EXPECT_EQ(1, destructorCount);
     });
-    ASSERT_EQ(dispatch_group_wait(group, _createEndTestTime()), 0);
-
-    EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
-    dispatch_queue_set_specific(queue, key, context, destructor);
-    EXPECT_EQ(2, destructorCount);
-
+	ASSERT_EQ(dispatch_group_wait(group, _createEndTestTime()), 0);
+    
+	EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
+	dispatch_queue_set_specific(queue, key, context, destructor);
+	EXPECT_EQ(2, destructorCount);
+    
     dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
-        EXPECT_EQ(2, destructorCount);
+		EXPECT_EQ(context, dispatch_get_specific(key));
+		EXPECT_EQ(2, destructorCount);
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-    dispatch_release(queue);
-    dispatch_release(group);
+	dispatch_release(queue);
+	dispatch_release(group);
 }
 
 TEST(DispatchTests, RemoveSpecific) {
-    dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-    dispatch_group_t group = dispatch_group_create();
+	dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
+	dispatch_group_t group = dispatch_group_create();
 
     dispatch_queue_set_specific(queue, key, context, nullptr);
-
+    
     dispatch_group_async(group, queue, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
+		EXPECT_EQ(context, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue, key, nullptr, nullptr);
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-    EXPECT_EQ(nullptr, dispatch_queue_get_specific(queue, key));
+	EXPECT_EQ(nullptr, dispatch_queue_get_specific(queue, key));
 
-    dispatch_release(queue);
-    dispatch_release(group);
+	dispatch_release(queue);
+	dispatch_release(group);
 }
 
 TEST(DispatchTests, MultipleQueues) {
     dispatch_queue_t queue1 = dispatch_queue_create("queue1", nullptr);
-    dispatch_queue_t queue2 = dispatch_queue_create("queue2", nullptr);
-    dispatch_queue_t queue3 = dispatch_queue_create("queue3", nullptr);
-    dispatch_group_t group = dispatch_group_create();
+	dispatch_queue_t queue2 = dispatch_queue_create("queue2", nullptr);
+	dispatch_queue_t queue3 = dispatch_queue_create("queue3", nullptr);
+	dispatch_group_t group = dispatch_group_create();
 
-    dispatch_queue_set_specific(queue1, key, context, nullptr);
-    dispatch_queue_set_specific(queue2, key, context2, nullptr);
-    dispatch_queue_set_specific(queue3, key, context3, nullptr);
+	dispatch_queue_set_specific(queue1, key, context, nullptr);
+	dispatch_queue_set_specific(queue2, key, context2, nullptr);
+	dispatch_queue_set_specific(queue3, key, context3, nullptr);
 
-    dispatch_group_async(group, queue1, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
+	dispatch_group_async(group, queue1, ^{
+		EXPECT_EQ(context, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue1, key, context2, nullptr);
     });
-    dispatch_group_async(group, queue2, ^{
-        EXPECT_EQ(context2, dispatch_get_specific(key));
+	dispatch_group_async(group, queue2, ^{
+		EXPECT_EQ(context2, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue2, key, context3, nullptr);
     });
-    dispatch_group_async(group, queue3, ^{
-        EXPECT_EQ(context3, dispatch_get_specific(key));
+	dispatch_group_async(group, queue3, ^{
+		EXPECT_EQ(context3, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue3, key, context, nullptr);
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
-
-    EXPECT_EQ(context2, dispatch_queue_get_specific(queue1, key));
-    EXPECT_EQ(context3, dispatch_queue_get_specific(queue2, key));
-    EXPECT_EQ(context, dispatch_queue_get_specific(queue3, key));
-
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    
+	EXPECT_EQ(context2, dispatch_queue_get_specific(queue1, key));
+	EXPECT_EQ(context3, dispatch_queue_get_specific(queue2, key));
+	EXPECT_EQ(context, dispatch_queue_get_specific(queue3, key));
+    
     dispatch_group_async(group, queue1, ^{
-        EXPECT_EQ(context2, dispatch_get_specific(key));
+		EXPECT_EQ(context2, dispatch_get_specific(key));
     });
-    dispatch_group_async(group, queue2, ^{
-        EXPECT_EQ(context3, dispatch_get_specific(key));
+	dispatch_group_async(group, queue2, ^{
+		EXPECT_EQ(context3, dispatch_get_specific(key));
     });
-    dispatch_group_async(group, queue3, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
+	dispatch_group_async(group, queue3, ^{
+		EXPECT_EQ(context, dispatch_get_specific(key));
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-    dispatch_queue_set_specific(queue1, key2, context, nullptr);
-    dispatch_queue_set_specific(queue1, key2, context3, nullptr);
-    dispatch_queue_set_specific(queue3, key3, context3, nullptr);
+	dispatch_queue_set_specific(queue1, key2, context, nullptr);
+	dispatch_queue_set_specific(queue1, key2, context3, nullptr);
+	dispatch_queue_set_specific(queue3, key3, context3, nullptr);
 
-    dispatch_group_async(group, queue1, ^{
-        EXPECT_EQ(context2, dispatch_get_specific(key));
-        EXPECT_EQ(context3, dispatch_get_specific(key2));
+	dispatch_group_async(group, queue1, ^{
+		EXPECT_EQ(context2, dispatch_get_specific(key));
+		EXPECT_EQ(context3, dispatch_get_specific(key2));
     });
-    dispatch_group_async(group, queue2, ^{
-        EXPECT_EQ(context3, dispatch_get_specific(key));
+	dispatch_group_async(group, queue2, ^{
+		EXPECT_EQ(context3, dispatch_get_specific(key));
     });
-    dispatch_group_async(group, queue3, ^{
-        EXPECT_EQ(context, dispatch_get_specific(key));
-        EXPECT_EQ(context3, dispatch_get_specific(key3));
+	dispatch_group_async(group, queue3, ^{
+		EXPECT_EQ(context, dispatch_get_specific(key));
+		EXPECT_EQ(context3, dispatch_get_specific(key3));
     });
-    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-    dispatch_release(queue1);
-    dispatch_release(queue2);
-    dispatch_release(queue3);
-    dispatch_release(group);
+	dispatch_release(queue1);
+	dispatch_release(queue2);
+	dispatch_release(queue3);
+	dispatch_release(group);
 }

--- a/tests/UnitTests/Foundation/DispatchTests.mm
+++ b/tests/UnitTests/Foundation/DispatchTests.mm
@@ -28,173 +28,173 @@ static int destructorCount = 0;
 
 // Create a 1 second end time for the test to timeout.
 static dispatch_time_t _createEndTestTime() {
-	return dispatch_time(DISPATCH_TIME_NOW, 1000000000000);
+    return dispatch_time(DISPATCH_TIME_NOW, 1000000000000);
 }
 
-static void destructor(void* x){
+static void destructor(void* x) {
     destructorCount++;
 }
 
 TEST(DispatchTests, SimpleSpecific) {
     dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-	dispatch_group_t group = dispatch_group_create();
+    dispatch_group_t group = dispatch_group_create();
 
-	dispatch_queue_set_specific(queue, key, context, nullptr);
+    dispatch_queue_set_specific(queue, key, context, nullptr);
 
-	dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
+    dispatch_group_async(group, queue, ^{
+        EXPECT_EQ(context, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue, key, context2, nullptr);
     });
-	
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
-    
-	EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
-    
-    dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(context2, dispatch_get_specific(key));
-    });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-	dispatch_release(group);
-	dispatch_release(queue);
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+
+    EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
+
+    dispatch_group_async(group, queue, ^{
+        EXPECT_EQ(context2, dispatch_get_specific(key));
+    });
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+
+    dispatch_release(group);
+    dispatch_release(queue);
 }
 
 TEST(DispatchTests, MultipleSpecificKeys) {
     dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-	dispatch_group_t group = dispatch_group_create();
+    dispatch_group_t group = dispatch_group_create();
 
     dispatch_queue_set_specific(queue, key, context, nullptr);
-	dispatch_queue_set_specific(queue, key2, context2, nullptr);
-    
+    dispatch_queue_set_specific(queue, key2, context2, nullptr);
+
     dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
-		EXPECT_EQ(context2, dispatch_get_specific(key2));
+        EXPECT_EQ(context, dispatch_get_specific(key));
+        EXPECT_EQ(context2, dispatch_get_specific(key2));
         dispatch_queue_set_specific(queue, key, context2, nullptr);
-		dispatch_queue_set_specific(queue, key2, context, nullptr);
+        dispatch_queue_set_specific(queue, key2, context, nullptr);
     });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
-    
-	EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
-	EXPECT_EQ(context, dispatch_queue_get_specific(queue, key2));
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-	dispatch_queue_set_specific(queue, key3, context3, nullptr);
-    
+    EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
+    EXPECT_EQ(context, dispatch_queue_get_specific(queue, key2));
+
+    dispatch_queue_set_specific(queue, key3, context3, nullptr);
+
     dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(context2, dispatch_get_specific(key));
-		EXPECT_EQ(context, dispatch_get_specific(key2));
-		EXPECT_EQ(context3, dispatch_get_specific(key3));
+        EXPECT_EQ(context2, dispatch_get_specific(key));
+        EXPECT_EQ(context, dispatch_get_specific(key2));
+        EXPECT_EQ(context3, dispatch_get_specific(key3));
     });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-	dispatch_release(queue);
-	dispatch_release(group);
+    dispatch_release(queue);
+    dispatch_release(group);
 }
 
 TEST(DispatchTests, SpecificDestructor) {
-	dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-	dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
+    dispatch_group_t group = dispatch_group_create();
 
     dispatch_queue_set_specific(queue, key, context, destructor);
 
-	EXPECT_EQ(0, destructorCount);
-    
-    dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(dispatch_get_specific(key), context);
-        dispatch_queue_set_specific(queue, key, context2, destructor);
-		EXPECT_EQ(1, destructorCount);
-    });
-	ASSERT_EQ(dispatch_group_wait(group, _createEndTestTime()), 0);
-    
-	EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
-	dispatch_queue_set_specific(queue, key, context, destructor);
-	EXPECT_EQ(2, destructorCount);
-    
-    dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
-		EXPECT_EQ(2, destructorCount);
-    });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    EXPECT_EQ(0, destructorCount);
 
-	dispatch_release(queue);
-	dispatch_release(group);
+    dispatch_group_async(group, queue, ^{
+        EXPECT_EQ(dispatch_get_specific(key), context);
+        dispatch_queue_set_specific(queue, key, context2, destructor);
+        EXPECT_EQ(1, destructorCount);
+    });
+    ASSERT_EQ(dispatch_group_wait(group, _createEndTestTime()), 0);
+
+    EXPECT_EQ(context2, dispatch_queue_get_specific(queue, key));
+    dispatch_queue_set_specific(queue, key, context, destructor);
+    EXPECT_EQ(2, destructorCount);
+
+    dispatch_group_async(group, queue, ^{
+        EXPECT_EQ(context, dispatch_get_specific(key));
+        EXPECT_EQ(2, destructorCount);
+    });
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+
+    dispatch_release(queue);
+    dispatch_release(group);
 }
 
 TEST(DispatchTests, RemoveSpecific) {
-	dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
-	dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
+    dispatch_group_t group = dispatch_group_create();
 
     dispatch_queue_set_specific(queue, key, context, nullptr);
-    
+
     dispatch_group_async(group, queue, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
+        EXPECT_EQ(context, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue, key, nullptr, nullptr);
     });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-	EXPECT_EQ(nullptr, dispatch_queue_get_specific(queue, key));
+    EXPECT_EQ(nullptr, dispatch_queue_get_specific(queue, key));
 
-	dispatch_release(queue);
-	dispatch_release(group);
+    dispatch_release(queue);
+    dispatch_release(group);
 }
 
 TEST(DispatchTests, MultipleQueues) {
     dispatch_queue_t queue1 = dispatch_queue_create("queue1", nullptr);
-	dispatch_queue_t queue2 = dispatch_queue_create("queue2", nullptr);
-	dispatch_queue_t queue3 = dispatch_queue_create("queue3", nullptr);
-	dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue2 = dispatch_queue_create("queue2", nullptr);
+    dispatch_queue_t queue3 = dispatch_queue_create("queue3", nullptr);
+    dispatch_group_t group = dispatch_group_create();
 
-	dispatch_queue_set_specific(queue1, key, context, nullptr);
-	dispatch_queue_set_specific(queue2, key, context2, nullptr);
-	dispatch_queue_set_specific(queue3, key, context3, nullptr);
+    dispatch_queue_set_specific(queue1, key, context, nullptr);
+    dispatch_queue_set_specific(queue2, key, context2, nullptr);
+    dispatch_queue_set_specific(queue3, key, context3, nullptr);
 
-	dispatch_group_async(group, queue1, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
+    dispatch_group_async(group, queue1, ^{
+        EXPECT_EQ(context, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue1, key, context2, nullptr);
     });
-	dispatch_group_async(group, queue2, ^{
-		EXPECT_EQ(context2, dispatch_get_specific(key));
+    dispatch_group_async(group, queue2, ^{
+        EXPECT_EQ(context2, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue2, key, context3, nullptr);
     });
-	dispatch_group_async(group, queue3, ^{
-		EXPECT_EQ(context3, dispatch_get_specific(key));
+    dispatch_group_async(group, queue3, ^{
+        EXPECT_EQ(context3, dispatch_get_specific(key));
         dispatch_queue_set_specific(queue3, key, context, nullptr);
     });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
-    
-	EXPECT_EQ(context2, dispatch_queue_get_specific(queue1, key));
-	EXPECT_EQ(context3, dispatch_queue_get_specific(queue2, key));
-	EXPECT_EQ(context, dispatch_queue_get_specific(queue3, key));
-    
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+
+    EXPECT_EQ(context2, dispatch_queue_get_specific(queue1, key));
+    EXPECT_EQ(context3, dispatch_queue_get_specific(queue2, key));
+    EXPECT_EQ(context, dispatch_queue_get_specific(queue3, key));
+
     dispatch_group_async(group, queue1, ^{
-		EXPECT_EQ(context2, dispatch_get_specific(key));
+        EXPECT_EQ(context2, dispatch_get_specific(key));
     });
-	dispatch_group_async(group, queue2, ^{
-		EXPECT_EQ(context3, dispatch_get_specific(key));
+    dispatch_group_async(group, queue2, ^{
+        EXPECT_EQ(context3, dispatch_get_specific(key));
     });
-	dispatch_group_async(group, queue3, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
+    dispatch_group_async(group, queue3, ^{
+        EXPECT_EQ(context, dispatch_get_specific(key));
     });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-	dispatch_queue_set_specific(queue1, key2, context, nullptr);
-	dispatch_queue_set_specific(queue1, key2, context3, nullptr);
-	dispatch_queue_set_specific(queue3, key3, context3, nullptr);
+    dispatch_queue_set_specific(queue1, key2, context, nullptr);
+    dispatch_queue_set_specific(queue1, key2, context3, nullptr);
+    dispatch_queue_set_specific(queue3, key3, context3, nullptr);
 
-	dispatch_group_async(group, queue1, ^{
-		EXPECT_EQ(context2, dispatch_get_specific(key));
-		EXPECT_EQ(context3, dispatch_get_specific(key2));
+    dispatch_group_async(group, queue1, ^{
+        EXPECT_EQ(context2, dispatch_get_specific(key));
+        EXPECT_EQ(context3, dispatch_get_specific(key2));
     });
-	dispatch_group_async(group, queue2, ^{
-		EXPECT_EQ(context3, dispatch_get_specific(key));
+    dispatch_group_async(group, queue2, ^{
+        EXPECT_EQ(context3, dispatch_get_specific(key));
     });
-	dispatch_group_async(group, queue3, ^{
-		EXPECT_EQ(context, dispatch_get_specific(key));
-		EXPECT_EQ(context3, dispatch_get_specific(key3));
+    dispatch_group_async(group, queue3, ^{
+        EXPECT_EQ(context, dispatch_get_specific(key));
+        EXPECT_EQ(context3, dispatch_get_specific(key3));
     });
-	ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
+    ASSERT_EQ(0, dispatch_group_wait(group, _createEndTestTime()));
 
-	dispatch_release(queue1);
-	dispatch_release(queue2);
-	dispatch_release(queue3);
-	dispatch_release(group);
+    dispatch_release(queue1);
+    dispatch_release(queue2);
+    dispatch_release(queue3);
+    dispatch_release(group);
 }

--- a/tests/UnitTests/WOCStdLib/OSSpinLockTest.mm
+++ b/tests/UnitTests/WOCStdLib/OSSpinLockTest.mm
@@ -19,15 +19,8 @@
 #import <dispatch/dispatch.h>
 #import <libkern/OSAtomic.h>
 
-static OSSpinLock lock1;
-static OSSpinLock lock2;
-static OSSpinLock lock3;
-static int spinValue;
-static dispatch_semaphore_t semaphore1;
-static dispatch_semaphore_t semaphore2;
-
 // Create a 1 second end time for the test to timeout.
-static dispatch_time_t _createEndTestTime() {
+dispatch_time_t _createEndTestTime() {
     return dispatch_time(DISPATCH_TIME_NOW, 1000000000);
 }
 
@@ -36,17 +29,16 @@ TEST(OSSpinLock, SpinLockTests) {
     dispatch_queue_t queue1 = dispatch_queue_create("queue", nullptr);
     dispatch_queue_t queue2 = dispatch_queue_create("queue", nullptr);
 
-    lock1 = OS_SPINLOCK_INIT;
-    lock2 = OS_SPINLOCK_INIT;
-    lock3 = OS_SPINLOCK_INIT;
+    __block OSSpinLock lock1 = OS_SPINLOCK_INIT;
+    __block OSSpinLock lock2 = OS_SPINLOCK_INIT;
+    __block OSSpinLock lock3 = OS_SPINLOCK_INIT;
+    __block int spinValue = 0;
+    __block dispatch_semaphore_t semaphore1 = dispatch_semaphore_create(0);
+    __block dispatch_semaphore_t semaphore2 = dispatch_semaphore_create(0);
 
-    spinValue = 0;
     OSSpinLockLock(&lock1);
     OSSpinLockLock(&lock2);
     OSSpinLockLock(&lock3);
-
-    semaphore1 = dispatch_semaphore_create(0);
-    semaphore2 = dispatch_semaphore_create(0);
 
     dispatch_async(queue1, ^{
         dispatch_semaphore_wait(semaphore1, _createEndTestTime());

--- a/tests/UnitTests/WOCStdLib/OSSpinLockTest.mm
+++ b/tests/UnitTests/WOCStdLib/OSSpinLockTest.mm
@@ -20,7 +20,7 @@
 #import <libkern/OSAtomic.h>
 
 // Create a 1 second end time for the test to timeout.
-dispatch_time_t _createEndTestTime() {
+static dispatch_time_t _createEndTestTime() {
     return dispatch_time(DISPATCH_TIME_NOW, 1000000000);
 }
 
@@ -28,13 +28,13 @@ TEST(OSSpinLock, SpinLockTests) {
     // Use two queues for concurrency as DISPATCH_QUEUE_CONCURRENT is not yet supported.
     dispatch_queue_t queue1 = dispatch_queue_create("queue", nullptr);
     dispatch_queue_t queue2 = dispatch_queue_create("queue", nullptr);
+    dispatch_semaphore_t semaphore1 = dispatch_semaphore_create(0);
+    dispatch_semaphore_t semaphore2 = dispatch_semaphore_create(0);
 
     __block OSSpinLock lock1 = OS_SPINLOCK_INIT;
     __block OSSpinLock lock2 = OS_SPINLOCK_INIT;
     __block OSSpinLock lock3 = OS_SPINLOCK_INIT;
     __block int spinValue = 0;
-    __block dispatch_semaphore_t semaphore1 = dispatch_semaphore_create(0);
-    __block dispatch_semaphore_t semaphore2 = dispatch_semaphore_create(0);
 
     OSSpinLockLock(&lock1);
     OSSpinLockLock(&lock2);
@@ -74,4 +74,6 @@ TEST(OSSpinLock, SpinLockTests) {
 
     dispatch_release(queue1);
     dispatch_release(queue2);
+    dispatch_release(semaphore1);
+    dispatch_release(semaphore2);
 }

--- a/tests/UnitTests/WOCStdLib/OSSpinLockTest.mm
+++ b/tests/UnitTests/WOCStdLib/OSSpinLockTest.mm
@@ -1,0 +1,60 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#import <TestFramework.h>
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+#import <libkern/OSAtomic.h>
+
+static OSSpinLock lock1;
+static OSSpinLock lock2;
+static OSSpinLock lock3;
+static int spinValue;
+
+TEST(OSSpinLock, SpinLockTests) {
+    dispatch_queue_t queue = dispatch_queue_create("queue", nullptr);
+
+    lock1 = OS_SPINLOCK_INIT;
+    lock2 = OS_SPINLOCK_INIT;
+    lock3 = OS_SPINLOCK_INIT;
+
+    spinValue = 0;
+    OSSpinLockLock(&lock1);
+    OSSpinLockLock(&lock2);
+    OSSpinLockLock(&lock3);
+
+    dispatch_async(queue, ^{
+        ASSERT_EQ(false, OSSpinLockTry(&lock1));
+        ASSERT_EQ(0, spinValue);
+        spinValue++;
+        ASSERT_EQ(1, spinValue);
+        OSSpinLockUnlock(&lock2);
+    });
+
+    dispatch_async(queue, ^{
+        OSSpinLockLock(&lock2);
+        ASSERT_EQ(false, OSSpinLockTry(&lock1));
+        ASSERT_EQ(1, spinValue);
+        spinValue++;
+        ASSERT_EQ(2, spinValue);
+        OSSpinLockUnlock(&lock1);
+        OSSpinLockUnlock(&lock2);
+        OSSpinLockUnlock(&lock3);
+    });
+
+    OSSpinLockLock(&lock3);
+    OSSpinLockUnlock(&lock3);
+}

--- a/tools/WOCStdLib/dll/WOCStdLib.def
+++ b/tools/WOCStdLib/dll/WOCStdLib.def
@@ -33,6 +33,9 @@ LIBRARY WOCStdLib
         OSSwapInt16
         OSSwapInt32
         OSSwapLittleToHostInt32
+		OSSpinLockLock
+		OSSpinLockUnlock
+		OSSpinLockTry
         arc4random
         arc4random_uniform
         mach_timebase_info

--- a/tools/WOCStdLib/dll/WOCStdLib.def
+++ b/tools/WOCStdLib/dll/WOCStdLib.def
@@ -33,9 +33,9 @@ LIBRARY WOCStdLib
         OSSwapInt16
         OSSwapInt32
         OSSwapLittleToHostInt32
-		OSSpinLockLock
-		OSSpinLockUnlock
-		OSSpinLockTry
+        OSSpinLockLock
+        OSSpinLockUnlock
+        OSSpinLockTry
         arc4random
         arc4random_uniform
         mach_timebase_info

--- a/tools/WOCStdLib/lib/OSSpinLock.cpp
+++ b/tools/WOCStdLib/lib/OSSpinLock.cpp
@@ -20,16 +20,16 @@
 #include <intrin.h>
 #endif
 
-extern "C" void OSSpinLockLock(volatile OSSpinLock *lock) {
+extern "C" void OSSpinLockLock(volatile OSSpinLock* lock) {
     while (_InterlockedCompareExchange((volatile long*)lock, ~0, 0) != 0) {
-		Sleep(0);
+        Sleep(0);
     }
 }
 
-extern "C" void OSSpinLockUnlock(volatile OSSpinLock *lock) {
+extern "C" void OSSpinLockUnlock(volatile OSSpinLock* lock) {
     _InterlockedExchange((volatile long*)lock, 0);
 }
 
-extern "C" bool OSSpinLockTry(volatile OSSpinLock *lock) {
+extern "C" bool OSSpinLockTry(volatile OSSpinLock* lock) {
     return (_InterlockedCompareExchange((volatile long*)lock, ~0, 0) == 0);
 }

--- a/tools/WOCStdLib/lib/OSSpinLock.cpp
+++ b/tools/WOCStdLib/lib/OSSpinLock.cpp
@@ -1,0 +1,35 @@
+//******************************************************************************
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+#include <libkern/OSAtomic.h>
+#include "windows.h"
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+extern "C" void OSSpinLockLock(volatile OSSpinLock *lock) {
+    while (_InterlockedCompareExchange((volatile long*)lock, ~0, 0) != 0) {
+		Sleep(0);
+    }
+}
+
+extern "C" void OSSpinLockUnlock(volatile OSSpinLock *lock) {
+    _InterlockedExchange((volatile long*)lock, 0);
+}
+
+extern "C" bool OSSpinLockTry(volatile OSSpinLock *lock) {
+    return (_InterlockedCompareExchange((volatile long*)lock, ~0, 0) == 0);
+}

--- a/tools/WOCStdLib/lib/WOCStdLibLib.vcxproj
+++ b/tools/WOCStdLib/lib/WOCStdLibLib.vcxproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -18,13 +17,11 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-  </ItemGroup>  
-
+  </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\..\common\common-build.props" />
-
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)UTSName.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)mach.cpp" />
@@ -40,6 +37,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)inet.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)random.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)time.cpp" />
+    <ClCompile Include="OSSpinLock.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{17D1A01F-08ED-4903-BAE1-D446150CC7D5}</ProjectGuid>

--- a/tools/WOCStdLib/lib/WOCStdLibLib.vcxproj
+++ b/tools/WOCStdLib/lib/WOCStdLibLib.vcxproj
@@ -37,7 +37,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)inet.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)random.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)time.cpp" />
-    <ClCompile Include="OSSpinLock.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)OSSpinLock.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{17D1A01F-08ED-4903-BAE1-D446150CC7D5}</ProjectGuid>

--- a/tools/include/WOCStdLib/libkern/OSAtomic.h
+++ b/tools/include/WOCStdLib/libkern/OSAtomic.h
@@ -19,7 +19,13 @@
 #ifndef _OSATOMIC_H_
 #define _OSATOMIC_H_
 
+#define OS_SPINLOCK_INIT 0
+
+#include <inttypes.h>
+#include <sys/cdefs.h>
+
 typedef int         __int32_t;
+typedef __int32_t   OSSpinLock;
 
 __BEGIN_DECLS
 
@@ -49,6 +55,10 @@ static __inline __int32_t OSAtomicDecrement32Barrier(volatile __int32_t *val)
 {
     return OSAtomicAdd32Barrier(-1, val);
 }
+
+void OSSpinLockLock(volatile OSSpinLock *lock);
+void OSSpinLockUnlock(volatile OSSpinLock *lock);
+bool OSSpinLockTry(volatile OSSpinLock *lock);
 
 __END_DECLS
 


### PR DESCRIPTION
Utilize CFLock/Unlock implementations to implement OSSpinLock in WoCStdLib for public use.

Fixes #2790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2820)
<!-- Reviewable:end -->
