### PR TITLE
KVO: fix possible duplicate observing of key

### DIFF
--- a/Frameworks/Foundation/NSKVOSupport.mm
+++ b/Frameworks/Foundation/NSKVOSupport.mm
@@ -301,7 +301,7 @@ static void _addNestedObserversAndOptionallyDependents(_NSKVOKeyObserver* keyObs
     }
 
     // If restOfKeypath is non-nil, we have to chain on further observers.
-    if (keyObserver.restOfKeypath) {
+    if (keyObserver.restOfKeypath && !keyObserver.restOfKeypathObserver) {
         keyObserver.restOfKeypathObserver =
             _addKeypathObserver([object valueForKey:key], keyObserver.restOfKeypath, keypathObserver, keyObserver.affectedObservers);
     }

--- a/Frameworks/Foundation/NSKVOSupport.mm
+++ b/Frameworks/Foundation/NSKVOSupport.mm
@@ -552,9 +552,8 @@ template <typename TFunc>
 inline static void _dispatchWillChange(id notifyingObject, NSString* key, TFunc&& func) {
     _NSKVOObservationInfo* observationInfo = (__bridge _NSKVOObservationInfo*)[notifyingObject observationInfo];
     for (_NSKVOKeyObserver* keyObserver in [observationInfo observersForKey:key]) {
-        _NSKVOKeypathObserver* keypathObserver = keyObserver.keypathObserver;
-
         // Skip any keypaths that are in the process of changing.
+        _NSKVOKeypathObserver* keypathObserver = keyObserver.keypathObserver;
         if ([keypathObserver pushWillChange]) {
             // Call into the lambda function, which will do the actual set-up for pendingChanges
             func(keyObserver);
@@ -569,10 +568,10 @@ inline static void _dispatchWillChange(id notifyingObject, NSString* key, TFunc&
                                                          context:keypathObserver.context];
                 [change removeObjectForKey:NSKeyValueChangeNotificationIsPriorKey];
             }
-
-            // This must happen regardless of whether we are currently notifying.
-            _removeNestedObserversAndOptionallyDependents(keyObserver, false);
         }
+
+        // This must happen regardless of whether we are currently notifying.
+        _removeNestedObserversAndOptionallyDependents(keyObserver, false);
     }
 }
 


### PR DESCRIPTION
Could happen when using dependent key paths, as the dependency handling can have added an observer for restOfKeypath already.

Following is a test case to reproduce the issue, which resulted in a KVO notification after removing the observer. This happened because `number` was observed twice internally, but only one observer was being removed internally on `-removeObserver:forKeyPath:`.

```objc

@interface Child : NSObject
@property (nonatomic, assign) NSUInteger number;
@end

@implementation Child
@end

@interface Parent : NSObject
@property (nonatomic, assign) BOOL useChild2;
@property (nonatomic, readonly) Child *child;
@property (nonatomic, strong) Child *child1;
@property (nonatomic, strong) Child *child2;
@end

@implementation Parent

- (id)init
{
	self = [super init];
	if (self) {
		self.child1 = [[Child alloc] init];
		self.child1.number = 1;
		self.child2 = [[Child alloc] init];
		self.child2.number = 2;;
	}
	return self;
}

+ (NSSet *)keyPathsForValuesAffectingChild
{
	return [NSSet setWithObject:@"useChild2"];
}

- (Child *)child
{
	return self.useChild2 ? self.child2 : self.child1;
}

@end

@interface Test : NSObject
@end

@implementation Test

- (void)test
{
	Parent *parent = [Parent new];

	[parent addObserver:self forKeyPath:@"child.number" options:NSKeyValueObservingOptionInitial context:NULL];
	[parent removeObserver:self forKeyPath:@"child.number"];

	// *** BUG: incorrectly triggers KVO ***
	parent.child.number = 999;
	// ***
}

- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
{
	NSLog(@"%@.%@ (change %@) = %@", object, keyPath, change, [object valueForKeyPath:keyPath]);
}

@end
```

_While I don’t expect this to be merged given the state of the project, I wanted to post this here for posterity in case anyone else is using this KVO implementation._