### PR TITLE
[GitVersion] Ignore commit db05d76, which has a confusing version number

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -34,4 +34,5 @@ branches:
     is-release-branch: false
     prevent-increment-of-merged-branch-version: true
 ignore:
-  sha: []
+  sha:
+    - db05d76b7c9e9371f3edd8bb0085e260d1ad4957


### PR DESCRIPTION
This fixes the stray `1711.1` version we're seeing on all of our packages.
That number was introduced by GitVersionTask reading the body of commit db05d76b7c9e9371f3edd8bb0085e260d1ad4957

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2832)
<!-- Reviewable:end -->
