### PR TITLE
Fix NSNullTests comparison between NSNull null and kCFNull

### DIFF
--- a/tests/unittests/Foundation/NSNullTests.mm
+++ b/tests/unittests/Foundation/NSNullTests.mm
@@ -18,7 +18,7 @@
 #import <Foundation/Foundation.h>
 
 TEST(NSNull, Bridged) {
-    ASSERT_EQ([NSNull null], kCFNull); // Pointer equality required.
+    ASSERT_EQ((void*)[NSNull null], (void*)kCFNull); // Pointer equality required.
 }
 
 TEST(NSNull, Singleton) {


### PR DESCRIPTION
The reference platform has stricter policies on comparisons between [NSNull null] and kCFNull.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2821)
<!-- Reviewable:end -->
