### PR TITLE
Fixed generics declarations for collection subclasses.

### DIFF
--- a/include/Foundation/NSCountedSet.h
+++ b/include/Foundation/NSCountedSet.h
@@ -26,6 +26,6 @@
 @class NSEnumerator;
 
 FOUNDATION_EXPORT_CLASS
-@interface NSCountedSet : NSMutableSet <NSCopying, NSFastEnumeration, NSMutableCopying, NSSecureCoding>
-- (NSUInteger)countForObject:(id)anObject;
+@interface NSCountedSet <ObjectType> : NSMutableSet <ObjectType>
+- (NSUInteger)countForObject:(ObjectType)anObject;
 @end

--- a/include/Foundation/NSMutableArray.h
+++ b/include/Foundation/NSMutableArray.h
@@ -28,7 +28,7 @@
 @class NSSortDescriptor;
 
 FOUNDATION_EXPORT_CLASS
-@interface NSMutableArray <ObjectType> : NSArray <NSCopying, NSFastEnumeration, NSMutableCopying, NSSecureCoding>
+@interface NSMutableArray <ObjectType> : NSArray <ObjectType>
 + (instancetype)arrayWithCapacity:(NSUInteger)numItems;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 - (void)addObject:(ObjectType)anObject;

--- a/include/Foundation/NSMutableDictionary.h
+++ b/include/Foundation/NSMutableDictionary.h
@@ -25,7 +25,7 @@
 @class NSArray<ObjectType>;
 
 FOUNDATION_EXPORT_CLASS
-@interface NSMutableDictionary <KeyType, ObjectType> : NSDictionary <NSCopying, NSFastEnumeration, NSMutableCopying, NSSecureCoding>
+@interface NSMutableDictionary <KeyType, ObjectType> : NSDictionary <KeyType, ObjectType>
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 + (NSMutableDictionary*)dictionaryWithSharedKeySet:(id)keyset;

--- a/include/Foundation/NSMutableIndexSet.h
+++ b/include/Foundation/NSMutableIndexSet.h
@@ -21,7 +21,7 @@
 #import <Foundation/NSIndexSet.h>
 
 FOUNDATION_EXPORT_CLASS
-@interface NSMutableIndexSet : NSIndexSet <NSCopying, NSMutableCopying, NSSecureCoding>
+@interface NSMutableIndexSet : NSIndexSet
 - (void)addIndex:(NSUInteger)index;
 - (void)addIndexes:(NSIndexSet*)indexSet;
 - (void)addIndexesInRange:(NSRange)indexRange;

--- a/include/Foundation/NSMutableOrderedSet.h
+++ b/include/Foundation/NSMutableOrderedSet.h
@@ -26,7 +26,7 @@
 @class NSSet<ObjectType>;
 
 FOUNDATION_EXPORT_CLASS
-@interface NSMutableOrderedSet <ObjectType> : NSOrderedSet <NSCopying, NSFastEnumeration, NSMutableCopying, NSSecureCoding>
+@interface NSMutableOrderedSet <ObjectType> : NSOrderedSet <ObjectType>
 +(instancetype)orderedSetWithCapacity : (NSUInteger)numItems STUB_METHOD;
 - (instancetype)initWithCapacity:(NSUInteger)numItems STUB_METHOD;
 - (instancetype)init;

--- a/include/Foundation/NSMutableSet.h
+++ b/include/Foundation/NSMutableSet.h
@@ -25,7 +25,7 @@
 @class NSArray<ObjectType>;
 
 FOUNDATION_EXPORT_CLASS
-@interface NSMutableSet <ObjectType> : NSSet <NSCopying, NSFastEnumeration, NSMutableCopying, NSSecureCoding>
+@interface NSMutableSet <ObjectType> : NSSet <ObjectType>
 + (instancetype)setWithCapacity:(NSUInteger)numItems;
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 - (void)addObject:(ObjectType)object;


### PR DESCRIPTION
Generics declarations of NSMutableArray, NSMutableDictionary, NSMutableOrderedSet, and NSMutableSet were not being passed up to superclass.

This meant that calling generic methods declared in the superclass on a subclass object were not recognized by the compiler to return a declared generic object type.

All protocol declarations that are being replaced with generics declarations are already declared by the respective superclass, and thus the list of implemented protocols does not change. Also removed unecessary protocol declarations on NSMutableIndexSet to match the other collection subclasses.

Also added missing generics declaration to NSCountedSet (subclass of NSMutableSet).