### PR TITLE
Make sure objc_2stage_init is included during all linking steps

### DIFF
--- a/tools/msvc/sbclang.targets
+++ b/tools/msvc/sbclang.targets
@@ -22,7 +22,8 @@
     <ClangCompileDependsOn>_SelectedFiles;MakeDirsForClang;GenerateHeaderMaps;ComputeClangOptions</ClangCompileDependsOn>
     <ClangCompileBeforeTargets>ClCompile;Link;Lib;ImpLib</ClangCompileBeforeTargets>
     <ClangCompileAfterTargets></ClangCompileAfterTargets>
-    <BeforeClCompileTargets>_ClangCompile;AddObjCTwoStageInitFile;$(BeforeClCompileTargets)</BeforeClCompileTargets>
+    <BeforeClCompileTargets>_ClangCompile;$(BeforeClCompileTargets)</BeforeClCompileTargets>
+    <ComputeCompileInputsTargets>AddObjCTwoStageInitFile;$(ComputeCompileInputsTargets)</ComputeCompileInputsTargets>
     <BuildCompileTargets>_ClangCompile;$(BuildCompileTargets)</BuildCompileTargets>
   </PropertyGroup>
 


### PR DESCRIPTION
This change moves the generation of the objc_2stage_init.cpp ClCompile item to
ComputeCompileInputsTargets.  BeforeClCompileTargets targets are only triggered
for ClCompile, which doesn't happen on every Link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/winobjc/2833)
<!-- Reviewable:end -->
