### PR TITLE
Add additional project.json files to frameworks to target net40

### DIFF
--- a/build/WinObjC.Frameworks.Core/project.json
+++ b/build/WinObjC.Frameworks.Core/project.json
@@ -1,0 +1,25 @@
+﻿{
+  "dependencies": {
+    "NuGet.Build.Packaging": "0.1.186"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.0": {
+      "imports": [
+        "dotnet",
+        "netstandard1.0",
+        "netstandard1.1",
+        "netstandard1.2",
+        "netstandard1.3",
+        "netstandard1.4",
+        "netstandard1.5",
+        "netstandard1.6",
+        "net20",
+        "net35",
+        "net40",
+        "native",
+        "monoandroid",
+        "xamarinios10"
+      ]
+    }
+  }
+}

--- a/build/WinObjC.Frameworks.ThirdParty/project.json
+++ b/build/WinObjC.Frameworks.ThirdParty/project.json
@@ -1,0 +1,25 @@
+﻿{
+  "dependencies": {
+    "NuGet.Build.Packaging": "0.1.186"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.0": {
+      "imports": [
+        "dotnet",
+        "netstandard1.0",
+        "netstandard1.1",
+        "netstandard1.2",
+        "netstandard1.3",
+        "netstandard1.4",
+        "netstandard1.5",
+        "netstandard1.6",
+        "net20",
+        "net35",
+        "net40",
+        "native",
+        "monoandroid",
+        "xamarinios10"
+      ]
+    }
+  }
+}

--- a/build/WinObjC.Frameworks.UWP.Core/project.json
+++ b/build/WinObjC.Frameworks.UWP.Core/project.json
@@ -1,0 +1,25 @@
+﻿{
+  "dependencies": {
+    "NuGet.Build.Packaging": "0.1.186"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.0": {
+      "imports": [
+        "dotnet",
+        "netstandard1.0",
+        "netstandard1.1",
+        "netstandard1.2",
+        "netstandard1.3",
+        "netstandard1.4",
+        "netstandard1.5",
+        "netstandard1.6",
+        "net20",
+        "net35",
+        "net40",
+        "native",
+        "monoandroid",
+        "xamarinios10"
+      ]
+    }
+  }
+}

--- a/build/WinObjC.Frameworks.UWP/project.json
+++ b/build/WinObjC.Frameworks.UWP/project.json
@@ -1,0 +1,25 @@
+﻿{
+  "dependencies": {
+    "NuGet.Build.Packaging": "0.1.186"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.0": {
+      "imports": [
+        "dotnet",
+        "netstandard1.0",
+        "netstandard1.1",
+        "netstandard1.2",
+        "netstandard1.3",
+        "netstandard1.4",
+        "netstandard1.5",
+        "netstandard1.6",
+        "net20",
+        "net35",
+        "net40",
+        "native",
+        "monoandroid",
+        "xamarinios10"
+      ]
+    }
+  }
+}

--- a/build/WinObjC.Frameworks/project.json
+++ b/build/WinObjC.Frameworks/project.json
@@ -1,0 +1,25 @@
+﻿{
+  "dependencies": {
+    "NuGet.Build.Packaging": "0.1.186"
+  },
+  "frameworks": {
+    ".NETFramework,Version=v4.0": {
+      "imports": [
+        "dotnet",
+        "netstandard1.0",
+        "netstandard1.1",
+        "netstandard1.2",
+        "netstandard1.3",
+        "netstandard1.4",
+        "netstandard1.5",
+        "netstandard1.6",
+        "net20",
+        "net35",
+        "net40",
+        "native",
+        "monoandroid",
+        "xamarinios10"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Nuget projects in each frameworks now require a project.json each specifying the net40 framework. An issue on nuget has been filed as the frameworks should not require a net40 dependency.

https://github.com/NuGet/Home/issues/6543

This fix is required for Visual Studio 2017 update 15.4.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2828)
<!-- Reviewable:end -->
